### PR TITLE
docs: organize introduction with mkdocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ __pycache__
 .fastapi
 # md files
 *.md
+!docs/**/*.md
 
 # sql files
 *.sql

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,12 @@
 
 Welcome to the AI Gateway documentation! This comprehensive guide covers everything you need to know about setting up, deploying, and operating the AI Gateway API.
 
+For a high-level overview of the project, see:
+
+- [What is the AI Gateway?](introduction/what-is-gateway.md)
+- [Key Features](introduction/key-features.md)
+- [When to Use the AI Gateway](introduction/use-cases.md)
+
 ## Quick Start
 
 1. **[Setup Guide](setup.md)** - Get started with local development
@@ -29,26 +35,6 @@ Welcome to the AI Gateway documentation! This comprehensive guide covers everyth
 ### Deployment
 - **[Deployment Guide](deployment.md)** - Production deployment instructions
 - **[Platform Support](deployment.md)** - Vercel, Railway, Heroku, and more
-
-## Key Features
-
-### Core Functionality
-- **Multi-Model AI Access**: Access to multiple AI models through OpenRouter
-- **Credit Management**: Token-based credit system with usage tracking
-- **Rate Limiting**: Comprehensive rate limiting and plan enforcement
-- **API Key Management**: Secure API key creation, rotation, and management
-
-### Security Features
-- **Phase 4 Security**: IP allowlists, domain restrictions, key rotation
-- **Audit Logging**: Comprehensive security event tracking
-- **Authentication**: Multi-layer API key validation
-- **Authorization**: Fine-grained permission controls
-
-### Monitoring & Analytics
-- **Real-time Monitoring**: System health and performance metrics
-- **Usage Analytics**: Detailed usage tracking and reporting
-- **Admin Dashboard**: System-wide monitoring and management
-- **Health Checks**: Automated health monitoring and alerting
 
 ## API Endpoints
 

--- a/docs/introduction/key-features.md
+++ b/docs/introduction/key-features.md
@@ -1,0 +1,23 @@
+# Key Features of the AI Gateway
+
+The AI Gateway provides a robust set of capabilities for managing multi-model AI workloads through a single interface.
+
+## Unified model access
+- Route requests to different model providers without changing your client code.
+- Manage model availability and preferences in one place.
+
+## Advanced user and key management
+- Self-service user registration with automatic primary key creation.
+- Create, rotate, and revoke multiple API keys with granular permissions and optional expiration.
+
+## Robust rate limiting and quotas
+- Enforce per-user and per-key limits across minute, hour, and day windows.
+- Configure plan-based entitlements and request caps.
+
+## Security and compliance
+- AES-128 encrypted key storage and hash-based validation.
+- IP allowlists, domain referrers, and comprehensive audit logging.
+
+## Monitoring and analytics
+- Usage dashboards for users and administrators.
+- Health checks and real-time metrics for system reliability.

--- a/docs/introduction/use-cases.md
+++ b/docs/introduction/use-cases.md
@@ -1,0 +1,12 @@
+# When to Use the AI Gateway
+
+The AI Gateway fits a variety of scenarios where control and insight into model usage are critical.
+
+Use the AI Gateway when you need to:
+
+- Support multiple AI providers without exposing your infrastructure.
+- Charge users or teams based on metered usage.
+- Enforce strict security controls around API access.
+- Gain insight into usage patterns and system health.
+
+Whether you're building a SaaS platform, internal tooling, or large-scale AI application, the AI Gateway offers a secure, extensible foundation for managing AI inference at scale.

--- a/docs/introduction/what-is-gateway.md
+++ b/docs/introduction/what-is-gateway.md
@@ -1,0 +1,16 @@
+# What is the AI Gateway?
+
+The AI Gateway is an open‑source service that provides a unified API for interacting with multiple AI models through a single, credit‑metered interface. It sits between your applications and upstream model providers, handling authentication, usage tracking, and security so you can focus on building great products.
+
+## Why use the AI Gateway?
+
+- **Single entry point for many models** – Access hundreds of models via a consistent REST API.
+- **Credit-based billing** – Meter usage with token-based credits that deduct automatically on each request.
+- **Strong security defaults** – Encrypted key storage, allowlists, domain restrictions, and key rotation to keep your systems safe.
+- **Operational transparency** – Real-time monitoring, audit logs, and detailed usage analytics for both users and admins.
+
+For a deeper look at the platform's capabilities and ideal scenarios, see:
+
+- [Key Features](key-features.md)
+- [When to Use the AI Gateway](use-cases.md)
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,17 @@
+site_name: AI Gateway Documentation
+docs_dir: docs
+nav:
+  - Home: index.md
+  - Introduction:
+      - What is the AI Gateway?: introduction/what-is-gateway.md
+      - Key Features: introduction/key-features.md
+      - When to Use the AI Gateway: introduction/use-cases.md
+  - Getting Started:
+      - Setup Guide: setup.md
+      - Environment Configuration: environment.md
+      - Architecture: architecture.md
+  - API Reference: api.md
+  - Deployment: deployment.md
+  - Operations: operations.md
+  - Troubleshooting: troubleshooting.md
+  - Contributing: contributing.md


### PR DESCRIPTION
## Summary
- split introduction into multiple pages covering overview, features, and use cases
- add mkdocs configuration for Read the Docs-style navigation
- allow committing markdown docs by unignoring them in `.gitignore`

## Testing
- `pip install mkdocs` *(fails: Could not find a version that satisfies the requirement mkdocs (proxy 403 Forbidden))*
- `mkdocs build` *(command not found: mkdocs)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'gateway')*

------
https://chatgpt.com/codex/tasks/task_b_68c3782111588323a6432af1ccdef84a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a structured documentation site with MkDocs, including navigation and site metadata.
  * Added new Introduction pages: What is the AI Gateway?, Key Features, and When to Use the AI Gateway.
  * Updated the main docs overview to a high-level summary and linked to dedicated introduction pages.
  * Preserved existing sections (Quick Start, Documentation Overview, API Endpoints) while relocating feature details to new pages.

* **Chores**
  * Updated ignore rules to ensure documentation Markdown files under docs are tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->