### PR TITLE
Refactor: Use direct provider APIs for Cerebras, Nebius, xAI, Novita

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,10 @@ stripe==13.0.1
 portkey-ai>=2.0.0
 google-cloud-aiplatform>=1.38.0
 
+# Provider SDKs
+cerebras-cloud-sdk>=1.0.0
+xai-sdk>=0.1.0
+
 # Analytics
 statsig-python-core==0.10.2
 posthog==6.7.8


### PR DESCRIPTION
## Summary
- Refactor: use direct provider APIs for Cerebras, Nebius, xAI, and Novita
- Google and Hugging Face continue to be resolved via Portkey filtering

## Changes
- Implemented direct API fetches for Cerebras, Nebius, xAI, and Novita using their OpenAI-compatible endpoints
- Added API key guards and 20s timeouts via Config (CEREBRAS_API_KEY, NEBIUS_API_KEY, XAI_API_KEY, NOVITA_API_KEY)
- Normalization of provider models remains via `normalize_portkey_provider_model` to ensure consistent catalog schema
- Caching updated with fetched models and timestamps, with clearer log messages
- Updated module header to reflect direct-provider integration approach
- Maintained Portkey-based filtering for Google and Hugging Face providers only

## Rationale
Direct provider API integration improves reliability and completeness compared to relying solely on Portkey's unified catalog for certain providers that may not be consistently reflected in Portkey responses.

## Testing Plan
- Pre-reqs: set API keys for Cerebras, Nebius, xAI, and Novita in Config (environment variables or secret manager)
- Verify each provider fetch:
  - Cerebras: call `fetch_models_from_cerebras()` and confirm non-empty model list or appropriate log when API returns nothing
  - Nebius: call `fetch_models_from_nebius()` and confirm non-empty model list or appropriate log
  - xAI: call `fetch_models_from_xai()` and confirm non-empty model list or appropriate log
  - Novita: call `fetch_models_from_novita()` and confirm non-empty model list or appropriate log
- Verify Google and Hugging Face still resolve correctly via Portkey filters
- Check cache timestamps and ensure models are normalized with the correct provider labels

## Notes
- No database migrations required
- Ensure API keys are stored securely and not committed
- If any provider changes their API shape, update the normalization step accordingly

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c7116e33-9567-41e8-a868-431a7730724e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches model fetching for Cerebras, Nebius, xAI, and Novita to native APIs/SDKs (with fallbacks), keeping Google/Hugging Face via Portkey, and adds required SDK dependencies.
> 
> - **Services (`src/services/portkey_providers.py`)**:
>   - **Direct integrations**:
>     - Cerebras: use `cerebras-cloud-sdk` with HTTP fallback to `https://api.cerebras.ai/v1/models`.
>     - Nebius: use OpenAI SDK with `base_url="https://api.studio.nebius.ai/v1/"`.
>     - xAI: use `xai-sdk` with fallback to OpenAI SDK `base_url="https://api.x.ai/v1"`.
>     - Novita: use OpenAI SDK with `base_url="https://api.novita.ai/v3/openai"`.
>   - Add API key guards via `Config` and update caching/log messages.
>   - Keep Google and Hugging Face resolved via Portkey filtering.
>   - Update normalization docstring to reflect provider-API inputs and consistent `@provider/model-id` format.
> - **Dependencies (`requirements.txt`)**:
>   - Add provider SDKs: `cerebras-cloud-sdk>=1.0.0`, `xai-sdk>=0.1.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 567e3a234b45b2ae819e3f849b75f1de54379d2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->