### PR TITLE
Improve Near/XAI model display with fallbacks and API fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,10 @@ TOGETHER_API_KEY=your-together-api-key
 GROQ_API_KEY=your-groq-api-key
 AIMO_API_KEY=your-aimo-api-key
 NEAR_API_KEY=your-near-api-key
+XAI_API_KEY=your-xai-api-key
+NEBIUS_API_KEY=your-nebius-api-key
+CEREBRAS_API_KEY=your-cerebras-api-key
+NOVITA_API_KEY=your-novita-api-key
 
 # Optional - Provider-specific keys (for use with Portkey)
 PROVIDER_OPENAI_API_KEY=sk-...

--- a/src/services/near_client.py
+++ b/src/services/near_client.py
@@ -11,14 +11,14 @@ def get_near_client():
     """Get Near AI client using OpenAI-compatible interface
 
     Near AI is a decentralized AI infrastructure providing private, verifiable, and user-owned AI services
-    Base URL: https://api.near.ai/v1
+    Base URL: https://cloud-api.near.ai/v1
     """
     try:
         if not Config.NEAR_API_KEY:
             raise ValueError("Near AI API key not configured")
 
         return OpenAI(
-            base_url="https://api.near.ai/v1",
+            base_url="https://cloud-api.near.ai/v1",
             api_key=Config.NEAR_API_KEY
         )
     except Exception as e:


### PR DESCRIPTION
## Summary
- Adds robust fallback lists for Near and xAI model discovery
- Aligns Near API endpoints with cloud-based service
- Improves resilience when external services fail or return empty results

## Changes
- src/services/models.py: fetch_near now targets cloud-api.near.ai/v1; if API returns models, normalizes and caches; if not, falls back to known Near AI models and caches them.
- src/services/near_client.py: base_url updated to cloud-api.near.ai/v1
- src/services/portkey_providers.py: fetch_models_from_xai now uses the xAI SDK when available; if not or if it returns empty, falls back to OpenAI SDK with base URL https://api.x.ai/v1; if that also fails, uses a predefined list of xAI models. All results are normalized and cached.
- .env.example: added keys XAI_API_KEY, NEBIUS_API_KEY, CEREBRAS_API_KEY, NOVITA_API_KEY

## Fallbacks added
- Near fallback models: deepseek-chat-v3-0324 (DeepSeek), gpt-oss-120b (GPT), llama-3-70b (Meta), qwen-2-72b (Alibaba)
- xAI fallback models: grok-beta (xAI), grok-vision-beta (xAI)

## Logging and caching
- Cache the fallback results with timestamps to avoid repeated fetches

## Why
- Prevents UI breakage when external APIs are down or return empty data
- Ensures deterministic model lists for Near and xAI

## Test plan
- [x] Simulate Near API failure and verify fallback Near models are returned
- [x] Verify Near client base URL points to the cloud endpoint
- [x] Verify xAI path uses SDK when available and falls back gracefully to OpenAI-based path
- [x] Simulate xAI API failure to trigger predefined xAI model fallback
- [x] Confirm environment example includes the new API keys

## Notes
- No breaking schema changes
- Ensure that the new API keys are configured in the environment when running locally

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a0388e10-a02b-46c7-90dd-0a94aa54b9ac

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds resilient Near and xAI model discovery with API endpoint updates and static fallbacks, plus new env keys for additional providers.
> 
> - **Models / Providers**:
>   - **Near AI**:
>     - Switch model fetch and client base URL to `https://cloud-api.near.ai/v1`.
>     - Add fallback model list when API fails/returns empty; normalize, cache, and log usage.
>   - **xAI (Grok)**:
>     - Prefer official SDK; if unavailable or empty result, fall back to OpenAI SDK; if that fails, use predefined models.
>     - Normalize, cache results, and improve empty/error handling and logging.
> - **Config**:
>   - `.env.example`: add `XAI_API_KEY`, `NEBIUS_API_KEY`, `CEREBRAS_API_KEY`, `NOVITA_API_KEY`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70c9eb76958d932db1493ff422766066340ed65f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  - Added support for four new AI provider API keys for expanded model access

* **Bug Fixes & Improvements**
  - Improved model fetching reliability with automatic fallback mechanisms when services are unavailable
  - Updated backend service endpoints for better stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->