### PR TITLE
Fix xAI SDK model listing and references

### DIFF
--- a/src/services/portkey_providers.py
+++ b/src/services/portkey_providers.py
@@ -341,6 +341,21 @@ def fetch_models_from_xai():
                 # Fallback to known xAI models
                 logger.warning(f"xAI API failed: {openai_error}. Using fallback xAI model list.")
                 models_list = [
+                    # Grok 4 Models (2025)
+                    {"id": "grok-4", "owned_by": "xAI"},
+                    {"id": "grok-4-latest", "owned_by": "xAI"},
+                    {"id": "grok-4-fast-reasoning", "owned_by": "xAI"},
+                    {"id": "grok-4-fast-non-reasoning", "owned_by": "xAI"},
+                    # Grok 3 Models
+                    {"id": "grok-3", "owned_by": "xAI"},
+                    {"id": "grok-3-latest", "owned_by": "xAI"},
+                    {"id": "grok-3-mini", "owned_by": "xAI"},
+                    # Grok 2 Models
+                    {"id": "grok-2", "owned_by": "xAI"},
+                    {"id": "grok-2-latest", "owned_by": "xAI"},
+                    {"id": "grok-2-mini", "owned_by": "xAI"},
+                    {"id": "grok-2-image-1212", "owned_by": "xAI"},
+                    # Legacy Beta Models
                     {"id": "grok-beta", "owned_by": "xAI"},
                     {"id": "grok-vision-beta", "owned_by": "xAI"},
                 ]
@@ -357,6 +372,21 @@ def fetch_models_from_xai():
         logger.error(f"Failed to fetch models from xAI: {e}", exc_info=True)
         # Return fallback models even on complete failure
         fallback_models = [
+            # Grok 4 Models (2025)
+            {"id": "grok-4", "owned_by": "xAI"},
+            {"id": "grok-4-latest", "owned_by": "xAI"},
+            {"id": "grok-4-fast-reasoning", "owned_by": "xAI"},
+            {"id": "grok-4-fast-non-reasoning", "owned_by": "xAI"},
+            # Grok 3 Models
+            {"id": "grok-3", "owned_by": "xAI"},
+            {"id": "grok-3-latest", "owned_by": "xAI"},
+            {"id": "grok-3-mini", "owned_by": "xAI"},
+            # Grok 2 Models
+            {"id": "grok-2", "owned_by": "xAI"},
+            {"id": "grok-2-latest", "owned_by": "xAI"},
+            {"id": "grok-2-mini", "owned_by": "xAI"},
+            {"id": "grok-2-image-1212", "owned_by": "xAI"},
+            # Legacy Beta Models
             {"id": "grok-beta", "owned_by": "xAI"},
             {"id": "grok-vision-beta", "owned_by": "xAI"},
         ]

--- a/src/services/xai_client.py
+++ b/src/services/xai_client.py
@@ -41,7 +41,7 @@ def make_xai_request_openai(messages, model, **kwargs):
 
     Args:
         messages: List of message objects
-        model: Model name (e.g., "grok-beta", "grok-vision-beta")
+        model: Model name (e.g., "grok-4", "grok-3", "grok-2", "grok-beta")
         **kwargs: Additional parameters like max_tokens, temperature, etc.
     """
     try:
@@ -62,7 +62,7 @@ def make_xai_request_openai_stream(messages, model, **kwargs):
 
     Args:
         messages: List of message objects
-        model: Model name (e.g., "grok-beta", "grok-vision-beta")
+        model: Model name (e.g., "grok-4", "grok-3", "grok-2", "grok-beta")
         **kwargs: Additional parameters like max_tokens, temperature, etc.
     """
     try:


### PR DESCRIPTION
## Summary
- Improves resilience of xAI model listing by introducing a fallback set of Grok models (4/3/2) plus legacy beta models when the xAI API fails or returns an error.
- Updates model-name documentation to reflect supported models used by the client.

## Changes

### Core Logic
- portkey_providers.py
  - In fetch_models_from_xai, extended fallback list to include:
    - Grok-4, grok-4-latest, grok-4-fast-reasoning, grok-4-fast-non-reasoning
    - Grok-3, grok-3-latest, grok-3-mini
    - Grok-2, grok-2-latest, grok-2-mini, grok-2-image-1212
    - Legacy beta models: grok-beta, grok-vision-beta
  - Same additions added to the complete failure fallback list.

### API Compatibility
- src/services/xai_client.py
  - Updated function docstrings to reflect supported model names, clarifying examples as grok-4, grok-3, grok-2, grok-beta in make_xai_request_openai and make_xai_request_openai_stream.

### Tests
- No unit tests added. The changes broaden the available model list and align docs with actual model naming. You can verify by triggering model listing with API failure and ensuring the full set of Grok variants and legacy models are returned.

## How to test
- Simulate an xAI API failure and call fetch_models_from_xai; verify the returned list includes:
  - Grok-4, grok-4-latest, grok-4-fast-reasoning, grok-4-fast-non-reasoning
  - Grok-3, grok-3-latest, grok-3-mini
  - Grok-2, grok-2-latest, grok-2-mini, grok-2-image-1212
  - grok-beta, grok-vision-beta
- Also verify that requests can be made with model names grok-4, grok-3, grok-2, grok-beta without errors.

## Notes
- This change is backward-compatible and simply expands the model listing options to improve reliability when the xAI API response is unavailable or unstable.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/3e27b2fc-2611-4497-9175-8b396a3448b2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands xAI fallback models to include Grok 4/3/2 variants and updates client docstrings to reference the supported model names.
> 
> - **xAI Models**:
>   - **Fallback expansion in `src/services/portkey_providers.py`**:
>     - Adds `grok-4`, `grok-4-latest`, `grok-4-fast-reasoning`, `grok-4-fast-non-reasoning`.
>     - Adds `grok-3`, `grok-3-latest`, `grok-3-mini`.
>     - Adds `grok-2`, `grok-2-latest`, `grok-2-mini`, `grok-2-image-1212`.
>     - Retains legacy `grok-beta`, `grok-vision-beta`.
>     - Applies to both OpenAI-API fallback and complete-failure fallback paths.
> - **Client Docs**:
>   - Updates model examples in `src/services/xai_client.py` docstrings to `grok-4`, `grok-3`, `grok-2`, `grok-beta`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b181b91e0b68730b40b975ae38098db6a2e9967. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded availability of xAI Grok models (grok-4, grok-3, grok-2 variants) as fallback options during API requests.

* **Documentation**
  * Updated model availability documentation to reflect the expanded set of Grok models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->