### PR TITLE
Fix negative pricing handling for models (sanitize pricing)

### DIFF
--- a/src/services/pricing.py
+++ b/src/services/pricing.py
@@ -53,8 +53,12 @@ def get_model_pricing(model_id: str) -> Dict[str, float]:
                 pricing = model.get("pricing", {})
 
                 # Convert pricing strings to floats, handling None and empty strings
+                # Also ensure negative values (e.g., -1 for dynamic pricing) are treated as 0
                 prompt_price = float(pricing.get("prompt", "0") or "0")
+                prompt_price = max(0.0, prompt_price)  # Convert negative to 0
+                
                 completion_price = float(pricing.get("completion", "0") or "0")
+                completion_price = max(0.0, completion_price)  # Convert negative to 0
 
                 logger.info(f"Found pricing for {model_id} (normalized: {normalized_model_id}): prompt=${prompt_price}, completion=${completion_price}")
 


### PR DESCRIPTION
## Summary
- Fix negative pricing values (e.g., -1 for dynamic pricing) by sanitizing pricing data and clamping to 0 where appropriate.
- Applies across model loading from OpenRouter and PortKey normalization, plus pricing retrieval.

## Changes
### src/services/models.py
- Added sanitize_pricing(pricing: dict) -> dict to convert negative pricing values to "0" for keys: prompt, completion, request, image, web_search, internal_reasoning.
- Applied sanitization when loading OpenRouter models:
  - In fetch_models_from_openrouter, sanitize model["pricing"] when present.
- Applied sanitization during PortKey model normalization:
  - In normalize_portkey_model, sanitize or_model["pricing"] before matching (exact, approximate, canonical).

### src/services/pricing.py
- In get_model_pricing, after parsing pricing, convert strings to floats and clamp negative values to 0 for:
  - prompt_price = max(0.0, float(pricing.get("prompt", "0") or "0"))
  - completion_price = max(0.0, float(pricing.get("completion", "0") or "0"))
- This ensures non-negative pricing is returned even if API provides dynamic pricing indicators (e.g., -1).

## Rationale
- Some backends (OpenRouter) use -1 to indicate dynamic pricing. Negative values can break downstream cost calculations and UI displays. Normalizing to 0 prevents erroneous billing calculations and simplifies pricing handling across the system.

## Testing
- [ ] Add unit tests to verify sanitize_pricing converts negative values to "0" and preserves non-negative values.
- [ ] Verify get_model_pricing returns non-negative prices when API returns "-1" or null values.
- [ ] Manually validate model loading and pricing normalization end-to-end to ensure dynamic pricing is displayed as zero cost where appropriate.

## Notes
- Logging has been in place to aid debugging around sanitized pricing values. Future cleanup may consolidate logging configuration paths if needed.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/bb423af1-00f2-4c6e-913b-82b884e69854

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sanitizes negative pricing from OpenRouter/Portkey and clamps pricing to non-negative floats in pricing lookup.
> 
> - **Backend**:
>   - **Pricing sanitation**:
>     - Add `sanitize_pricing(pricing: dict)` to convert negative values to `"0"` for `prompt`, `completion`, `request`, `image`, `web_search`, `internal_reasoning`.
>     - Apply in `fetch_models_from_openrouter` to sanitize each model’s `pricing`.
>     - Apply in `normalize_portkey_model` when pulling `pricing` from matched OpenRouter entries (exact/approx/canonical).
>   - **Pricing lookup**:
>     - In `get_model_pricing`, parse prices as floats and clamp negatives to `0.0` for `prompt` and `completion`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 676f51d489cacc220489b07bd9e5436d8ae454a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where model pricing could display negative values. Pricing data is now automatically validated and corrected, ensuring accurate pricing information is consistently displayed across all model sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->