### PR TITLE
Bump safety to fix packaging conflict and pass tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ mypy==1.8.0  # Type checker
 
 # Security
 bandit==1.7.6  # Security linter
-safety==2.3.5  # Dependency vulnerability scanner
+safety==3.2.0  # Dependency vulnerability scanner (updated to fix packaging conflict)
 
 # Pre-commit hooks
 pre-commit==3.6.0


### PR DESCRIPTION
## Summary
- Bump safety from 2.3.5 to 3.2.0 in requirements-dev.txt to resolve a packaging conflict
- This change helps ensure all build and test suites pass in CI/CD

## Changes
### Dev dependencies
- safety==3.2.0 (replaces 2.3.5) in requirements-dev.txt

### Rationale
- Addresses packaging conflicts observed with the previous safety version
- Keeps dependency vulnerability scanning up-to-date

## Test plan
- [x] CI build and test workflow should pass with updated safety
- [x] Local verification:
  - Install dev requirements
  - Run pytest and any existing test suites
  - Run mypy/linters if configured in project
- [x] Ensure pre-commit hooks remain compatible

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/fdbf73d0-bdeb-4bbe-8cb6-bea40a372dfd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps dev dependency `safety` from `2.3.5` to `3.2.0` in `requirements-dev.txt` to resolve packaging conflicts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a0e87f32627d6c19a9bebbe31f59b79ac1fb15d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->