### PR TITLE
Fix chat failover flow to correctly propagate upstream errors

### DIFF
--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -554,19 +554,19 @@ async def chat_completions(
                         logger.error("Unexpected upstream error (%s): %s", attempt_provider, exc)
                     http_exc = map_provider_error(attempt_provider, request_model, exc)
 
-                last_http_exc = http_exc
-                if idx < len(provider_chain) - 1 and should_failover(http_exc):
-                    next_provider = provider_chain[idx + 1]
-                    logger.warning(
-                        "Provider '%s' failed with status %s (%s). Falling back to '%s'.",
-                        attempt_provider,
-                        http_exc.status_code,
-                        http_exc.detail,
-                        next_provider,
-                    )
-                    continue
+                    last_http_exc = http_exc
+                    if idx < len(provider_chain) - 1 and should_failover(http_exc):
+                        next_provider = provider_chain[idx + 1]
+                        logger.warning(
+                            "Provider '%s' failed with status %s (%s). Falling back to '%s'.",
+                            attempt_provider,
+                            http_exc.status_code,
+                            http_exc.detail,
+                            next_provider,
+                        )
+                        continue
 
-                raise http_exc
+                    raise http_exc
 
             raise last_http_exc or HTTPException(status_code=502, detail="Upstream error")
 
@@ -662,19 +662,19 @@ async def chat_completions(
                     logger.error("Unexpected upstream error (%s): %s", attempt_provider, exc)
                 http_exc = map_provider_error(attempt_provider, request_model, exc)
 
-            last_http_exc = http_exc
-            if idx < len(provider_chain) - 1 and should_failover(http_exc):
-                next_provider = provider_chain[idx + 1]
-                logger.warning(
-                    "Provider '%s' failed with status %s (%s). Falling back to '%s'.",
-                    attempt_provider,
-                    http_exc.status_code,
-                    http_exc.detail,
-                    next_provider,
-                )
-                continue
+                last_http_exc = http_exc
+                if idx < len(provider_chain) - 1 and should_failover(http_exc):
+                    next_provider = provider_chain[idx + 1]
+                    logger.warning(
+                        "Provider '%s' failed with status %s (%s). Falling back to '%s'.",
+                        attempt_provider,
+                        http_exc.status_code,
+                        http_exc.detail,
+                        next_provider,
+                    )
+                    continue
 
-            raise http_exc
+                raise http_exc
 
         if processed is None:
             raise last_http_exc or HTTPException(status_code=502, detail="Upstream error")


### PR DESCRIPTION
## Summary
- Fixes a bug in chat provider failover logic that could raise upstream errors prematurely or skip valid fallbacks, improving reliability of chat completions when using multiple providers.

## Changes
### Core logic
- Corrected the failover flow in src/routes/chat.py to properly update last_http_exc and only fall back to the next provider when should_failover(http_exc) is true.
- Adjusted indentation and control flow to ensure both success and exception paths share the same error propagation behavior.
- When there are no more eligible providers to failover to, the code now raises the appropriate upstream error rather than an inconsistent or premature error.

### Error handling
- Unified error propagation: raise the current http_exc only when no further providers can handle the request; otherwise continue to the next provider and preserve last_http_exc for final error reporting.

### Logging
- Maintains existing provider-fallback warnings; no user-facing log changes beyond the corrected behavior.

## Test plan
- [x] Simulate a provider chain with multiple providers where the first fails and should_failover is true; confirm fallback to the next provider.
- [x] Simulate a failure where should_failover is false; confirm the error is raised immediately and not swallowed by fallback.
- [x] Simulate all providers failing; verify final error reflects the last upstream error (or a 502 if upstream is unavailable).
- [x] End-to-end sanity checks of chat completions with multiple providers to ensure stability and correct error reporting.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/631cc2c1-e0ba-45cd-9e15-0aae8294040a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes chat provider failover so errors only raise when no valid fallback remains, preserving last upstream error for both streaming and non-streaming paths.
> 
> - **Backend**
>   - **Failover logic (chat completions)**:
>     - In `src/routes/chat.py`, fixes exception handling for both streaming and non-streaming flows to:
>       - Update `last_http_exc` on failure and continue only when `should_failover(http_exc)` is true.
>       - Raise the current `http_exc` when no further fallback is allowed.
>     - Ensures final error surfaces as `last_http_exc` (or 502) when all providers fail.
>   - **Logging**: Retains existing fallback warnings; no functional changes to log output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58c6dc61af139e7584546dd535e093a63277c57b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->