### PR TITLE
Handle 404 for model not found on provider in failover

### DIFF
--- a/src/services/provider_failover.py
+++ b/src/services/provider_failover.py
@@ -115,6 +115,8 @@ def map_provider_error(
             status = 400
         elif status == 403:
             detail = f"{provider} authentication error"
+        elif status == 404:
+            detail = f"Model {model} not found or unavailable on {provider}"
         elif 500 <= status < 600:
             detail = "Upstream service error"
 

--- a/tests/services/test_provider_failover.py
+++ b/tests/services/test_provider_failover.py
@@ -487,6 +487,22 @@ class TestMapProviderErrorOpenAI:
 
         assert mapped.status_code == 500
 
+    def test_map_api_status_error_404_generic(self):
+        """Test generic APIStatusError with 404 status provides proper error message"""
+        response = Mock()
+        response.status_code = 404
+        error = APIStatusError("Not Found", response=response, body=None)
+        error.status_code = 404
+        error.message = "Not Found"
+        mapped = map_provider_error("openrouter", "test-model", error)
+
+        assert mapped.status_code == 404
+        assert "test-model" in mapped.detail
+        assert "openrouter" in mapped.detail.lower()
+        assert "not found" in mapped.detail.lower()
+        # Should NOT be just "Not Found" - should include model and provider
+        assert mapped.detail != "Not Found"
+
 
 # ============================================================
 # TEST CLASS: Error Mapping - Generic Exceptions


### PR DESCRIPTION
## Summary
- Fix 404 error mapping for model not found on provider in failover logic
- Improve error detail to include model and provider in APIStatusError cases
- Add tests to verify 404 mapping includes model/provider and meaningful message

## Changes

### Error mapping
- In `src/services/provider_failover.py`, `map_provider_error` now handles 404 status by returning a detail like:
  `"Model {model} not found or unavailable on {provider}"` (instead of a generic/less informative message).

### Tests
- Extend `tests/services/test_provider_failover.py` with a new test:
  - `test_map_api_status_error_404_generic`
  - Verifies that a 404 `APIStatusError` maps to a response with:
    - `status_code` 404
    - Detail containing the model name, provider, and the phrase "not found" (case-insensitive)
    - Detail is not merely the string "Not Found"

### Backwards compatibility
- No breaking changes beyond providing more descriptive error messages for 404 errors related to missing models on providers.

## Test plan
- Run full test suite, focusing on provider failover tests
- Specifically ensure the new 404 test passes and existing tests remain green

## How to test
- Trigger a 404 upstream error for a given model/provider combo
- Call `map_provider_error` and verify the returned detail includes:
  - The model name (e.g., `test-model`)
  - The provider name (e.g., `openrouter`)
  - The phrase `not found` (case-insensitive)
  - The detail is not simply `Not Found`

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/19523727-473e-43c8-8b6b-fd7d1d4f14a8