### PR TITLE
Fix remaining test failures in trial service

### DIFF
--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -51,7 +51,7 @@ from src.schemas.payments import (
     PaymentResponse,
     PaymentUpdate,
     PaymentRecord,
-    SubscriptionPlan,
+    SubscriptionPlan as PaymentSubscriptionPlan,  # Rename to avoid conflict
     CreateSubscriptionRequest,
     SubscriptionResponse,
     CreditPurchaseRequest,
@@ -83,6 +83,7 @@ from src.schemas.payments import (
 from src.schemas.plans import (
     PlanResponse,
     SubscriptionHistory,
+    SubscriptionPlan,  # This is the correct one for trial service
     SubscriptionPlansResponse,
     UserPlanResponse,
     AssignPlanRequest,

--- a/src/services/trial_service.py
+++ b/src/services/trial_service.py
@@ -290,20 +290,23 @@ class TrialService:
                 plans = []
                 for plan_data in result.data:
                     plan = SubscriptionPlan(
-                        id=plan_data['id'],
+                        id=plan_data.get('id'),
                         plan_name=plan_data['plan_name'],
                         plan_type=PlanType(plan_data['plan_type']),
-                        monthly_price=plan_data['monthly_price'],
-                        yearly_price=plan_data['yearly_price'],
-                        max_requests_per_month=plan_data['max_requests_per_month'],
-                        max_tokens_per_month=plan_data['max_tokens_per_month'],
-                        max_requests_per_day=plan_data['max_requests_per_day'],
-                        max_tokens_per_day=plan_data['max_tokens_per_day'],
-                        max_concurrent_requests=plan_data['max_concurrent_requests'],
-                        features=plan_data['features'],
-                        is_active=plan_data['is_active'],
-                        created_at=datetime.fromisoformat(plan_data['created_at'].replace('Z', '+00:00')) if plan_data['created_at'] else None,
-                        updated_at=datetime.fromisoformat(plan_data['updated_at'].replace('Z', '+00:00')) if plan_data['updated_at'] else None
+                        description=plan_data.get('description', ''),
+                        monthly_price=plan_data.get('monthly_price', 0.0),
+                        yearly_price=plan_data.get('yearly_price'),
+                        monthly_request_limit=plan_data.get('max_requests_per_month', plan_data.get('monthly_request_limit', 1000)),
+                        monthly_token_limit=plan_data.get('max_tokens_per_month', plan_data.get('monthly_token_limit', 100000)),
+                        daily_request_limit=plan_data.get('max_requests_per_day', plan_data.get('daily_request_limit', 1000)),
+                        daily_token_limit=plan_data.get('max_tokens_per_day', plan_data.get('daily_token_limit', 100000)),
+                        max_concurrent_requests=plan_data.get('max_concurrent_requests', 5),
+                        price_per_token=plan_data.get('price_per_token'),
+                        features=plan_data.get('features', []),
+                        is_active=plan_data.get('is_active', True),
+                        is_pay_as_you_go=plan_data.get('is_pay_as_you_go', False),
+                        created_at=datetime.fromisoformat(plan_data['created_at'].replace('Z', '+00:00')) if plan_data.get('created_at') else None,
+                        updated_at=datetime.fromisoformat(plan_data['updated_at'].replace('Z', '+00:00')) if plan_data.get('updated_at') else None
                     )
                     plans.append(plan)
                 
@@ -338,6 +341,7 @@ class TrialService:
                     is_expired=False,
                     remaining_tokens=0,
                     remaining_requests=0,
+                    remaining_credits=0.0,
                     error_message="Failed to get trial status"
                 )
             
@@ -351,6 +355,7 @@ class TrialService:
                     is_expired=False,
                     remaining_tokens=0,
                     remaining_requests=0,
+                    remaining_credits=0.0,
                     error_message="Not a trial account"
                 )
             
@@ -362,6 +367,7 @@ class TrialService:
                     is_expired=True,
                     remaining_tokens=0,
                     remaining_requests=0,
+                    remaining_credits=0.0,
                     trial_end_date=status.trial_end_date,
                     error_message="Trial has expired"
                 )

--- a/tests/services/test_trial_service.py
+++ b/tests/services/test_trial_service.py
@@ -452,7 +452,7 @@ class TestGetSubscriptionPlans:
             {
                 'id': 1,
                 'plan_name': 'starter',
-                'plan_type': 'monthly',
+                'plan_type': 'dev',  # Valid PlanType enum value
                 'monthly_price': 9.99,
                 'yearly_price': 99.99,
                 'max_requests_per_month': 10000,
@@ -626,14 +626,14 @@ class TestValidateTrialAccess:
                 trial_status=Mock(
                     is_trial=True,
                     trial_expired=False,
-                    trial_remaining_tokens=500000,
-                    trial_remaining_requests=500,
+                    trial_remaining_tokens=2000000,  # Enough tokens (2M)
+                    trial_remaining_requests=500,  # Enough requests
                     trial_remaining_credits=0.01,  # Very low credits
                     trial_end_date=datetime.now() + timedelta(days=2)
                 )
             )
 
-            # Request 1M tokens (estimated cost: $0.02)
+            # Request 1M tokens (estimated cost: $0.02, but only $0.01 credits remaining)
             result = await trial_service.validate_trial_access('test_key', tokens_used=1000000)
 
             assert result.is_valid is False


### PR DESCRIPTION
## Summary
- Fix remaining test failures in trial service by aligning with updated SubscriptionPlan schema, resolving import conflicts, and updating test data.

## Changes
### Schemas
- src/schemas/__init__.py
  - Rename SubscriptionPlan import from payments to avoid conflicts (use PaymentSubscriptionPlan alias) and ensure trial service uses the SubscriptionPlan from plans.

### Trial service
- src/services/trial_service.py
  - Map plan_data to SubscriptionPlan with extended fields:
    - id via get
    - description
    - monthly_price, yearly_price
    - monthly_request_limit, monthly_token_limit
    - daily_request_limit, daily_token_limit
    - max_concurrent_requests, price_per_token, features
    - is_active, is_pay_as_you_go
    - created_at / updated_at parsing when present
  - Ensure remaining_credits is included in trial status responses for all branches.

### Tests
- tests/services/test_trial_service.py
  - Update test fixtures:
    - plan_type: 'dev' (valid PlanType)
    - trial status: tokens 2,000,000 and credits 0.01
    - adjust expectations accordingly

## Rationale
- Aligns code with updated schemas and avoids symbol conflicts between SubscriptionPlan definitions
- Ensures trial service tests exercise new fields and status handling

## Test plan
- Run pytest for tests/services/test_trial_service.py
- Verify all trial service tests pass and no import conflicts remain

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/052fff03-35fe-41fd-b5eb-4789d32daad2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns trial service with the updated SubscriptionPlan schema, adds explicit credit-limit validation, resolves SubscriptionPlan import conflict, and updates tests accordingly.
> 
> - **Schemas**:
>   - Alias `src.schemas.payments.SubscriptionPlan` as `PaymentSubscriptionPlan` and ensure trial uses `src.schemas.plans.SubscriptionPlan`.
> - **Trial Service**:
>   - `get_subscription_plans`: Map to `SubscriptionPlan` with new/optional fields (`description`, `price_per_token`, `is_pay_as_you_go`), tolerate missing IDs/timestamps, and rename limit fields (`monthly_request_limit`, `daily_request_limit`, etc.).
>   - `validate_trial_access`: Include `remaining_credits` in all responses and enforce credit-limit check based on token cost.
> - **Tests**:
>   - Update plan fixtures (`plan_type='dev'`) and expectations; add insufficient-credit scenario with 1M tokens vs $0.01 credits; adjust assertions to match new fields and responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42b19c630fa5ac253e52d55fa00043458e945a71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->