### PR TITLE
Expose tier and end-date in user profile for badge display

### DIFF
--- a/src/db/users.py
+++ b/src/db/users.py
@@ -681,7 +681,9 @@ def get_user_profile(api_key: str) -> Dict[str, Any]:
             "email": user.get("email"),
             "auth_method": user.get("auth_method"),
             "subscription_status": user.get("subscription_status"),
+            "tier": user.get("tier"),  # Include subscription tier (basic, pro, max)
             "trial_expires_at": user.get("trial_expires_at"),
+            "subscription_end_date": user.get("subscription_end_date"),  # Unix timestamp
             "is_active": user.get("is_active"),
             "registration_date": user.get("registration_date")
         }

--- a/src/schemas/users.py
+++ b/src/schemas/users.py
@@ -55,7 +55,9 @@ class UserProfileResponse(BaseModel):
     email: Optional[str]
     auth_method: Optional[str]
     subscription_status: Optional[str]
+    tier: Optional[str] = None  # Subscription tier: 'basic', 'pro', or 'max'
     trial_expires_at: Optional[str]
+    subscription_end_date: Optional[int] = None  # Unix timestamp for subscription end date
     is_active: Optional[bool]
     registration_date: Optional[str]
     created_at: Optional[str]

--- a/tests/routes/test_users.py
+++ b/tests/routes/test_users.py
@@ -47,7 +47,9 @@ def mock_user():
         'email': 'test@example.com',
         'credits': 100.0,
         'api_key': 'sk-test-key-12345',
-        'subscription_status': 'active'
+        'subscription_status': 'active',
+        'tier': 'pro',
+        'subscription_end_date': None
     }
 
 
@@ -61,7 +63,9 @@ def mock_trial_user():
         'credits': 10.0,
         'api_key': 'sk-trial-key-12345',
         'subscription_status': 'trial',
-        'trial_end_date': (datetime.now(timezone.utc) + timedelta(days=3)).isoformat()
+        'tier': 'basic',
+        'trial_end_date': (datetime.now(timezone.utc) + timedelta(days=3)).isoformat(),
+        'subscription_end_date': None
     }
 
 
@@ -109,7 +113,9 @@ def mock_user_profile():
         'email': 'test@example.com',
         'auth_method': 'email',
         'subscription_status': 'active',
+        'tier': 'pro',  # Subscription tier: basic, pro, or max
         'trial_expires_at': None,
+        'subscription_end_date': None,  # Unix timestamp for subscription end
         'is_active': True,
         'registration_date': '2024-01-01T00:00:00Z',
         'created_at': '2024-01-01T00:00:00Z',


### PR DESCRIPTION
## Summary
- Exposes subscription tier and end date in the user profile to support correct tier badge rendering on the frontend
- Updates API schema and tests accordingly so frontend can reliably display tier-based badges

## Changes

### Backend
- Include `tier` and `subscription_end_date` in the `get_user_profile` response
- Extend `UserProfileResponse` schema to include `tier` and `subscription_end_date` fields

### Tests
- Update test fixtures in `tests/routes/test_users.py` to include `tier` and `subscription_end_date` where applicable
- Ensure user profile payloads now contain `tier` and `subscription_end_date` fields in mocked data

### Data Model / Schema
- Mark `tier` as Optional with default `None` and `subscription_end_date` as Optional with default `None` to maintain backward compatibility

## Test plan
- [x] Run unit tests for user endpoints
- [x] Verify user profile responses include `tier` and `subscription_end_date`
- [x] Ensure existing responses remain valid when fields are absent

## Notes
- This change is backward compatible thanks to optional fields with defaults. Frontend should now be able to render tier badges based on `tier` and handle the end date via `subscription_end_date` when provided.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/7ba029a9-5a62-4bfe-85e2-12f389f5c761

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose `tier` and `subscription_end_date` in user profile responses and update schema/tests accordingly.
> 
> - **Backend**:
>   - Update `src/db/users.py` `get_user_profile` to include `tier` and `subscription_end_date` in returned `profile`.
> - **API Schema**:
>   - Extend `UserProfileResponse` in `src/schemas/users.py` with optional `tier` and `subscription_end_date` fields.
> - **Tests**:
>   - Update fixtures in `tests/routes/test_users.py` (`mock_user`, `mock_trial_user`, `mock_user_profile`) to include `tier` and `subscription_end_date`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d02e47cd00c5d3ce98ad81a06f4fdd8f19d099a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->