### PR TITLE
Add Fal.ai image provider with API key integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,7 @@ NEBIUS_API_KEY=your-nebius-api-key
 CEREBRAS_API_KEY=your-cerebras-api-key
 NOVITA_API_KEY=your-novita-api-key
 HUG_API_KEY=your-huggingface-api-key
+FAL_API_KEY=your-fal-api-key
 
 # Optional - Provider-specific keys (for use with Portkey)
 PROVIDER_OPENAI_API_KEY=sk-...

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -61,6 +61,9 @@ class Config:
     # Near AI Configuration
     NEAR_API_KEY = os.environ.get("NEAR_API_KEY")
 
+    # Fal.ai Configuration
+    FAL_API_KEY = os.environ.get("FAL_API_KEY")
+
     # Google Generative AI Configuration (for language models)
     GOOGLE_API_KEY = os.environ.get("GOOGLE_API_KEY")
 

--- a/src/services/fal_image_client.py
+++ b/src/services/fal_image_client.py
@@ -1,0 +1,120 @@
+import logging
+import httpx
+import time
+from typing import Dict, Any
+
+from src.config import Config
+
+# Initialize logging
+logging.basicConfig(level=logging.ERROR)
+logger = logging.getLogger(__name__)
+
+
+def make_fal_image_request(
+    prompt: str,
+    model: str = "fal-ai/stable-diffusion-v15",
+    size: str = "1024x1024",
+    n: int = 1,
+    **kwargs
+) -> Dict[str, Any]:
+    """Make image generation request to Fal.ai
+
+    Args:
+        prompt: Text description of the image to generate
+        model: Model to use (e.g., "fal-ai/stable-diffusion-v15")
+        size: Image dimensions (e.g., "512x512", "1024x1024")
+        n: Number of images to generate
+        **kwargs: Additional parameters like negative_prompt, guidance_scale, etc.
+
+    Returns:
+        Dict containing generated images in OpenAI-compatible format
+    """
+    try:
+        if not Config.FAL_API_KEY:
+            raise ValueError("Fal.ai API key not configured. Please set FAL_API_KEY environment variable")
+
+        # Fal.ai API endpoint - using subscribe endpoint for synchronous requests
+        url = f"https://fal.run/{model}"
+
+        headers = {
+            "Authorization": f"Key {Config.FAL_API_KEY}",
+            "Content-Type": "application/json"
+        }
+
+        # Parse size to width and height for Fal.ai
+        try:
+            width, height = map(int, size.split('x'))
+        except (ValueError, AttributeError):
+            width, height = 1024, 1024  # Default size
+
+        # Map standard size strings to Fal.ai image_size format
+        size_mapping = {
+            "512x512": "square",
+            "1024x1024": "square_hd",
+            "768x1024": "portrait_4_3",
+            "576x1024": "portrait_16_9",
+            "1024x768": "landscape_4_3",
+            "1024x576": "landscape_16_9"
+        }
+
+        # Build Fal.ai request payload
+        payload = {
+            "prompt": prompt,
+            "num_images": n
+        }
+
+        # Add image size - use mapping or custom dimensions
+        if size in size_mapping:
+            payload["image_size"] = size_mapping[size]
+        else:
+            payload["image_size"] = {
+                "width": width,
+                "height": height
+            }
+
+        # Add optional Fal.ai-specific parameters from kwargs
+        fal_params = [
+            "negative_prompt",
+            "num_inference_steps",
+            "seed",
+            "guidance_scale",
+            "sync_mode",
+            "enable_safety_checker",
+            "expand_prompt",
+            "format"
+        ]
+
+        for param in fal_params:
+            if param in kwargs:
+                payload[param] = kwargs[param]
+
+        logger.info(f"Making image generation request to Fal.ai with model {model}")
+
+        # Make synchronous request to Fal.ai
+        response = httpx.post(url, headers=headers, json=payload, timeout=120.0)
+        response.raise_for_status()
+
+        fal_response = response.json()
+
+        # Convert Fal.ai response to OpenAI-compatible format
+        data = []
+        if "images" in fal_response:
+            for img in fal_response["images"]:
+                data.append({
+                    "url": img.get("url"),
+                    "b64_json": None  # Fal.ai returns URLs by default
+                })
+
+        return {
+            "created": int(time.time()),
+            "data": data,
+            "provider": "fal",
+            "model": model
+        }
+
+    except httpx.HTTPStatusError as e:
+        logger.error(f"Fal.ai image generation HTTP error: {e.response.status_code} - {e.response.text}")
+        raise
+    except Exception as e:
+        logger.error(f"Fal.ai image generation request failed: {e}")
+        raise


### PR DESCRIPTION
## Summary
- Adds Fal.ai as a new image generation provider gated by FAL_API_KEY
- Integrates Fal.ai into the /v1/images/generations flow
- Converts Fal.ai responses to OpenAI-compatible format and preserves gateway usage metrics

## Changes
### Core Functionality
- New Fal.ai client: src/services/fal_image_client.py implementing make_fal_image_request
- Updated image route: src/routes/images.py to handle provider == "fal" and call make_fal_image_request
- Docstring example for Fal.ai usage added to images route to illustrate request/response

### Config & Environment
- Load FAL_API_KEY in src/config/config.py
- Update environment example: .env.example with FAL_API_KEY placeholder

### Tests
- Extended tests/routes/test_images.py with Fal.ai test fixtures and tests
- Added test_generate_image_fal_success to cover Fal.ai path, including mocks for response processing and credits deduction

### Documentation
- Documented Fal.ai usage scenario within the images route documentation example

## Test plan
- [x] Unit tests for Fal.ai provider integration
- [x] Regression tests for existing providers (DeepInfra, Portkey, Google Vertex)
- [x] Credits deduction and gateway usage metadata verification

## How to run locally
- Ensure FAL_API_KEY is set in environment (.env or system env)
- Run tests: pytest -q

## Notes
- Fal.ai endpoint used in the client is https://fal.run/{model}
- Request payload supports image_size mapping for common sizes (e.g., 1024x1024) or explicit width/height for custom sizes
- API key is sent via the Authorization header as "Key <API_KEY>"

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/14ef6af3-ed81-4373-af89-84e971f978c0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates Fal.ai as an image generation provider with API key support, routing, OpenAI-compatible responses, and tests.
> 
> - **Images Backend**:
>   - Add Fal.ai provider handling in `src/routes/images.py` (`provider == "fal"`) with docstring example and updated unsupported-provider message.
>   - New client `src/services/fal_image_client.py` to call `https://fal.run/{model}`, map `size` to Fal `image_size`, and return OpenAI-compatible `data`.
> - **Config & Env**:
>   - Load `FAL_API_KEY` in `src/config/config.py` and add placeholder to `.env.example`.
> - **Tests**:
>   - Extend `tests/routes/test_images.py` with Fal fixtures and `test_generate_image_fal_success`, verifying credits, usage, and response processing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e41c347af8ca49c5dfa6a9a9ebab8021db065c14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->