### PR TITLE
Fix API: include tools field in function-call options

### DIFF
--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -444,7 +444,7 @@ async def chat_completions(
         original_model = req.model
 
         optional = {}
-        for name in ("max_tokens", "temperature", "top_p", "frequency_penalty", "presence_penalty"):
+        for name in ("max_tokens", "temperature", "top_p", "frequency_penalty", "presence_penalty", "tools"):
             val = getattr(req, name, None)
             if val is not None:
                 optional[name] = val
@@ -1022,7 +1022,7 @@ async def unified_responses(
         original_model = req.model
 
         optional = {}
-        for name in ("max_tokens", "temperature", "top_p", "frequency_penalty", "presence_penalty"):
+        for name in ("max_tokens", "temperature", "top_p", "frequency_penalty", "presence_penalty", "tools"):
             val = getattr(req, name, None)
             if val is not None:
                 optional[name] = val


### PR DESCRIPTION
## Summary
- Propagates the tools field in optional function-call parameters for chat completions and unified responses.

## Changes
- src/routes/chat.py
  - Include "tools" in the list of optional parameters gathered from request in `chat_completions`.
  - Include "tools" in the list of optional parameters gathered from request in `unified_responses`.

## Validation / Backwards Compatibility
- No behavior changes when tools is not provided; existing fields remain unaffected.

## How to test
- Send a chat completion request with a `tools` field and verify it appears in the optional parameters passed downstream.
- Send requests without `tools` and ensure behavior is unchanged.
- Run existing tests to confirm no regressions.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6b114837-cde7-474d-89ad-3fc91ad3937a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Passes through the `tools` field from requests to upstream calls in both `chat_completions` and `unified_responses`.
> 
> - **Backend/API** (`src/routes/chat.py`):
>   - **Chat Completions (`/v1/chat/completions`)**: Include `tools` in collected optional params forwarded upstream.
>   - **Unified Responses (`/v1/responses`)**: Include `tools` in collected optional params forwarded upstream.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3f52e9c26bbb5fc1732738e98cc9851b539535c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->