### PR TITLE
Add Near support and normalize Near model IDs

### DIFF
--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -74,6 +74,12 @@ def transform_model_id(model_id: str, provider: str) -> str:
         else:
             logger.info(f"Preserving 'openrouter/auto' - this model requires the full ID")
 
+    # Special handling for Near: strip 'near/' prefix if present
+    if provider_lower == "near" and model_id.startswith("near/"):
+        stripped = model_id[len("near/"):]
+        logger.info(f"Stripped 'near/' prefix: '{model_id}' -> '{stripped}' for Near")
+        model_id = stripped
+
     # Get the mapping for this provider
     mapping = get_model_id_mapping(provider_lower)
 
@@ -428,6 +434,10 @@ def detect_provider_from_model_id(model_id: str) -> Optional[str]:
         # Google Vertex models (e.g., "google/gemini-2.0-flash")
         if org == "google":
             return "google-vertex"
+
+        # Near AI models (e.g., "near/deepseek-chat-v3-0324")
+        if org == "near":
+            return "near"
 
         # OpenRouter models (e.g., "openrouter/auto")
         if org == "openrouter":


### PR DESCRIPTION
## Summary
- Introduces Near provider support in the chat flow and normalizes Near model IDs to avoid upstream rejection
- Adds Near request/response handling for both streaming and non-streaming paths
- Extends model ID detection to recognize Near models
- Updates Vercel runtime to Python 3.12 to align with dependencies

## Changes
### Backend
- chat.py
  - Import and integrate Near client: `make_near_request_openai`, `process_near_response`, `make_near_request_openai_stream`
  - Routing adjustments to route Near requests through streaming path when applicable
  - Non-streaming Near request handling added to the existing provider attempt flow
- model_transformations.py
  - Transform: If provider is Near and model_id starts with `near/`, strip the prefix (e.g., `near/deepseek-chat-v3-0324` -> `deepseek-chat-v3-0324`)
  - Detect provider: Extend `detect_provider_from_model_id` to recognize Near-based model IDs (org == "near" -> provider "near")
- vercel.json
  - Update runtime to `python3.12`

### Behavior
- Normalizes Near model IDs by removing the `near/` prefix before downstream mapping, preventing upstream rejection due to incorrect ID formats
- Ensures Near models participate in both streaming and non-streaming OpenAI-like request flows using the dedicated Near service calls

### Testing Plan
- [x] Verify `detect_provider_from_model_id` returns `near` for Near-style IDs (e.g., `near/deepseek-chat-v3-0324`)
- [x] Verify `transform_model_id` strips `near/` prefix when provider is Near
- [x] End-to-end: simulate a Near model request and ensure the system uses Near request/response paths (streaming and non-streaming) without errors
- [x] Regression: ensure existing providers (OpenRouter, Google Vertex, Chutes) remain unaffected

## Notes
- No breaking changes introduced; this adds Near support and normalization to existing flow
- Additional logging provides visibility into the normalization step for easier debugging
- Verce runtime updated to Python 3.12 for compatibility

🌿 Generated by [Terry](https://www.terragonlabs.com)


📎 **Task**: https://www.terragonlabs.com/task/a22008c4-602f-4244-a1a1-6ab94beb6ece

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Near provider support to chat routing (streaming and non-streaming) and normalizes/detects Near model IDs.
> 
> - **Providers**
>   - **Near integration**: Wire `near` into `chat.py` routing for both streaming and non-streaming requests using `make_near_request_openai(_stream)` and `process_near_response`.
> - **Model IDs**
>   - **Normalization**: In `transform_model_id`, strip `near/` prefix when provider is `near`.
>   - **Detection**: Update `detect_provider_from_model_id` to return `near` for IDs prefixed with `near/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7dc43cf8797e0821243302f45e410b1f5543a430. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->