### PR TITLE
Fix model-not-found by correct provider detection for Vertex AI and Portkey

### DIFF
--- a/tests/services/test_model_transformations.py
+++ b/tests/services/test_model_transformations.py
@@ -44,3 +44,32 @@ def test_detect_provider_from_model_id_existing_providers():
     for model_id, expected in test_cases:
         result = detect_provider_from_model_id(model_id)
         assert result == expected, f"Expected '{expected}' for {model_id}, got {result}"
+
+
+def test_detect_provider_google_vertex_models():
+    """Test that Google Vertex AI models are correctly detected"""
+    test_cases = [
+        ("gemini-2.5-flash", "google-vertex"),
+        ("gemini-2.0-flash", "google-vertex"),
+        ("gemini-1.5-pro", "google-vertex"),
+        ("google/gemini-2.5-flash", "google-vertex"),
+        ("google/gemini-2.0-flash", "google-vertex"),
+        ("@google/models/gemini-2.5-flash", "google-vertex"),  # Key test case - should NOT be portkey
+        ("@google/models/gemini-2.0-flash", "google-vertex"),
+    ]
+
+    for model_id, expected in test_cases:
+        result = detect_provider_from_model_id(model_id)
+        assert result == expected, f"Expected '{expected}' for {model_id}, got {result}"
+
+
+def test_detect_provider_portkey_models():
+    """Test that Portkey models with @ prefix are correctly detected"""
+    test_cases = [
+        ("@anthropic/claude-3-sonnet", "portkey"),
+        ("@openai/gpt-4", "portkey"),
+    ]
+
+    for model_id, expected in test_cases:
+        result = detect_provider_from_model_id(model_id)
+        assert result == expected, f"Expected '{expected}' for {model_id}, got {result}"


### PR DESCRIPTION
## Summary
- Fixes model-not-found errors by correctly detecting providers for Google Vertex AI and Portkey formats
- Extends mappings to support @google/models prefixed IDs for Gemini and other Vertex AI models
- Adds tests to ensure proper provider detection across Vertex AI and Portkey formats

## Changes
### Core Logic
- Update transform_model_id to not eagerly treat @google/models/… as Portkey, allowing proper Vertex AI handling
- Extend get_model_id_mapping to include mappings for @google/models/... variants (e.g., @google/models/gemini-2.5-flash, gemini-2.5-pro, etc.)
- Improve detect_provider_from_model_id:
  - Detect Google Vertex AI models first, including patterns like gemini-2.x and @google/models/gemini-*/…
  - Ensure @google/models/... is treated as google-vertex, not Portkey
  - Allow simple gemini-*/… strings (without a slash) to map to google-vertex
  - Portkey detection only applies to @org/model formats with a slash and not to @google/models/ formats

## Tests
- Added tests to verify provider detection:
  - test_detect_provider_google_vertex_models: ensures gemini-* and @google/models/gemini-* variants map to google-vertex
  - test_detect_provider_portkey_models: ensures typical Portkey IDs (e.g., @anthropic/claude-3-sonnet, @openai/gpt-4) map to portkey

## Test plan
- Run unit tests for model transformations:
  - tests/services/test_model_transformations.py
- Verify new cases pass:
  - "gemini-2.5-flash" → google-vertex
  - "@google/models/gemini-2.5-flash" → google-vertex (not portkey)
  - "@anthropic/claude-3-sonnet" → portkey
- Ensure existing behavior for non-Vertex AI IDs remains unchanged

## Rollout considerations
- No API surface changes; just improved provider detection and additional mappings
- Should resolve intermittent model-not-found errors when using Vertex AI IDs with @google/models/ prefix

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9893f612-907e-48a6-b457-53a3e18011ca

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix provider detection to treat @google/models/* as Google Vertex AI (not Portkey) and extend Gemini mappings; add tests for Vertex and Portkey cases.
> 
> - **Core logic**:
>   - **Provider detection (`detect_provider_from_model_id`)**: Prioritize Google Vertex AI; recognize `projects/.../models/...`, `@google/models/gemini-*`, simple `gemini-*`, and `google/gemini-*`; only treat `@org/model` as Portkey when not `@google/models/*`.
>   - **ID transformation (`transform_model_id`)**: Do not auto-pass `@google/models/*` as Portkey; allow Vertex handling.
>   - **Mappings (`get_model_id_mapping`)**: Add `@google/models/*` and additional `google/gemini-*` entries for Gemini 2.5/2.0/1.5/1.0 variants; keep concise aliases.
> - **Tests**:
>   - Add `test_detect_provider_google_vertex_models` for `gemini-*`, `google/gemini-*`, and `@google/models/gemini-*` → `google-vertex`.
>   - Add `test_detect_provider_portkey_models` for `@anthropic/*`, `@openai/*` → `portkey`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fec7249d1336e8dccca4607d12303e46b3c362f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->