### PR TITLE
Fail fast when Vercel AI API key is missing (no placeholder)

### DIFF
--- a/src/services/vercel_ai_gateway_client.py
+++ b/src/services/vercel_ai_gateway_client.py
@@ -19,10 +19,7 @@ def get_vercel_ai_gateway_client():
     try:
         api_key = Config.VERCEL_AI_GATEWAY_API_KEY
         if not api_key:
-            # If no API key is configured, create a client with a placeholder
-            # The actual error will be caught at request time if needed
-            api_key = "placeholder-key"
-            logger.warning("Vercel AI Gateway API key not configured, using placeholder")
+            raise ValueError("Vercel AI Gateway API key not configured. Please set VERCEL_AI_GATEWAY_API_KEY environment variable.")
 
         return OpenAI(
             base_url="https://ai-gateway.vercel.sh/v1",


### PR DESCRIPTION
## Summary
- Improves configuration error handling to resolve 502 Bad Gateway errors from Vercel AI Gateway by removing placeholder API key usage.
- Now the client raises a clear, actionable error if VERCEL_AI_GATEWAY_API_KEY is not configured.

## Changes
### Core Functionality
- src/services/vercel_ai_gateway_client.py
  - If VERCEL_AI_GATEWAY_API_KEY is not configured, raise a ValueError with guidance to set the environment variable.
  - Removed the previous placeholder API key fallback and the associated warning.
  - Behavior now requires a valid API key to initialize the OpenAI client; otherwise, startup/request paths surface a clear misconfiguration.

### Error Handling
- Updated error message to explicitly instruct setting the VERCEL_AI_GATEWAY_API_KEY environment variable.

### Logging
- Removed the placeholder-key warning to avoid misleading logs in environments without a configured key.

## Test plan
- [x] Run service without VERCEL_AI_GATEWAY_API_KEY set and confirm startup fails with a clear error message.
- [x] Set VERCEL_AI_GATEWAY_API_KEY and verify the Vercel AI Gateway client initializes and makes requests as expected.
- [x] Ensure no usage of placeholder keys in any code paths.
- [x] Validate that misconfigurations surface quickly rather than producing a 502 downstream.

## Notes
- This change enforces proper configuration and should prevent 502 Bad Gateway errors caused by invalid or placeholder API keys.
- No public API surface changes; this is an internal reliability improvement.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/afac3b77-5ef7-4cd6-a282-3746b9099c79

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove placeholder key and raise a clear error when VERCEL_AI_GATEWAY_API_KEY is missing.
> 
> - **Backend**:
>   - **Vercel AI Gateway client (`src/services/vercel_ai_gateway_client.py`)**:
>     - Remove placeholder API key fallback and warning.
>     - Fail fast by raising `ValueError` when `VERCEL_AI_GATEWAY_API_KEY` is unset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a7d59f1f50a44ddbaa208afcb492fcb08d91c20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->