### PR TITLE
fix: resolve PR #120 linting failures - apply Black and isort formatting

### DIFF
--- a/src/routes/catalog.py
+++ b/src/routes/catalog.py
@@ -1185,7 +1185,11 @@ async def get_all_gateways_summary_endpoint(
         if "error" in summary:
             raise HTTPException(status_code=500, detail=summary["error"])
 
-        return {"success": True, "data": summary, "timestamp": datetime.now(timezone.utc).isoformat()}
+        return {
+            "success": True,
+            "data": summary,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
 
     except HTTPException:
         raise

--- a/src/routes/system.py
+++ b/src/routes/system.py
@@ -999,7 +999,11 @@ async def get_cache_status():
                 "has_data": False,
             }
 
-        return {"success": True, "data": cache_status, "timestamp": datetime.now(timezone.utc).isoformat()}
+        return {
+            "success": True,
+            "data": cache_status,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
 
     except Exception as e:
         logger.error(f"Failed to get cache status: {e}")
@@ -1509,7 +1513,11 @@ async def get_modelz_cache_status():
     """
     try:
         cache_status = get_modelz_cache_status_func()
-        return {"success": True, "data": cache_status, "timestamp": datetime.now(timezone.utc).isoformat()}
+        return {
+            "success": True,
+            "data": cache_status,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
     except Exception as e:
         logger.error(f"Failed to get Modelz cache status: {e}")
         raise HTTPException(
@@ -1546,7 +1554,11 @@ async def refresh_modelz_cache_endpoint():
         logger.info("Refreshing Modelz cache via API endpoint")
         refresh_result = await refresh_modelz_cache()
 
-        return {"success": True, "data": refresh_result, "timestamp": datetime.now(timezone.utc).isoformat()}
+        return {
+            "success": True,
+            "data": refresh_result,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
     except Exception as e:
         logger.error(f"Failed to refresh Modelz cache: {e}")
         raise HTTPException(

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -88,7 +88,10 @@ from src.schemas.payments import (
 from src.schemas.payments import (
     SubscriptionPlan as PaymentSubscriptionPlan,  # Stripe-specific models; Rename to avoid conflict
 )
-from src.schemas.payments import SubscriptionResponse, WebhookProcessingResult
+from src.schemas.payments import (
+    SubscriptionResponse,
+    WebhookProcessingResult,
+)
 
 # Plan models
 from src.schemas.plans import SubscriptionPlan  # This is the correct one for trial service


### PR DESCRIPTION
- Apply Black formatting to src/routes/system.py and src/routes/catalog.py
- Fix import sorting in src/schemas/__init__.py with isort and ruff
- All linting checks (ruff, black, isort) now pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Applies Black/isort formatting to responses in `src/routes/catalog.py` and `src/routes/system.py` and tidies imports in `src/schemas/__init__.py`, with no functional changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bef3306180043d18e8db982c39fae277ccb0cf5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->