### PR TITLE
Fix Gemini 2.5 Flash chat authentication error

### DIFF
--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -297,6 +297,14 @@ def get_model_id_mapping(provider: str) -> Dict[str, str]:
             # Google Vertex AI models - simple names
             # Full resource names are constructed by the client
             # Gemini 2.5 models (newest)
+            # Flash Lite (stable and preview)
+            "gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
+            "google/gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
+            "@google/models/gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
+            "gemini-2.5-flash-lite-preview-09-2025": "gemini-2.5-flash-lite-preview-09-2025",
+            "google/gemini-2.5-flash-lite-preview-09-2025": "gemini-2.5-flash-lite-preview-09-2025",
+            "@google/models/gemini-2.5-flash-lite-preview-09-2025": "gemini-2.5-flash-lite-preview-09-2025",
+            # Flash (preview)
             "gemini-2.5-flash-preview-09-2025": GEMINI_2_5_FLASH_PREVIEW,
             "gemini-2.5-flash": GEMINI_2_5_FLASH_PREVIEW,
             "gemini-2.5-flash-preview": GEMINI_2_5_FLASH_PREVIEW,

--- a/src/services/portkey_providers.py
+++ b/src/services/portkey_providers.py
@@ -737,6 +737,24 @@ def fetch_models_from_google_vertex():
         # These are the officially supported models available in Vertex AI
         vertex_models = [
             {
+                "id": "gemini-2.5-flash-lite",
+                "display_name": "Gemini 2.5 Flash Lite (GA)",
+                "description": "Lightweight, cost-effective model for high-throughput applications (stable version)",
+                "max_input_tokens": 1000000,
+                "max_output_tokens": 8192,
+                "modalities": ["text", "image", "audio", "video"],
+                "supported_generation_methods": ["generateContent", "streamGenerateContent"]
+            },
+            {
+                "id": "gemini-2.5-flash-lite-preview-09-2025",
+                "display_name": "Gemini 2.5 Flash Lite Preview (Sep 2025)",
+                "description": "Preview version with improved performance (887 tokens/sec) and enhanced reasoning capabilities",
+                "max_input_tokens": 1000000,
+                "max_output_tokens": 8192,
+                "modalities": ["text", "image", "audio", "video"],
+                "supported_generation_methods": ["generateContent", "streamGenerateContent"]
+            },
+            {
                 "id": "gemini-2.0-flash",
                 "display_name": "Gemini 2.0 Flash",
                 "description": "Fast, efficient model optimized for real-time applications",


### PR DESCRIPTION
- Add gemini-2.5-flash-lite to Google Vertex AI models catalog
- Add model ID transformations for google-vertex provider
- Support multiple input formats: gemini-2.5-flash-lite, google/gemini-2.5-flash-lite, @google/models/gemini-2.5-flash-lite
- Fixes chat playground authentication issues caused by missing model

This resolves issues where the frontend attempted to use gemini-2.5-flash-lite but the backend didn't recognize it, causing model detection failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Gemini 2.5 Flash Lite (GA and Sep 2025 preview) to Vertex AI catalog and supports multiple input aliases in model ID transformations.
> 
> - **Google Vertex AI**:
>   - Adds `gemini-2.5-flash-lite` (GA) and `gemini-2.5-flash-lite-preview-09-2025` to `vertex_models` in `src/services/portkey_providers.py`.
> - **Model ID Transformations**:
>   - Maps multiple aliases to Vertex formats in `src/services/model_transformations.py` for:
>     - `gemini-2.5-flash-lite` (e.g., `google/gemini-2.5-flash-lite`, `@google/models/gemini-2.5-flash-lite`).
>     - `gemini-2.5-flash-lite-preview-09-2025` (and `google/` and `@google/models/` variants).
>   - Keeps existing `gemini-2.5-flash` and `gemini-2.5-pro` preview mappings unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23916838e64c43339cbb0293b8fc82451b0a5b4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->