### PR TITLE
Add Claude code fallback for failures

### DIFF
--- a/.github/workflows/claude-on-failure.yml
+++ b/.github/workflows/claude-on-failure.yml
@@ -14,11 +14,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repo at failed commit
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-
       - name: Find associated PR number
         id: find_pr
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0


### PR DESCRIPTION
Add automated Claude Code integration that triggers when CI Pipeline or Run Tests workflows fail. The workflow will automatically analyze failures and provide diagnostic feedback on PRs.

- Triggers on completion of CI Pipeline and Run Tests workflows
- Only runs when workflow conclusion is 'failure'
- Finds associated PR and runs Claude Code in review mode
- Provides failure diagnostics and suggested fixes
- Customized system prompt for Gatewayz backend patterns

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a GitHub Actions workflow that, on CI/Test failures, locates the associated PR and runs Claude Code in review mode to post failure diagnostics.
> 
> - **CI Workflow** (`.github/workflows/claude-on-failure.yml`):
>   - Triggers on `workflow_run` completion of `"CI Pipeline"` and `"Run Tests"`.
>   - Runs only on failed runs from the same repository.
>   - Finds the associated PR via `actions/github-script` using the run’s head SHA.
>   - Executes `anthropics/claude-code-action` in `review` mode with a tailored prompt to summarize failures and suggest fixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51f5a9cd16daa597514aa34307b56248dc92bcfb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->