### PR TITLE
fix: remove invalid pr_number parameter and add required permissions

### DIFF
--- a/.github/workflows/claude-on-failure.yml
+++ b/.github/workflows/claude-on-failure.yml
@@ -13,29 +13,18 @@ jobs:
           github.event.workflow_run.head_repository.full_name == github.repository }}
     runs-on: ubuntu-latest
 
-    steps:
-      - name: Find associated PR number
-        id: find_pr
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const sha = context.payload.workflow_run.head_sha;
-            const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner, repo, commit_sha: sha
-            });
-            if (prs.data.length === 0) {
-              core.warning("No PR found for this commit. Skipping Claude run.");
-              return;
-            }
-            core.setOutput("pr", prs.data[0].number.toString());
+    # Required permissions for Claude Code action
+    permissions:
+      id-token: write      # Required for OIDC token
+      contents: write      # Required to push commits
+      pull-requests: write # Required to comment on PRs
+      actions: read        # Required to read workflow run data
 
-      - name: Run Claude Code (failure diagnostics)
-        if: ${{ steps.find_pr.outputs.pr }}
+    steps:
+      - name: Run Claude Code (fix CI failures and push)
         uses: anthropics/claude-code-action@8a1c4371755898f67cd97006ba7c97702d5fc4bf  # v1.0.16
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          pr_number: ${{ steps.find_pr.outputs.pr }}
           use_commit_signing: true
           claude_args: "--max-turns 15"
           prompt: |


### PR DESCRIPTION
Fix GitHub Actions errors in Claude Code workflow:

Error 1: "Unexpected input(s) 'pr_number'"
- Removed invalid 'pr_number' parameter (not in action's input schema)
- Removed manual PR finding step with github-script
- Action auto-detects PR from workflow_run event context

Error 2: "Could not fetch an OIDC token. Did you remember to add id-token: write"
- Added permissions block with required scopes:
  * id-token: write (for OIDC authentication)
  * contents: write (to push commits to PR)
  * pull-requests: write (to comment on PRs)
  * actions: read (to read workflow run data)

The workflow is now simplified and should work correctly:
- Triggers on CI Pipeline or Run Tests failure
- Auto-detects associated PR
- Claude analyzes failures and pushes fixes
- All with proper authentication

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies the Claude-on-failure workflow by removing manual PR discovery and invalid pr_number input, adding required permissions, and running the action directly on failed CI runs.
> 
> - **CI/CD (GitHub Actions)**:
>   - **`.github/workflows/claude-on-failure.yml`**:
>     - Add `permissions` block: `id-token: write`, `contents: write`, `pull-requests: write`, `actions: read`.
>     - Remove PR lookup step (`actions/github-script`) and reliance on commit-associated PR.
>     - Remove invalid `pr_number` input; rely on action’s auto-detection.
>     - Run Claude Code step directly with commit signing and `--max-turns 15`; rename step to "Run Claude Code (fix CI failures and push)".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbda133fac136e3988048beb2daa4e37e9903247. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->