### PR TITLE
Google Mod Implementation

### DIFF
--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -17,6 +17,7 @@ MODEL_PROVIDER_OVERRIDES = {
 }
 
 # Gemini model name constants to reduce duplication
+GEMINI_2_5_FLASH_LITE_PREVIEW = "gemini-2.5-flash-lite-preview-09-2025"
 GEMINI_2_5_FLASH_PREVIEW = "gemini-2.5-flash-preview-09-2025"
 GEMINI_2_5_PRO_PREVIEW = "gemini-2.5-pro-preview-09-2025"
 GEMINI_2_0_FLASH = "gemini-2.0-flash"
@@ -298,12 +299,13 @@ def get_model_id_mapping(provider: str) -> Dict[str, str]:
             # Full resource names are constructed by the client
             # Gemini 2.5 models (newest)
             # Flash Lite (stable and preview)
-            "gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
-            "google/gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
-            "@google/models/gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
-            "gemini-2.5-flash-lite-preview-09-2025": "gemini-2.5-flash-lite-preview-09-2025",
-            "google/gemini-2.5-flash-lite-preview-09-2025": "gemini-2.5-flash-lite-preview-09-2025",
-            "@google/models/gemini-2.5-flash-lite-preview-09-2025": "gemini-2.5-flash-lite-preview-09-2025",
+            # NOTE: Using preview version for now as stable version may not be available yet
+            "gemini-2.5-flash-lite": GEMINI_2_5_FLASH_LITE_PREVIEW,
+            "google/gemini-2.5-flash-lite": GEMINI_2_5_FLASH_LITE_PREVIEW,
+            "@google/models/gemini-2.5-flash-lite": GEMINI_2_5_FLASH_LITE_PREVIEW,
+            "gemini-2.5-flash-lite-preview-09-2025": GEMINI_2_5_FLASH_LITE_PREVIEW,
+            "google/gemini-2.5-flash-lite-preview-09-2025": GEMINI_2_5_FLASH_LITE_PREVIEW,
+            "@google/models/gemini-2.5-flash-lite-preview-09-2025": GEMINI_2_5_FLASH_LITE_PREVIEW,
             # Flash (preview)
             "gemini-2.5-flash-preview-09-2025": GEMINI_2_5_FLASH_PREVIEW,
             "gemini-2.5-flash": GEMINI_2_5_FLASH_PREVIEW,

--- a/tests/services/test_google_vertex_client.py
+++ b/tests/services/test_google_vertex_client.py
@@ -49,7 +49,7 @@ class TestTransformGoogleVertexModelId:
             "gemini-1.5-pro",
             "gemini-1.5-flash",
             "gemini-1.0-pro",
-            "gemini-2.5-flash-lite",
+            "gemini-2.5-flash-lite-preview-09-2025",
         ]
         for model in models:
             result = transform_google_vertex_model_id(model)
@@ -167,7 +167,7 @@ class TestProcessGoogleVertexResponse:
         assert result["choices"][0]["message"]["content"] == "Part 1 Part 2"
 
     def test_process_gemini_flash_lite_response(self):
-        """Test processing response from gemini-2.5-flash-lite"""
+        """Test processing response from gemini-2.5-flash-lite-preview-09-2025"""
         response_data = {
             "candidates": [
                 {
@@ -185,9 +185,9 @@ class TestProcessGoogleVertexResponse:
             }
         }
 
-        result = _process_google_vertex_rest_response(response_data, "gemini-2.5-flash-lite")
+        result = _process_google_vertex_rest_response(response_data, "gemini-2.5-flash-lite-preview-09-2025")
 
-        assert result["model"] == "gemini-2.5-flash-lite"
+        assert result["model"] == "gemini-2.5-flash-lite-preview-09-2025"
         assert result["choices"][0]["message"]["content"] == "Flash Lite response"
         assert result["usage"]["total_tokens"] == 8
 
@@ -303,7 +303,7 @@ class TestMakeGoogleVertexRequest:
     @patch("src.services.google_vertex_client.httpx.Client")
     @patch("src.services.google_vertex_client.get_google_vertex_access_token")
     def test_make_request_gemini_flash_lite(self, mock_get_token, mock_httpx_client):
-        """Test making a request to gemini-2.5-flash-lite"""
+        """Test making a request to gemini-2.5-flash-lite (maps to preview version)"""
         # Mock access token
         mock_get_token.return_value = "test-access-token"
 
@@ -338,15 +338,15 @@ class TestMakeGoogleVertexRequest:
 
         result = make_google_vertex_request_openai(
             messages=messages,
-            model="gemini-2.5-flash-lite"
+            model="gemini-2.5-flash-lite-preview-09-2025"
         )
 
-        assert result["model"] == "gemini-2.5-flash-lite"
+        assert result["model"] == "gemini-2.5-flash-lite-preview-09-2025"
         assert result["choices"][0]["message"]["content"] == "Flash Lite works!"
 
-        # Verify the correct model endpoint was called
+        # Verify the correct model endpoint was called (should use preview version)
         call_args = mock_client_instance.post.call_args
-        assert "gemini-2.5-flash-lite:generateContent" in call_args[0][0]
+        assert "gemini-2.5-flash-lite-preview-09-2025:generateContent" in call_args[0][0]
 
 
 @pytest.mark.skipif(not GOOGLE_VERTEX_AVAILABLE, reason="Google Vertex AI SDK not available")


### PR DESCRIPTION
The stable gemini-2.5-flash-lite model may not be available yet on Vertex AI. Map all gemini-2.5-flash-lite requests to the preview version (gemini-2.5-flash-lite-preview-09-2025) which is confirmed to be available.

Changes:
- Add GEMINI_2_5_FLASH_LITE_PREVIEW constant
- Map gemini-2.5-flash-lite to preview version in transformations
- Update tests to reflect the preview version usage

This fixes empty responses when trying to use Google models.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Map all `gemini-2.5-flash-lite` variants to `gemini-2.5-flash-lite-preview-09-2025` and adjust tests to expect the preview model and endpoint.
> 
> - **Model transformations (`src/services/model_transformations.py`)**:
>   - Add `GEMINI_2_5_FLASH_LITE_PREVIEW` constant.
>   - Map all `gemini-2.5-flash-lite` identifiers (including `google/` and `@google/models/`) to `gemini-2.5-flash-lite-preview-09-2025`.
> - **Tests (`tests/services/test_google_vertex_client.py`)**:
>   - Update model lists, response processing, and request tests to use/expect `gemini-2.5-flash-lite-preview-09-2025` and its endpoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 499d9852b49e4f0969537cb9d4062ded5a5243d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->