### PR TITLE
Fix deployment script to use Railway --environment flag

### DIFF
--- a/.github/workflows/deploy-railway-cli.yml
+++ b/.github/workflows/deploy-railway-cli.yml
@@ -276,7 +276,7 @@ jobs:
           echo ""
 
           # Link to Railway service
-          railway link --environmentName="$ENV"
+          railway link --environment="$ENV"
 
           # Deploy the application
           echo "⏳ Deploying application..."

--- a/docs/RAILWAY_DEPLOYMENT.md
+++ b/docs/RAILWAY_DEPLOYMENT.md
@@ -120,7 +120,7 @@ pytest tests/ --cov=src --cov-report=term-summary
 - Detaches process to allow workflow continuation
 
 ```bash
-railway link --environmentName="$ENV"
+railway link --environment="$ENV"
 railway up --service=gatewayz --detach --skip-database=true
 ```
 
@@ -306,7 +306,7 @@ Common commands used in workflow:
 
 ```bash
 # Link to a Railway service
-railway link --environmentName="production"
+railway link --environment="production"
 
 # Deploy the app
 railway up --detach --skip-database=true


### PR DESCRIPTION
## Summary
- Corrects Railway CLI argument from environmentName to environment in deployment script
- Updates documentation to reflect the correct flag, ensuring consistency across workflow and docs

## Changes

### CI Workflow
- Updated .github/workflows/deploy-railway-cli.yml to use: `railway link --environment="$ENV"` (previously `--environmentName`)

### Documentation
- Updated docs/RAILWAY_DEPLOYMENT.md sample commands to `railway link --environment="$ENV"` (previously `--environmentName`)

### Impact
- No functional changes to application logic; fixes deployment error caused by incorrect CLI flag usage

## Test plan
- [x] Trigger the deployment workflow to verify the correct flag is used in the link step
- [x] Review logs to confirm the railway link command uses `--environment` (not `--environmentName`)
- [x] Ensure documentation examples align with the actual commands used in CI


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6243bdfb-da08-4a66-b1ad-c48c24733dca

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace `railway link --environmentName` with `--environment` in the workflow and docs.
> 
> - **CI/CD**:
>   - Update `railway link` in `.github/workflows/deploy-railway-cli.yml` to use `--environment="$ENV"` (replacing `--environmentName`).
> - **Docs**:
>   - Align `docs/RAILWAY_DEPLOYMENT.md` command examples to `railway link --environment="..."`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30dbe3f66b2ad55b774ade01f393eaeba4521606. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->