### PR TITLE
Graceful handling of missing rate-limit tables (Vertex AI)

### DIFF
--- a/supabase/migrations/20251105000000_add_missing_rate_limit_tables.sql
+++ b/supabase/migrations/20251105000000_add_missing_rate_limit_tables.sql
@@ -1,0 +1,107 @@
+-- Create rate_limit_configs table
+-- Stores per-API-key rate limit configurations
+CREATE TABLE IF NOT EXISTS "public"."rate_limit_configs" (
+    "id" bigint NOT NULL DEFAULT nextval('rate_limit_configs_id_seq'::regclass),
+    "api_key_id" bigint NOT NULL,
+    "window_type" text DEFAULT 'sliding'::text,
+    "window_size" integer DEFAULT 3600,
+    "max_requests" integer DEFAULT 1000,
+    "max_tokens" integer DEFAULT 1000000,
+    "burst_limit" integer DEFAULT 100,
+    "concurrency_limit" integer DEFAULT 10,
+    "is_active" boolean DEFAULT true,
+    "created_at" timestamp with time zone DEFAULT (now() AT TIME ZONE 'UTC'::text),
+    "updated_at" timestamp with time zone DEFAULT (now() AT TIME ZONE 'UTC'::text),
+    CONSTRAINT "rate_limit_configs_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "rate_limit_configs_api_key_id_fkey" FOREIGN KEY ("api_key_id") REFERENCES "public"."api_keys_new"("id") ON DELETE CASCADE
+);
+
+-- Create index on api_key_id for faster lookups
+CREATE INDEX IF NOT EXISTS "rate_limit_configs_api_key_id_idx" ON "public"."rate_limit_configs" USING btree ("api_key_id");
+
+-- Create rate_limit_usage table
+-- Tracks rate limit window usage (minute, hour, day windows)
+CREATE TABLE IF NOT EXISTS "public"."rate_limit_usage" (
+    "id" bigint NOT NULL DEFAULT nextval('rate_limit_usage_id_seq'::regclass),
+    "user_id" bigint NOT NULL,
+    "api_key" text NOT NULL,
+    "window_type" text NOT NULL,
+    "window_start" timestamp with time zone NOT NULL,
+    "requests_count" integer DEFAULT 0,
+    "tokens_count" integer DEFAULT 0,
+    "created_at" timestamp with time zone DEFAULT (now() AT TIME ZONE 'UTC'::text),
+    "updated_at" timestamp with time zone DEFAULT (now() AT TIME ZONE 'UTC'::text),
+    CONSTRAINT "rate_limit_usage_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "rate_limit_usage_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE CASCADE,
+    CONSTRAINT "rate_limit_usage_unique" UNIQUE ("api_key", "window_type", "window_start")
+);
+
+-- Create indexes on rate_limit_usage for performance
+CREATE INDEX IF NOT EXISTS "rate_limit_usage_api_key_idx" ON "public"."rate_limit_usage" USING btree ("api_key");
+CREATE INDEX IF NOT EXISTS "rate_limit_usage_user_id_idx" ON "public"."rate_limit_usage" USING btree ("user_id");
+CREATE INDEX IF NOT EXISTS "rate_limit_usage_window_start_idx" ON "public"."rate_limit_usage" USING btree ("window_start");
+CREATE INDEX IF NOT EXISTS "rate_limit_usage_window_type_idx" ON "public"."rate_limit_usage" USING btree ("window_type");
+
+-- Create api_key_audit_logs table
+-- Stores audit trail of API key operations
+CREATE TABLE IF NOT EXISTS "public"."api_key_audit_logs" (
+    "id" bigint NOT NULL DEFAULT nextval('api_key_audit_logs_id_seq'::regclass),
+    "user_id" bigint NOT NULL,
+    "api_key_id" bigint,
+    "action" text NOT NULL,
+    "details" jsonb DEFAULT '{}'::jsonb,
+    "timestamp" timestamp with time zone DEFAULT (now() AT TIME ZONE 'UTC'::text),
+    CONSTRAINT "api_key_audit_logs_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "api_key_audit_logs_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE CASCADE,
+    CONSTRAINT "api_key_audit_logs_api_key_id_fkey" FOREIGN KEY ("api_key_id") REFERENCES "public"."api_keys_new"("id") ON DELETE SET NULL
+);
+
+-- Create indexes on api_key_audit_logs for performance
+CREATE INDEX IF NOT EXISTS "api_key_audit_logs_user_id_idx" ON "public"."api_key_audit_logs" USING btree ("user_id");
+CREATE INDEX IF NOT EXISTS "api_key_audit_logs_api_key_id_idx" ON "public"."api_key_audit_logs" USING btree ("api_key_id");
+CREATE INDEX IF NOT EXISTS "api_key_audit_logs_action_idx" ON "public"."api_key_audit_logs" USING btree ("action");
+CREATE INDEX IF NOT EXISTS "api_key_audit_logs_timestamp_idx" ON "public"."api_key_audit_logs" USING btree ("timestamp");
+
+-- Create sequences if they don't exist
+CREATE SEQUENCE IF NOT EXISTS "public"."rate_limit_configs_id_seq" OWNED BY "public"."rate_limit_configs"."id";
+CREATE SEQUENCE IF NOT EXISTS "public"."rate_limit_usage_id_seq" OWNED BY "public"."rate_limit_usage"."id";
+CREATE SEQUENCE IF NOT EXISTS "public"."api_key_audit_logs_id_seq" OWNED BY "public"."api_key_audit_logs"."id";
+
+-- Enable Row Level Security (RLS)
+ALTER TABLE "public"."rate_limit_configs" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."rate_limit_usage" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."api_key_audit_logs" ENABLE ROW LEVEL SECURITY;
+
+-- Set up RLS policies for rate_limit_configs
+CREATE POLICY "Users can read their own rate limit configs" ON "public"."rate_limit_configs"
+    FOR SELECT USING (
+        api_key_id IN (
+            SELECT id FROM public.api_keys_new WHERE user_id = auth.uid()
+        )
+    );
+
+CREATE POLICY "Service role can manage rate limit configs" ON "public"."rate_limit_configs"
+    FOR ALL USING (auth.role() = 'service_role');
+
+-- Set up RLS policies for rate_limit_usage
+CREATE POLICY "Users can read their own rate limit usage" ON "public"."rate_limit_usage"
+    FOR SELECT USING (user_id = auth.uid());
+
+CREATE POLICY "Service role can manage rate limit usage" ON "public"."rate_limit_usage"
+    FOR ALL USING (auth.role() = 'service_role');
+
+-- Set up RLS policies for api_key_audit_logs
+CREATE POLICY "Users can read their own audit logs" ON "public"."api_key_audit_logs"
+    FOR SELECT USING (user_id = auth.uid());
+
+CREATE POLICY "Service role can manage audit logs" ON "public"."api_key_audit_logs"
+    FOR ALL USING (auth.role() = 'service_role');
+
+-- Grant permissions
+GRANT SELECT, INSERT, UPDATE, DELETE ON "public"."rate_limit_configs" TO "authenticated";
+GRANT SELECT, INSERT, UPDATE, DELETE ON "public"."rate_limit_usage" TO "authenticated";
+GRANT SELECT ON "public"."api_key_audit_logs" TO "authenticated";
+
+GRANT ALL ON "public"."rate_limit_configs" TO "service_role";
+GRANT ALL ON "public"."rate_limit_usage" TO "service_role";
+GRANT ALL ON "public"."api_key_audit_logs" TO "service_role";


### PR DESCRIPTION
## Summary
- Adds resilience for Vertex AI flow by gracefully handling missing rate-limit tables during migration
- Introduces new rate-limit tables and a migration to support legacy API keys: rate_limit_configs, rate_limit_usage, and api_key_audit_logs
- Improves fallback logic for fetching/updating rate limit configs to work when migration is incomplete

## Changes

### Core Functionality
- rate_limit checks now tolerate missing rate_limit_usage table by wrapping access in a try/except and allowing requests with a clear migration-pending reason
- rate_limit usage updates skip when the table is not available, with informational logs instead of failing
- get_rate_limit_config now attempts api_keys_new first, gracefully falls back to rate_limit_configs or defaults if tables/columns are unavailable
- update_rate_limit_config tries api_keys_new first, then falls back to rate_limit_configs; returns a boolean indicating success

### Database Migrations
- Added new migration file: 20251105000000_add_missing_rate_limit_tables.sql
  - Creates rate_limit_configs, rate_limit_usage, and api_key_audit_logs tables with appropriate columns, defaults, and constraints
  - Creates helpful indexes for performance
  - Enables Row Level Security (RLS) and adds policies for users and service roles
  - Grants to authenticated and service_role where appropriate

## Observability
- Added warnings/logs when rate_limit_usage table is missing or inaccessible during rate limit checks
- Logs provide context that migration may be pending, aiding debugging in Vertex AI environments

## Testing plan
- [ ] Deploy migration and verify that new tables exist with correct schema
- [ ] Run existing requests with the rate_limit_usage table present and verify normal behavior
- [ ] Simulate missing rate_limit_usage table and confirm requests are allowed with a migration-pending reason
- [ ] Verify get_rate_limit_config returns configured values when available, and falls back to defaults when tables/columns are missing
- [ ] Verify update_rate_limit_config updates data in api_keys_new when available, and in rate_limit_configs when appropriate; returns True on success and False when neither path is available
- [ ] Validate Row Level Security policies by performing actions as authenticated user and as service_role

## Risk and rollback
- These changes introduce safe fallbacks; if the rate-limit tables are absent, requests are allowed and logged with migration context instead of failing hard
- The new migration is additive and can be rolled back by removing the tables if necessary, though it is designed to be backward-compatible with existing behavior once migrated


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6084358d-94c2-4e0a-8d1e-1848c7b46255

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gracefully handle missing rate-limit tables and add migrations for `rate_limit_configs`, `rate_limit_usage`, and `api_key_audit_logs` with fallbacks and RLS.
> 
> - **Rate limiting (backend)**
>   - `check_rate_limit`: wrap `rate_limit_usage` reads in try/except; allow requests with migration-pending reason when table inaccessible.
>   - `update_rate_limit_usage`: probe for `rate_limit_usage` existence before upsert; skip updates with info logs if missing; still update `api_keys_new.last_used_at` for new keys.
>   - `get_rate_limit_config`/`update_rate_limit_config`: prefer `api_keys_new.rate_limit_config`, fall back to `rate_limit_configs`, otherwise defaults; return success boolean for updates.
> - **Database (migration)**
>   - Add `supabase/migrations/20251105000000_add_missing_rate_limit_tables.sql` creating `rate_limit_configs`, `rate_limit_usage`, `api_key_audit_logs` with keys, indexes, sequences.
>   - Enable RLS with user/service-role policies and grant appropriate privileges.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01e230f8f9d7dd40e588bcc37a43eda785ba4692. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->