### PR TITLE
Debug Near connection issue: fix model ID mapping

### DIFF
--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -352,6 +352,21 @@ def get_model_id_mapping(provider: str) -> dict[str, str]:
             # Pass-through format - any model ID is supported
             # Minimal mappings to avoid conflicts with other providers during auto-detection
         },
+        "near": {
+            # Near AI uses simple model names without org prefixes
+            # Maps org/model format to simple model names
+            "deepseek-ai/deepseek-v3": "deepseek-v3",
+            "meta-llama/llama-3-70b": "llama-3-70b",
+            "meta-llama/llama-3.1-70b": "llama-3.1-70b",
+            "qwen/qwen-2-72b": "qwen-2-72b",
+            "gpt-oss/gpt-oss-120b": "gpt-oss-120b",
+            # Also support without org prefix (pass-through)
+            "deepseek-v3": "deepseek-v3",
+            "llama-3-70b": "llama-3-70b",
+            "llama-3.1-70b": "llama-3.1-70b",
+            "qwen-2-72b": "qwen-2-72b",
+            "gpt-oss-120b": "gpt-oss-120b",
+        },
     }
 
     return mappings.get(provider, {})


### PR DESCRIPTION
## Summary
- Fixes Near provider connection issue by correcting model ID mappings
- Adds explicit mappings for Near's simple model names and passthrough variants

## Changes

### Near model ID mappings
- Updated src/services/model_transformations.py to extend get_model_id_mapping with a new "near" provider map
- Maps Near full org/model IDs to simple model names used by Near:
  - "deepseek-ai/deepseek-v3" → "deepseek-v3"
  - "meta-llama/llama-3-70b" → "llama-3-70b"
  - "meta-llama/llama-3.1-70b" → "llama-3.1-70b"
  - "qwen/qwen-2-72b" → "qwen-2-72b"
  - "gpt-oss/gpt-oss-120b" → "gpt-oss-120b"
- Also supports passthrough without org prefix (e.g., "deepseek-v3" → "deepseek-v3", etc.)

### Backward compatibility
- Existing mappings for other providers remain unchanged

## Test plan
- [x] Validate Near model IDs map to the expected simple names
- [x] Verify passthrough IDs continue to work for Near
- [ ] Run full end-to-end tests in a Near-enabled environment to confirm connectivity


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/462e8d7c-3205-41ba-a9dc-665dcba38fd3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Near provider mappings to translate org/model IDs to Near’s simple model names, with passthrough support for non-prefixed IDs.
> 
> - **Model transformations (`src/services/model_transformations.py`)**:
>   - **Near provider mapping**: Extend `get_model_id_mapping` with `"near"` to map org/model IDs to simple names and support passthrough:
>     - `deepseek-ai/deepseek-v3` → `deepseek-v3`
>     - `meta-llama/llama-3-70b` → `llama-3-70b`
>     - `meta-llama/llama-3.1-70b` → `llama-3.1-70b`
>     - `qwen/qwen-2-72b` → `qwen-2-72b`
>     - `gpt-oss/gpt-oss-120b` → `gpt-oss-120b`
>     - Passthrough: `deepseek-v3`, `llama-3-70b`, `llama-3.1-70b`, `qwen-2-72b`, `gpt-oss-120b`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit effe88a671e3ea9a1fbc8c962f7c4248ad60f784. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->