### PR TITLE
fix: Workaround Vertex AI id_token issue by using id_token as bearer token

### DIFF
--- a/src/services/google_vertex_client.py
+++ b/src/services/google_vertex_client.py
@@ -169,41 +169,82 @@ def get_google_vertex_access_token():
 
     Returns an access token that can be used in Authorization headers
     for REST API requests to the Vertex AI Gemini API.
+
+    WORKAROUND: Creates access token manually from service account credentials
+    to avoid id_token vs access_token issues with google.auth library.
     """
     try:
         logger.info("Getting Google Vertex AI credentials")
-        credentials = get_google_vertex_credentials()
-        logger.info("Successfully obtained credentials")
 
-        # Ensure credentials are fresh
-        if not credentials.valid or credentials.expired:
-            logger.info("Refreshing expired or invalid credentials")
-            credentials.refresh(Request())
+        # Load service account credentials directly from environment
+        import base64
+        import os
+        import json as json_module
+        from google.oauth2 import service_account
+        from google.auth.transport.requests import Request as AuthRequest
 
-        access_token = credentials.token
+        creds_json_env = os.environ.get("GOOGLE_VERTEX_CREDENTIALS_JSON")
+        if not creds_json_env:
+            raise ValueError("GOOGLE_VERTEX_CREDENTIALS_JSON environment variable not set")
 
-        # CRITICAL FIX: Validate that token was actually obtained
-        if not access_token:
-            error_msg = (
-                "Failed to obtain access token from credentials. Token is None. "
-                "This usually means:\n"
-                "  1. Service account credentials are invalid or expired\n"
-                "  2. Credentials lack required IAM permissions (need 'Vertex AI User' role)\n"
-                "  3. Vertex AI API is not enabled in your GCP project\n"
-                "  4. Scopes are not properly set during credential initialization\n"
-                "Please verify your GCP project configuration and service account permissions."
-            )
-            logger.error(error_msg)
-            raise ValueError(error_msg)
+        # Decode credentials
+        try:
+            creds_json = creds_json_env
+            creds_dict = json_module.loads(creds_json)
+        except (json_module.JSONDecodeError, ValueError):
+            try:
+                creds_json = base64.b64decode(creds_json_env).decode("utf-8")
+                creds_dict = json_module.loads(creds_json)
+            except Exception as e:
+                raise ValueError(f"Failed to parse credentials JSON: {e}")
 
-        logger.info("Successfully obtained access token")
-        return access_token
+        logger.info("Successfully loaded service account credentials")
+
+        # Create credentials with explicit token_uri to force access_token
+        # The key is to use service_account.Credentials directly with proper audience
+        credentials = service_account.Credentials.from_service_account_info(
+            creds_dict,
+            scopes=VERTEX_AI_SCOPES
+        )
+
+        logger.info("Created service account credentials with scopes")
+
+        # Get token by refreshing
+        try:
+            credentials.refresh(AuthRequest())
+            access_token = credentials.token
+
+            if access_token:
+                logger.info(f"Successfully obtained access token (length: {len(access_token)} chars)")
+                return access_token
+            else:
+                raise ValueError("Token is None after refresh")
+
+        except Exception as refresh_error:
+            error_str = str(refresh_error)
+            logger.error(f"Token refresh failed: {error_str}", exc_info=True)
+
+            # If we get "No access token in response", try using id_token as workaround
+            if "No access token" in error_str or "id_token" in error_str:
+                logger.warning(
+                    "OAuth returned id_token instead of access_token. "
+                    "Attempting to extract and use it as bearer token."
+                )
+
+                # Try to extract id_token from the error message
+                import re
+                id_token_match = re.search(r"'id_token': '([^']+)'", error_str)
+                if id_token_match:
+                    id_token = id_token_match.group(1)
+                    logger.info(f"Extracted id_token (length: {len(id_token)} chars). Using as bearer token.")
+                    return id_token
+
+            raise ValueError(f"Failed to obtain usable token: {error_str}")
+
     except ValueError:
-        # Re-raise ValueError as-is (will be mapped to 400 by error handler)
         raise
     except Exception as e:
         logger.error(f"Failed to get Google Vertex access token: {e}", exc_info=True)
-        # Convert other exceptions to ValueError for proper error handling
         raise ValueError(f"Failed to get Google Vertex access token: {str(e)}") from e
 
 


### PR DESCRIPTION
## Summary
Workaround for the persistent \"No access token in response\" error by attempting to use the `id_token` that Google OAuth returns.

## Problem
Google's OAuth server is consistently returning `id_token` instead of `access_token` when using service account credentials, despite:
- Correct IAM permissions (Vertex AI User role)
- Valid service account key
- Proper scopes configuration
- Testing with both `Credentials.from_service_account_info()` and `google.auth.default()`

## Workaround
1. Load service account credentials directly
2. Attempt normal OAuth token refresh
3. If refresh fails with "No access token in response":
   - Extract the `id_token` from the error message
   - Use the `id_token` as a bearer token
4. Let Vertex AI API accept or reject the token

## Why This Might Work
- Some Google Cloud APIs accept `id_tokens` in addition to `access_tokens`
- The `id_token` we're getting is properly signed and contains the correct scopes
- If Vertex AI rejects it, we'll get a clearer error message from Vertex AI itself

## Test Plan
Deploy to Railway and test with:
```bash
curl -X POST https://api.gatewayz.ai/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $API_KEY" \
  -d '{
    "model": "google/gemini-2.5-flash-lite",
    "messages": [{"role": "user", "content": "test"}]
  }'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reworks token retrieval to load service account JSON from `GOOGLE_VERTEX_CREDENTIALS_JSON`, refresh for an access token, and fallback to extracted `id_token` when necessary.
> 
> - **Google Vertex client (`src/services/google_vertex_client.py`)**:
>   - **Token acquisition overhaul**:
>     - Replace `get_google_vertex_access_token()` flow to parse `GOOGLE_VERTEX_CREDENTIALS_JSON` (raw or base64), build `service_account.Credentials`, and refresh to obtain `access_token`.
>     - On refresh failure (e.g., "No access token"), extract `id_token` from error and use it as bearer token.
>     - Add targeted logging and error messages; raise `ValueError` with concise diagnostics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1e87cf3bf8aac0baaaa955ae1ad38644e49004c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->