### PR TITLE
Enable tool calling support in Anthropic-to-OpenAI transformer

### DIFF
--- a/src/routes/messages.py
+++ b/src/routes/messages.py
@@ -277,6 +277,8 @@ async def anthropic_messages(
             top_p=req.top_p,
             top_k=req.top_k,
             stop_sequences=req.stop_sequences,
+            tools=req.tools,
+            tool_choice=req.tool_choice,
         )
 
         # === 2.1) Inject conversation history if session_id provided ===

--- a/src/schemas/proxy.py
+++ b/src/schemas/proxy.py
@@ -162,6 +162,7 @@ class MessagesRequest(BaseModel):
     - 'max_tokens' is REQUIRED (not optional)
     - Content can be string or array of content blocks
     - No frequency_penalty or presence_penalty
+    - Supports tool use (function calling)
     """
 
     model: str  # e.g., "claude-sonnet-4-5-20250929"
@@ -174,6 +175,8 @@ class MessagesRequest(BaseModel):
     stop_sequences: list[str] | None = None
     stream: bool | None = False
     metadata: dict[str, Any] | None = None
+    tools: list[dict[str, Any]] | None = None  # Tool definitions for function calling
+    tool_choice: str | dict[str, Any] | None = None  # Tool selection: "auto", "required", or specific tool
 
     # Gateway-specific fields (not part of Anthropic API)
     provider: str | None = None

--- a/src/services/anthropic_transformer.py
+++ b/src/services/anthropic_transformer.py
@@ -15,6 +15,8 @@ def transform_anthropic_to_openai(
     top_p: float | None = None,
     top_k: int | None = None,
     stop_sequences: list[str] | None = None,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: str | dict[str, Any] | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """
     Transform Anthropic Messages API request to OpenAI Chat Completions format.
@@ -27,6 +29,8 @@ def transform_anthropic_to_openai(
         top_p: Top-p parameter
         top_k: Top-k parameter (Anthropic-specific, ignored)
         stop_sequences: Stop sequences (maps to 'stop' in OpenAI)
+        tools: Tool/function definitions for function calling
+        tool_choice: Tool selection strategy ("auto", "required", or specific tool)
 
     Returns:
         Tuple of (openai_messages, openai_params)
@@ -101,6 +105,10 @@ def transform_anthropic_to_openai(
         openai_params["top_p"] = top_p
     if stop_sequences:
         openai_params["stop"] = stop_sequences
+    if tools:
+        openai_params["tools"] = tools
+    if tool_choice:
+        openai_params["tool_choice"] = tool_choice
 
     # Note: top_k is Anthropic-specific and not supported in OpenAI
     # We log it but don't pass it through


### PR DESCRIPTION
## Summary
- Adds support for tool calling (function calling) in the Anthropic-to-OpenAI transformation flow.
- Propagates tool definitions and tool selection from API routes through the transformer to OpenAI payloads.
- Maintains backward compatibility when tools are not provided.

## Changes
### Routes
- src/routes/messages.py: pass `tools` and `tool_choice` from the request to `anthropic_messages` to enable function calling in downstream processing.

### Schemas
- src/schemas/proxy.py: extend `MessagesRequest` with:
  - `tools: list[dict[str, Any]] | None` — tool definitions for function calling
  - `tool_choice: str | dict[str, Any] | None` — tool selection strategy (e.g., "auto", "required", or a specific tool)

### Transformer
- src/services/anthropic_transformer.py: update `transform_anthropic_to_openai` to accept `tools` and `tool_choice` and pass them through to the OpenAI-like payload as
  - `tools`
  - `tool_choice`

## Why
This enables clients to leverage function calling semantics when interacting with Anthropic models via the OpenAI-style payload, enabling richer integrations and automated tool usage in prompts.

## Test plan
- [x] Ensure API accepts and forwards `tools` and `tool_choice` without breaking existing flows when not provided
- [x] Validate that when `tools` and `tool_choice` are provided, the resulting OpenAI payload contains `tools` and `tool_choice` fields
- [x] Maintain compatibility for existing requests that omit tool calling fields

## Notes
- This change is backward-compatible and opt-in via new fields.
- Documentation and example payloads can be added in a follow-up PR if needed.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/32a33704-d2ae-49a3-abee-aec680e32ec3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds tool calling by passing `tools` and `tool_choice` from request → router → transformer → OpenAI payload.
> 
> - **Tool calling support (Anthropic → OpenAI path)**:
>   - **Schemas**: Extend `src/schemas/proxy.py` `MessagesRequest` with `tools` and `tool_choice`.
>   - **Routes**: In `src/routes/messages.py` forward `req.tools` and `req.tool_choice` to `transform_anthropic_to_openai`.
>   - **Transformer**: Update `src/services/anthropic_transformer.py` to accept `tools`/`tool_choice` and include them in OpenAI params (`tools`, `tool_choice`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a7ba247e861381de6a3cdee5adfa0006c4d0016. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->