### PR TITLE
Fix Run Claude Failure Workflow: increase timeout and streamline steps

### DIFF
--- a/.github/workflows/claude-on-failure.yml
+++ b/.github/workflows/claude-on-failure.yml
@@ -133,56 +133,53 @@ jobs:
           echo "✅ GitHub token is available"
 
       - name: Run Claude Code (fix CI failures and push)
-        timeout-minutes: 30
+        timeout-minutes: 45
         uses: anthropics/claude-code-action@8a1c4371755898f67cd97006ba7c97702d5fc4bf  # v1.0.16
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           use_commit_signing: false
-          claude_args: "--max-turns 15"
+          claude_args: "--max-turns 10"
           prompt: |
-            The CI pipeline has failed on this PR. Your task is to:
+            The CI pipeline has failed. Your task is to diagnose and fix the failures:
 
-            1. **Check for merge conflicts** - If there are any merge conflict markers (<<<<<<< <branch>, =======, >>>>>>>) in the codebase:
-               - Read each conflicted file
-               - Understand what changed in each branch
-               - Resolve conflicts by choosing the appropriate code or merging both changes intelligently
+            1. **Check for merge conflicts FIRST** - Look for <<<<<<< <branch> markers in the code:
+               - If found, resolve them by understanding both branches and merging intelligently
                - Remove all conflict markers
-               - This is often the root cause of CI failures, so resolve this FIRST before analyzing other errors
+               - This is often the root cause, so fix this before anything else
 
-            2. **Read the failure logs** - Check the 'failure-logs.md' file which contains:
-               - Complete CI failure logs from the failed workflow run
-               - Failed job names and their output
-               - Failed step details
-               - Error messages and stack traces
+            2. **Read failure-logs.md** - This file contains the complete failure details:
+               - Failed test names and error messages
+               - Linting/type check errors
+               - Build or import errors
+               - Any other failure information
 
-            3. **Analyze the root cause** - Identify what specifically failed:
-               - Which tests are failing and why
-               - What linting/type errors exist (these often arise from unresolved conflicts)
-               - Any build or import errors
-               - Security or coverage issues
+            3. **Identify root causes** - Determine what specifically failed and why:
+               - Test assertion failures or timeouts?
+               - Linting errors (ruff, black, isort, mypy)?
+               - Import or dependency issues?
+               - Coverage below 25% threshold?
+               - Build/startup errors?
 
-            4. **Implement fixes** - Make the necessary code changes to resolve the failures:
-               - Fix failing tests
-               - Resolve linting/type errors
-               - Address import or dependency issues
-               - Fix any other errors preventing CI from passing
+            4. **Fix the issues** - Make targeted code changes to resolve failures:
+               - Fix failing tests or mock configuration
+               - Resolve linting/formatting issues
+               - Fix import/dependency problems
+               - Ensure coverage stays above 25%
 
-            5. **Commit and push** - Once fixed:
-               - Use clear commit messages explaining what was fixed
-               - If you resolved merge conflicts, mention that in the commit message
-               - Push changes to this PR branch
+            5. **Commit and push** - Once all fixes are complete:
+               - Create clear commit messages explaining what was fixed
+               - Push to this PR branch
 
-            Common failure patterns in this Gatewayz backend codebase:
-            - Merge conflicts: <<<<<<< markers (with branch/commit names), conflicting changes between branches
-            - Test failures: pytest assertion errors, timeout issues, mock configuration
-            - Linting errors: ruff, black, isort, mypy type errors
-            - Security scans: bandit warnings, safety vulnerability checks
-            - Import/dependency errors: missing packages, circular imports
-            - Coverage drops: ensure coverage stays above 25% threshold
-            - Integration test failures: endpoint tests, auth, payments, database
-            - Build/startup errors: FastAPI app initialization, missing env vars
+            Common issues in this codebase:
+            - Merge conflicts (<<<<<<< markers)
+            - Test failures (pytest assertions, timeouts, mocks)
+            - Code formatting (ruff, black, isort violations)
+            - Type errors (mypy)
+            - Coverage drops
+            - Integration test failures
+            - FastAPI initialization issues
 
-            **IMPORTANT**: Check for merge conflicts first, then read 'failure-logs.md' to see exactly what failed!
+            **IMPORTANT**: Always check for merge conflicts first, then read failure-logs.md for exact error details!
 
       - name: Report completion
         if: always()


### PR DESCRIPTION
## Summary
- Updates the Claude-on-failure workflow to improve reliability and responsiveness by increasing timeout, tightening Claude usage, and simplifying failure guidance.

## Changes
### Workflow updates
- **.github/workflows/claude-on-failure.yml**:
  - Increase timeout-minutes: 30 -> 45
  - Update claude_args: "--max-turns 15" -> "--max-turns 10"
  - Rework prompt to a concise diagnostic directive:
    - "The CI pipeline has failed. Your task is to diagnose and fix the failures:"
  - Replace verbose failure-steps with a streamlined sequence:
    1) Check for merge conflicts FIRST
    2) Read failure-logs.md
    3) Identify root causes
    4) Fix the issues
    5) Commit and push
  - Retains the final "Report completion" step

## Rationale
- Longer timeout accommodates longer Claude analyses on failing PRs.
- Reducing max turns helps keep Claude responses concise and faster.
- A streamlined prompt reduces noise and focuses on actionable steps.

## Testing plan
- [ ] Trigger a PR with known CI failures and verify Claude runs within 45 minutes and outputs the structured guidance.
- [ ] Verify the guidance starts with merge-conflict checks and proceeds to failure-logs review and root-cause analysis.
- [ ] Confirm the workflow still reports completion on success/failure.

## Notes
- This is a CI workflow improvement only; no changes to application code.

## Rollback plan
- If issues arise, revert this PR to restore previous timeout and max-turns settings for Claude.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/5bb69764-a43d-401c-a1b8-532b879760e4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase timeout to 45m, reduce Claude max turns to 10, and replace verbose instructions with a concise, step-by-step prompt in the failure workflow.
> 
> - **CI Workflow** (`.github/workflows/claude-on-failure.yml`):
>   - Increase `timeout-minutes` from `30` to `45` for the Claude step.
>   - Reduce `claude_args` max turns from `15` to `10`.
>   - Replace verbose guidance with a concise, ordered prompt emphasizing:
>     - Check for merge conflicts first, then read `failure-logs.md`, identify root causes, fix issues, and commit/push.
>   - Keep completion reporting step intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d289f2ff1ba73d099648b23f0d3e5c8036bf4cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->