### PR TITLE
List Google Gemini 2.5 variants in mapping

### DIFF
--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -286,28 +286,26 @@ def get_model_id_mapping(provider: str) -> dict[str, str]:
         "google-vertex": {
             # Google Vertex AI models - simple names
             # Full resource names are constructed by the client
-            # Only stable, generally available models are included
-            # Preview models (with -preview- in name) are not available in all projects
-            # Map 2.5 preview requests to stable 2.0 versions
-            "gemini-2.5-flash-lite": GEMINI_2_0_FLASH,  # Map to stable 2.0 version
-            "gemini-2.5-flash-lite-preview-09-2025": GEMINI_2_0_FLASH,
-            "google/gemini-2.5-flash-lite": GEMINI_2_0_FLASH,
-            "google/gemini-2.5-flash-lite-preview-09-2025": GEMINI_2_0_FLASH,
-            "@google/models/gemini-2.5-flash-lite": GEMINI_2_0_FLASH,
-            "@google/models/gemini-2.5-flash-lite-preview-09-2025": GEMINI_2_0_FLASH,
-            # Map 2.5 flash/pro requests to stable 2.0 versions
-            "gemini-2.5-flash": GEMINI_2_0_FLASH,
-            "gemini-2.5-flash-preview-09-2025": GEMINI_2_0_FLASH,
-            "gemini-2.5-flash-preview": GEMINI_2_0_FLASH,
-            "google/gemini-2.5-flash": GEMINI_2_0_FLASH,
-            "google/gemini-2.5-flash-preview-09-2025": GEMINI_2_0_FLASH,
-            "@google/models/gemini-2.5-flash": GEMINI_2_0_FLASH,
-            "@google/models/gemini-2.5-flash-preview-09-2025": GEMINI_2_0_FLASH,
-            # Map 2.5 pro requests to stable 2.0 pro version
-            "gemini-2.5-pro": GEMINI_2_0_PRO,
-            "gemini-2.5-pro-preview-09-2025": GEMINI_2_0_PRO,
-            "google/gemini-2.5-pro": GEMINI_2_0_PRO,
-            "@google/models/gemini-2.5-pro": GEMINI_2_0_PRO,
+            # Gemini 2.5 models (preview)
+            "gemini-2.5-flash-lite": GEMINI_2_5_FLASH_LITE_PREVIEW,
+            "gemini-2.5-flash-lite-preview-09-2025": GEMINI_2_5_FLASH_LITE_PREVIEW,
+            "google/gemini-2.5-flash-lite": GEMINI_2_5_FLASH_LITE_PREVIEW,
+            "google/gemini-2.5-flash-lite-preview-09-2025": GEMINI_2_5_FLASH_LITE_PREVIEW,
+            "@google/models/gemini-2.5-flash-lite": GEMINI_2_5_FLASH_LITE_PREVIEW,
+            "@google/models/gemini-2.5-flash-lite-preview-09-2025": GEMINI_2_5_FLASH_LITE_PREVIEW,
+            # Gemini 2.5 flash models
+            "gemini-2.5-flash": GEMINI_2_5_FLASH_PREVIEW,
+            "gemini-2.5-flash-preview-09-2025": GEMINI_2_5_FLASH_PREVIEW,
+            "gemini-2.5-flash-preview": GEMINI_2_5_FLASH_PREVIEW,
+            "google/gemini-2.5-flash": GEMINI_2_5_FLASH_PREVIEW,
+            "google/gemini-2.5-flash-preview-09-2025": GEMINI_2_5_FLASH_PREVIEW,
+            "@google/models/gemini-2.5-flash": GEMINI_2_5_FLASH_PREVIEW,
+            "@google/models/gemini-2.5-flash-preview-09-2025": GEMINI_2_5_FLASH_PREVIEW,
+            # Gemini 2.5 pro models
+            "gemini-2.5-pro": GEMINI_2_5_PRO_PREVIEW,
+            "gemini-2.5-pro-preview-09-2025": GEMINI_2_5_PRO_PREVIEW,
+            "google/gemini-2.5-pro": GEMINI_2_5_PRO_PREVIEW,
+            "@google/models/gemini-2.5-pro": GEMINI_2_5_PRO_PREVIEW,
             # Gemini 2.0 models (stable versions)
             "gemini-2.0-flash": GEMINI_2_0_FLASH,
             "gemini-2.0-flash-thinking": "gemini-2.0-flash-thinking",


### PR DESCRIPTION
## Summary
- Update Google Vertex AI model mapping to include Gemini 2.5 variants (preview, flash, pro) under the google-vertex provider.
- Keeps existing Gemini 2.0 stable mappings intact.

## Changes
### Backend/Data Transformation
- **src/services/model_transformations.py**: Replaced the previous 2.5 mapping block with explicit mappings for Gemini 2.5 variants, including:
  - gemini-2.5-flash-lite → GEMINI_2_5_FLASH_LITE_PREVIEW
  - gemini-2.5-flash-lite-preview-09-2025 → GEMINI_2_5_FLASH_LITE_PREVIEW
  - google/gemini-2.5-flash-lite → GEMINI_2_5_FLASH_LITE_PREVIEW
  - google/gemini-2.5-flash-lite-preview-09-2025 → GEMINI_2_5_FLASH_LITE_PREVIEW
  - @google/models/gemini-2.5-flash-lite → GEMINI_2_5_FLASH_LITE_PREVIEW
  - gemini-2.5-flash → GEMINI_2_5_FLASH_PREVIEW
  - gemini-2.5-flash-preview-09-2025 → GEMINI_2_5_FLASH_PREVIEW
  - gemini-2.5-flash-preview → GEMINI_2_5_FLASH_PREVIEW
  - google/gemini-2.5-flash → GEMINI_2_5_FLASH_PREVIEW
  - google/gemini-2.5-flash-preview-09-2025 → GEMINI_2_5_FLASH_PREVIEW
  - @google/models/gemini-2.5-flash → GEMINI_2_5_FLASH_PREVIEW
  - @google/models/gemini-2.5-flash-preview-09-2025 → GEMINI_2_5_FLASH_PREVIEW
  - gemini-2.5-pro → GEMINI_2_5_PRO_PREVIEW
  - gemini-2.5-pro-preview-09-2025 → GEMINI_2_5_PRO_PREVIEW
  - google/gemini-2.5-pro → GEMINI_2_5_PRO_PREVIEW
  - @google/models/gemini-2.5-pro → GEMINI_2_5_PRO_PREVIEW
- Retains existing Gemini 2.0 models (stable) mappings:
  - gemini-2.0-flash
  - gemini-2.0-flash-thinking

### Rationale
- Aligns the mapping with Google Gemini 2.5 model lineup, including preview/flux variants, ensuring the gateway serves the intended model versions.
- Preserves stable 2.0 mappings for backward compatibility.

## Testing plan
- [x] Validate that get_model_id_mapping("google-vertex") returns correct GEMINI_2_5_*_PREVIEW/PRO_PREVIEW constants for 2.5 variant keys
- [x] Verify 2.0 mappings (e.g., gemini-2.0-flash) remain intact
- [ ] Add/update unit tests to cover new 2.5 keys (if test suite exists)
- [x] Manual spot checks for a few representative keys:
  - gemini-2.5-flash-lite → GEMINI_2_5_FLASH_LITE_PREVIEW
  - gemini-2.5-flash → GEMINI_2_5_FLASH_PREVIEW
  - gemini-2.5-pro → GEMINI_2_5_PRO_PREVIEW

## Notes
- No external API changes; this is a internal mapping adjustment to reflect Google’s current model variants.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/fcdeed7c-ba75-4ebe-9f66-e29b728a7c86

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Google Vertex model mapping to resolve Gemini 2.5 variants directly to preview IDs while keeping Gemini 2.0 stable mappings.
> 
> - **Backend/Data Transformation**:
>   - **`src/services/model_transformations.py`**:
>     - Update `google-vertex` mappings to explicitly map Gemini 2.5 variants (`flash-lite`, `flash`, `pro`, including `google/` and `@google/models/` aliases) to `GEMINI_2_5_*_PREVIEW`.
>     - Remove prior remaps of 2.5 variants to `GEMINI_2_0_*`; retain existing Gemini 2.0 stable mappings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3289d480d735aabe7edd65cdfb20a3fe44251a2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->