### PR TITLE
Fix token estimation for multimodal content in chat stream

### DIFF
--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -323,7 +323,19 @@ async def stream_generator(
         if total_tokens == 0:
             # Rough estimate: 1 token ≈ 4 characters
             completion_tokens = max(1, len(accumulated_content) // 4)
-            prompt_tokens = max(1, sum(len(m.get("content", "")) for m in messages) // 4)
+
+            # Calculate prompt tokens, handling both string and multimodal content
+            prompt_chars = 0
+            for m in messages:
+                content = m.get("content", "")
+                if isinstance(content, str):
+                    prompt_chars += len(content)
+                elif isinstance(content, list):
+                    # For multimodal content, extract text parts
+                    for item in content:
+                        if isinstance(item, dict) and item.get("type") == "text":
+                            prompt_chars += len(item.get("text", ""))
+            prompt_tokens = max(1, prompt_chars // 4)
             total_tokens = prompt_tokens + completion_tokens
 
         elapsed = max(0.001, time.monotonic() - start_time)


### PR DESCRIPTION
## Summary
- Corrects token counting for prompt in stream_generator by considering multimodal content (lists with text segments) in addition to plain strings

## Changes

### Core Functionality
- In `src/routes/chat.py`, updated `prompt_tokens` calculation to:
  - accumulate `prompt_chars` across messages
  - if `content` is a string, add its length
  - if `content` is a list (multimodal), iterate and extract text parts from items with `type == "text"` and sum their lengths
- Kept `completion_tokens` and total token calculation unchanged; ensures `total_tokens = prompt_tokens + completion_tokens`, with a safe minimum of 1

### Why
- Previously, multimodal messages were not fully accounted for, leading to inaccurate token estimates. This fix provides a more accurate prompt token estimate for both text and multimodal content.

### Tests / Validation
- [x] Manual verification with messages containing multimodal content (text in lists) yields expected `prompt_tokens`
- [x] No regressions observed for plain-string content
- [ ] Add unit tests for multimodal token counting (to be added in next PR)

### Impact
- Minor calculation improvement; no API changes.

### Notes
- This change is isolated to chat streaming token estimation and does not affect message content or API interfaces.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c92ff5b2-c0f1-48b4-bbc4-24489671afea

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix prompt token estimation in `stream_generator` by counting text from multimodal `messages` (list items with `type: text`) in addition to plain strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd25800803fb2f971e9d727ae36fe5f7006a1953. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->