### PR TITLE
Add tests for cache module; fix None checks in freshness helpers

### DIFF
--- a/src/cache.py
+++ b/src/cache.py
@@ -250,7 +250,7 @@ def clear_modelz_cache():
 
 def is_cache_fresh(cache: dict) -> bool:
     """Check if cache is within fresh TTL"""
-    if not cache.get("data") or not cache.get("timestamp"):
+    if cache.get("data") is None or cache.get("timestamp") is None:
         return False
     cache_age = (datetime.now(timezone.utc) - cache["timestamp"]).total_seconds()
     return cache_age < cache.get("ttl", 3600)
@@ -258,7 +258,7 @@ def is_cache_fresh(cache: dict) -> bool:
 
 def is_cache_stale_but_usable(cache: dict) -> bool:
     """Check if cache is stale but within stale-while-revalidate window"""
-    if not cache.get("data") or not cache.get("timestamp"):
+    if cache.get("data") is None or cache.get("timestamp") is None:
         return False
     cache_age = (datetime.now(timezone.utc) - cache["timestamp"]).total_seconds()
     ttl = cache.get("ttl", 3600)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -393,8 +393,8 @@ class TestCacheStaleness:
 
     def test_cache_stale_custom_ttl(self):
         """Test stale window with custom TTL"""
-        # 25 minutes ago with 30 min TTL and 60 min stale
-        old_time = datetime.now(timezone.utc) - timedelta(minutes=25)
+        # 35 minutes ago with 30 min TTL and 60 min stale (stale but usable)
+        old_time = datetime.now(timezone.utc) - timedelta(minutes=35)
         cache = {
             "data": {"model": "test"},
             "timestamp": old_time,
@@ -505,7 +505,7 @@ class TestShouldRevalidateInBackground:
 class TestInitializeFalCache:
     """Test initialize_fal_cache_from_catalog function"""
 
-    @patch('src.cache.load_fal_models_catalog')
+    @patch('src.services.fal_image_client.load_fal_models_catalog')
     def test_initialize_fal_cache_success(self, mock_load_catalog):
         """Test successful FAL cache initialization"""
         mock_models = [
@@ -525,7 +525,7 @@ class TestInitializeFalCache:
         assert cache_module._fal_models_cache["data"] == mock_models
         assert cache_module._fal_models_cache["timestamp"] is not None
 
-    @patch('src.cache.load_fal_models_catalog')
+    @patch('src.services.fal_image_client.load_fal_models_catalog')
     def test_initialize_fal_cache_empty_catalog(self, mock_load_catalog):
         """Test FAL cache initialization with empty catalog"""
         mock_load_catalog.return_value = []
@@ -538,7 +538,7 @@ class TestInitializeFalCache:
         # Cache should remain empty
         assert cache_module._fal_models_cache["data"] is None
 
-    @patch('src.cache.load_fal_models_catalog')
+    @patch('src.services.fal_image_client.load_fal_models_catalog')
     def test_initialize_fal_cache_import_error(self, mock_load_catalog):
         """Test FAL cache initialization with import error"""
         mock_load_catalog.side_effect = ImportError("Module not found")
@@ -552,7 +552,7 @@ class TestInitializeFalCache:
         # Cache should remain None
         assert cache_module._fal_models_cache["data"] is None
 
-    @patch('src.cache.load_fal_models_catalog')
+    @patch('src.services.fal_image_client.load_fal_models_catalog')
     def test_initialize_fal_cache_os_error(self, mock_load_catalog):
         """Test FAL cache initialization with OS error"""
         mock_load_catalog.side_effect = OSError("File not found")
@@ -565,7 +565,7 @@ class TestInitializeFalCache:
 
         assert cache_module._fal_models_cache["data"] is None
 
-    @patch('src.cache.load_fal_models_catalog')
+    @patch('src.services.fal_image_client.load_fal_models_catalog')
     def test_initialize_fal_cache_timestamp_set(self, mock_load_catalog):
         """Test that FAL cache timestamp is set on successful init"""
         mock_models = [{"id": "fal-ai/test"}]


### PR DESCRIPTION
## Summary
- Introduces a full test suite for the cache module to validate initialization, retrieval, freshness, staleness, revalidation logic, and FAL cache integration.

## Changes
### Test Coverage
- Adds tests/test_cache.py with extensive unit tests for:
  - Cache initialization for models, portkey, providers, and gateway caches
  - get_models_cache by gateway, including case-insensitive lookups and aliases (e.g., hug -> huggingface)
  - get_providers_cache structure and retrieval
  - Clearing caches for individual gateways and all gateways
  - FAL cache initialization from catalog with various scenarios (success, empty catalog, ImportError, OS error) and timestamp behavior
  - Modelz cache operations (get, structure, clear)
  - Cache freshness and staleness checks:
    - is_cache_fresh
    - is_cache_stale_but_usable
    - should_revalidate_in_background
  - Integration tests for full cache lifecycle and independence between caches
  - Boundary and edge-case coverage for TTL and stale_ttl values
  - Handling invalid inputs (empty gateway, invalid gateway)
+  - Bug fix: is_cache_fresh and is_cache_stale_but_usable now treat missing data/timestamp as invalid (None checks) to prevent incorrect truthiness checks.

### Test Utilities
- Uses mocks (patch) to simulate load_fal_models_catalog and control catalog data
- Employs deterministic time checks with datetime, timezone, and timedelta to validate timestamps

### Design notes
- Emphasizes TTL and stale TTL boundary conditions to ensure correct freshness/staleness decisions
- Verifies backward compatibility alias and gateway name case-insensitivity
- Ensures errors during FAL cache initialization are gracefully handled without crashing tests

## Test plan
- [x] Run pytest to ensure all cache tests pass
- [x] Validate edge cases and boundary conditions for TTL and stale TTL
- [x] Verify FAL cache initialization handles ImportError and OS errors gracefully
- [x] Confirm cache operations remain independent across gateways
- [x] Check behavior for invalid inputs (empty/invalid gateway) does not raise

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e6460fbe-98c2-4c54-9f0b-fa0500cf9bd8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add extensive unit and integration tests for `src.cache` covering initialization, gateway retrieval, TTL freshness/staleness/revalidation, clearing ops, Modelz/FAL handling, and edge cases.
> 
> - **Tests** (`tests/test_cache.py`):
>   - Validate cache initialization and structure for `models`, `portkey`, `providers`, and all gateway-specific caches.
>   - Gateway retrieval via `get_models_cache` with case-insensitivity and alias (`hug` -> `huggingface`).
>   - Freshness logic: `is_cache_fresh`, `is_cache_stale_but_usable`, `should_revalidate_in_background`, including TTL/stale_ttl boundaries and edge cases.
>   - Clearing operations: `clear_models_cache` (per-gateway and all), `clear_providers_cache`, ensuring independence across gateways.
>   - Modelz cache: `get_modelz_cache`, structure validation, `clear_modelz_cache`.
>   - FAL cache initialization: `initialize_fal_cache_from_catalog` using mocked `load_fal_models_catalog` (success, empty, ImportError/OSError), timestamp behavior.
>   - Integration checks for full cache lifecycle and TTL variations.
+
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10a097d747c240d014e310563543b5afbe823395. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
 <!-- /CURSOR_SUMMARY -->
