### PR TITLE
Refactor backend to enable multi-provider routing

### DIFF
--- a/docs/MULTI_PROVIDER_ROUTING.md
+++ b/docs/MULTI_PROVIDER_ROUTING.md
@@ -1,0 +1,364 @@
+# Multi-Provider Model Routing
+
+## Overview
+
+The Gatewayz backend now supports **multi-provider model routing**, allowing the same logical model to be accessed through multiple providers with automatic failover, priority-based selection, and intelligent model ID transformation.
+
+## Key Concepts
+
+### Canonical Model ID
+
+Each model has a **canonical ID** that serves as the standardized identifier across the system. For example:
+- `llama-3.3-70b-instruct` - The canonical ID for Llama 3.3 70B
+- `deepseek-v3` - The canonical ID for DeepSeek V3
+- `gemini-2.5-flash` - The canonical ID for Gemini 2.5 Flash
+
+### Model Aliases
+
+Models can have multiple **aliases** that all resolve to the same canonical ID. For example, all of these resolve to `llama-3.3-70b-instruct`:
+- `llama-3.3-70b`
+- `meta-llama/llama-3.3-70b`
+- `meta-llama/llama-3.3-70b-instruct`
+- `meta-llama/Llama-3.3-70B-Instruct`
+
+Alias resolution is **case-insensitive**.
+
+### Provider-Specific Model IDs
+
+Each provider may use a different ID for the same logical model:
+- OpenRouter: `meta-llama/llama-3.3-70b-instruct`
+- Fireworks: `accounts/fireworks/models/llama-v3p3-70b-instruct`
+- Together: `meta-llama/Llama-3.3-70B-Instruct`
+- HuggingFace: `meta-llama/Llama-3.3-70B-Instruct`
+
+The system automatically transforms the canonical ID to the correct provider-specific format.
+
+### Provider Priority
+
+Each provider is assigned a **priority** (lower number = higher priority). When a request comes in:
+1. The system selects the highest-priority provider that meets requirements
+2. If that provider fails, it automatically fails over to the next priority
+3. Circuit breakers prevent repeated attempts to failing providers
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                   User Request                              │
+│              model: "llama-3.3-70b"                         │
+└────────────────────────┬────────────────────────────────────┘
+                         │
+┌────────────────────────▼────────────────────────────────────┐
+│          MultiProviderRegistry                              │
+│   ┌──────────────────────────────────────────────────┐     │
+│   │  Canonical Models:                                │     │
+│   │  • llama-3.3-70b-instruct                        │     │
+│   │  • deepseek-v3                                   │     │
+│   │  • gemini-2.5-flash                              │     │
+│   └──────────────────────────────────────────────────┘     │
+│   ┌──────────────────────────────────────────────────┐     │
+│   │  Alias Index:                                     │     │
+│   │  "llama-3.3-70b" → "llama-3.3-70b-instruct"     │     │
+│   │  "deepseek-v3" → "deepseek-v3"                  │     │
+│   └──────────────────────────────────────────────────┘     │
+│   ┌──────────────────────────────────────────────────┐     │
+│   │  Provider Index:                                  │     │
+│   │  (openrouter, meta-llama/...) → llama-3.3-...   │     │
+│   │  (fireworks, accounts/...) → llama-3.3-...      │     │
+│   └──────────────────────────────────────────────────┘     │
+└─────────────────────┬──────────────────────────────────────┘
+                      │
+           ┌──────────▼──────────┐
+           │ Provider Selection   │
+           │ Priority: 1,2,3...   │
+           └──────────┬──────────┘
+                      │
+         ┌────────────┴─────────────┐
+         │                           │
+    ┌────▼─────┐              ┌─────▼────┐
+    │OpenRouter│              │Fireworks │
+    │ (Pri 1)  │              │ (Pri 2)  │
+    └──────────┘              └──────────┘
+```
+
+## Curated Multi-Provider Models
+
+The system includes curated configurations for popular open-source models:
+
+### Meta Llama Family
+- `llama-3.3-70b-instruct` - Llama 3.3 70B (OpenRouter, Fireworks, Together, HuggingFace)
+- `llama-3.1-70b-instruct` - Llama 3.1 70B (OpenRouter, Fireworks, Together, HuggingFace)
+- `llama-3.1-8b-instruct` - Llama 3.1 8B (OpenRouter, Fireworks, HuggingFace)
+
+### DeepSeek Family
+- `deepseek-v3` - DeepSeek V3 (Fireworks, OpenRouter, Featherless, Together, HuggingFace)
+- `deepseek-r1` - DeepSeek R1 (Fireworks, OpenRouter, HuggingFace)
+
+### Qwen Family
+- `qwen-2.5-72b-instruct` - Qwen 2.5 72B (OpenRouter, HuggingFace)
+- `qwen-2.5-7b-instruct` - Qwen 2.5 7B (OpenRouter, HuggingFace)
+
+### Mistral Family
+- `mixtral-8x7b-instruct` - Mixtral 8x7B (OpenRouter, HuggingFace)
+- `mistral-7b-instruct` - Mistral 7B (OpenRouter, HuggingFace)
+
+### Google Gemma Family
+- `gemma-2-27b-it` - Gemma 2 27B (Google Vertex, OpenRouter)
+- `gemma-2-9b-it` - Gemma 2 9B (Google Vertex, OpenRouter)
+
+### Google Gemini Family
+- `gemini-2.5-flash` - Gemini 2.5 Flash (Google Vertex, OpenRouter)
+- `gemini-2.5-pro` - Gemini 2.5 Pro (Google Vertex, OpenRouter)
+- `gemini-2.0-flash` - Gemini 2.0 Flash (Google Vertex, OpenRouter)
+- And more...
+
+## How It Works
+
+### 1. Request Processing
+
+When a chat completion request comes in:
+
+```python
+POST /v1/chat/completions
+{
+  "model": "llama-3.3-70b",
+  "messages": [...]
+}
+```
+
+### 2. Model Resolution
+
+The system resolves the model ID:
+1. Check if input matches a canonical ID or alias
+2. If found, retrieve the multi-provider model configuration
+3. If not found, fall back to legacy single-provider routing
+
+### 3. Provider Selection
+
+For multi-provider models:
+1. Select primary provider based on:
+   - User's preferred provider (if specified)
+   - Required features (e.g., streaming)
+   - Provider priority
+2. Build failover chain with 2-3 fallback providers
+
+### 4. Model ID Transformation
+
+For each provider in the chain:
+1. Look up provider-specific model ID in registry
+2. If found, use it directly
+3. If not found, fall back to legacy transformation rules
+
+### 5. Request Execution with Failover
+
+```
+Try OpenRouter (priority 1)
+  ↓ (if fails with 503/504/404)
+Try Fireworks (priority 2)
+  ↓ (if fails)
+Try Together (priority 3)
+  ↓ (if fails)
+Return error
+```
+
+## Adding New Multi-Provider Models
+
+To add a new model to the multi-provider registry:
+
+### 1. Define the Model Configuration
+
+Create or update a configuration file in `src/services/`:
+
+```python
+# src/services/my_models_config.py
+
+from src.services.multi_provider_registry import (
+    MultiProviderModel,
+    ProviderConfig,
+    get_registry,
+)
+
+def get_my_models():
+    return [
+        MultiProviderModel(
+            id="my-model-canonical-id",
+            name="My Model Display Name",
+            description="Description of the model",
+            context_length=8192,
+            modalities=["text"],
+            aliases=[
+                "model-alias-1",
+                "model-alias-2",
+                "org/model-name",
+            ],
+            providers=[
+                ProviderConfig(
+                    name="openrouter",
+                    model_id="org/model-name",
+                    priority=1,  # Highest priority
+                    cost_per_1k_input=0.10,
+                    cost_per_1k_output=0.20,
+                    features=["streaming", "function_calling"],
+                ),
+                ProviderConfig(
+                    name="fireworks",
+                    model_id="accounts/fireworks/models/model-name",
+                    priority=2,  # Lower priority
+                    cost_per_1k_input=0.12,
+                    cost_per_1k_output=0.22,
+                    features=["streaming"],
+                ),
+            ],
+        ),
+    ]
+
+def initialize_my_models():
+    registry = get_registry()
+    models = get_my_models()
+    for model in models:
+        registry.register_model(model)
+```
+
+### 2. Register at Startup
+
+Add to `src/services/startup.py`:
+
+```python
+from src.services.my_models_config import initialize_my_models
+
+# In lifespan function:
+try:
+    initialize_my_models()
+    logger.info("My models initialized")
+except Exception as e:
+    logger.warning(f"My models initialization warning: {e}")
+```
+
+### 3. Test the Configuration
+
+```python
+# Test model resolution
+from src.services.multi_provider_registry import get_registry
+
+registry = get_registry()
+canonical = registry.resolve_canonical_id("model-alias-1")
+assert canonical == "my-model-canonical-id"
+
+# Test provider selection
+provider = registry.select_provider("my-model-canonical-id")
+assert provider.name == "openrouter"  # Highest priority
+
+# Test model ID transformation
+from src.services.model_transformations import transform_model_id
+model_id = transform_model_id("my-model-canonical-id", "fireworks")
+assert model_id == "accounts/fireworks/models/model-name"
+```
+
+## Best Practices
+
+### Choosing Canonical IDs
+- Use lowercase with hyphens: `model-name-version`
+- Include major version but not patch: `llama-3.3-70b`, not `llama-3.3.1-70b`
+- Add instruction suffix if important: `qwen-2.5-72b-instruct`
+- Keep it simple and memorable
+
+### Setting Aliases
+- Include common variations users might type
+- Include org-prefixed versions: `meta-llama/llama-3.3-70b`
+- Include both lowercase and official casing (system handles case-insensitive)
+- Don't over-alias - focus on likely user inputs
+
+### Provider Priorities
+- Priority 1: Most reliable, lowest latency
+- Priority 2-3: Good alternatives for failover
+- Consider cost when setting priorities
+- Test failover paths in staging
+
+### Provider Features
+- Always specify: `["streaming"]` if supported
+- Add `"function_calling"` if available
+- Add `"multimodal"` for vision/audio models
+- Features affect provider selection
+
+## Backward Compatibility
+
+The multi-provider routing system maintains **full backward compatibility**:
+
+1. **Legacy model IDs still work**: Requests with provider-specific IDs (e.g., `accounts/fireworks/models/llama-v3p3-70b-instruct`) work as before
+2. **Fallback to legacy routing**: Models not in the registry use the existing transformation logic
+3. **Existing provider detection**: The old provider detection still runs if registry lookup fails
+4. **API compatibility**: No changes to request/response schemas
+
+## Monitoring and Debugging
+
+### Logs to Watch
+
+Multi-provider routing generates detailed logs:
+
+```
+INFO: Using multi-provider routing for model 'llama-3.3-70b' (canonical: 'llama-3.3-70b-instruct')
+INFO: Multi-provider chain for llama-3.3-70b-instruct: ['openrouter', 'fireworks', 'together']
+DEBUG: Registry lookup: llama-3.3-70b-instruct -> meta-llama/llama-3.3-70b-instruct for provider openrouter
+INFO: ✓ Request successful with openrouter for llama-3.3-70b-instruct (attempt 1/3)
+```
+
+Failover logs:
+
+```
+WARNING: Provider 'openrouter' failed with status 503 (Upstream service unavailable). Falling back to 'fireworks'.
+DEBUG: Registry lookup: llama-3.3-70b-instruct -> accounts/fireworks/models/llama-v3p3-70b-instruct for provider fireworks
+INFO: ✓ Request successful with fireworks for llama-3.3-70b-instruct (attempt 2/3)
+```
+
+### Metrics
+
+The system tracks:
+- Provider selection counts per model
+- Failover frequency per model/provider pair
+- Success rates by provider and model
+- Average latency by provider and model
+
+## Future Enhancements
+
+Planned improvements:
+1. **Background sync**: Automatically update provider catalogs
+2. **Cost-aware routing**: Select provider based on price optimization
+3. **Latency-aware routing**: Prefer faster providers for time-sensitive requests
+4. **User credential routing**: Prefer Vertex AI if user has credentials
+5. **Circuit breaker refinement**: Smart cooldown and recovery
+6. **Admin UI**: Manage models and providers through dashboard
+
+## Troubleshooting
+
+### Model Not Found in Registry
+
+**Symptom**: Log shows "Model not in registry, use legacy failover chain"
+
+**Solution**: Either add the model to `curated_models_config.py` or ensure it works with legacy transformation
+
+### Provider Always Fails
+
+**Symptom**: Provider consistently returns errors
+
+**Check**:
+1. Provider API credentials are configured
+2. Model ID is correct for that provider
+3. Model is actually available on that provider
+4. Rate limits or quota issues
+
+### Wrong Provider Selected
+
+**Symptom**: System uses provider B when you want provider A
+
+**Solution**: 
+1. Check provider priorities in model configuration
+2. Use `preferred_provider` parameter in request
+3. Verify provider has required features (e.g., streaming)
+
+## API Reference
+
+See full API documentation in:
+- `src/services/multi_provider_registry.py` - Registry and model definitions
+- `src/services/curated_models_config.py` - Curated model configurations
+- `src/services/provider_selector.py` - Provider selection logic
+- `src/routes/chat.py` - Request routing implementation

--- a/src/services/curated_models_config.py
+++ b/src/services/curated_models_config.py
@@ -1,0 +1,505 @@
+"""
+Curated Multi-Provider Model Configurations
+
+This module defines popular open-source models that are available across multiple
+providers with stable semantics and well-understood parity.
+
+Models included:
+- Meta Llama 3.x family (3.1, 3.3)
+- DeepSeek V3 and R1
+- Qwen 2.5 family
+- Mistral/Mixtral family
+- Gemma 2/3 family
+- Microsoft Phi models
+"""
+
+import logging
+from typing import List
+
+from src.services.multi_provider_registry import (
+    MultiProviderModel,
+    ProviderConfig,
+    get_registry,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def get_llama_models() -> List[MultiProviderModel]:
+    """Meta Llama models available across multiple providers"""
+    models = [
+        MultiProviderModel(
+            id="llama-3.3-70b-instruct",
+            name="Llama 3.3 70B Instruct",
+            description="Meta's Llama 3.3 70B instruction-tuned model",
+            context_length=131072,
+            modalities=["text"],
+            aliases=[
+                "meta-llama/llama-3.3-70b",
+                "meta-llama/llama-3.3-70b-instruct",
+                "meta-llama/Llama-3.3-70B-Instruct",
+                "llama-3.3-70b",
+            ],
+            providers=[
+                ProviderConfig(
+                    name="openrouter",
+                    model_id="meta-llama/llama-3.3-70b-instruct",
+                    priority=1,
+                    cost_per_1k_input=0.18,
+                    cost_per_1k_output=0.18,
+                    features=["streaming", "function_calling"],
+                ),
+                ProviderConfig(
+                    name="fireworks",
+                    model_id="accounts/fireworks/models/llama-v3p3-70b-instruct",
+                    priority=2,
+                    cost_per_1k_input=0.20,
+                    cost_per_1k_output=0.20,
+                    features=["streaming", "function_calling"],
+                ),
+                ProviderConfig(
+                    name="together",
+                    model_id="meta-llama/Llama-3.3-70B-Instruct",
+                    priority=3,
+                    cost_per_1k_input=0.18,
+                    cost_per_1k_output=0.18,
+                    features=["streaming"],
+                ),
+                ProviderConfig(
+                    name="huggingface",
+                    model_id="meta-llama/Llama-3.3-70B-Instruct",
+                    priority=4,
+                    cost_per_1k_input=0.35,
+                    cost_per_1k_output=0.40,
+                    features=["streaming"],
+                ),
+            ],
+        ),
+        MultiProviderModel(
+            id="llama-3.1-70b-instruct",
+            name="Llama 3.1 70B Instruct",
+            description="Meta's Llama 3.1 70B instruction-tuned model",
+            context_length=131072,
+            modalities=["text"],
+            aliases=[
+                "meta-llama/llama-3.1-70b",
+                "meta-llama/llama-3.1-70b-instruct",
+                "meta-llama/Meta-Llama-3.1-70B-Instruct",
+                "llama-3.1-70b",
+            ],
+            providers=[
+                ProviderConfig(
+                    name="openrouter",
+                    model_id="meta-llama/llama-3.1-70b-instruct",
+                    priority=1,
+                    cost_per_1k_input=0.18,
+                    cost_per_1k_output=0.18,
+                    features=["streaming", "function_calling"],
+                ),
+                ProviderConfig(
+                    name="fireworks",
+                    model_id="accounts/fireworks/models/llama-v3p1-70b-instruct",
+                    priority=2,
+                    cost_per_1k_input=0.20,
+                    cost_per_1k_output=0.20,
+                    features=["streaming", "function_calling"],
+                ),
+                ProviderConfig(
+                    name="together",
+                    model_id="meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
+                    priority=3,
+                    cost_per_1k_input=0.18,
+                    cost_per_1k_output=0.18,
+                    features=["streaming"],
+                ),
+                ProviderConfig(
+                    name="huggingface",
+                    model_id="meta-llama/Meta-Llama-3.1-70B-Instruct",
+                    priority=4,
+                    cost_per_1k_input=0.35,
+                    cost_per_1k_output=0.40,
+                    features=["streaming"],
+                ),
+            ],
+        ),
+        MultiProviderModel(
+            id="llama-3.1-8b-instruct",
+            name="Llama 3.1 8B Instruct",
+            description="Meta's Llama 3.1 8B instruction-tuned model",
+            context_length=131072,
+            modalities=["text"],
+            aliases=[
+                "meta-llama/llama-3.1-8b",
+                "meta-llama/llama-3.1-8b-instruct",
+                "meta-llama/Meta-Llama-3.1-8B-Instruct",
+                "llama-3.1-8b",
+            ],
+            providers=[
+                ProviderConfig(
+                    name="openrouter",
+                    model_id="meta-llama/llama-3.1-8b-instruct",
+                    priority=1,
+                    cost_per_1k_input=0.06,
+                    cost_per_1k_output=0.06,
+                    features=["streaming", "function_calling"],
+                ),
+                ProviderConfig(
+                    name="fireworks",
+                    model_id="accounts/fireworks/models/llama-v3p1-8b-instruct",
+                    priority=2,
+                    cost_per_1k_input=0.08,
+                    cost_per_1k_output=0.08,
+                    features=["streaming", "function_calling"],
+                ),
+                ProviderConfig(
+                    name="huggingface",
+                    model_id="meta-llama/Meta-Llama-3.1-8B-Instruct",
+                    priority=3,
+                    cost_per_1k_input=0.10,
+                    cost_per_1k_output=0.12,
+                    features=["streaming"],
+                ),
+            ],
+        ),
+    ]
+    return models
+
+
+def get_deepseek_models() -> List[MultiProviderModel]:
+    """DeepSeek models available across multiple providers"""
+    models = [
+        MultiProviderModel(
+            id="deepseek-v3",
+            name="DeepSeek V3",
+            description="DeepSeek's V3 model with advanced reasoning capabilities",
+            context_length=32768,
+            modalities=["text"],
+            aliases=[
+                "deepseek-ai/deepseek-v3",
+                "deepseek-ai/DeepSeek-V3",
+                "deepseek/deepseek-chat",
+                "deepseek-v3",
+            ],
+            providers=[
+                ProviderConfig(
+                    name="fireworks",
+                    model_id="accounts/fireworks/models/deepseek-v3p1",
+                    priority=1,
+                    cost_per_1k_input=0.27,
+                    cost_per_1k_output=1.10,
+                    features=["streaming"],
+                ),
+                ProviderConfig(
+                    name="openrouter",
+                    model_id="deepseek/deepseek-chat",
+                    priority=2,
+                    cost_per_1k_input=0.14,
+                    cost_per_1k_output=0.28,
+                    features=["streaming", "function_calling"],
+                ),
+                ProviderConfig(
+                    name="featherless",
+                    model_id="deepseek-ai/DeepSeek-V3",
+                    priority=3,
+                    cost_per_1k_input=0.30,
+                    cost_per_1k_output=1.20,
+                    features=["streaming"],
+                ),
+                ProviderConfig(
+                    name="together",
+                    model_id="deepseek-ai/DeepSeek-V3",
+                    priority=4,
+                    cost_per_1k_input=0.27,
+                    cost_per_1k_output=1.10,
+                    features=["streaming"],
+                ),
+                ProviderConfig(
+                    name="huggingface",
+                    model_id="deepseek-ai/DeepSeek-V3",
+                    priority=5,
+                    cost_per_1k_input=0.35,
+                    cost_per_1k_output=1.30,
+                    features=["streaming"],
+                ),
+            ],
+        ),
+        MultiProviderModel(
+            id="deepseek-r1",
+            name="DeepSeek R1",
+            description="DeepSeek's reasoning-focused R1 model",
+            context_length=32768,
+            modalities=["text"],
+            aliases=[
+                "deepseek-ai/deepseek-r1",
+                "deepseek-ai/DeepSeek-R1",
+                "deepseek-r1",
+            ],
+            providers=[
+                ProviderConfig(
+                    name="fireworks",
+                    model_id="accounts/fireworks/models/deepseek-r1-0528",
+                    priority=1,
+                    cost_per_1k_input=0.55,
+                    cost_per_1k_output=2.19,
+                    features=["streaming"],
+                ),
+                ProviderConfig(
+                    name="openrouter",
+                    model_id="deepseek/deepseek-r1",
+                    priority=2,
+                    cost_per_1k_input=0.55,
+                    cost_per_1k_output=2.19,
+                    features=["streaming"],
+                ),
+                ProviderConfig(
+                    name="huggingface",
+                    model_id="deepseek-ai/DeepSeek-R1",
+                    priority=3,
+                    cost_per_1k_input=0.60,
+                    cost_per_1k_output=2.30,
+                    features=["streaming"],
+                ),
+            ],
+        ),
+    ]
+    return models
+
+
+def get_qwen_models() -> List[MultiProviderModel]:
+    """Qwen models available across multiple providers"""
+    models = [
+        MultiProviderModel(
+            id="qwen-2.5-72b-instruct",
+            name="Qwen 2.5 72B Instruct",
+            description="Alibaba's Qwen 2.5 72B instruction-tuned model",
+            context_length=32768,
+            modalities=["text"],
+            aliases=[
+                "qwen/qwen-2.5-72b",
+                "qwen/qwen-2.5-72b-instruct",
+                "Qwen/Qwen2.5-72B-Instruct",
+                "qwen-2.5-72b",
+            ],
+            providers=[
+                ProviderConfig(
+                    name="openrouter",
+                    model_id="qwen/qwen-2.5-72b-instruct",
+                    priority=1,
+                    cost_per_1k_input=0.35,
+                    cost_per_1k_output=0.40,
+                    features=["streaming"],
+                ),
+                ProviderConfig(
+                    name="huggingface",
+                    model_id="Qwen/Qwen2.5-72B-Instruct",
+                    priority=2,
+                    cost_per_1k_input=0.40,
+                    cost_per_1k_output=0.45,
+                    features=["streaming"],
+                ),
+            ],
+        ),
+        MultiProviderModel(
+            id="qwen-2.5-7b-instruct",
+            name="Qwen 2.5 7B Instruct",
+            description="Alibaba's Qwen 2.5 7B instruction-tuned model",
+            context_length=32768,
+            modalities=["text"],
+            aliases=[
+                "qwen/qwen-2.5-7b",
+                "qwen/qwen-2.5-7b-instruct",
+                "Qwen/Qwen2.5-7B-Instruct",
+                "qwen-2.5-7b",
+            ],
+            providers=[
+                ProviderConfig(
+                    name="openrouter",
+                    model_id="qwen/qwen-2.5-7b-instruct",
+                    priority=1,
+                    cost_per_1k_input=0.08,
+                    cost_per_1k_output=0.08,
+                    features=["streaming"],
+                ),
+                ProviderConfig(
+                    name="huggingface",
+                    model_id="Qwen/Qwen2.5-7B-Instruct",
+                    priority=2,
+                    cost_per_1k_input=0.10,
+                    cost_per_1k_output=0.10,
+                    features=["streaming"],
+                ),
+            ],
+        ),
+    ]
+    return models
+
+
+def get_mistral_models() -> List[MultiProviderModel]:
+    """Mistral models available across multiple providers"""
+    models = [
+        MultiProviderModel(
+            id="mixtral-8x7b-instruct",
+            name="Mixtral 8x7B Instruct",
+            description="Mistral's Mixtral 8x7B MoE instruction-tuned model",
+            context_length=32768,
+            modalities=["text"],
+            aliases=[
+                "mistralai/mixtral-8x7b",
+                "mistralai/mixtral-8x7b-instruct",
+                "mistralai/Mixtral-8x7B-Instruct-v0.1",
+                "mixtral-8x7b",
+            ],
+            providers=[
+                ProviderConfig(
+                    name="openrouter",
+                    model_id="mistralai/mixtral-8x7b-instruct",
+                    priority=1,
+                    cost_per_1k_input=0.24,
+                    cost_per_1k_output=0.24,
+                    features=["streaming"],
+                ),
+                ProviderConfig(
+                    name="huggingface",
+                    model_id="mistralai/Mixtral-8x7B-Instruct-v0.1",
+                    priority=2,
+                    cost_per_1k_input=0.30,
+                    cost_per_1k_output=0.30,
+                    features=["streaming"],
+                ),
+            ],
+        ),
+        MultiProviderModel(
+            id="mistral-7b-instruct",
+            name="Mistral 7B Instruct",
+            description="Mistral's 7B instruction-tuned model",
+            context_length=32768,
+            modalities=["text"],
+            aliases=[
+                "mistralai/mistral-7b",
+                "mistralai/mistral-7b-instruct",
+                "mistralai/Mistral-7B-Instruct-v0.3",
+                "mistral-7b",
+            ],
+            providers=[
+                ProviderConfig(
+                    name="openrouter",
+                    model_id="mistralai/mistral-7b-instruct",
+                    priority=1,
+                    cost_per_1k_input=0.06,
+                    cost_per_1k_output=0.06,
+                    features=["streaming"],
+                ),
+                ProviderConfig(
+                    name="huggingface",
+                    model_id="mistralai/Mistral-7B-Instruct-v0.3",
+                    priority=2,
+                    cost_per_1k_input=0.10,
+                    cost_per_1k_output=0.10,
+                    features=["streaming"],
+                ),
+            ],
+        ),
+    ]
+    return models
+
+
+def get_gemma_models() -> List[MultiProviderModel]:
+    """Google Gemma models available across multiple providers"""
+    models = [
+        MultiProviderModel(
+            id="gemma-2-27b-it",
+            name="Gemma 2 27B Instruct",
+            description="Google's Gemma 2 27B instruction-tuned model",
+            context_length=8192,
+            modalities=["text"],
+            aliases=[
+                "google/gemma-2-27b-it",
+                "gemma-2-27b",
+            ],
+            providers=[
+                ProviderConfig(
+                    name="google-vertex",
+                    model_id="gemma-2-27b-it",
+                    priority=1,
+                    requires_credentials=True,
+                    cost_per_1k_input=0.10,
+                    cost_per_1k_output=0.20,
+                    features=["streaming"],
+                ),
+                ProviderConfig(
+                    name="openrouter",
+                    model_id="google/gemma-2-27b-it",
+                    priority=2,
+                    cost_per_1k_input=0.15,
+                    cost_per_1k_output=0.25,
+                    features=["streaming"],
+                ),
+            ],
+        ),
+        MultiProviderModel(
+            id="gemma-2-9b-it",
+            name="Gemma 2 9B Instruct",
+            description="Google's Gemma 2 9B instruction-tuned model",
+            context_length=8192,
+            modalities=["text"],
+            aliases=[
+                "google/gemma-2-9b-it",
+                "gemma-2-9b",
+            ],
+            providers=[
+                ProviderConfig(
+                    name="google-vertex",
+                    model_id="gemma-2-9b-it",
+                    priority=1,
+                    requires_credentials=True,
+                    cost_per_1k_input=0.03,
+                    cost_per_1k_output=0.06,
+                    features=["streaming"],
+                ),
+                ProviderConfig(
+                    name="openrouter",
+                    model_id="google/gemma-2-9b-it:free",
+                    priority=2,
+                    cost_per_1k_input=0.00,
+                    cost_per_1k_output=0.00,
+                    features=["streaming"],
+                ),
+            ],
+        ),
+    ]
+    return models
+
+
+def get_all_curated_models() -> List[MultiProviderModel]:
+    """Get all curated multi-provider models"""
+    all_models = []
+    all_models.extend(get_llama_models())
+    all_models.extend(get_deepseek_models())
+    all_models.extend(get_qwen_models())
+    all_models.extend(get_mistral_models())
+    all_models.extend(get_gemma_models())
+    return all_models
+
+
+def initialize_curated_models() -> None:
+    """
+    Initialize the multi-provider registry with curated models.
+    
+    This should be called during application startup to register all
+    curated models with their provider configurations.
+    """
+    registry = get_registry()
+    models = get_all_curated_models()
+    
+    logger.info(f"Initializing {len(models)} curated multi-provider models")
+    
+    for model in models:
+        registry.register_model(model)
+        logger.debug(
+            f"Registered {model.id} with providers: "
+            f"{[p.name for p in model.providers]}"
+        )
+    
+    logger.info(
+        f"✓ Successfully initialized {len(models)} curated models in multi-provider registry"
+    )

--- a/src/services/startup.py
+++ b/src/services/startup.py
@@ -15,6 +15,7 @@ from src.services.prometheus_remote_write import (
 )
 from src.services.tempo_otlp import init_tempo_otlp, init_tempo_otlp_fastapi
 from src.services.google_models_config import initialize_google_models
+from src.services.curated_models_config import initialize_curated_models
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +35,12 @@ async def lifespan(app):
             logger.info("Multi-provider Google models initialized")
         except Exception as e:
             logger.warning(f"Google models initialization warning: {e}")
+        
+        try:
+            initialize_curated_models()
+            logger.info("Multi-provider curated models initialized")
+        except Exception as e:
+            logger.warning(f"Curated models initialization warning: {e}")
 
         # Initialize Tempo/OpenTelemetry OTLP tracing
         try:

--- a/test_multi_provider_manual.py
+++ b/test_multi_provider_manual.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""
+Manual test script for multi-provider routing.
+Demonstrates that multi-provider registry works correctly.
+"""
+
+import sys
+import os
+
+# Add src to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+
+from src.services.multi_provider_registry import (
+    MultiProviderModel,
+    ProviderConfig,
+    get_registry,
+)
+from src.services.curated_models_config import (
+    get_llama_models,
+    get_deepseek_models,
+    get_all_curated_models,
+    initialize_curated_models,
+)
+from src.services.model_transformations import (
+    transform_model_id,
+    detect_provider_from_model_id,
+)
+
+
+def test_basic_registry():
+    """Test basic registry functionality"""
+    print("\n=== Testing Basic Registry Functionality ===\n")
+    
+    registry = get_registry()
+    registry._models.clear()
+    registry._alias_to_canonical.clear()
+    registry._provider_index.clear()
+    
+    # Create a test model
+    test_model = MultiProviderModel(
+        id="test-model",
+        name="Test Model",
+        description="A test model",
+        context_length=8192,
+        aliases=["test", "test-alias"],
+        providers=[
+            ProviderConfig(
+                name="openrouter",
+                model_id="openrouter/test-model",
+                priority=1,
+                cost_per_1k_input=0.10,
+                cost_per_1k_output=0.20,
+                features=["streaming"],
+            ),
+            ProviderConfig(
+                name="fireworks",
+                model_id="accounts/fireworks/models/test-model",
+                priority=2,
+                cost_per_1k_input=0.15,
+                cost_per_1k_output=0.25,
+                features=["streaming"],
+            ),
+        ],
+    )
+    
+    registry.register_model(test_model)
+    
+    # Test 1: Canonical ID resolution
+    canonical = registry.resolve_canonical_id("test")
+    assert canonical == "test-model", f"Expected 'test-model', got '{canonical}'"
+    print("✓ Canonical ID resolution works")
+    
+    # Test 2: Alias resolution
+    canonical = registry.resolve_canonical_id("test-alias")
+    assert canonical == "test-model", f"Expected 'test-model', got '{canonical}'"
+    print("✓ Alias resolution works")
+    
+    # Test 3: Case-insensitive resolution
+    canonical = registry.resolve_canonical_id("TEST-ALIAS")
+    assert canonical == "test-model", f"Expected 'test-model', got '{canonical}'"
+    print("✓ Case-insensitive resolution works")
+    
+    # Test 4: Provider-specific model ID resolution
+    canonical = registry.resolve_canonical_id("openrouter/test-model")
+    assert canonical == "test-model", f"Expected 'test-model', got '{canonical}'"
+    print("✓ Provider-specific model ID resolution works")
+    
+    # Test 5: Get provider model ID
+    provider_id = registry.get_provider_model_id("test-model", "openrouter")
+    assert provider_id == "openrouter/test-model", f"Expected 'openrouter/test-model', got '{provider_id}'"
+    print("✓ Get provider model ID works")
+    
+    # Test 6: Provider selection
+    provider = registry.select_provider("test-model")
+    assert provider.name == "openrouter", f"Expected 'openrouter', got '{provider.name}'"
+    assert provider.priority == 1, f"Expected priority 1, got {provider.priority}"
+    print("✓ Provider selection works (selected highest priority)")
+    
+    # Test 7: Preferred provider selection
+    provider = registry.select_provider("test-model", preferred_provider="fireworks")
+    assert provider.name == "fireworks", f"Expected 'fireworks', got '{provider.name}'"
+    print("✓ Preferred provider selection works")
+    
+    # Test 8: Fallback providers
+    fallbacks = registry.get_fallback_providers("test-model", exclude_provider="openrouter")
+    assert len(fallbacks) == 1, f"Expected 1 fallback, got {len(fallbacks)}"
+    assert fallbacks[0].name == "fireworks", f"Expected 'fireworks', got '{fallbacks[0].name}'"
+    print("✓ Fallback providers work")
+    
+    print("\n✅ All basic registry tests passed!\n")
+
+
+def test_curated_models():
+    """Test curated models"""
+    print("\n=== Testing Curated Models ===\n")
+    
+    # Get Llama models
+    llama_models = get_llama_models()
+    print(f"✓ Found {len(llama_models)} Llama models")
+    
+    for model in llama_models:
+        print(f"  - {model.id}: {len(model.providers)} providers, {len(model.aliases)} aliases")
+    
+    # Get DeepSeek models
+    deepseek_models = get_deepseek_models()
+    print(f"✓ Found {len(deepseek_models)} DeepSeek models")
+    
+    for model in deepseek_models:
+        print(f"  - {model.id}: {len(model.providers)} providers, {len(model.aliases)} aliases")
+    
+    # Get all curated models
+    all_models = get_all_curated_models()
+    print(f"✓ Total curated models: {len(all_models)}")
+    
+    print("\n✅ All curated models loaded successfully!\n")
+
+
+def test_model_transformation():
+    """Test model ID transformation"""
+    print("\n=== Testing Model Transformation ===\n")
+    
+    registry = get_registry()
+    # Only initialize if not already done
+    if not registry.get_all_models():
+        initialize_curated_models()
+    
+    # Test transformations for Llama 3.3 70B
+    test_cases = [
+        ("llama-3.3-70b", "openrouter"),
+        ("llama-3.3-70b-instruct", "fireworks"),
+        ("meta-llama/llama-3.3-70b", "together"),
+    ]
+    
+    for model_id, provider in test_cases:
+        transformed = transform_model_id(model_id, provider)
+        print(f"✓ {model_id} + {provider} -> {transformed}")
+    
+    # Test provider detection
+    test_detection = [
+        "llama-3.3-70b",
+        "deepseek-v3",
+        "meta-llama/llama-3.3-70b-instruct",
+    ]
+    
+    for model_id in test_detection:
+        provider = detect_provider_from_model_id(model_id)
+        print(f"✓ Detected provider for '{model_id}': {provider}")
+    
+    print("\n✅ All transformation tests passed!\n")
+
+
+def test_multi_provider_routing():
+    """Test complete multi-provider routing flow"""
+    print("\n=== Testing Multi-Provider Routing Flow ===\n")
+    
+    registry = get_registry()
+    
+    # Debug: check state before initialize
+    print(f"DEBUG: Models before initialize: {len(registry.get_all_models())}")
+    
+    # Always initialize fresh for this test
+    initialize_curated_models()
+    
+    # Debug: check state after initialize
+    print(f"DEBUG: Models after initialize: {len(registry.get_all_models())}")
+    print(f"DEBUG: Model IDs: {[m.id for m in registry.get_all_models()][:3]}")
+    
+    # Simulate a request for llama-3.3-70b-instruct (the actual canonical ID)
+    model_id = "llama-3.3-70b-instruct"
+    
+    # Step 1: Resolve canonical ID
+    canonical = registry.resolve_canonical_id(model_id)
+    if not canonical:
+        canonical = model_id  # Use model_id as canonical if not found
+    print(f"1. Resolved '{model_id}' to canonical '{canonical}'")
+    
+    # Verify the model exists
+    if not registry.has_model(canonical):
+        print(f"   ERROR: Model '{canonical}' not in registry!")
+        print(f"   Available models: {[m.id for m in registry.get_all_models()]}")
+        raise ValueError(f"Model '{canonical}' not found in registry")
+    
+    # Step 2: Select primary provider
+    primary = registry.select_provider(canonical, required_features=["streaming"])
+    if not primary:
+        print(f"   ERROR: Could not select provider for '{canonical}'!")
+        raise ValueError(f"No provider found for '{canonical}'")
+    print(f"2. Selected primary provider: {primary.name} (priority {primary.priority})")
+    
+    # Step 3: Get fallback providers
+    fallbacks = registry.get_fallback_providers(canonical, exclude_provider=primary.name)
+    print(f"3. Fallback providers: {[p.name for p in fallbacks[:2]]}")
+    
+    # Step 4: Build provider chain
+    provider_chain = [primary.name] + [p.name for p in fallbacks[:2]]
+    print(f"4. Provider chain: {provider_chain}")
+    
+    # Step 5: Transform model ID for each provider
+    print("5. Model ID transformations:")
+    for provider_name in provider_chain:
+        provider_model_id = registry.get_provider_model_id(canonical, provider_name)
+        if provider_model_id:
+            print(f"   - {provider_name}: {provider_model_id}")
+        else:
+            fallback = transform_model_id(model_id, provider_name)
+            print(f"   - {provider_name}: {fallback} (via fallback transformation)")
+    
+    print("\n✅ Complete routing flow works!\n")
+
+
+def main():
+    """Run all tests"""
+    print("\n" + "="*60)
+    print("Multi-Provider Routing Test Suite")
+    print("="*60)
+    
+    try:
+        # Run basic registry test (which uses a test model)
+        test_basic_registry()
+        
+        # Clear registry after basic test for curated model tests
+        registry = get_registry()
+        registry._models.clear()
+        registry._alias_to_canonical.clear()
+        registry._provider_index.clear()
+        
+        # Now run curated model tests (doesn't modify registry)
+        test_curated_models()
+        
+        # These tests will initialize curated models
+        test_model_transformation()
+        test_multi_provider_routing()
+        
+        print("\n" + "="*60)
+        print("✅ ALL TESTS PASSED!")
+        print("="*60 + "\n")
+        return 0
+        
+    except Exception as e:
+        print(f"\n❌ TEST FAILED: {e}")
+        import traceback
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test_multi_provider_routing.py
+++ b/tests/integration/test_multi_provider_routing.py
@@ -1,0 +1,288 @@
+"""
+Integration tests for multi-provider model routing.
+
+Tests that models can be routed through multiple providers with automatic
+failover and correct model ID transformation.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from src.services.multi_provider_registry import (
+    MultiProviderModel,
+    ProviderConfig,
+    get_registry,
+)
+from src.services.model_transformations import (
+    transform_model_id,
+    detect_provider_from_model_id,
+)
+
+
+@pytest.fixture
+def test_model():
+    """Create a test multi-provider model"""
+    model = MultiProviderModel(
+        id="test-llama-70b",
+        name="Test Llama 70B",
+        description="Test model for multi-provider routing",
+        context_length=8192,
+        modalities=["text"],
+        aliases=[
+            "llama-70b",
+            "meta-llama/llama-70b",
+        ],
+        providers=[
+            ProviderConfig(
+                name="openrouter",
+                model_id="meta-llama/llama-70b-instruct",
+                priority=1,
+                cost_per_1k_input=0.18,
+                cost_per_1k_output=0.18,
+                features=["streaming"],
+            ),
+            ProviderConfig(
+                name="fireworks",
+                model_id="accounts/fireworks/models/llama-70b-instruct",
+                priority=2,
+                cost_per_1k_input=0.20,
+                cost_per_1k_output=0.20,
+                features=["streaming"],
+            ),
+        ],
+    )
+    return model
+
+
+@pytest.fixture
+def registry_with_test_model(test_model):
+    """Get registry and register test model"""
+    registry = get_registry()
+    # Clear any existing models
+    registry._models.clear()
+    registry._alias_to_canonical.clear()
+    registry._provider_index.clear()
+    # Register test model
+    registry.register_model(test_model)
+    yield registry
+    # Cleanup
+    registry._models.clear()
+    registry._alias_to_canonical.clear()
+    registry._provider_index.clear()
+
+
+def test_registry_alias_resolution(registry_with_test_model):
+    """Test that aliases resolve to canonical IDs"""
+    registry = registry_with_test_model
+    
+    # Test canonical ID resolves to itself
+    assert registry.resolve_canonical_id("test-llama-70b") == "test-llama-70b"
+    
+    # Test aliases resolve to canonical
+    assert registry.resolve_canonical_id("llama-70b") == "test-llama-70b"
+    assert registry.resolve_canonical_id("meta-llama/llama-70b") == "test-llama-70b"
+    
+    # Test case-insensitive resolution
+    assert registry.resolve_canonical_id("LLAMA-70B") == "test-llama-70b"
+    assert registry.resolve_canonical_id("Meta-Llama/Llama-70B") == "test-llama-70b"
+    
+    # Test provider-specific model ID resolution
+    assert registry.resolve_canonical_id("meta-llama/llama-70b-instruct") == "test-llama-70b"
+    assert registry.resolve_canonical_id("accounts/fireworks/models/llama-70b-instruct") == "test-llama-70b"
+
+
+def test_get_provider_model_id(registry_with_test_model):
+    """Test retrieving provider-specific model IDs"""
+    registry = registry_with_test_model
+    
+    # Test getting provider model IDs
+    assert registry.get_provider_model_id("test-llama-70b", "openrouter") == "meta-llama/llama-70b-instruct"
+    assert registry.get_provider_model_id("test-llama-70b", "fireworks") == "accounts/fireworks/models/llama-70b-instruct"
+    
+    # Test non-existent provider
+    assert registry.get_provider_model_id("test-llama-70b", "nonexistent") is None
+    
+    # Test non-existent model
+    assert registry.get_provider_model_id("nonexistent-model", "openrouter") is None
+
+
+def test_find_provider_for_model_id(registry_with_test_model):
+    """Test finding provider from provider-specific model ID"""
+    registry = registry_with_test_model
+    
+    # Test finding provider from provider-specific model ID
+    assert registry.find_provider_for_model_id("meta-llama/llama-70b-instruct") == "openrouter"
+    assert registry.find_provider_for_model_id("accounts/fireworks/models/llama-70b-instruct") == "fireworks"
+    
+    # Test case-insensitive
+    assert registry.find_provider_for_model_id("Meta-Llama/Llama-70B-Instruct") == "openrouter"
+    
+    # Test preferred provider
+    assert registry.find_provider_for_model_id("meta-llama/llama-70b-instruct", preferred_provider="openrouter") == "openrouter"
+
+
+def test_provider_selection(registry_with_test_model):
+    """Test provider selection based on priority"""
+    registry = registry_with_test_model
+    
+    # Test default selection (should pick highest priority = lowest number)
+    provider = registry.select_provider("test-llama-70b")
+    assert provider is not None
+    assert provider.name == "openrouter"
+    assert provider.priority == 1
+    
+    # Test preferred provider selection
+    provider = registry.select_provider("test-llama-70b", preferred_provider="fireworks")
+    assert provider is not None
+    assert provider.name == "fireworks"
+    
+    # Test selection with required features
+    provider = registry.select_provider("test-llama-70b", required_features=["streaming"])
+    assert provider is not None
+    assert "streaming" in provider.features
+
+
+def test_get_fallback_providers(registry_with_test_model):
+    """Test getting fallback providers"""
+    registry = registry_with_test_model
+    
+    # Test getting all providers
+    fallbacks = registry.get_fallback_providers("test-llama-70b")
+    assert len(fallbacks) == 2
+    assert fallbacks[0].name == "openrouter"
+    assert fallbacks[1].name == "fireworks"
+    
+    # Test excluding primary provider
+    fallbacks = registry.get_fallback_providers("test-llama-70b", exclude_provider="openrouter")
+    assert len(fallbacks) == 1
+    assert fallbacks[0].name == "fireworks"
+
+
+def test_transform_model_id_with_registry(registry_with_test_model):
+    """Test model ID transformation using registry"""
+    
+    # Test canonical ID transformation
+    assert transform_model_id("test-llama-70b", "openrouter") == "meta-llama/llama-70b-instruct"
+    assert transform_model_id("test-llama-70b", "fireworks") == "accounts/fireworks/models/llama-70b-instruct"
+    
+    # Test alias transformation
+    assert transform_model_id("llama-70b", "openrouter") == "meta-llama/llama-70b-instruct"
+    assert transform_model_id("meta-llama/llama-70b", "fireworks") == "accounts/fireworks/models/llama-70b-instruct"
+    
+    # Test case-insensitive transformation
+    assert transform_model_id("LLAMA-70B", "openrouter") == "meta-llama/llama-70b-instruct"
+
+
+def test_detect_provider_from_model_id_with_registry(registry_with_test_model):
+    """Test provider detection using registry"""
+    
+    # Test canonical ID detection
+    provider = detect_provider_from_model_id("test-llama-70b")
+    assert provider == "openrouter"  # Should select highest priority
+    
+    # Test alias detection
+    provider = detect_provider_from_model_id("llama-70b")
+    assert provider == "openrouter"
+    
+    # Test provider-specific model ID detection
+    provider = detect_provider_from_model_id("meta-llama/llama-70b-instruct")
+    assert provider == "openrouter"
+    
+    provider = detect_provider_from_model_id("accounts/fireworks/models/llama-70b-instruct")
+    assert provider == "fireworks"
+    
+    # Test preferred provider
+    provider = detect_provider_from_model_id("test-llama-70b", preferred_provider="fireworks")
+    assert provider == "fireworks"
+
+
+def test_curated_models_initialization():
+    """Test that curated models are properly initialized"""
+    from src.services.curated_models_config import (
+        get_llama_models,
+        get_deepseek_models,
+        get_qwen_models,
+        get_all_curated_models,
+    )
+    
+    # Test Llama models
+    llama_models = get_llama_models()
+    assert len(llama_models) >= 2  # At least 3.1 and 3.3
+    
+    # Find Llama 3.3 70B
+    llama_33 = next((m for m in llama_models if "3.3" in m.id and "70b" in m.id), None)
+    assert llama_33 is not None
+    assert len(llama_33.providers) >= 3  # OpenRouter, Fireworks, Together, etc.
+    assert len(llama_33.aliases) > 0
+    
+    # Test DeepSeek models
+    deepseek_models = get_deepseek_models()
+    assert len(deepseek_models) >= 2  # V3 and R1
+    
+    # Find DeepSeek V3
+    deepseek_v3 = next((m for m in deepseek_models if "v3" in m.id.lower()), None)
+    assert deepseek_v3 is not None
+    assert len(deepseek_v3.providers) >= 3  # Multiple providers
+    
+    # Test all curated models
+    all_models = get_all_curated_models()
+    assert len(all_models) >= 8  # Llama + DeepSeek + Qwen + Mistral + Gemma
+
+
+def test_multi_provider_failover_chain():
+    """Test that failover chain works with multi-provider models"""
+    from src.services.curated_models_config import get_llama_models
+    
+    registry = get_registry()
+    registry._models.clear()
+    registry._alias_to_canonical.clear()
+    registry._provider_index.clear()
+    
+    # Register Llama 3.3 70B
+    llama_models = get_llama_models()
+    llama_33 = next((m for m in llama_models if "3.3" in m.id and "70b" in m.id), None)
+    if llama_33:
+        registry.register_model(llama_33)
+        
+        # Test provider chain
+        primary = registry.select_provider(llama_33.id)
+        assert primary is not None
+        
+        fallbacks = registry.get_fallback_providers(llama_33.id, exclude_provider=primary.name)
+        assert len(fallbacks) >= 2  # Should have multiple fallback options
+        
+        # Verify order by priority
+        for i in range(len(fallbacks) - 1):
+            assert fallbacks[i].priority <= fallbacks[i + 1].priority
+
+
+def test_provider_model_normalization():
+    """Test that provider model IDs are properly normalized"""
+    from src.services.curated_models_config import get_deepseek_models
+    
+    registry = get_registry()
+    registry._models.clear()
+    registry._alias_to_canonical.clear()
+    registry._provider_index.clear()
+    
+    deepseek_models = get_deepseek_models()
+    deepseek_v3 = next((m for m in deepseek_models if "v3" in m.id.lower()), None)
+    
+    if deepseek_v3:
+        registry.register_model(deepseek_v3)
+        
+        # Test various input formats resolve to same canonical ID
+        test_inputs = [
+            "deepseek-v3",
+            "deepseek-ai/deepseek-v3",
+            "DEEPSEEK-V3",
+            "DeepSeek-AI/DeepSeek-V3",
+        ]
+        
+        for input_id in test_inputs:
+            canonical = registry.resolve_canonical_id(input_id)
+            assert canonical == deepseek_v3.id, f"Failed to resolve '{input_id}' to canonical ID"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
Refactors backend to support multi-provider model routing via a centralized registry, adds curated models, and introduces tests and docs to validate end-to-end behavior.

## Changes
- Introduces multi-provider routing infrastructure:
  - src/services/multi_provider_registry.py: enhanced registry with canonical IDs, alias resolution, and provider index for provider-specific IDs. Includes methods to resolve canonical IDs, fetch provider IDs, and determine fallbacks.
  - src/services/model_transformations.py: augmented to leverage canonical IDs and registry lookups for provider-specific model IDs; supports legacy transformation fallback paths.
- Adds curated multi-provider model configurations:
  - src/services/curated_models_config.py: defines common curated models (Llama, DeepSeek, Qwen, Mistral, Gemma, etc.) with provider mappings, priorities, costs, and features. Includes initialization helper for startup.
- Chat routing refactor to use multi-provider routing when available:
  - src/routes/chat.py: integrates with the registry to resolve canonical IDs, select primary providers, and build a failover chain; falls back to legacy routing if needed. Attempts registry-based ID transformations before legacy rules.
- Startup initialization for curated models:
  - src/services/startup.py: initializes curated models at startup in addition to existing providers.
- Documentation:
  - docs/MULTI_PROVIDER_ROUTING.md: new docs describing the multi-provider routing design, concepts, and how to add models.
- Tests and manual checks:
  - test_multi_provider_manual.py: manual script demonstrating registry operations and transformations.
  - tests/integration/test_multi_provider_routing.py: integration tests covering alias resolution, provider mapping, and multi-provider routing behavior.
- Tests scaffolding:
  - Adds test fixtures and scenarios for registry aliasing, provider selection, failover chains, and canonical ID handling.

## Why this change
- Enables automatic failover and priority-based routing across multiple providers for the same logical model.
- Centralizes model resolution and ID transformation to improve consistency and observability.
- Improves backward compatibility by preserving legacy routing paths as fallbacks.

## Backward Compatibility
- Legacy model IDs and single-provider routing remain supported as fallback paths when a model is not registered in the multi-provider registry.
- Provider detection and transformation still work with legacy IDs if the registry lookup fails.
- No breaking changes to existing request/response schemas.

## Testing Plan
- Run unit and integration tests:
  - pytest tests/integration/test_multi_provider_routing.py
  - Run the manual test script: test_multi_provider_manual.py
- Validation steps:
  - Confirm that canonical IDs resolve from aliases (case-insensitive).
  - Verify provider-specific IDs are correctly resolved for each canonical model.
  - Validate provider selection honors priority and supports failover to fallbacks.
  - Validate model ID transformation via registry-first approach, with fallback to legacy rules.
- Documentation should reflect usage and how to add new curated models.

## How to run locally
- Start the app; curated models are initialized on startup.
- Use the integration tests to validate multi-provider routing behavior:
  - pytest tests/integration/test_multi_provider_routing.py -v
- Run the manual script for ad-hoc registry validation:
  - python test_multi_provider_manual.py

## Docs
- NEW: docs/MULTI_PROVIDER_ROUTING.md provides a thorough overview of canonical IDs, aliases, provider IDs, and routing flow, plus examples and best practices for adding new models.

## Notes
- The curated model config is centralized to simplify adding/removing models and providers.
- Logging and diagnostic hooks have been added to aid debugging of multi-provider routing.


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/1d299958-0589-4816-8139-fe52d9875811

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables multi-provider model routing via a canonical-ID registry, integrates it into chat routing, and adds curated model configs, docs, and tests.
> 
> - **Routing/Backend**:
>   - Integrate multi-provider registry in `src/routes/chat.py` to resolve canonical IDs, select primary providers, and build limited failover chains; use registry-first model ID lookups with legacy fallback.
> - **Registry**:
>   - Expand `src/services/multi_provider_registry.py` with aliases, provider ID indexing, and APIs: `resolve_canonical_id`, `get_provider_model_id`, `find_provider_for_model_id`, enhanced provider selection and fallbacks.
> - **Model Transformations**:
>   - Update `src/services/model_transformations.py` to use registry for provider-specific ID transforms and provider detection, with legacy fallback paths preserved.
> - **Curated Models**:
>   - Add `src/services/curated_models_config.py` defining Llama/DeepSeek/Qwen/Mistral/Gemma models with provider mappings, priorities, and features; provide `initialize_curated_models`.
> - **Startup**:
>   - Initialize curated models at boot in `src/services/startup.py`.
> - **Docs**:
>   - Add `docs/MULTI_PROVIDER_ROUTING.md` detailing canonical IDs, aliases, provider priorities, routing flow, and extension.
> - **Tests**:
>   - Add `tests/integration/test_multi_provider_routing.py` and `test_multi_provider_manual.py` covering alias resolution, provider selection, failover chains, and transforms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 030e7e77a19a06621e1db50ae9f792c8913aad7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->