### PR TITLE
Refactor gatewayz backend for multi-provider routing

### DIFF
--- a/docs/MULTI_PROVIDER_REGISTRY.md
+++ b/docs/MULTI_PROVIDER_REGISTRY.md
@@ -1,0 +1,62 @@
+# Multi-Provider Registry
+
+The gateway now keeps a **canonical registry** of every logical model and all of the providers
+that can serve it. This registry powers catalog responses, automatic failover, and
+provider-specific routing metadata (costs, features, availability).
+
+## How the registry works
+
+1. **Provider fetchers** push their normalized catalogs into the registry via
+   `sync_provider_catalog(provider_name, models)`. This happens automatically from
+   `src/services/models.py` and `src/services/portkey_providers.py`.
+2. Each model entry is keyed by `canonical_slug` (or `slug`/`id` as a fallback) and
+   tracks every provider's pricing, capabilities, and provider-specific model ID.
+3. The registry exposes a canonical snapshot that backs `get_cached_models("all")`.
+   Downstream consumers (pricing, catalog endpoints, etc.) should treat the registry
+   as the source of truth instead of manually merging provider caches.
+4. `ProviderSelector` consumes the registry and builds an ordered plan of providers
+   for every request, applying circuit breaking and provider priorities.
+
+## Registering a new provider / model
+
+1. Ensure the provider's fetcher returns normalized models with:
+   - `id`: provider-specific ID (what the upstream API expects)
+   - `canonical_slug`: shared logical identifier (e.g., `google/gemini-2.0-flash`)
+   - `pricing`, `context_length`, `source_gateway`, etc.
+2. After the fetcher caches results, call the helper in `src/services/models.py`:
+
+   ```python
+   return _sync_registry("provider-name", normalized_models)
+   ```
+
+   For providers defined in `src/services/portkey_providers.py`, use `_cache_normalized_models`
+   which already syncs the registry.
+3. If a model is available across multiple providers, ensure each provider reports the
+   same `canonical_slug`. The registry will merge them automatically and expose a single
+   logical model with multiple `ProviderConfig` entries.
+4. Re-run the failure-plan tests to confirm the model fans out across providers:
+
+   ```bash
+   pytest tests/services/test_multi_provider_registry.py
+   pytest tests/services/test_provider_failover.py -k registry_plan
+   ```
+
+## Provider failover & routing
+
+- `src/routes/chat.py` and `src/routes/messages.py` call
+  `plan_provider_attempts(model_id, provider)` which delegates to `ProviderSelector`.
+- The selector returns a list of `ProviderAttempt` objects that include both the provider
+  name **and** the provider-specific model ID pulled from the registry.
+- Every success/failure is recorded via `provider_selector.record_success/failure`, enabling
+  circuit breaking without additional code in the routes.
+- `build_provider_failover_chain(initial_provider, model_id=...)` now defers to this plan,
+  so legacy callers still gain registry-driven ordering when they pass a model ID.
+
+## Useful references
+
+- Canonical ingestion helper: `src/services/models._sync_registry`
+- Provider selector & circuit breaker: `src/services/provider_selector.py`
+- Registry data model: `src/services/multi_provider_registry.py`
+- Tests validating end-to-end behavior:
+  - `tests/services/test_multi_provider_registry.py`
+  - `tests/services/test_provider_failover.py` (registry plan test)

--- a/docs/README.md
+++ b/docs/README.md
@@ -143,6 +143,7 @@ Comprehensive documentation is available in the `docs/` directory:
 - **[Chutes Integration](CHUTES_INTEGRATION.md)** - Chutes provider setup
 - **[Featherless Integration](FEATHERLESS_INTEGRATION.md)** - Featherless provider setup
 - **[Portkey Testing](PORTKEY_TESTING_GUIDE.md)** - Portkey provider testing
+- **[Multi-Provider Registry](MULTI_PROVIDER_REGISTRY.md)** - Canonical model registry ingestion and routing
 
 ### Operations
 - **[Deployment Guide](DEPLOYMENT.md)** - Production deployment instructions
@@ -539,4 +540,3 @@ If you find this project useful, please consider giving it a star! ⭐
 **Built with ❤️ by the AI Gateway team**
 
 *Making AI accessible, secure, and affordable for everyone.*
-

--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -66,9 +66,10 @@ def transform_model_id(model_id: str, provider: str, use_multi_provider: bool = 
             from src.services.multi_provider_registry import get_registry
 
             registry = get_registry()
-            if registry.has_model(model_id):
+            canonical_id = registry.resolve_canonical_id(model_id) or model_id
+            if registry.has_model(canonical_id):
                 # Get provider-specific model ID from registry
-                model = registry.get_model(model_id)
+                model = registry.get_model(canonical_id)
                 if model:
                     provider_config = model.get_provider_by_name(provider)
                     if provider_config:
@@ -526,13 +527,14 @@ def detect_provider_from_model_id(model_id: str, preferred_provider: Optional[st
         from src.services.multi_provider_registry import get_registry
 
         registry = get_registry()
-        if registry.has_model(model_id):
+        canonical_id = registry.resolve_canonical_id(model_id) or model_id
+        if registry.has_model(canonical_id):
             # Model is in multi-provider registry
             from src.services.provider_selector import get_selector
 
             selector = get_selector()
             selected_provider = selector.registry.select_provider(
-                model_id=model_id,
+                model_id=canonical_id,
                 preferred_provider=preferred_provider,
             )
 

--- a/src/services/multi_provider_registry.py
+++ b/src/services/multi_provider_registry.py
@@ -1,119 +1,266 @@
 """
-Multi-Provider Model Registry
+Canonical Multi-Provider Model Registry
+=======================================
 
-This module provides support for models that can be accessed through multiple providers
-with automatic failover, priority-based selection, and cost optimization.
+This module aggregates provider catalogs into a single canonical registry so that
+each logical model (e.g., "google/gemini-2.5-flash") knows every provider that can
+serve it along with costs, features, and availability. The registry keeps provider
+fetchers in sync, exposes helper APIs for routing, and powers provider selection
+with circuit breaking.
 """
 
+from __future__ import annotations
+
 import logging
-from typing import List, Optional, Dict, Any
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
 
 logger = logging.getLogger(__name__)
+
+# Default provider ordering. Lower index == higher priority.
+DEFAULT_PROVIDER_PRIORITY: Sequence[str] = (
+    "google-vertex",
+    "openrouter",
+    "vercel-ai-gateway",
+    "portkey",
+    "featherless",
+    "huggingface",
+    "hug",
+    "fireworks",
+    "together",
+    "aihubmix",
+    "anannas",
+    "fal",
+    "near",
+    "aimo",
+    "cerebras",
+    "deepinfra",
+    "groq",
+    "novita",
+    "xai",
+    "nebius",
+    "chutes",
+)
+
+
+def _utcnow() -> datetime:
+    """Return a timezone-aware utcnow."""
+    return datetime.now(timezone.utc)
 
 
 @dataclass
 class ProviderConfig:
-    """Configuration for a single provider for a model"""
+    """Configuration + runtime metadata for a single provider of a model."""
 
-    name: str  # Provider name (e.g., "google-vertex", "openrouter")
-    model_id: str  # Provider-specific model ID
-    priority: int = 1  # Lower number = higher priority (1 is highest)
-    requires_credentials: bool = False  # Whether this provider needs user credentials
-    cost_per_1k_input: Optional[float] = None  # Cost in credits per 1k input tokens
-    cost_per_1k_output: Optional[float] = None  # Cost in credits per 1k output tokens
-    enabled: bool = True  # Whether this provider is currently enabled
-    max_tokens: Optional[int] = None  # Max tokens supported by this provider
-    features: List[str] = field(default_factory=list)  # Supported features (e.g., "streaming", "function_calling")
+    name: str
+    model_id: str
+    priority: int = 1
+    requires_credentials: bool = False
+    cost_per_1k_input: Optional[float] = None
+    cost_per_1k_output: Optional[float] = None
+    enabled: bool = True
+    max_tokens: Optional[int] = None
+    features: List[str] = field(default_factory=list)
+    availability: str = "unknown"
+    last_synced: datetime = field(default_factory=_utcnow)
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
-    def __post_init__(self):
-        """Validate the configuration"""
+    def __post_init__(self) -> None:
         if self.priority < 1:
             raise ValueError(f"Priority must be >= 1, got {self.priority}")
 
 
 @dataclass
 class MultiProviderModel:
-    """A model that can be accessed through multiple providers"""
+    """Canonical model representation shared across providers."""
 
-    id: str  # Canonical model ID (what users specify)
-    name: str  # Display name
-    providers: List[ProviderConfig]  # List of provider configurations
+    id: str
+    name: str
+    providers: List[ProviderConfig]
     description: Optional[str] = None
     context_length: Optional[int] = None
     modalities: List[str] = field(default_factory=lambda: ["text"])
+    aliases: Set[str] = field(default_factory=set)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    pricing: Dict[str, Any] = field(default_factory=dict)
+    last_updated: datetime = field(default_factory=_utcnow)
+    source_models: Dict[str, Dict[str, Any]] = field(default_factory=dict)
 
-    def __post_init__(self):
-        """Validate and sort providers by priority"""
-        if not self.providers:
-            raise ValueError(f"Model {self.id} must have at least one provider")
-
-        # Sort providers by priority (lower number = higher priority)
-        self.providers.sort(key=lambda p: p.priority)
-
-        logger.debug(
-            f"Model {self.id} configured with {len(self.providers)} providers: "
-            f"{[p.name for p in self.providers]}"
-        )
+    def __post_init__(self) -> None:
+        if self.providers:
+            self.providers.sort(key=lambda p: p.priority)
+            logger.debug(
+                "Model %s configured with providers: %s",
+                self.id,
+                [p.name for p in self.providers],
+            )
 
     def get_enabled_providers(self) -> List[ProviderConfig]:
-        """Get list of enabled providers, sorted by priority"""
         return [p for p in self.providers if p.enabled]
 
     def get_primary_provider(self) -> Optional[ProviderConfig]:
-        """Get the highest priority enabled provider"""
         enabled = self.get_enabled_providers()
         return enabled[0] if enabled else None
 
     def get_provider_by_name(self, name: str) -> Optional[ProviderConfig]:
-        """Get a specific provider configuration by name"""
         for provider in self.providers:
             if provider.name == name:
                 return provider
         return None
 
     def supports_provider(self, provider_name: str) -> bool:
-        """Check if this model supports a specific provider"""
         return any(p.name == provider_name and p.enabled for p in self.providers)
+
+    def register_aliases(self, *aliases: str) -> None:
+        for alias in aliases:
+            if alias:
+                self.aliases.add(alias)
+
+    def upsert_provider(self, provider: ProviderConfig) -> None:
+        replaced = False
+        for idx, existing in enumerate(self.providers):
+            if existing.name == provider.name:
+                self.providers[idx] = provider
+                replaced = True
+                break
+        if not replaced:
+            self.providers.append(provider)
+        self.providers.sort(key=lambda p: p.priority)
+        self.last_updated = _utcnow()
+
+    def to_catalog_entry(self) -> Dict[str, Any]:
+        primary = self.get_primary_provider()
+        source_gateway = primary.name if primary else None
+        providers_payload = [
+            {
+                "provider": p.name,
+                "model_id": p.model_id,
+                "priority": p.priority,
+                "cost_per_1k_input": p.cost_per_1k_input,
+                "cost_per_1k_output": p.cost_per_1k_output,
+                "max_tokens": p.max_tokens,
+                "features": p.features,
+                "enabled": p.enabled,
+                "availability": p.availability,
+            }
+            for p in self.providers
+        ]
+        return {
+            "id": self.id,
+             "slug": self.id,
+             "canonical_slug": self.id,
+            "name": self.name,
+            "description": self.description,
+            "context_length": self.context_length,
+            "modalities": self.modalities,
+            "aliases": sorted(self.aliases),
+            "providers": providers_payload,
+            "metadata": self.metadata,
+            "pricing": self.pricing,
+            "last_updated": self.last_updated.isoformat(),
+            "source_gateway": source_gateway,
+            "source_gateways": [p["provider"] for p in providers_payload],
+        }
 
 
 class MultiProviderRegistry:
     """
-    Registry for multi-provider models with provider selection and failover logic.
-
-    This class maintains a registry of models that can be accessed through multiple
-    providers and provides methods for intelligent provider selection based on
-    priority, availability, cost, and features.
+    Registry for multi-provider models with canonical aggregation, alias mapping,
+    and helper utilities for provider selection + failover.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._models: Dict[str, MultiProviderModel] = {}
+        self._alias_index: Dict[str, str] = {}
         logger.info("Initialized MultiProviderRegistry")
 
+    # ------------------------------------------------------------------ #
+    # Canonical registration and lookup
+    # ------------------------------------------------------------------ #
+
     def register_model(self, model: MultiProviderModel) -> None:
-        """Register a multi-provider model"""
-        self._models[model.id] = model
+        key = self._normalize_key(model.id)
+        self._models[key] = model
+        self._index_model(model)
         logger.info(
-            f"Registered multi-provider model: {model.id} with "
-            f"{len(model.providers)} providers"
+            "Registered multi-provider model %s with %d providers",
+            model.id,
+            len(model.providers),
         )
 
-    def register_models(self, models: List[MultiProviderModel]) -> None:
-        """Register multiple models at once"""
+    def register_models(self, models: Iterable[MultiProviderModel]) -> None:
         for model in models:
             self.register_model(model)
 
     def get_model(self, model_id: str) -> Optional[MultiProviderModel]:
-        """Get a multi-provider model by ID"""
-        return self._models.get(model_id)
+        if not model_id:
+            return None
+        key = self._normalize_key(model_id)
+        model = self._models.get(key)
+        if model:
+            return model
+        alias_target = self._alias_index.get(key)
+        if alias_target:
+            return self._models.get(alias_target)
+        return None
 
     def has_model(self, model_id: str) -> bool:
-        """Check if a model is registered"""
-        return model_id in self._models
+        return self.get_model(model_id) is not None
 
     def get_all_models(self) -> List[MultiProviderModel]:
-        """Get all registered models"""
         return list(self._models.values())
+
+    def resolve_canonical_id(self, candidate_id: str) -> Optional[str]:
+        if not candidate_id:
+            return None
+        key = self._normalize_key(candidate_id)
+        if key in self._models:
+            return self._models[key].id
+        alias_target = self._alias_index.get(key)
+        if alias_target:
+            model = self._models.get(alias_target)
+            return model.id if model else None
+        return None
+
+    # ------------------------------------------------------------------ #
+    # Provider catalog ingestion
+    # ------------------------------------------------------------------ #
+
+    def sync_provider_catalog(
+        self,
+        provider_name: str,
+        models: Optional[List[Dict[str, Any]]],
+    ) -> None:
+        if models is None:
+            logger.warning(
+                "Skipping canonical sync for provider %s because payload is None",
+                provider_name,
+            )
+            return
+
+        ingested: Set[str] = set()
+        for payload in models:
+            canonical_id = self._derive_canonical_id(provider_name, payload)
+            model = self._upsert_canonical_model(canonical_id, payload)
+            provider_cfg = self._build_provider_config(provider_name, payload)
+            model.upsert_provider(provider_cfg)
+            model.source_models[provider_name] = payload
+            self._index_aliases(model, provider_name, payload)
+            ingested.add(self._normalize_key(model.id))
+
+        logger.info(
+            "Canonical registry ingested %d models for provider %s",
+            len(ingested),
+            provider_name,
+        )
+
+    def get_catalog_snapshot(self) -> List[Dict[str, Any]]:
+        return [model.to_catalog_entry() for model in self._models.values()]
+
+    # ------------------------------------------------------------------ #
+    # Provider selection
+    # ------------------------------------------------------------------ #
 
     def select_provider(
         self,
@@ -122,70 +269,66 @@ class MultiProviderRegistry:
         required_features: Optional[List[str]] = None,
         max_cost: Optional[float] = None,
     ) -> Optional[ProviderConfig]:
-        """
-        Select the best provider for a model based on criteria.
-
-        Args:
-            model_id: The model to select a provider for
-            preferred_provider: If specified, try to use this provider first
-            required_features: List of required features (e.g., ["streaming"])
-            max_cost: Maximum acceptable cost per 1k tokens
-
-        Returns:
-            The selected provider configuration, or None if no suitable provider found
-        """
-        model = self.get_model(model_id)
+        canonical_id = self.resolve_canonical_id(model_id) or model_id
+        model = self.get_model(canonical_id)
         if not model:
-            logger.warning(f"Model {model_id} not found in multi-provider registry")
+            logger.warning("Model %s not found in multi-provider registry", model_id)
             return None
 
-        # Get enabled providers
         candidates = model.get_enabled_providers()
         if not candidates:
-            logger.error(f"No enabled providers for model {model_id}")
+            logger.error("No enabled providers remain for %s", model_id)
             return None
 
-        # Filter by required features
         if required_features:
             candidates = [
-                p for p in candidates
+                p
+                for p in candidates
                 if all(feature in p.features for feature in required_features)
             ]
             if not candidates:
                 logger.warning(
-                    f"No providers for {model_id} support required features: {required_features}"
+                    "No providers for %s satisfy required features %s",
+                    model_id,
+                    required_features,
                 )
                 return None
 
-        # Filter by cost
         if max_cost is not None:
             candidates = [
-                p for p in candidates
-                if p.cost_per_1k_input is None or p.cost_per_1k_input <= max_cost
+                p
+                for p in candidates
+                if (p.cost_per_1k_input is None or p.cost_per_1k_input <= max_cost)
             ]
             if not candidates:
                 logger.warning(
-                    f"No providers for {model_id} within cost limit: {max_cost}"
+                    "No providers for %s within cost limit %s",
+                    model_id,
+                    max_cost,
                 )
                 return None
 
-        # If preferred provider specified and available, use it
         if preferred_provider:
             for provider in candidates:
                 if provider.name == preferred_provider:
                     logger.info(
-                        f"Selected preferred provider {preferred_provider} for {model_id}"
+                        "Selected preferred provider %s for %s",
+                        preferred_provider,
+                        model_id,
                     )
                     return provider
             logger.warning(
-                f"Preferred provider {preferred_provider} not available for {model_id}, "
-                f"falling back to priority-based selection"
+                "Preferred provider %s unavailable for %s; falling back to priority order",
+                preferred_provider,
+                model_id,
             )
 
-        # Return highest priority provider
         selected = candidates[0]
         logger.info(
-            f"Selected provider {selected.name} (priority {selected.priority}) for {model_id}"
+            "Selected provider %s (priority %d) for %s",
+            selected.name,
+            selected.priority,
+            model_id,
         )
         return selected
 
@@ -194,35 +337,17 @@ class MultiProviderRegistry:
         model_id: str,
         exclude_provider: Optional[str] = None,
     ) -> List[ProviderConfig]:
-        """
-        Get ordered list of fallback providers for a model.
-
-        Args:
-            model_id: The model to get fallbacks for
-            exclude_provider: Provider to exclude (typically the one that just failed)
-
-        Returns:
-            List of provider configurations ordered by priority
-        """
-        model = self.get_model(model_id)
+        canonical_id = self.resolve_canonical_id(model_id) or model_id
+        model = self.get_model(canonical_id)
         if not model:
             return []
 
         providers = model.get_enabled_providers()
-
-        # Exclude specified provider
         if exclude_provider:
             providers = [p for p in providers if p.name != exclude_provider]
-
         return providers
 
     def disable_provider(self, model_id: str, provider_name: str) -> bool:
-        """
-        Temporarily disable a provider for a model (e.g., after repeated failures).
-
-        Returns:
-            True if provider was disabled, False if not found
-        """
         model = self.get_model(model_id)
         if not model:
             return False
@@ -230,18 +355,11 @@ class MultiProviderRegistry:
         provider = model.get_provider_by_name(provider_name)
         if provider:
             provider.enabled = False
-            logger.warning(f"Disabled provider {provider_name} for model {model_id}")
+            logger.warning("Disabled provider %s for %s", provider_name, model_id)
             return True
-
         return False
 
     def enable_provider(self, model_id: str, provider_name: str) -> bool:
-        """
-        Re-enable a previously disabled provider.
-
-        Returns:
-            True if provider was enabled, False if not found
-        """
         model = self.get_model(model_id)
         if not model:
             return False
@@ -249,13 +367,182 @@ class MultiProviderRegistry:
         provider = model.get_provider_by_name(provider_name)
         if provider:
             provider.enabled = True
-            logger.info(f"Enabled provider {provider_name} for model {model_id}")
+            logger.info("Enabled provider %s for %s", provider_name, model_id)
             return True
-
         return False
 
+    # ------------------------------------------------------------------ #
+    # Internal helpers
+    # ------------------------------------------------------------------ #
 
-# Global registry instance
+    def _normalize_key(self, value: str) -> str:
+        return value.lower()
+
+    def _derive_canonical_id(self, provider_name: str, payload: Dict[str, Any]) -> str:
+        candidates = [
+            payload.get("canonical_slug"),
+            payload.get("slug"),
+            payload.get("id"),
+        ]
+        for candidate in candidates:
+            if candidate:
+                return candidate
+        fallback = f"{provider_name}:{payload.get('id', 'unknown-model')}"
+        logger.debug(
+            "Synthesized canonical id %s for provider %s because payload was missing slug metadata",
+            fallback,
+            provider_name,
+        )
+        return fallback
+
+    def _upsert_canonical_model(
+        self,
+        canonical_id: str,
+        payload: Dict[str, Any],
+    ) -> MultiProviderModel:
+        key = self._normalize_key(canonical_id)
+        model = self._models.get(key)
+        if not model:
+            model = MultiProviderModel(
+                id=canonical_id,
+                name=payload.get("name")
+                or payload.get("display_name")
+                or canonical_id,
+                description=payload.get("description"),
+                context_length=payload.get("context_length")
+                or payload.get("max_context_length")
+                or payload.get("max_tokens"),
+                modalities=_coerce_modalities(payload),
+                providers=[],
+            )
+            self._models[key] = model
+        else:
+            model.name = payload.get("name") or model.name
+            model.description = payload.get("description") or model.description
+            model.context_length = payload.get("context_length") or model.context_length
+            modalities = _coerce_modalities(payload)
+            if modalities:
+                model.modalities = modalities
+
+        model.register_aliases(canonical_id, payload.get("id"), payload.get("slug"))
+        pricing = payload.get("pricing")
+        if pricing:
+            model.pricing = pricing
+        model.metadata.update({"provider_count": len(model.providers)})
+        model.last_updated = _utcnow()
+        return model
+
+    def _build_provider_config(self, provider_name: str, payload: Dict[str, Any]) -> ProviderConfig:
+        pricing = payload.get("pricing") or {}
+        prompt_cost = _safe_float(pricing.get("prompt"))
+        completion_cost = _safe_float(pricing.get("completion"))
+        max_tokens = (
+            payload.get("max_tokens")
+            or payload.get("context_length")
+            or payload.get("max_context_length")
+        )
+        features = _derive_features(payload)
+        priority = self._infer_priority(provider_name)
+
+        return ProviderConfig(
+            name=provider_name,
+            model_id=payload.get("id")
+            or payload.get("slug")
+            or payload.get("canonical_slug")
+            or "",
+            priority=priority,
+            requires_credentials=payload.get("requires_api_key", False)
+            or payload.get("requires_credentials", False),
+            cost_per_1k_input=prompt_cost,
+            cost_per_1k_output=completion_cost,
+            enabled=payload.get("enabled", True),
+            max_tokens=max_tokens,
+            features=features,
+            availability=payload.get("availability", "unknown"),
+            metadata={
+                "source_gateway": payload.get("source_gateway"),
+                "provider_slug": payload.get("provider_slug"),
+                "pricing": pricing,
+            },
+        )
+
+    def _infer_priority(self, provider_name: str) -> int:
+        provider_lower = provider_name.lower()
+        if provider_lower in DEFAULT_PROVIDER_PRIORITY:
+            return DEFAULT_PROVIDER_PRIORITY.index(provider_lower) + 1
+        return len(DEFAULT_PROVIDER_PRIORITY) + 1
+
+    def _index_aliases(
+        self,
+        model: MultiProviderModel,
+        provider_name: str,
+        payload: Dict[str, Any],
+    ) -> None:
+        aliases = {
+            model.id,
+            payload.get("id"),
+            payload.get("slug"),
+            payload.get("canonical_slug"),
+            f"{provider_name}:{payload.get('id')}",
+        }
+        for alias in aliases:
+            if not alias:
+                continue
+            key = self._normalize_key(alias)
+            self._alias_index[key] = self._normalize_key(model.id)
+
+    def _index_model(self, model: MultiProviderModel) -> None:
+        canonical_key = self._normalize_key(model.id)
+        self._alias_index[canonical_key] = canonical_key
+        for alias in model.aliases:
+            self._alias_index[self._normalize_key(alias)] = canonical_key
+        for provider in model.providers:
+            alias = provider.model_id
+            if alias:
+                self._alias_index[self._normalize_key(alias)] = canonical_key
+            composite = f"{provider.name}:{alias}"
+            self._alias_index[self._normalize_key(composite)] = canonical_key
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    try:
+        if value is None or value == "":
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _derive_features(payload: Dict[str, Any]) -> List[str]:
+    features: Set[str] = set()
+    if payload.get("supports_streaming") or payload.get("streaming"):
+        features.add("streaming")
+    if payload.get("supports_function_calling"):
+        features.add("function_calling")
+    architecture = payload.get("architecture") or {}
+    modality = architecture.get("modality")
+    if modality and modality not in ("text", "unknown"):
+        features.add(modality)
+    for flag in ("multimodal", "vision", "audio", "video"):
+        if payload.get(flag) or architecture.get(flag):
+            features.add(flag)
+    return sorted(features)
+
+
+def _coerce_modalities(payload: Dict[str, Any]) -> List[str]:
+    architecture = payload.get("architecture") or {}
+    input_modalities = architecture.get("input_modalities")
+    if isinstance(input_modalities, list) and input_modalities:
+        return input_modalities
+    if payload.get("modalities"):
+        return payload["modalities"]
+    modality = architecture.get("modality")
+    if modality:
+        return [modality]
+    return ["text"]
+
+
+# Global registry instance ------------------------------------------------- #
 _registry = MultiProviderRegistry()
 
 

--- a/tests/services/test_multi_provider_registry.py
+++ b/tests/services/test_multi_provider_registry.py
@@ -1,0 +1,64 @@
+import pytest
+
+from src.services.multi_provider_registry import MultiProviderRegistry
+from src.services.provider_selector import ProviderSelector
+
+
+def _vertex_model():
+    return {
+        "id": "gemini-2.0-flash",
+        "slug": "google/gemini-2.0-flash",
+        "canonical_slug": "google/gemini-2.0-flash",
+        "name": "Gemini 2.0 Flash",
+        "description": "Fast multimodal model",
+        "context_length": 1000000,
+        "architecture": {"modality": "text"},
+        "pricing": {"prompt": "0.1", "completion": "0.4"},
+        "provider_slug": "google-vertex",
+        "source_gateway": "google-vertex",
+    }
+
+
+def _openrouter_model():
+    return {
+        "id": "google/gemini-2.0-flash",
+        "slug": "google/gemini-2.0-flash",
+        "canonical_slug": "google/gemini-2.0-flash",
+        "name": "Gemini 2.0 Flash",
+        "description": "Proxy model",
+        "context_length": 8192,
+        "architecture": {"modality": "text"},
+        "pricing": {"prompt": "0.12", "completion": "0.48"},
+        "provider_slug": "openrouter",
+        "source_gateway": "openrouter",
+    }
+
+
+def test_registry_merges_providers_by_canonical_slug():
+    registry = MultiProviderRegistry()
+    registry.sync_provider_catalog("google-vertex", [_vertex_model()])
+    registry.sync_provider_catalog("openrouter", [_openrouter_model()])
+
+    model = registry.get_model("google/gemini-2.0-flash")
+    assert model is not None
+    provider_names = [p.name for p in model.providers]
+    assert provider_names == ["google-vertex", "openrouter"]
+    assert model.aliases  # contains canonical + provider ids
+
+
+def test_provider_selector_plan_orders_by_priority(monkeypatch):
+    registry = MultiProviderRegistry()
+    registry.sync_provider_catalog("google-vertex", [_vertex_model()])
+    registry.sync_provider_catalog("openrouter", [_openrouter_model()])
+
+    # Ensure ProviderSelector uses our temporary registry instance
+    monkeypatch.setattr(
+        "src.services.provider_selector.get_registry",
+        lambda: registry,
+    )
+
+    selector = ProviderSelector()
+    plan = selector.build_attempt_plan("google/gemini-2.0-flash")
+
+    assert [attempt.provider for attempt in plan][:2] == ["google-vertex", "openrouter"]
+    assert plan[0].provider_model_id == "gemini-2.0-flash"


### PR DESCRIPTION
## Summary
Refactor gatewayz backend to enable canonical multi-provider routing with registry-driven planning, failover, and provider-aware catalogs. Introduces a canonical registry, provider-plan based routing, and updates routing paths and tests to leverage registry-driven decisions.

## Changes
- Core canonical multi-provider registry
  - Added src/services/multi_provider_registry.py with:
    - ProviderConfig and MultiProviderModel data structures
    - Canonical model registration, aliasing, and catalog ingestion via sync_provider_catalog
    - get_catalog_snapshot for aggregated catalogs
    - resolve_canonical_id and provider selection helpers
    - Ability to derive and expose provider configurations per model
- Provider planning and failover
  - Updated src/services/provider_selector.py:
    - New ProviderAttempt dataclass
    - build_attempt_plan to produce an ordered plan based on registry data, priority, and health
    - record_success / record_failure hooks and health tracking integration
    - check_provider_health and per-model provider availability handling
- Route integration updates
  - src/routes/chat.py, src/routes/messages.py, and unified responses now use plan_provider_attempts(model_id, preferred_provider) to drive provider selection and failover instead of static chains
  - Replaced build_provider_failover_chain usage with registry-driven attempt plans in routing logic
  - Logging and model-id transformations updated to reflect planned provider model IDs
- Failover logic updates
  - src/services/provider_failover.py now relies on the registry-driven plan when model_id is provided, falling back to default behavior otherwise
- Catalog ingestion and registry sync across providers
  - Many model fetchers now push catalogs into the canonical registry via _sync_registry (e.g., huggingface, portkey, etc.)
  - HuggingFace HF models sync with registry; portkey and others updated to push catalogs
  - Returns from model fetchers now go through registry sync to ensure canonical state
- Documentation and docs scaffolding
  - Added docs/MULTI_PROVIDER_REGISTRY.md describing the canonical registry, ingestion workflow, and routing implications
  - docs/README.md updated to link the new Multi-Provider Registry docs
- Tests and test coverage
  - New tests: tests/services/test_multi_provider_registry.py validates canonical merging and provider plan ordering
  - Updated tests to patch plan_provider_attempts in tests/routes/test_chat.py and tests/routes/test_messages.py
  - Extended tests to verify registry-driven planning is used in provider failover flows
- Internal helpers and typing improvements
  - Introduced utility wrappers and typing hints to support registry-driven cataloging and planning logic

## Why this change
- Enables a canonical, synchronized view of models across providers
- Enables automatic, registry-driven provider failover and cost-aware routing
- Improves consistency of catalog responses and routing metadata across providers
- Reduces manual maintenance of provider caches by centralizing CLI workflows through the registry

## Test plan
- unit tests updated to exercise registry-driven planning and routing paths
- new tests validating registry merges for canonical slugs and provider plans
- run: pytest tests/services/test_multi_provider_registry.py and pytest tests/routes (chat, messages)

## Migration notes
- This is a wide refactor that introduces a canonical registry and plan-based routing. Ensure environment has all new dependencies loaded and run the test suite to validate integration points.
- Existing code paths that directly referenced old provider failover chains should now rely on plan_provider_attempts; tests patching those call sites have been updated accordingly.

## Notes for reviewers
- The registry is designed to be source-of-truth for model catalogs and provider capabilities. downstream endpoints should query the registry snapshot via get_catalog_snapshot where applicable.
- The plan builder respects preferred_provider when available, otherwise falls back to priority and health checks.
- Documentation has been added to guide future provider integrations and ensure consistent behavior across providers.

## References
- docs/MULTI_PROVIDER_REGISTRY.md
- src/services/multi_provider_registry.py
- src/services/provider_selector.py
- src/routes/chat.py, src/routes/messages.py
- tests/services/test_multi_provider_registry.py
- tests/routes/test_chat.py, tests/routes/test_messages.py

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4909086b-af75-44ff-8593-53a2446b5ce1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a canonical multi-provider registry and switches routing/failover to registry-driven provider attempt plans with catalog sync across providers.
> 
> - **Core Services**:
>   - **Canonical Registry**: New `src/services/multi_provider_registry.py` aggregating provider catalogs into logical models with aliasing, pricing/features, provider priorities, and snapshot via `get_catalog_snapshot()`.
>   - **Provider Selection**: `src/services/provider_selector.py` adds `ProviderAttempt`, `build_attempt_plan`, circuit-breaker health, and `record_success/failure` hooks.
> - **Routing & Failover**:
>   - **Routes**: `src/routes/chat.py` and `src/routes/messages.py` now use `plan_provider_attempts(model_id, preferred_provider)`; replace static chains, transform IDs per planned provider model, and record success/failure.
>   - **Failover**: `src/services/provider_failover.py` uses registry-driven plan when `model_id` is provided; retains legacy fallback otherwise.
> - **Catalog Ingestion**:
>   - **Registry Sync**: `src/services/models.py`, `src/services/huggingface_models.py`, and `src/services/portkey_providers.py` push normalized catalogs via `_sync_registry(...)`; `get_cached_models("all")` returns the registry snapshot.
>   - **Model ID Logic**: `src/services/model_transformations.py` resolves canonical IDs and pulls provider-specific IDs from the registry.
> - **Docs**:
>   - Add `docs/MULTI_PROVIDER_REGISTRY.md`; link from `docs/README.md`.
> - **Tests**:
>   - New `tests/services/test_multi_provider_registry.py` (merge + plan ordering) and updates in route tests to mock `plan_provider_attempts`; extend failover tests to verify registry plan usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26af345334757868c549a43e848f7322a7c63f10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->