### PR TITLE
Allow tests to continue after errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,6 @@ jobs:
           # Exclude smoke tests (they require a running server)
           pytest tests/ -v --tb=short \
             -n auto \
-            --maxfail=1 \
             --dist=loadfile \
             --splits 4 --group ${{ matrix.shard }} \
             --cov=src \

--- a/pytest.ini
+++ b/pytest.ini
@@ -28,7 +28,6 @@ addopts =
     --disable-warnings
     -p no:warnings
     --color=yes
-    --maxfail=3
     --ff
     --timeout=30
     -n auto


### PR DESCRIPTION
- Removed --maxfail=3 from pytest.ini
- Removed --maxfail=1 from CI workflow
- Tests will now run to completion even when failures occur
- This allows full visibility into all test failures rather than stopping early

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes pytest --maxfail flags from CI workflow and pytest.ini so test runs continue to completion instead of stopping early.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c38cfe82ac3a6f396d8b451c1b915dd2c275b0a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->