### PR TITLE
Debug Helicone models not loading

### DIFF
--- a/src/services/models.py
+++ b/src/services/models.py
@@ -378,6 +378,7 @@ def get_all_models_parallel():
             "aimo",
             "near",
             "fal",
+            "helicone",
             "anannas",
         ]
 
@@ -425,6 +426,7 @@ def get_all_models_sequential():
     aimo_models = get_cached_models("aimo") or []
     near_models = get_cached_models("near") or []
     fal_models = get_cached_models("fal") or []
+    helicone_models = get_cached_models("helicone") or []
     anannas_models = get_cached_models("anannas") or []
     return (
         openrouter_models
@@ -443,6 +445,7 @@ def get_all_models_sequential():
         + aimo_models
         + near_models
         + fal_models
+        + helicone_models
         + anannas_models
     )
 


### PR DESCRIPTION
Issue: Helicone models were not appearing in the model catalog despite the integration being complete (client, cache, fetch function all implemented).

Root cause: The 'helicone' gateway was missing from both the parallel and sequential model aggregation functions in get_all_models_parallel() and get_all_models_sequential().

Fix: Added 'helicone' to the gateway lists in both functions so that Helicone models are now fetched and included in the aggregated catalog.

Files changed:
- src/services/models.py: Added 'helicone' to gateways list in both get_all_models_parallel() and get_all_models_sequential()

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Helicone to both parallel and sequential model aggregation so Helicone models are fetched and included.
> 
> - **Model aggregation**:
>   - Add `"helicone"` to `gateways` in `get_all_models_parallel()` in `src/services/models.py`.
>   - Fetch and merge `helicone_models` in `get_all_models_sequential()` return list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cb7934a1894b505bf13f1f333b3d10a1c70b30c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->