### PR TITLE
Fix invalid model ID error with OpenRouter

### DIFF
--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -414,21 +414,32 @@ def get_model_id_mapping(provider: str) -> Dict[str, str]:
         },
         "near": {
             # Near AI uses simple model names without org prefixes
-            # Maps org/model format to simple model names
-            "deepseek-ai/deepseek-v3": "deepseek-v3",
+            # Maps org/model format to actual NEAR model IDs
+            # Note: NEAR API returns model IDs like "deepseek-chat-v3-0324", "gpt-oss-120b", etc.
+
+            # DeepSeek models - map to actual NEAR model ID
+            "deepseek-ai/deepseek-v3": "deepseek-chat-v3-0324",
+            "deepseek-ai/deepseek-chat-v3-0324": "deepseek-chat-v3-0324",
+            "deepseek-v3": "deepseek-chat-v3-0324",
+            "deepseek-chat-v3-0324": "deepseek-chat-v3-0324",
+
+            # Meta Llama models
             "meta-llama/llama-3-70b": "llama-3-70b",
             "meta-llama/llama-3.1-70b": "llama-3.1-70b",
-            "qwen/qwen-2-72b": "qwen-2-72b",
-            "gpt-oss/gpt-oss-120b": "gpt-oss-120b",
-            # GLM models
-            "zai-org/glm-4.6-fp8": "glm-4.6-fp8",
-            "zai-org/glm-4.6": "glm-4.6",
-            # Also support without org prefix (pass-through)
-            "deepseek-v3": "deepseek-v3",
             "llama-3-70b": "llama-3-70b",
             "llama-3.1-70b": "llama-3.1-70b",
+
+            # Qwen models
+            "qwen/qwen-2-72b": "qwen-2-72b",
             "qwen-2-72b": "qwen-2-72b",
+
+            # GPT-OSS models
+            "gpt-oss/gpt-oss-120b": "gpt-oss-120b",
             "gpt-oss-120b": "gpt-oss-120b",
+
+            # GLM models from Zhipu AI
+            "zai-org/glm-4.6-fp8": "glm-4.6-fp8",
+            "zai-org/glm-4.6": "glm-4.6",
             "glm-4.6-fp8": "glm-4.6-fp8",
             "glm-4.6": "glm-4.6",
         },

--- a/src/services/models.py
+++ b/src/services/models.py
@@ -1588,6 +1588,7 @@ def fetch_models_from_near():
             {"id": "gpt-oss-120b", "owned_by": "GPT"},
             {"id": "llama-3-70b", "owned_by": "Meta"},
             {"id": "qwen-2-72b", "owned_by": "Alibaba"},
+            {"id": "glm-4.6-fp8", "owned_by": "Zhipu AI"},
         ]
 
         normalized_models = [normalize_near_model(model) for model in fallback_models if model]


### PR DESCRIPTION
- Add provider override to route zai-org/glm-4.6-fp8 to NEAR instead of OpenRouter
- Add model ID transformations for NEAR to handle GLM-4.6 models
- Support both org/model format (zai-org/glm-4.6-fp8) and simple format (glm-4.6-fp8)

This fixes the error: "zai-org/glm-4.6-fp8 is not a valid model ID" which occurred because the model was being incorrectly routed to OpenRouter instead of NEAR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Routes `zai-org/glm-4.6(-fp8)` to NEAR, adds precise NEAR model ID transforms (incl. DeepSeek aliasing) and updates NEAR fallback catalog.
> 
> - **Model routing/transformations**
>   - Add provider override: `MODEL_PROVIDER_OVERRIDES["zai-org/glm-4.6-fp8"] = "near"`.
>   - Expand `near` mappings in `get_model_id_mapping`:
>     - DeepSeek: map aliases to `deepseek-chat-v3-0324` (`deepseek-ai/deepseek-v3`, `deepseek-v3`, etc.).
>     - GLM (Zhipu AI): add `zai-org/glm-4.6(-fp8)` and simple forms -> `glm-4.6(-fp8)`.
>     - Keep/support Meta Llama, Qwen, and GPT-OSS IDs.
> - **Catalog fallback**
>   - Add `"glm-4.6-fp8"` to NEAR fallback models in `fetch_models_from_near()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3bf6fda45c7fbc39d3f1d2402f90d51789bdcaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->