### PR TITLE
Add Helicone model catalog integration

### DIFF
--- a/src/cache.py
+++ b/src/cache.py
@@ -153,6 +153,13 @@ _vercel_ai_gateway_models_cache = {
     "stale_ttl": 7200,
 }
 
+_helicone_models_cache = {
+    "data": None,
+    "timestamp": None,
+    "ttl": 3600,  # 1 hour TTL for Helicone AI Gateway catalog
+    "stale_ttl": 7200,
+}
+
 _aihubmix_models_cache = {
     "data": None,
     "timestamp": None,
@@ -195,6 +202,7 @@ def get_models_cache(gateway: str):
         "near": _near_models_cache,
         "fal": _fal_models_cache,
         "vercel-ai-gateway": _vercel_ai_gateway_models_cache,
+        "helicone": _helicone_models_cache,
         "aihubmix": _aihubmix_models_cache,
         "anannas": _anannas_models_cache,
         "modelz": _modelz_cache,
@@ -225,6 +233,7 @@ def clear_models_cache(gateway: str):
         "novita": _novita_models_cache,
         "huggingface": _huggingface_models_cache,
         "hug": _huggingface_models_cache,  # Alias for backward compatibility
+        "helicone": _helicone_models_cache,
         "aimo": _aimo_models_cache,
         "near": _near_models_cache,
         "fal": _fal_models_cache,

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -70,6 +70,9 @@ class Config:
     # Vercel AI Gateway Configuration
     VERCEL_AI_GATEWAY_API_KEY = os.environ.get("VERCEL_AI_GATEWAY_API_KEY")
 
+    # Helicone AI Gateway Configuration
+    HELICONE_API_KEY = os.environ.get("HELICONE_API_KEY")
+
     # Vercel AI SDK Configuration
     AI_SDK_API_KEY = os.environ.get("AI_SDK_API_KEY")
 

--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -106,6 +106,11 @@ from src.services.vercel_ai_gateway_client import (
     process_vercel_ai_gateway_response,
     make_vercel_ai_gateway_request_openai_stream,
 )
+from src.services.helicone_client import (
+    make_helicone_request_openai,
+    process_helicone_response,
+    make_helicone_request_openai_stream,
+)
 from src.services.aihubmix_client import (
     make_aihubmix_request_openai,
     process_aihubmix_response,
@@ -822,6 +827,13 @@ async def chat_completions(
                             request_model,
                             **optional,
                         )
+                    elif attempt_provider == "helicone":
+                        stream = await _to_thread(
+                            make_helicone_request_openai_stream,
+                            messages,
+                            request_model,
+                            **optional,
+                        )
                     elif attempt_provider == "aihubmix":
                         stream = await _to_thread(
                             make_aihubmix_request_openai_stream,
@@ -1002,6 +1014,17 @@ async def chat_completions(
                         timeout=request_timeout,
                     )
                     processed = await _to_thread(process_vercel_ai_gateway_response, resp_raw)
+                elif attempt_provider == "helicone":
+                    resp_raw = await asyncio.wait_for(
+                        _to_thread(
+                            make_helicone_request_openai,
+                            messages,
+                            request_model,
+                            **optional,
+                        ),
+                        timeout=request_timeout,
+                    )
+                    processed = await _to_thread(process_helicone_response, resp_raw)
                 elif attempt_provider == "aihubmix":
                     resp_raw = await asyncio.wait_for(
                         _to_thread(

--- a/src/services/helicone_client.py
+++ b/src/services/helicone_client.py
@@ -1,0 +1,192 @@
+import logging
+from openai import OpenAI
+from src.config import Config
+from src.services.anthropic_transformer import extract_message_with_tools
+
+# Initialize logging
+logger = logging.getLogger(__name__)
+
+
+def get_helicone_client():
+    """Get Helicone AI Gateway client using OpenAI-compatible interface
+
+    Helicone AI Gateway is an observability and monitoring platform that provides
+    access to multiple AI providers with logging, caching, and analytics capabilities.
+
+    Base URL: https://ai-gateway.helicone.ai/v1
+    Documentation: https://docs.helicone.ai/gateway/overview
+    """
+    try:
+        api_key = Config.HELICONE_API_KEY
+        if not api_key:
+            raise ValueError(
+                "Helicone AI Gateway API key not configured. Please set HELICONE_API_KEY environment variable."
+            )
+
+        return OpenAI(base_url="https://ai-gateway.helicone.ai/v1", api_key=api_key)
+    except Exception as e:
+        logger.error(f"Failed to initialize Helicone AI Gateway client: {e}")
+        raise
+
+
+def make_helicone_request_openai(messages, model, **kwargs):
+    """Make request to Helicone AI Gateway using OpenAI client
+
+    Args:
+        messages: List of message objects
+        model: Model name (e.g., "gpt-4o-mini", "claude-3-sonnet")
+        **kwargs: Additional parameters like max_tokens, temperature, etc.
+    """
+    try:
+        client = get_helicone_client()
+        response = client.chat.completions.create(model=model, messages=messages, **kwargs)
+        return response
+    except Exception as e:
+        logger.error(f"Helicone AI Gateway request failed: {e}")
+        raise
+
+
+def make_helicone_request_openai_stream(messages, model, **kwargs):
+    """Make streaming request to Helicone AI Gateway using OpenAI client
+
+    Args:
+        messages: List of message objects
+        model: Model name (e.g., "gpt-4o-mini", "claude-3-sonnet")
+        **kwargs: Additional parameters like max_tokens, temperature, etc.
+    """
+    try:
+        client = get_helicone_client()
+        stream = client.chat.completions.create(
+            model=model, messages=messages, stream=True, **kwargs
+        )
+        return stream
+    except Exception as e:
+        logger.error(f"Helicone AI Gateway streaming request failed: {e}")
+        raise
+
+
+def process_helicone_response(response):
+    """Process Helicone AI Gateway response to extract relevant data"""
+    try:
+        choices = []
+        for choice in response.choices:
+            msg = extract_message_with_tools(choice.message)
+
+            choices.append({
+                "index": choice.index,
+                "message": msg,
+                "finish_reason": choice.finish_reason,
+            })
+
+        return {
+            "id": response.id,
+            "object": response.object,
+            "created": response.created,
+            "model": response.model,
+            "choices": choices,
+            "usage": (
+                {
+                    "prompt_tokens": response.usage.prompt_tokens,
+                    "completion_tokens": response.usage.completion_tokens,
+                    "total_tokens": response.usage.total_tokens,
+                }
+                if response.usage
+                else {}
+            ),
+        }
+    except Exception as e:
+        logger.error(f"Failed to process Helicone AI Gateway response: {e}")
+        raise
+
+
+def fetch_model_pricing_from_helicone(model_id: str):
+    """Fetch pricing information for a specific model from Helicone AI Gateway
+
+    Helicone AI Gateway routes requests to various providers (OpenAI, Anthropic, etc.)
+    This function attempts to determine the pricing by looking up the base provider's pricing.
+
+    Args:
+        model_id: Model identifier (e.g., "gpt-4o-mini", "claude-3-sonnet")
+
+    Returns:
+        dict with 'prompt' and 'completion' pricing per 1M tokens, or None if not available
+    """
+    try:
+        import httpx
+
+        api_key = Config.HELICONE_API_KEY
+        if not api_key or api_key == "placeholder-key":
+            logger.debug(f"Cannot fetch pricing for {model_id}: no valid API key configured")
+            return None
+
+        # Attempt to fetch from Helicone pricing endpoint (if it exists)
+        headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
+        try:
+            response = httpx.get(
+                "https://ai-gateway.helicone.ai/v1/pricing", headers=headers, timeout=5.0
+            )
+
+            if response.status_code == 200:
+                pricing_data = response.json()
+                # Look for model in response
+                if isinstance(pricing_data, dict):
+                    if model_id in pricing_data:
+                        return pricing_data[model_id]
+                    # Try without provider prefix
+                    model_name = model_id.split("/")[-1] if "/" in model_id else model_id
+                    if model_name in pricing_data:
+                        return pricing_data[model_name]
+        except (httpx.RequestError, httpx.TimeoutException) as e:
+            logger.debug(f"Helicone pricing endpoint not available: {e}")
+
+        # Fallback: use provider-specific pricing lookup
+        return get_provider_pricing_for_helicone_model(model_id)
+
+    except Exception as e:
+        logger.error(f"Failed to fetch pricing for Helicone model {model_id}: {e}")
+        return None
+
+
+def get_provider_pricing_for_helicone_model(model_id: str):
+    """Get pricing for a Helicone model by looking up the underlying provider's pricing
+
+    Helicone routes models to providers like OpenAI, Anthropic, etc.
+    We can determine pricing by identifying the provider and looking up their rates.
+
+    Args:
+        model_id: Model identifier (e.g., "gpt-4o-mini", "claude-3-sonnet")
+
+    Returns:
+        dict with 'prompt' and 'completion' pricing per 1M tokens
+    """
+    try:
+        # Cross-reference with known provider pricing from the system
+        # This leverages the existing pricing infrastructure
+        try:
+            from src.services.pricing import get_model_pricing
+
+            # Try the full model ID first
+            pricing = get_model_pricing(model_id)
+            if pricing and pricing.get("found"):
+                return {
+                    "prompt": pricing.get("prompt", "0"),
+                    "completion": pricing.get("completion", "0"),
+                }
+
+            # Try without the provider prefix
+            model_name_only = model_id.split("/")[-1] if "/" in model_id else model_id
+            pricing = get_model_pricing(model_name_only)
+            if pricing and pricing.get("found"):
+                return {
+                    "prompt": pricing.get("prompt", "0"),
+                    "completion": pricing.get("completion", "0"),
+                }
+        except ImportError:
+            logger.debug("pricing module not available for cross-reference")
+
+        return None
+
+    except Exception as e:
+        logger.debug(f"Failed to get provider pricing for {model_id}: {e}")
+        return None

--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -402,6 +402,12 @@ def get_model_id_mapping(provider: str) -> Dict[str, str]:
             # Using pass-through format - any model ID is supported
             # Minimal mappings to avoid conflicts with other providers during auto-detection
         },
+        "helicone": {
+            # Helicone AI Gateway uses standard model identifiers
+            # The gateway provides observability on top of standard provider APIs
+            # Using pass-through format - any model ID is supported
+            # Minimal mappings to avoid conflicts with other providers during auto-detection
+        },
         "aihubmix": {
             # AiHubMix uses OpenAI-compatible model identifiers
             # Pass-through format - any model ID is supported
@@ -638,6 +644,7 @@ def detect_provider_from_model_id(model_id: str, preferred_provider: Optional[st
         "chutes",
         "google-vertex",
         "vercel-ai-gateway",
+        "helicone",
         "aihubmix",
         "anannas",
         "near",
@@ -674,6 +681,10 @@ def detect_provider_from_model_id(model_id: str, preferred_provider: Optional[st
         # OpenRouter models (e.g., "openrouter/auto")
         if org == "openrouter":
             return "openrouter"
+
+        # Helicone models (e.g., "helicone/gpt-4o-mini")
+        if org == "helicone":
+            return "helicone"
 
         # DeepSeek models are primarily on Fireworks in this system
         if org == "deepseek-ai" and "deepseek" in model_name.lower():

--- a/src/services/models.py
+++ b/src/services/models.py
@@ -26,6 +26,7 @@ from src.cache import (
     _near_models_cache,
     _fal_models_cache,
     _vercel_ai_gateway_models_cache,
+    _helicone_models_cache,
     _anannas_models_cache,
     _multi_provider_catalog_cache,
     is_cache_fresh,
@@ -377,6 +378,7 @@ def get_all_models_parallel():
             "aimo",
             "near",
             "fal",
+            "helicone",
             "anannas",
         ]
 
@@ -424,6 +426,7 @@ def get_all_models_sequential():
     aimo_models = get_cached_models("aimo") or []
     near_models = get_cached_models("near") or []
     fal_models = get_cached_models("fal") or []
+    helicone_models = get_cached_models("helicone") or []
     anannas_models = get_cached_models("anannas") or []
     return (
         openrouter_models
@@ -442,6 +445,7 @@ def get_all_models_sequential():
         + aimo_models
         + near_models
         + fal_models
+        + helicone_models
         + anannas_models
     )
 
@@ -648,6 +652,13 @@ def get_cached_models(gateway: str = "openrouter"):
             _register_canonical_records("vercel-ai-gateway", result)
             return result
 
+        if gateway == "helicone":
+            cached = _fresh_cached_models(_helicone_models_cache, "helicone")
+            if cached is not None:
+                return cached
+            result = fetch_models_from_helicone()
+            _register_canonical_records("helicone", result)
+            return result
 
         if gateway == "anannas":
             cached = _fresh_cached_models(_anannas_models_cache, "anannas")
@@ -2936,6 +2947,149 @@ def normalize_aihubmix_model(model) -> Optional[dict]:
     except Exception as e:
         logger.error("Failed to normalize AiHubMix model: %s", sanitize_for_logging(str(e)))
         return None
+
+
+def fetch_models_from_helicone():
+    """Fetch models from Helicone AI Gateway via OpenAI-compatible API
+
+    Helicone AI Gateway provides access to models from multiple providers
+    through a unified OpenAI-compatible endpoint with observability features.
+    """
+    try:
+        from src.services.helicone_client import get_helicone_client
+
+        client = get_helicone_client()
+        response = client.models.list()
+
+        if not response or not hasattr(response, "data"):
+            logger.warning("No models returned from Helicone AI Gateway")
+            return []
+
+        # Normalize models
+        normalized_models = [normalize_helicone_model(model) for model in response.data if model]
+
+        _helicone_models_cache["data"] = normalized_models
+        _helicone_models_cache["timestamp"] = datetime.now(timezone.utc)
+
+        logger.info(f"Fetched {len(normalized_models)} models from Helicone AI Gateway")
+        return _helicone_models_cache["data"]
+    except Exception as e:
+        logger.error(
+            "Failed to fetch models from Helicone AI Gateway: %s", sanitize_for_logging(str(e))
+        )
+        return []
+
+
+def normalize_helicone_model(model) -> Optional[dict]:
+    """Normalize Helicone AI Gateway model to catalog schema
+
+    Helicone models can originate from various providers (OpenAI, Anthropic, etc.)
+    The gateway provides observability and monitoring on top of provider routing.
+    Pricing is dynamically fetched from the underlying provider's pricing data.
+    """
+    # Extract model ID
+    model_id = getattr(model, "id", None)
+    if not model_id:
+        logger.warning("Helicone model missing 'id' field: %s", sanitize_for_logging(str(model)))
+        return None
+
+    # Determine provider from model ID
+    # Models typically come in standard formats like "gpt-4o-mini", "claude-3-sonnet", etc.
+    provider_slug = "helicone"
+    display_name = model_id
+
+    # Try to detect provider from model name
+    if "/" in model_id:
+        provider_slug = model_id.split("/")[0]
+        display_name = model_id.split("/")[1]
+    elif "gpt" in model_id.lower() or "o1" in model_id.lower():
+        provider_slug = "openai"
+    elif "claude" in model_id.lower():
+        provider_slug = "anthropic"
+    elif "gemini" in model_id.lower():
+        provider_slug = "google"
+
+    # Get description - Helicone doesn't provide this, so we create one
+    description = getattr(model, "description", None) or "Model available through Helicone AI Gateway"
+
+    # Get context length if available
+    context_length = getattr(model, "context_length", 4096)
+
+    # Get created date if available
+    created = getattr(model, "created_at", None)
+
+    # Fetch pricing dynamically from Helicone or underlying provider
+    pricing = get_helicone_model_pricing(model_id)
+
+    normalized = {
+        "id": model_id,
+        "slug": f"helicone/{model_id}",
+        "canonical_slug": f"helicone/{model_id}",
+        "hugging_face_id": None,
+        "name": display_name,
+        "created": created,
+        "description": description,
+        "context_length": context_length,
+        "architecture": {
+            "modality": MODALITY_TEXT_TO_TEXT,
+            "input_modalities": ["text"],
+            "output_modalities": ["text"],
+            "instruct_type": "chat",
+        },
+        "pricing": pricing,
+        "top_provider": None,
+        "per_request_limits": None,
+        "supported_parameters": [],
+        "default_parameters": {},
+        "provider_slug": provider_slug,
+        "provider_site_url": "https://www.helicone.ai",
+        "model_logo_url": "https://www.helicone.ai/favicon.ico",
+        "source_gateway": "helicone",
+    }
+
+    return normalized
+
+
+def get_helicone_model_pricing(model_id: str) -> dict:
+    """Get pricing for a Helicone AI Gateway model
+
+    Fetches pricing from Helicone or the underlying provider.
+    Falls back to default zero pricing if unavailable.
+
+    Args:
+        model_id: Model identifier (e.g., "gpt-4o-mini")
+
+    Returns:
+        dict with 'prompt', 'completion', 'request', and 'image' pricing fields
+    """
+    try:
+        from src.services.helicone_client import fetch_model_pricing_from_helicone
+
+        # Attempt to fetch pricing from Helicone or underlying provider
+        pricing_data = fetch_model_pricing_from_helicone(model_id)
+
+        if pricing_data:
+            # Normalize to standard schema with default zeros for missing fields
+            return {
+                "prompt": str(pricing_data.get("prompt", "0")),
+                "completion": str(pricing_data.get("completion", "0")),
+                "request": str(pricing_data.get("request", "0")),
+                "image": str(pricing_data.get("image", "0")),
+            }
+    except Exception as e:
+        logger.debug(
+            "Failed to fetch Helicone pricing for %s: %s",
+            sanitize_for_logging(model_id),
+            sanitize_for_logging(str(e)),
+        )
+
+    # Fallback: return default zero pricing
+    return {
+        "prompt": "0",
+        "completion": "0",
+        "request": "0",
+        "image": "0",
+    }
 
 
 def fetch_models_from_anannas():

--- a/src/services/providers.py
+++ b/src/services/providers.py
@@ -77,6 +77,7 @@ def get_provider_logo_from_services(provider_id: str, site_url: str = None) -> s
             "ai21": "https://cdn.jsdelivr.net/gh/simple-icons/simple-icons@develop/icons/ai21labs.svg",
             "inflection": "https://cdn.jsdelivr.net/gh/simple-icons/simple-icons@develop/icons/inflection.svg",
             "vercel": "https://cdn.jsdelivr.net/gh/simple-icons/simple-icons@develop/icons/vercel.svg",
+            "helicone": "https://www.helicone.ai/favicon.ico",
             "aihubmix": "https://aihubmix.com/favicon.ico",
             "anannas": "https://api.anannas.ai/favicon.ico",
         }


### PR DESCRIPTION
## Summary
- Integrates Helicone AI Gateway models into the catalog
- Fetches, normalizes, and caches Helicone models for catalog delivery
- Adds Helicone OpenAI-compatible client and streaming support
- Extends provider detection, pricing, and logo mappings to cover Helicone
- Updates chat routing to support Helicone-based completions

## Changes
### Core Catalog / Backend
- Implement Helicone model caching: _helicone_models_cache with ttl and stale_ttl
- Extend get_models_cache and clear_models_cache to include Helicone under the gateway key
- Add Helicone model fetching and normalization flow:
  - fetch_models_from_helicone(): calls Helicone API via new client, normalizes models, updates cache
  - normalize_helicone_model(model): converts Helicone model into catalog schema
- Introduce Helicone pricing integration:
  - get_helicone_model_pricing(model_id): fetches pricing via Helicone API or underlying provider pricing
  - get_provider_pricing_for_helicone_model(model_id): fallback cross-reference to provider pricing
- Extend model and provider pipelines to recognize Helicone models and branding

### Helicone Client (new)
- src/services/helicone_client.py
  - get_helicone_client(): returns an OpenAI-compatible client targeting Helicone gateway with HELICONE_API_KEY
  - make_helicone_request_openai(messages, model, **kwargs): non-stream request wrapper
  - make_helicone_request_openai_stream(messages, model, **kwargs): streaming request wrapper
  - process_helicone_response(response): normalize Helicone response to internal schema
  - fetch_model_pricing_from_helicone(model_id): fetch pricing data from Helicone pricing endpoint or provider
  - get_provider_pricing_for_helicone_model(model_id): provider-based pricing lookup fallback

### Chat Routes / Runtime
- src/routes/chat.py
  - Import Helicone client methods and add handling for attempt_provider == "helicone" (streaming and non-streaming paths)
  - Route Helicone responses through process_helicone_response for consistency

### Model Transformations / Detection
- src/services/model_transformations.py
  - Recognize "helicone" in provider detection paths
  - Extend mapping to accommodate Helicone models in auto-detection

### Models Catalog Integration
- src/services/models.py
  - Register helicone in available model lists for parallel and sequential fetch
  - Wire in _helicone_models_cache usage in get_cached_models for catalog

### Pricing / Provider Logos
- src/services/providers.py
  - Add Helicone logo URL to provider logo mapping

### Configuration
- src/config/config.py
  - Add HELICONE_API_KEY environment variable support

## Test plan
- Set HELICONE_API_KEY in the environment
- Run catalog fetch and verify Helicone models appear under the catalog with expected fields (id, slug, name, pricing, provider_slug, etc.)
- Verify pricing data for Helicone models is populated or gracefully falls back when unavailable
- Validate chat completions with attempt_provider set to helicone both for streaming and non-streaming paths
- Confirm Helicone models caching respects TTL and stale behavior

## Migration notes
- No migration required. Requires HELICONE_API_KEY to enable Helicone model catalog support.
- If Helicone pricing endpoint is unavailable, pricing will gracefully fall back to provider pricing or default zeros.



🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c820057a-c503-490e-8766-8cda653b2b9e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Helicone AI Gateway across catalog and runtime: model fetch/normalize/cache, chat routing (stream + non-stream), provider detection, pricing, and logo; configurable via HELICONE_API_KEY.
> 
> - **Catalog / Caching**
>   - Add `helicone` cache (`_helicone_models_cache`) and wire into `get_models_cache`/`clear_models_cache` and aggregation (`get_all_models_*`).
>   - Implement `fetch_models_from_helicone()` and `normalize_helicone_model()` with pricing via `get_helicone_model_pricing()`.
>   - Register Helicone in canonical registry flow and cache freshness paths.
> - **Runtime / Chat**
>   - Route Helicone requests in `src/routes/chat.py` for both streaming and non-streaming via `make_helicone_request_openai(_stream)` and `process_helicone_response`.
> - **Client (new)**
>   - Add `src/services/helicone_client.py` with `get_helicone_client()`, request wrappers, response processing, and pricing lookup (`fetch_model_pricing_from_helicone`, provider fallback).
> - **Model Detection / Transformations**
>   - Recognize `helicone` in `detect_provider_from_model_id()` and add mapping namespace in `get_model_id_mapping()`.
> - **Config**
>   - Introduce `Config.HELICONE_API_KEY`.
> - **Providers / Branding**
>   - Add Helicone logo mapping in `src/services/providers.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fff78102cc5ae22c8012aaa8e21335d622ac4103. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->