### PR TITLE
Preload Featherless cache to fix loading issue

### DIFF
--- a/src/cache.py
+++ b/src/cache.py
@@ -313,3 +313,34 @@ def initialize_fal_cache_from_catalog():
     except (ImportError, OSError) as error:
         # Log failure but continue - models will be loaded on first request
         logger.debug(f"{_FAL_CACHE_INIT_DEFERRED}: {type(error).__name__}")
+
+
+def initialize_featherless_cache_from_catalog():
+    """Load and initialize Featherless models cache from static catalog export
+
+    Unlike FAL which has a static JSON catalog, Featherless uses CSV exports.
+    This function attempts to load from available CSV exports and initializes
+    the cache structure even if no data is found (to enable lazy loading).
+    """
+    try:
+        from src.services.models import load_featherless_catalog_export
+
+        # Try to load from CSV export
+        raw_models = load_featherless_catalog_export()
+
+        if raw_models and len(raw_models) > 0:
+            # Successfully loaded from export
+            _featherless_models_cache["data"] = raw_models
+            _featherless_models_cache["timestamp"] = datetime.now(timezone.utc)
+            logger.debug(f"Preloaded {len(raw_models)} Featherless models from catalog export")
+        else:
+            # No export available - initialize empty to enable lazy loading via API
+            _featherless_models_cache["data"] = []
+            _featherless_models_cache["timestamp"] = None
+            logger.debug("Featherless cache initialized empty - will load from API on first request")
+
+    except (ImportError, OSError) as error:
+        # Log failure but continue - initialize empty cache for lazy loading
+        _featherless_models_cache["data"] = []
+        _featherless_models_cache["timestamp"] = None
+        logger.debug(f"Featherless cache init deferred: {type(error).__name__}")

--- a/src/services/models.py
+++ b/src/services/models.py
@@ -235,6 +235,16 @@ except ImportError:
     # Initialization will be deferred to first request if import fails
     logger.debug(f"{_FAL_CACHE_INIT_DEFERRED} on import")
 
+# Initialize Featherless models cache on module import for better performance
+# This ensures Featherless cache structure is ready even if no static catalog exists
+try:
+    from src.cache import initialize_featherless_cache_from_catalog
+
+    initialize_featherless_cache_from_catalog()
+except ImportError:
+    # Initialization will be deferred to first request if import fails
+    logger.debug("Featherless cache initialization deferred on import")
+
 
 def load_featherless_catalog_export() -> list:
     """


### PR DESCRIPTION
## Summary
- Preloads Featherless models cache at startup to prevent loading failures when a static catalog is missing.
- Ensures cache structure exists for lazy loading via API.

## Changes
### Cache layer
- Added `initialize_featherless_cache_from_catalog` in `src/cache.py`.
  - Attempts to load Featherless models from CSV export via `load_featherless_catalog_export`.
  - If data is found: populate `_featherless_models_cache` with data and set a UTC timestamp; log preload.
  - If no data: initialize an empty cache with `timestamp=None` to enable lazy loading.
  - On `ImportError`/`OSError`: initialize an empty cache and log deferred initialization.
  - Keeps behavior non-blocking: if loading fails, API will lazy-load on first request.

### Models service
- Invoked `initialize_featherless_cache_from_catalog()` during module import in `src/services/models.py`.
- If import fails, initialization is deferred to the first request with a debug log.

### Behavior
- Improves startup performance and resilience when the CSV export is unavailable or missing.

## Rationale
- Featherless catalog uses CSV exports; previously, the cache might not be ready, causing first-request latency or errors. This change ensures the cache structure is prepared and supports lazy loading as needed.

## Testing
- [x] Start service with/without Featherless CSV export; ensure API initializes without crashes.
- [x] Access Featherless models endpoint and verify data loads (or an empty structure if no export).
- [x] Ensure no blocking failure if the CSV export is absent.

## Notes
- No user-facing API changes; this is an internal performance and reliability improvement.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/2ef7639a-b51c-4bba-b855-388868c32025

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Featherless cache preloading from CSV export and initializes the cache structure on module import, falling back to empty for lazy API loading.
> 
> - **Cache layer (`src/cache.py`)**:
>   - **Featherless init**: Adds `initialize_featherless_cache_from_catalog` to load models from CSV export via `load_featherless_catalog_export`; sets cache with UTC timestamp or initializes empty on missing data/errors.
> - **Models service (`src/services/models.py`)**:
>   - **On-import init**: Invokes `initialize_featherless_cache_from_catalog()` during module import; defers on `ImportError` with debug log.
>   - **CSV loader**: Ensures `load_featherless_catalog_export()` checks multiple export candidates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f91a4cfdec483481eaf009ccd343c0335e72a9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->