### PR TITLE
fix(backend): optimistic model availability default + error report

### DIFF
--- a/src/cache.py
+++ b/src/cache.py
@@ -17,8 +17,10 @@ _models_cache = {
 }
 
 # Unified multi-provider catalog cache (canonical + provider adapters)
+# Note: data initialized to [] instead of None to distinguish between
+# "not yet cached" (timestamp=None) and "cached but empty" (timestamp set, data=[])
 _multi_provider_catalog_cache = {
-    "data": None,
+    "data": [],
     "timestamp": None,
     "ttl": 900,  # 15 minutes TTL for aggregated catalog snapshots
     "stale_ttl": 1800,

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -37,6 +37,19 @@ class TestCacheInitialization:
         assert cache_module._provider_cache["data"] is None
         assert cache_module._provider_cache["timestamp"] is None
 
+    def test_multi_provider_catalog_cache_initialized(self):
+        """Test multi-provider catalog cache is initialized with empty list
+
+        The multi-provider catalog cache should initialize with data=[] instead
+        of data=None to distinguish between "not yet cached" (timestamp=None)
+        and "cached but empty" (timestamp set, data=[]).
+        """
+        assert cache_module._multi_provider_catalog_cache is not None
+        assert cache_module._multi_provider_catalog_cache["data"] == []
+        assert cache_module._multi_provider_catalog_cache["timestamp"] is None
+        assert cache_module._multi_provider_catalog_cache["ttl"] == 900
+        assert cache_module._multi_provider_catalog_cache["stale_ttl"] == 1800
+
     def test_all_gateway_caches_exist(self):
         """Test all gateway-specific caches are initialized"""
         expected_gateways = [


### PR DESCRIPTION
## Summary

- Updates backend submodule with fix for circuit breaker false positives
- Adds comprehensive error report from 8-hour Railway log review (Dec 28-29, 2025)
- Includes 5 new tests for model availability handling

## Backend Changes

**PR**: https://github.com/Alpaca-Network/gatewayz-backend/pull/722
**Commit**: b5809663

### Fix Applied

Changed `is_model_available()` to return `True` (optimistic) when no availability record exists for a model, preventing circuit breaker from blocking new/unknown models.

**Before**: Unknown models returned `False` → blocked by circuit breaker → emergency fallback used
**After**: Unknown models return `True` → allowed to proceed → circuit breaker only activates after actual failures

### Test Coverage Added

- Unknown models defaulting to available
- Open circuit breaker blocking requests  
- Maintenance mode detection
- Unavailable status handling
- Cache timeout scenarios

## Error Report Summary

Documented 7 issues from Railway logs:

| Severity | Issue | Status |
|----------|-------|--------|
| **High** | Circuit breaker emergency fallback | ✅ Fixed |
| **High** | Encryption keys not configured | 🔧 Manual config needed |
| **Medium** | Supabase query returns None | 📋 Documented |
| **Medium** | Vertex upstream timeouts | 📋 Documented |
| **Low** | Function calling not supported for Vertex REST | 📋 Documented |
| **Info** | Rate limiting active | ✅ Working as designed |
| **Info** | Audit logging format | 📋 Documented |

## Immediate Action Required

### Configure Encryption Keys (P0 - Security)
```bash
# In Railway environment variables:
KEY_VERSION=1
KEYRING_1=<fernet-key>
```

## Test Plan

- [x] Added 5 tests for model availability states
- [x] Backend submodule points to clean commit
- [ ] Verify encryption keys configured in production
- [ ] Verify Supabase table permissions

## Related PRs

- Backend: https://github.com/Alpaca-Network/gatewayz-backend/pull/722
- #240 | Fix OpenRouter credit drain | Merged
- #239 | Health-service column name fix | Merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)