### PR TITLE
test(cache): add test for multi-provider catalog cache initialization

### DIFF
--- a/src/cache.py
+++ b/src/cache.py
@@ -17,8 +17,10 @@ _models_cache = {
 }
 
 # Unified multi-provider catalog cache (canonical + provider adapters)
+# Note: data initialized to [] instead of None to distinguish between
+# "not yet cached" (timestamp=None) and "cached but empty" (timestamp set, data=[])
 _multi_provider_catalog_cache = {
-    "data": None,
+    "data": [],
     "timestamp": None,
     "ttl": 900,  # 15 minutes TTL for aggregated catalog snapshots
     "stale_ttl": 1800,

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -37,6 +37,19 @@ class TestCacheInitialization:
         assert cache_module._provider_cache["data"] is None
         assert cache_module._provider_cache["timestamp"] is None
 
+    def test_multi_provider_catalog_cache_initialized(self):
+        """Test multi-provider catalog cache is initialized with empty list
+
+        The multi-provider catalog cache should initialize with data=[] instead
+        of data=None to distinguish between "not yet cached" (timestamp=None)
+        and "cached but empty" (timestamp set, data=[]).
+        """
+        assert cache_module._multi_provider_catalog_cache is not None
+        assert cache_module._multi_provider_catalog_cache["data"] == []
+        assert cache_module._multi_provider_catalog_cache["timestamp"] is None
+        assert cache_module._multi_provider_catalog_cache["ttl"] == 900
+        assert cache_module._multi_provider_catalog_cache["stale_ttl"] == 1800
+
     def test_all_gateway_caches_exist(self):
         """Test all gateway-specific caches are initialized"""
         expected_gateways = [


### PR DESCRIPTION
Initialize _multi_provider_catalog_cache data field with an empty list instead of None to clearly distinguish between "not yet cached" (timestamp=None) and "cached but empty" (timestamp set, data=[]).

Add corresponding test to verify correct initialization of multi-provider catalog cache fields.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Initialize `_multi_provider_catalog_cache` with `data=[]` (not `None`) and add a test to verify correct initialization.
> 
> - **Cache**:
>   - Initialize `_multi_provider_catalog_cache` with `data=[]` to differentiate between uncached and cached-empty states.
>   - Clarify freshness/staleness checks to consider only `timestamp`, allowing empty lists as valid cached values.
> - **Tests**:
>   - Add `test_multi_provider_catalog_cache_initialized` to assert `data == []`, `timestamp is None`, and TTLs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69f227280b97b6b440ea2f9a0803c3602bf77fa9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->