### PR TITLE
Resolve Qwen3-30B-A3B-Instruct Model Access

### DIFF
--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -438,6 +438,11 @@ def get_model_id_mapping(provider: str) -> Dict[str, str]:
             # Qwen models
             "qwen/qwen-2-72b": "qwen-2-72b",
             "qwen-2-72b": "qwen-2-72b",
+            # Qwen3 models - proper case required
+            "qwen/qwen3-30b-a3b-instruct-2507": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "qwen3-30b-a3b-instruct-2507": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "qwen/qwen3-30b-a3b-thinking-2507": "Qwen/Qwen3-30B-A3B-Thinking-2507",
+            "qwen3-30b-a3b-thinking-2507": "Qwen/Qwen3-30B-A3B-Thinking-2507",
 
             # GPT-OSS models
             "gpt-oss/gpt-oss-120b": "gpt-oss-120b",


### PR DESCRIPTION
## Summary
- Adds proper-case Qwen3 mappings to enable access to Qwen3-30B-A3B-Instruct and Thinking variants.
- Ensures both prefixed and non-prefixed host keys map to the canonical model IDs.

## Changes
### Core Functionality
- Updated src/services/model_transformations.py in get_model_id_mapping with new Qwen3 entries:
  - "qwen/qwen3-30b-a3b-instruct-2507" → "Qwen/Qwen3-30B-A3B-Instruct-2507"
  - "qwen3-30b-a3b-instruct-2507" → "Qwen/Qwen3-30B-A3B-Instruct-2507"
  - "qwen/qwen3-30b-a3b-thinking-2507" → "Qwen/Qwen3-30B-A3B-Thinking-2507"
  - "qwen3-30b-a3b-thinking-2507" → "Qwen/Qwen3-30B-A3B-Thinking-2507"

### Notes
- Keeps existing Qwen2 and GPT-OSS mappings intact.

## Validation / Test Plan
- [x] Validate mapping keys resolve to the correct canonical IDs for both prefixed (qwen/...) and non-prefixed (qwen3-...) forms
- [x] Smoke-test model resolution in gateway for:
  - Qwen/qwen3-30b-a3b-instruct-2507
  - qwen3-30b-a3b-instruct-2507
  - Qwen/qwen3-30b-a3b-thinking-2507
  - qwen3-30b-a3b-thinking-2507

## Rationale
- This change fixes access for the Qwen3-30B-A3B-Instruct model by aligning both key formats to the correct, properly-cased model identifier used by downstream systems.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b4f111f3-b52e-43ea-b1cd-78567a339084

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Near provider mappings for Qwen3-30B-A3B Instruct and Thinking (prefixed and non-prefixed) to proper-case model IDs.
> 
> - **Near provider mappings**:
>   - **Qwen3 models (proper-case resolution)**:
>     - Map `qwen/qwen3-30b-a3b-instruct-2507` and `qwen3-30b-a3b-instruct-2507` → `Qwen/Qwen3-30B-A3B-Instruct-2507`.
>     - Map `qwen/qwen3-30b-a3b-thinking-2507` and `qwen3-30b-a3b-thinking-2507` → `Qwen/Qwen3-30B-A3B-Thinking-2507`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64eaffcb6bb151590ac5ce07f4526ae3b9058c81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->