### PR TITLE
Add Alpaca Network provider to gateways

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -86,6 +86,9 @@ class Config:
     # Anannas Configuration
     ANANNAS_API_KEY = os.environ.get("ANANNAS_API_KEY")
 
+    # Alpaca Network Configuration
+    ALPACA_NETWORK_API_KEY = os.environ.get("ALPACA_NETWORK_API_KEY")
+
     # Google Vertex AI Configuration (for image generation)
     GOOGLE_PROJECT_ID = os.environ.get("GOOGLE_PROJECT_ID", "gatewayz-468519")
     GOOGLE_VERTEX_LOCATION = os.environ.get("GOOGLE_VERTEX_LOCATION", "us-central1")

--- a/src/data/manual_pricing.json
+++ b/src/data/manual_pricing.json
@@ -73,13 +73,22 @@
       "pricing_model": "per_image"
     }
   },
+  "alpaca-network": {
+    "deepseek-v3-1": {
+      "prompt": "0.27",
+      "completion": "1.10",
+      "request": "0",
+      "image": "0"
+    }
+  },
   "_metadata": {
-    "last_updated": "2025-01-15",
+    "last_updated": "2025-11-10",
     "note": "Manual pricing data for providers that don't expose pricing via API",
     "sources": [
       "https://deepinfra.com/pricing",
       "https://featherless.ai/pricing",
-      "https://chutes.ai/pricing"
+      "https://chutes.ai/pricing",
+      "https://console.anyscale.com/services (Alpaca Network via Anyscale)"
     ],
     "currency": "USD",
     "units": "per 1M tokens (unless specified otherwise)"

--- a/src/services/alpaca_network_client.py
+++ b/src/services/alpaca_network_client.py
@@ -1,0 +1,97 @@
+import logging
+
+from openai import OpenAI
+
+from src.config import Config
+from src.services.anthropic_transformer import extract_message_with_tools
+
+# Initialize logging
+logger = logging.getLogger(__name__)
+
+
+def get_alpaca_network_client():
+    """Get Alpaca Network client using OpenAI-compatible interface
+
+    Alpaca Network provides access to DeepSeek and other models via Anyscale infrastructure
+    """
+    try:
+        if not Config.ALPACA_NETWORK_API_KEY:
+            raise ValueError("Alpaca Network API key not configured")
+
+        return OpenAI(
+            base_url="https://deepseek-v3-1-b18ty.cld-kvytpjjrw13e2gvq.s.anyscaleuserdata.com",
+            api_key=Config.ALPACA_NETWORK_API_KEY,
+        )
+    except Exception as e:
+        logger.error(f"Failed to initialize Alpaca Network client: {e}")
+        raise
+
+
+def make_alpaca_network_request_openai(messages, model, **kwargs):
+    """Make request to Alpaca Network using OpenAI client
+
+    Args:
+        messages: List of message objects
+        model: Model name to use
+        **kwargs: Additional parameters like max_tokens, temperature, etc.
+    """
+    try:
+        client = get_alpaca_network_client()
+        response = client.chat.completions.create(model=model, messages=messages, **kwargs)
+        return response
+    except Exception as e:
+        logger.error(f"Alpaca Network request failed: {e}")
+        raise
+
+
+def make_alpaca_network_request_openai_stream(messages, model, **kwargs):
+    """Make streaming request to Alpaca Network using OpenAI client
+
+    Args:
+        messages: List of message objects
+        model: Model name to use
+        **kwargs: Additional parameters like max_tokens, temperature, etc.
+    """
+    try:
+        client = get_alpaca_network_client()
+        stream = client.chat.completions.create(
+            model=model, messages=messages, stream=True, **kwargs
+        )
+        return stream
+    except Exception as e:
+        logger.error(f"Alpaca Network streaming request failed: {e}")
+        raise
+
+
+def process_alpaca_network_response(response):
+    """Process Alpaca Network response to extract relevant data"""
+    try:
+        choices = []
+        for choice in response.choices:
+            msg = extract_message_with_tools(choice.message)
+
+            choices.append({
+                "index": choice.index,
+                "message": msg,
+                "finish_reason": choice.finish_reason,
+            })
+
+        return {
+            "id": response.id,
+            "object": response.object,
+            "created": response.created,
+            "model": response.model,
+            "choices": choices,
+            "usage": (
+                {
+                    "prompt_tokens": response.usage.prompt_tokens,
+                    "completion_tokens": response.usage.completion_tokens,
+                    "total_tokens": response.usage.total_tokens,
+                }
+                if response.usage
+                else {}
+            ),
+        }
+    except Exception as e:
+        logger.error(f"Failed to process Alpaca Network response: {e}")
+        raise

--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -462,6 +462,19 @@ def get_model_id_mapping(provider: str) -> Dict[str, str]:
             "glm-4.6-fp8": "glm-4.6-fp8",
             "glm-4.6": "glm-4.6",
         },
+        "alpaca-network": {
+            # Alpaca Network uses Anyscale infrastructure with DeepSeek models
+            # Service: deepseek-v3-1 via https://deepseek-v3-1-b18ty.cld-kvytpjjrw13e2gvq.s.anyscaleuserdata.com
+
+            # DeepSeek V3.1 models
+            "deepseek-ai/deepseek-v3.1": "deepseek-v3-1",
+            "deepseek-ai/deepseek-v3": "deepseek-v3-1",  # Map v3 to v3.1
+            "deepseek/deepseek-v3.1": "deepseek-v3-1",
+            "deepseek/deepseek-v3": "deepseek-v3-1",
+            "deepseek-v3.1": "deepseek-v3-1",
+            "deepseek-v3": "deepseek-v3-1",
+            "deepseek-v3-1": "deepseek-v3-1",  # Direct service name
+        },
     }
 
     return mappings.get(provider, {})
@@ -661,6 +674,7 @@ def detect_provider_from_model_id(model_id: str, preferred_provider: Optional[st
         "aihubmix",
         "anannas",
         "near",
+        "alpaca-network",
         "fal",
     ]:
         mapping = get_model_id_mapping(provider)
@@ -698,6 +712,10 @@ def detect_provider_from_model_id(model_id: str, preferred_provider: Optional[st
         # Helicone models (e.g., "helicone/gpt-4o-mini")
         if org == "helicone":
             return "helicone"
+
+        # Alpaca Network models (e.g., "alpaca-network/deepseek-v3-1")
+        if org == "alpaca-network" or org == "alpaca":
+            return "alpaca-network"
 
         # DeepSeek models are primarily on Fireworks in this system
         if org == "deepseek-ai" and "deepseek" in model_name.lower():

--- a/src/services/providers.py
+++ b/src/services/providers.py
@@ -80,6 +80,7 @@ def get_provider_logo_from_services(provider_id: str, site_url: str = None) -> s
             "helicone": "https://www.helicone.ai/favicon.ico",
             "aihubmix": "https://aihubmix.com/favicon.ico",
             "anannas": "https://api.anannas.ai/favicon.ico",
+            "alpaca-network": "https://console.anyscale.com/favicon.ico",
         }
 
         # Try manual mapping first


### PR DESCRIPTION
## Summary
- Adds Alpaca Network provider integration to gateways, enabling access to DeepSeek models via Anyscale infrastructure.
- Introduces a new Alpaca Network OpenAI-compatible client and wiring to support streaming and non-streaming paths.
- Extends model mapping, pricing data, and provider metadata to recognize alpaca-network.

## Changes

### Core
- New: src/services/alpaca_network_client.py
  - Loads ALPACA_NETWORK_API_KEY from Config
  - make_alpaca_network_request_openai and make_alpaca_network_request_openai_stream implement OpenAI-like interactions
  - process_alpaca_network_response normalizes response using extract_message_with_tools

### Routing
- src/routes/chat.py
  - Import and wire Alpaca Network client
  - Add handling for attempt_provider alpaca-network for both streaming and non-stream paths

### Transformations
- src/services/model_transformations.py
  - Extend provider mappings with alpaca-network, resolving to deepseek-v3-1
  - detect_provider_from_model_id recognizes alpaca-network or alpaca as provider

### Config
- src/config/config.py
  - Add ALPACA_NETWORK_API_KEY from environment

### Data
- src/data/manual_pricing.json
  - Add manual pricing block for alpaca-network deepseek-v3-1 with token pricing
  - Update _metadata last_updated and sources to include Anyscale note

### UI/Providers
- src/services/providers.py
  - Add logo mapping for alpaca-network

## Test plan
- [x] Run chat with provider alpaca-network using a valid ALPACA_NETWORK_API_KEY
- [x] Validate both streaming and non-streaming responses
- [x] Verify model_id to provider mapping detects alpaca-network correctly
- [x] Check manual pricing entry loads and is used in pricing logic
- [x] Ensure provider logo appears for alpaca-network in UI



🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6cb6d557-178c-4149-9daa-789ceff945c9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Alpaca Network (DeepSeek v3-1) support with OpenAI-compatible client, routing (stream/non-stream), model mapping/detection, pricing, and provider metadata.
> 
> - **Backend/Core**:
>   - New `src/services/alpaca_network_client.py` with OpenAI-compatible requests (streaming and non-streaming) and response normalization.
> - **Routing**:
>   - Wire `alpaca-network` into `chat_completions` and `unified_responses` paths for streaming/non-streaming in `src/routes/chat.py`.
> - **Model Transformations**:
>   - Add `alpaca-network` mappings (various `deepseek-*` -> `deepseek-v3-1`) and provider detection in `src/services/model_transformations.py`.
> - **Config**:
>   - Add `ALPACA_NETWORK_API_KEY` in `src/config/config.py`.
> - **Pricing/Data**:
>   - Add manual pricing for `alpaca-network/deepseek-v3-1`; update `_metadata` (date, sources) in `src/data/manual_pricing.json`.
> - **Provider Metadata**:
>   - Add logo mapping for `alpaca-network` in `src/services/providers.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1dbfe4c953495e0e1155d5f6db3099197de792f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->