### PR TITLE
Fix pip command not found error in Railway deployment

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# Activate virtual environment if it exists (for Nixpacks/Railway deployments)
+if [ -d "/opt/venv" ]; then
+    source /opt/venv/bin/activate
+fi
+
 echo "🔍 Checking dependency versions..."
 
 # Check current httpx version
@@ -13,7 +18,7 @@ echo "Current openai version: $OPENAI_VERSION"
 # If versions are wrong, reinstall correct ones
 if [ "$HTTPX_VERSION" != "0.27.0" ] || [ "$OPENAI_VERSION" != "1.44.0" ]; then
     echo "⚠️  Wrong versions detected! Fixing..."
-    pip install --no-cache-dir --force-reinstall httpx==0.27.0 openai==1.44.0
+    python -m pip install --no-cache-dir --force-reinstall httpx==0.27.0 openai==1.44.0
     echo "✅ Dependencies fixed!"
 else
     echo "✅ Correct versions already installed"


### PR DESCRIPTION
## Summary
- Fixed critical deployment issue where `pip: command not found` errors were preventing the container from starting
- Added virtual environment activation in `start.sh` for Nixpacks/Railway environments
- Changed `pip` invocation to `python -m pip` for more reliable execution

## Problem
The application was failing to start on Railway with repeated errors:
```
🔍 Checking dependency versions...
Current httpx version: not found
Current openai version: not found
⚠️  Wrong versions detected! Fixing...
start.sh: line 16: pip: command not found
```

## Root Cause
The `start.sh` script was trying to use `pip` directly, but in the Nixpacks build environment:
1. Dependencies are installed in a virtual environment at `/opt/venv`
2. The `pip` command wasn't in PATH because the venv wasn't activated
3. This prevented the script from fixing dependency versions and starting the app

## Solution
Updated `start.sh` to:
1. **Activate the virtual environment** before running any commands (if `/opt/venv` exists)
2. **Use `python -m pip`** instead of `pip` for more reliable invocation across different environments

## Test Plan
- Deploy to Railway and verify:
  - [ ] Container starts successfully without pip errors
  - [ ] Dependencies are installed/verified correctly
  - [ ] Application runs and responds to health checks
  - [ ] No regression in other deployment environments (Vercel, Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Activates `/opt/venv` when present and switches to `python -m pip` in `start.sh` to prevent pip not found errors during deployment.
> 
> - **Startup script (`start.sh`)**:
>   - Activate virtual environment at `/opt/venv` if present.
>   - Replace `pip` with `python -m pip` for dependency reinstalls.
>   - Keeps version checks and app startup via `uvicorn` unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9577eac9e5053e6c8a3965cb07c47b0e8245256. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->