### PR TITLE
Fix Docker build by running pip in Nixpacks phase

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -9,5 +9,11 @@ cmds = [
   '. /opt/venv/bin/activate && pip install --no-cache-dir -r requirements.txt'
 ]
 
+[phases.build]
+cmds = [
+  '. /opt/venv/bin/activate && pip install --no-cache-dir --force-reinstall httpx==0.27.0 openai==1.44.0',
+  '. /opt/venv/bin/activate && pip install --no-cache-dir -r requirements.txt'
+]
+
 [start]
-cmd = 'uvicorn src.main:app --host 0.0.0.0 --port ${PORT:-8000}'
+cmd = 'bash start.sh'


### PR DESCRIPTION
## Summary
- Addresses Docker build failure by executing pip install commands in a dedicated Nixpacks build phase
- Ensures specific package versions are installed (httpx==0.27.0, openai==1.44.0) with force reinstall
- Updates startup to execute start.sh via bash to properly initialize the environment

## Changes

### Build configuration
- **nixpacks.toml**: Added a new [phases.build] section to run pip installs inside the build phase:
  - Activate virtual environment: `. /opt/venv/bin/activate`
  - Install pinned packages with force reinstall: `pip install --no-cache-dir --force-reinstall httpx==0.27.0 openai==1.44.0`
  - Install remaining dependencies: `pip install --no-cache-dir -r requirements.txt`

### Startup
- **Start command**: Changed from
  - `uvicorn src.main:app --host 0.0.0.0 --port ${PORT:-8000}`
  to
  - `bash start.sh`

## Test plan
- [x] Build image to verify no "pip: command not found" errors during build
- [x] Confirm pinned packages (httpx==0.27.0, openai==1.44.0) are installed
- [x] Run container and ensure the app starts via start.sh
- [x] Verify service responds on the expected port (e.g., health check or root endpoint)

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9c675385-5eb8-489d-abd0-ad5b65d429fc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Nixpacks build phase to force-install pinned deps and switches startup to run `bash start.sh`.
> 
> - **Build configuration**:
>   - Add `phases.build` in `nixpacks.toml` to activate venv and `pip install --force-reinstall` pinned `httpx==0.27.0` and `openai==1.44.0`, then reinstall from `requirements.txt`.
> - **Startup**:
>   - Change start command to `bash start.sh` instead of running `uvicorn` directly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5b788fd2630ad1f3c40e4196f664125d9414677. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->