### PR TITLE
Bump Python to 3.12 and update tooling (Ruff/Black/MyPy)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "gatewayz-backend"
 version = "2.0.3"
 description = "Gatewayz Universal Inference API"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.13"
 dependencies = [
     # Core web framework
     "fastapi==0.104.1",
@@ -80,7 +80,7 @@ full = [
 # Ruff Configuration (Fast Python Linter)
 [tool.ruff]
 # Python version
-target-version = "py310"
+target-version = "py312"
 
 # Line length
 line-length = 100
@@ -131,7 +131,7 @@ unfixable = []
 # Black Configuration (Code Formatter)
 [tool.black]
 line-length = 100
-target-version = ['py310']
+target-version = ['py312']
 include = '\.pyi?$'
 extend-exclude = '''
 /(
@@ -163,7 +163,7 @@ skip_glob = ["**/migrations/*", "**/__pycache__/*"]
 
 # MyPy Configuration (Type Checker)
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false  # Set to true when ready for strict typing


### PR DESCRIPTION
## Summary
- Aligns Gatewayz Backend with Python 3.12 for Vercel deployment
- Updates tooling configuration to target Python 3.12 (Ruff, Black, MyPy)
- Maintains existing dependencies and runtime constraints

## Changes
### Build & Tooling
- **pyproject.toml**
  - requires-python: from ">=3.10" to ">=3.10,<3.13"
  - Ruff: [tool.ruff] target-version → "py312"
  - Black: [tool.black] target-version → ['py312']
  - MyPy: [tool.mypy] python_version → "3.12"

### CI / Deployment
- No code changes required; updates ensure compatibility with Vercel’s Python 3.12 runtime

### Notes
- No application logic changes. All updates are tooling/configuration related to the Python runtime.

## Test plan
- [x] Build and run locally with Python 3.12
- [x] Run static checks: Ruff, Black, and MyPy pass
- [x] Validate deployment on Vercel with Python 3.12 runtime

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/797204b9-f587-4207-b905-821440ee5de5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Constrain Python to >=3.10,<3.13 and bump Ruff/Black/MyPy targets to 3.12 in pyproject.toml.
> 
> - **Build & Tooling (`pyproject.toml`)**:
>   - Update `requires-python` to `>=3.10,<3.13`.
>   - Set Ruff `target-version` to `py312`.
>   - Set Black `target-version` to `['py312']`.
>   - Set MyPy `python_version` to `3.12`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bdf1e7a4d90ecb6888e19a927bf829584bc75e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->