### PR TITLE
chore: add deployment note to trigger Railway rebuild for Vertex ADC

### DIFF
--- a/src/services/google_vertex_client.py
+++ b/src/services/google_vertex_client.py
@@ -14,6 +14,8 @@ The library will automatically find credentials from:
 1. GOOGLE_APPLICATION_CREDENTIALS environment variable (path to JSON file)
 2. GOOGLE_VERTEX_CREDENTIALS_JSON environment variable (raw JSON, written to temp file)
 3. Application Default Credentials (gcloud auth, GCE metadata server, etc.)
+
+Deployment Note: This implementation was updated to use ADC in PR #252.
 """
 
 import json


### PR DESCRIPTION
## Summary
This PR triggers a fresh deployment to Railway to ensure the Google Vertex AI ADC implementation from PR #252 is properly deployed.

## Background
PR #252 successfully merged the Google Vertex AI migration from manual JWT token exchange to Application Default Credentials (ADC) using the Vertex AI SDK. However, the changes may not have been picked up by Railway's deployment system.

## Changes
- Added a deployment note comment to `google_vertex_client.py` to trigger a rebuild
- No functional changes - this is purely to force a fresh deployment

## What Was Already Merged in PR #252
✅ Replaced REST API + manual JWT with Vertex AI SDK + ADC  
✅ Added `initialize_vertex_ai()` for ADC-based authentication  
✅ Updated all tests to mock SDK calls instead of HTTP calls  
✅ Updated dependent modules (`image_generation_client.py`, `portkey_providers.py`)  
✅ All CI checks passing  

## Expected Impact
- Railway will rebuild and deploy with the ADC-based Google Vertex implementation
- Google Vertex models should work correctly in production
- No breaking changes - purely deployment-related

## Testing
- All existing tests pass (already validated in PR #252)
- This PR only adds a comment, no code changes

---
🌿 Generated by [Terry](https://www.terragonlabs.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a deployment note in `src/services/google_vertex_client.py` docstring to trigger a rebuild; no functional changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78b4eff98a49115456a139b5718a9d8079c51211. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

📎 **Task**: https://www.terragonlabs.com/task/7c956b84-0365-4aa9-8d68-4babb1bc0742