### PR TITLE
Fix dashboard health API by correcting project root path

### DIFF
--- a/scripts/diagnostic/check_and_fix_gateway_models.py
+++ b/scripts/diagnostic/check_and_fix_gateway_models.py
@@ -21,7 +21,10 @@ from datetime import datetime, timezone
 from typing import Dict, List, Tuple, Optional
 
 # Add the project root to the path
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# Get the project root (two directories up from this script)
+script_dir = os.path.dirname(os.path.abspath(__file__))
+project_root = os.path.dirname(os.path.dirname(script_dir))
+sys.path.insert(0, project_root)
 
 from src.services.models import get_cached_models
 from src.config import Config


### PR DESCRIPTION
## Summary
- Fixes an import path issue causing dashboard health API access problems by correcting how the diagnostic script locates the project root.

## Changes

### Core Functionality
- Compute project_root as two directories up from scripts/diagnostic/check_and_fix_gateway_models.py and insert it into sys.path.
- This replaces the previous approach that used the script directory level as the project root, ensuring imports like src.services.models and src.config resolve correctly when the dashboard health API runs.

### Test plan
- [x] Run the dashboard health API to verify gateway model imports no longer raise ImportError
- [x] Run the diagnostic script locally to confirm it imports modules from src without path issues
- [ ] If applicable, re-run existing health checks to confirm no regressions

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/1d321200-8030-486c-aa9a-fe41c6645279

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts sys.path to insert the project root (two directories up) so `src` imports resolve in `scripts/diagnostic/check_and_fix_gateway_models.py`.
> 
> - **Scripts**:
>   - Update `scripts/diagnostic/check_and_fix_gateway_models.py` to compute and insert project root (`../../`) into `sys.path`, fixing imports for `src.services.models`, `src.config`, and caches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e8c99e0a3fb66da2029efa32eb575b94a1dfc97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->