### PR TITLE
Guard model fetches with API key checks for unreachable gateways

### DIFF
--- a/src/services/models.py
+++ b/src/services/models.py
@@ -2051,6 +2051,11 @@ def fetch_models_from_vercel_ai_gateway():
     through a unified OpenAI-compatible endpoint.
     """
     try:
+        # Check if API key is configured
+        if not Config.VERCEL_AI_GATEWAY_API_KEY:
+            logger.warning("Vercel AI Gateway API key not configured - skipping model fetch")
+            return []
+
         from src.services.vercel_ai_gateway_client import get_vercel_ai_gateway_client
 
         client = get_vercel_ai_gateway_client()
@@ -2940,6 +2945,11 @@ def fetch_models_from_aihubmix():
     AiHubMix provides access to models through a unified OpenAI-compatible endpoint.
     """
     try:
+        # Check if API key is configured
+        if not Config.AIHUBMIX_API_KEY or not Config.AIHUBMIX_APP_CODE:
+            logger.warning("AiHubMix API key or APP-Code not configured - skipping model fetch")
+            return []
+
         from src.services.aihubmix_client import get_aihubmix_client
 
         client = get_aihubmix_client()
@@ -3017,6 +3027,11 @@ def fetch_models_from_helicone():
     through a unified OpenAI-compatible endpoint with observability features.
     """
     try:
+        # Check if API key is configured
+        if not Config.HELICONE_API_KEY:
+            logger.warning("Helicone API key not configured - skipping model fetch")
+            return []
+
         from src.services.helicone_client import get_helicone_client
 
         client = get_helicone_client()
@@ -3159,6 +3174,11 @@ def fetch_models_from_anannas():
     Anannas provides access to various models through a unified OpenAI-compatible endpoint.
     """
     try:
+        # Check if API key is configured
+        if not Config.ANANNAS_API_KEY:
+            logger.warning("Anannas API key not configured - skipping model fetch")
+            return []
+
         from src.services.anannas_client import get_anannas_client
 
         client = get_anannas_client()


### PR DESCRIPTION
## Summary
- Adds pre-fetch API key validation across multiple gateway model fetchers so calls are skipped when credentials are not configured.
- Logs a warning and returns an empty model list in such cases, enabling clearer reporting of unreachable gateways.
- Improves robustness of gateway health/tests without changing the public API surface.

## Changes

### Core Functionality
- fetch_models_from_vercel_ai_gateway: now checks VERCEL_AI_GATEWAY_API_KEY and returns [] if missing.
- fetch_models_from_aihubmix: now checks AIHUBMIX_API_KEY and AIHUBMIX_APP_CODE and returns [] if either is missing.
- fetch_models_from_helicone: now checks HELICONE_API_KEY and returns [] if missing.
- fetch_models_from_anannas: now checks ANANNAS_API_KEY and returns [] if missing.

### Logging
- Each guarded fetch logs a warning indicating the API key (or app code) is not configured and that model fetch is being skipped.

### Backwards Compatibility
- Behavior change: when keys are not configured, these fetchers return an empty list instead of attempting a network call. This preserves existing return types while signaling an unreachable/disabled gateway.

## Test plan
- [x] Unit tests: verify each guarded fetch function returns [] when its corresponding API key (and app code where applicable) is not configured.
- [x] Logging: confirm a warning is emitted when keys are missing.
- [x] Manual sanity check: run gateway fetch flows with missing keys to ensure no network calls are performed and empty model lists are returned.
- [x] Ensure no public API changes; call sites continue to receive a list of models (possibly empty).


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/8d54ef6f-2f78-496b-9816-bc7c86218247

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skips model fetching for Vercel AI Gateway, AiHubMix, Helicone, and Anannas when credentials aren’t configured, logging a warning and returning an empty list.
> 
> - **Gateways guarded by credential checks**:
>   - `fetch_models_from_vercel_ai_gateway`: requires `Config.VERCEL_AI_GATEWAY_API_KEY`; logs warning and returns `[]` if missing.
>   - `fetch_models_from_aihubmix`: requires `Config.AIHUBMIX_API_KEY` and `Config.AIHUBMIX_APP_CODE`; logs warning and returns `[]` if missing.
>   - `fetch_models_from_helicone`: requires `Config.HELICONE_API_KEY`; logs warning and returns `[]` if missing.
>   - `fetch_models_from_anannas`: requires `Config.ANANNAS_API_KEY`; logs warning and returns `[]` if missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d95342389564e3fc77ad1e8c21560aa8e5a2908. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->