### PR TITLE
Setup OpenTelemetry (Tempo/Loki) for FastAPI on Railway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,3 +63,29 @@ POSTHOG_DEBUG=false  # Set to true for debug logging
 
 # Braintrust - AI observability and evaluation platform
 BRAINTRUST_API_KEY=sk-your-braintrust-api-key
+
+# ==================== Observability Configuration ====================
+
+# OpenTelemetry Service Configuration
+OTEL_SERVICE_NAME=gatewayz-api
+
+# Tempo Configuration (Distributed Tracing)
+# Set to true to enable OpenTelemetry tracing to Tempo
+TEMPO_ENABLED=false
+# For Railway internal networking (recommended):
+TEMPO_OTLP_HTTP_ENDPOINT=http://tempo.railway.internal:4318
+# For external services or public URLs:
+# TEMPO_OTLP_HTTP_ENDPOINT=https://tempo-production-xxxx.up.railway.app:4318
+
+# Grafana Loki Configuration (Structured Logging)
+# Set to true to enable log shipping to Loki
+LOKI_ENABLED=false
+# For Railway internal networking (recommended):
+LOKI_PUSH_URL=http://loki.railway.internal:3100/loki/api/v1/push
+# For external services or public URLs:
+# LOKI_PUSH_URL=https://loki-production-xxxx.up.railway.app/loki/api/v1/push
+
+# Prometheus Configuration (Metrics)
+PROMETHEUS_ENABLED=true
+PROMETHEUS_SCRAPE_ENABLED=true
+# Prometheus scrapes metrics from /metrics endpoint automatically

--- a/docs/OBSERVABILITY_QUICKSTART.md
+++ b/docs/OBSERVABILITY_QUICKSTART.md
@@ -1,0 +1,241 @@
+# Observability Quick Start Guide
+
+Get your Gatewayz API fully observable in 5 minutes!
+
+## TL;DR
+
+Add these environment variables and restart your API:
+
+```bash
+# Enable observability
+TEMPO_ENABLED=true
+LOKI_ENABLED=true
+PROMETHEUS_ENABLED=true
+
+# Configure endpoints (Railway internal networking)
+TEMPO_OTLP_HTTP_ENDPOINT=http://tempo.railway.internal:4318
+LOKI_PUSH_URL=http://loki.railway.internal:3100/loki/api/v1/push
+
+# Service name
+OTEL_SERVICE_NAME=gatewayz-api
+```
+
+That's it! Your API now sends metrics, logs, and traces to your observability stack.
+
+## Quick Setup
+
+### 1. Configure Environment Variables
+
+**For Railway deployment** (API on same Railway project):
+```bash
+TEMPO_ENABLED=true
+LOKI_ENABLED=true
+TEMPO_OTLP_HTTP_ENDPOINT=http://tempo.railway.internal:4318
+LOKI_PUSH_URL=http://loki.railway.internal:3100/loki/api/v1/push
+```
+
+**For external deployment** (API outside Railway):
+1. Expose Loki and Tempo in Railway (Settings → Networking → Generate Domain)
+2. Use public URLs:
+```bash
+TEMPO_ENABLED=true
+LOKI_ENABLED=true
+TEMPO_OTLP_HTTP_ENDPOINT=https://tempo-production-xxxx.up.railway.app:4318
+LOKI_PUSH_URL=https://loki-production-xxxx.up.railway.app/loki/api/v1/push
+```
+
+### 2. Verify Configuration
+
+Check your API logs on startup:
+```
+🔭 Initializing OpenTelemetry tracing...
+   Tempo endpoint: http://tempo.railway.internal:4318
+   HTTP client instrumentation enabled
+✅ OpenTelemetry tracing initialized successfully
+✅ FastAPI application instrumented with OpenTelemetry
+
+📝 Console logging configured
+✅ Loki logging enabled: http://loki.railway.internal:3100/loki/api/v1/push
+```
+
+### 3. Generate Some Traffic
+
+```bash
+# Health check
+curl https://api.gatewayz.ai/health
+
+# Chat completion
+curl -X POST https://api.gatewayz.ai/v1/chat/completions \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+```
+
+### 4. View in Grafana
+
+Open Grafana at `http://grafana.railway.internal:3000` (or your public URL)
+
+#### View Metrics
+1. Go to **Explore** → **Prometheus**
+2. Query: `fastapi_requests_total`
+3. You should see your requests!
+
+#### View Logs
+1. Go to **Explore** → **Loki**
+2. Query: `{app="gatewayz-api"}`
+3. You should see structured logs with trace IDs!
+
+#### View Traces
+1. Go to **Explore** → **Tempo**
+2. Click **Search** → Service Name: `gatewayz-api`
+3. You should see your request traces!
+
+#### Log-to-Trace Correlation
+1. In **Loki** logs, find a log entry with a `trace_id`
+2. **Click the trace_id** link
+3. You'll jump directly to the full trace in Tempo!
+
+## What You Get
+
+### ✅ Automatic Metrics
+- Request rate, duration, error rate
+- Model inference metrics
+- Database query metrics
+- Cache hit/miss rates
+- Credit consumption
+
+### ✅ Structured Logs
+- JSON-formatted logs
+- Trace correlation (trace_id, span_id)
+- Request context (path, method, status)
+- Automatic push to Loki
+
+### ✅ Distributed Traces
+- Full request timeline
+- HTTP client calls (to OpenRouter, Portkey, etc.)
+- Custom spans for important operations
+- Exception tracking
+
+### ✅ Log-to-Trace Correlation
+- Click from logs to traces
+- See logs for specific traces
+- Debug with full context
+
+## Common Queries
+
+### Metrics (Prometheus)
+
+```promql
+# Request rate (req/sec)
+rate(fastapi_requests_total[5m])
+
+# P99 latency
+histogram_quantile(0.99, rate(fastapi_requests_duration_seconds_bucket[5m]))
+
+# Error rate
+rate(fastapi_requests_total{status_code=~"5.."}[5m])
+
+# Model inference rate
+rate(model_inference_requests_total[5m])
+```
+
+### Logs (Loki)
+
+```logql
+# All logs
+{app="gatewayz-api"}
+
+# Errors only
+{app="gatewayz-api"} |= "ERROR"
+
+# Specific endpoint
+{app="gatewayz-api", path="/v1/chat/completions"}
+
+# Logs with traces
+{app="gatewayz-api"} | json | trace_id != ""
+```
+
+### Traces (Tempo)
+
+- Go to **Explore** → **Tempo** → **Search**
+- Filter by:
+  - Service: `gatewayz-api`
+  - Min duration: `1s` (find slow requests)
+  - Status: `error` (find failed requests)
+
+## Dashboards
+
+### Import FastAPI Dashboard
+
+1. Go to **Dashboards** → **Import**
+2. Enter dashboard ID: **16110**
+3. Select Prometheus data source
+4. Click **Import**
+
+You'll get:
+- Request rate and error rate graphs
+- Latency percentiles (P50, P95, P99)
+- Top endpoints by traffic
+- Request/response sizes
+
+## Troubleshooting
+
+### No traces appearing?
+
+```bash
+# Check Tempo is enabled
+echo $TEMPO_ENABLED  # Should be "true"
+
+# Check endpoint
+echo $TEMPO_OTLP_HTTP_ENDPOINT
+
+# Check Tempo is reachable
+curl http://tempo.railway.internal:4318/v1/traces
+
+# Check API logs
+grep "OpenTelemetry" <your-api-logs>
+```
+
+### No logs appearing?
+
+```bash
+# Check Loki is enabled
+echo $LOKI_ENABLED  # Should be "true"
+
+# Check endpoint
+echo $LOKI_PUSH_URL
+
+# Check Loki is reachable
+curl http://loki.railway.internal:3100/ready
+
+# Check API logs
+grep "Loki" <your-api-logs>
+```
+
+### Metrics working but traces/logs not?
+
+That's normal! Prometheus scrapes the `/metrics` endpoint (pull model), while traces and logs are pushed. Check:
+
+1. **Environment variables** are set correctly
+2. **Tempo and Loki services** are running
+3. **Network connectivity** between services
+
+## Next Steps
+
+- Read the full [OpenTelemetry Setup Guide](./OPENTELEMETRY_SETUP.md)
+- Learn about [custom spans](./OPENTELEMETRY_SETUP.md#3-custom-spans)
+- Configure [trace sampling](./OPENTELEMETRY_SETUP.md#trace-sampling) for high traffic
+- Set up [alerting](./ALERTING.md) based on metrics
+
+## Help
+
+If you encounter issues:
+1. Check the [Troubleshooting section](./OPENTELEMETRY_SETUP.md#troubleshooting)
+2. Review Railway service logs
+3. Verify network connectivity between services
+4. Check Grafana data source configuration
+
+Happy observing! 🔭

--- a/docs/OPENTELEMETRY_SETUP.md
+++ b/docs/OPENTELEMETRY_SETUP.md
@@ -1,0 +1,416 @@
+# OpenTelemetry Setup for Gatewayz API
+
+This guide explains how to configure OpenTelemetry to send metrics, logs, and traces from the Gatewayz API to your Railway observability stack (Prometheus, Loki, and Tempo).
+
+## Overview
+
+The Gatewayz API now includes comprehensive observability through:
+
+- **Metrics (Prometheus)**: HTTP request metrics, model inference metrics, database metrics, etc.
+- **Logs (Loki)**: Structured JSON logs with trace correlation
+- **Traces (Tempo)**: Distributed tracing for request flows
+
+## Architecture
+
+```
+┌─────────────────────┐
+│   Gatewayz API      │
+│   (FastAPI)         │
+└──────┬──────────────┘
+       │
+       ├─── Metrics ────────► Prometheus (Port 9090)
+       │    (/metrics)           │
+       │                         ▼
+       │                    Grafana (Port 3000)
+       │                         ▲
+       ├─── Logs ───────────► Loki (Port 3100)
+       │    (HTTP Push)          │
+       │                         │
+       └─── Traces ─────────► Tempo (Port 4318)
+            (OTLP HTTP)
+```
+
+## Configuration
+
+### Step 1: Environment Variables
+
+Add these environment variables to your `.env` file or Railway service configuration:
+
+```bash
+# OpenTelemetry Service Configuration
+OTEL_SERVICE_NAME=gatewayz-api
+
+# Tempo Configuration (Tracing)
+TEMPO_ENABLED=true
+TEMPO_OTLP_HTTP_ENDPOINT=http://tempo:4318
+
+# Loki Configuration (Logging)
+LOKI_ENABLED=true
+LOKI_PUSH_URL=http://loki:3100/loki/api/v1/push
+
+# Prometheus Configuration (Metrics)
+PROMETHEUS_ENABLED=true
+PROMETHEUS_SCRAPE_ENABLED=true
+```
+
+### Step 2: Railway-Specific Configuration
+
+#### Option A: Internal Railway Networking (Recommended)
+
+If your API is deployed on Railway alongside your observability stack, use internal URLs:
+
+```bash
+TEMPO_OTLP_HTTP_ENDPOINT=http://tempo.railway.internal:4318
+LOKI_PUSH_URL=http://loki.railway.internal:3100/loki/api/v1/push
+```
+
+#### Option B: Public URLs (External API)
+
+If your API is deployed outside Railway (e.g., Vercel), you need to expose Loki and Tempo:
+
+1. **Expose Loki**:
+   - Go to Loki service → Settings → Networking
+   - Click "Generate Domain"
+   - Copy the URL (e.g., `loki-production-xxxx.up.railway.app`)
+
+2. **Expose Tempo**:
+   - Go to Tempo service → Settings → Networking
+   - Click "Generate Domain"
+   - Copy the URL (e.g., `tempo-production-xxxx.up.railway.app`)
+
+3. **Update environment variables**:
+   ```bash
+   TEMPO_OTLP_HTTP_ENDPOINT=https://tempo-production-xxxx.up.railway.app:4318
+   LOKI_PUSH_URL=https://loki-production-xxxx.up.railway.app/loki/api/v1/push
+   ```
+
+### Step 3: Verify Prometheus is Scraping Metrics
+
+Your Prometheus configuration should already be scraping the `/metrics` endpoint:
+
+**prometheus.yml**:
+```yaml
+scrape_configs:
+  - job_name: 'gatewayz_api'
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['api.gatewayz.ai:443']
+    scheme: https
+```
+
+## Features
+
+### 1. Automatic Request Tracing
+
+Every HTTP request is automatically traced with:
+- Request method and path
+- Response status code
+- Request duration
+- HTTP headers
+- Exception tracking
+
+### 2. Log-to-Trace Correlation
+
+Logs automatically include trace and span IDs, allowing you to:
+- Click from a log entry to see the full trace in Grafana
+- Follow request flows across services
+- Debug issues with complete context
+
+**Example log entry**:
+```json
+{
+  "timestamp": "2025-11-12T10:30:45.123Z",
+  "level": "INFO",
+  "logger": "src.routes.chat",
+  "message": "Processing chat completion request",
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "span_id": "00f067aa0ba902b7",
+  "path": "/v1/chat/completions",
+  "method": "POST"
+}
+```
+
+### 3. Custom Spans
+
+Add custom spans to track specific operations:
+
+```python
+from src.config.opentelemetry_config import OpenTelemetryConfig
+
+tracer = OpenTelemetryConfig.get_tracer(__name__)
+
+@app.get("/process")
+async def process_data():
+    with tracer.start_as_current_span("process_data") as span:
+        span.set_attribute("user.id", "123")
+        span.set_attribute("model", "gpt-4")
+
+        # Your processing logic
+        result = await do_something()
+
+        span.set_attribute("result.count", len(result))
+        return result
+```
+
+### 4. HTTP Client Instrumentation
+
+HTTPX and Requests are automatically instrumented, so outbound HTTP calls (e.g., to OpenRouter, Portkey) are traced automatically:
+
+```python
+import httpx
+
+# This request is automatically traced!
+async with httpx.AsyncClient() as client:
+    response = await client.post(
+        "https://openrouter.ai/api/v1/chat/completions",
+        json={"model": "gpt-4", "messages": [...]},
+    )
+```
+
+## Viewing Observability Data in Grafana
+
+### 1. Metrics (Prometheus)
+
+1. Go to Grafana → Explore → Prometheus
+2. Try these queries:
+   ```promql
+   # Total requests
+   fastapi_requests_total{job="gatewayz_api"}
+
+   # Request rate (requests per second)
+   rate(fastapi_requests_total[5m])
+
+   # P99 latency
+   histogram_quantile(0.99,
+     rate(fastapi_requests_duration_seconds_bucket[5m])
+   )
+
+   # Error rate
+   rate(fastapi_requests_total{status_code=~"5.."}[5m])
+   ```
+
+### 2. Logs (Loki)
+
+1. Go to Grafana → Explore → Loki
+2. Try these queries:
+   ```logql
+   # All logs from the API
+   {app="gatewayz-api"}
+
+   # Error logs only
+   {app="gatewayz-api"} |= "ERROR"
+
+   # Logs for a specific endpoint
+   {app="gatewayz-api", path="/v1/chat/completions"}
+
+   # Logs with trace correlation
+   {app="gatewayz-api"} | json | trace_id != ""
+   ```
+
+3. **Click on a trace_id** in a log entry to jump to the full trace!
+
+### 3. Traces (Tempo)
+
+1. Go to Grafana → Explore → Tempo
+2. Click "Search"
+3. Filter by:
+   - **Service Name**: `gatewayz-api`
+   - **Operation**: (e.g., `POST /v1/chat/completions`)
+   - **Duration**: (e.g., `> 1s` to find slow requests)
+4. Click on a trace to see:
+   - Full request timeline
+   - All spans (API → OpenRouter → etc.)
+   - Tags and attributes
+   - Correlated logs
+
+## Dashboards
+
+### FastAPI Observability Dashboard
+
+Import the pre-built dashboard:
+
+1. Go to Grafana → Dashboards → Import
+2. Use dashboard ID: **16110** (FastAPI Observability)
+3. Or import from file: `/root/repo/docs/grafana-fastapi-dashboard.json`
+
+This dashboard shows:
+- Request rate and error rate
+- Request duration percentiles (P50, P95, P99)
+- Requests in progress
+- Request/response sizes
+- Top endpoints by volume and latency
+
+### Custom Dashboard
+
+Create a custom dashboard with panels for:
+
+1. **HTTP Metrics**:
+   - Request rate: `rate(fastapi_requests_total[5m])`
+   - Error rate: `rate(fastapi_requests_total{status_code=~"5.."}[5m])`
+   - P99 latency: `histogram_quantile(0.99, rate(fastapi_requests_duration_seconds_bucket[5m]))`
+
+2. **Model Metrics**:
+   - Inference requests: `rate(model_inference_requests_total[5m])`
+   - Token consumption: `rate(model_tokens_total[5m])`
+   - Credits used: `rate(credits_deducted_total[5m])`
+
+3. **Logs Panel** (Loki):
+   - Query: `{app="gatewayz-api"} |= "ERROR"`
+   - Shows recent errors
+
+4. **Traces Panel** (Tempo):
+   - Linked from logs via trace_id
+
+## Troubleshooting
+
+### Traces not appearing in Tempo
+
+1. **Check Tempo is reachable**:
+   ```bash
+   curl http://tempo:4318/v1/traces
+   ```
+
+2. **Check environment variable**:
+   ```bash
+   echo $TEMPO_ENABLED  # Should be "true"
+   echo $TEMPO_OTLP_HTTP_ENDPOINT  # Should be correct URL
+   ```
+
+3. **Check application logs**:
+   ```
+   grep "OpenTelemetry" /var/log/app.log
+   ```
+
+4. **Verify in Grafana**:
+   - Go to Tempo → Search
+   - Check if service name appears in dropdown
+
+### Logs not appearing in Loki
+
+1. **Check Loki is reachable**:
+   ```bash
+   curl http://loki:3100/ready
+   ```
+
+2. **Check environment variable**:
+   ```bash
+   echo $LOKI_ENABLED  # Should be "true"
+   echo $LOKI_PUSH_URL  # Should be correct URL
+   ```
+
+3. **Check application logs**:
+   ```
+   grep "Loki" /var/log/app.log
+   ```
+
+4. **Test Loki query**:
+   - Go to Grafana → Explore → Loki
+   - Query: `{app="gatewayz-api"}`
+   - Check "Last 15 minutes"
+
+### Prometheus not scraping metrics
+
+1. **Check /metrics endpoint**:
+   ```bash
+   curl https://api.gatewayz.ai/metrics
+   ```
+   Should return metrics in Prometheus format
+
+2. **Check Prometheus targets**:
+   - Go to Prometheus UI → Status → Targets
+   - Check if `gatewayz_api` target is "UP"
+
+3. **Check Prometheus logs**:
+   ```bash
+   docker logs prometheus
+   ```
+
+### High cardinality warnings
+
+If you see warnings about high cardinality metrics:
+
+1. **Check path normalization** in `src/middleware/observability_middleware.py`
+2. Ensure dynamic path segments (IDs, UUIDs) are replaced with `{id}`
+3. Limit the number of unique label values
+
+## Performance Considerations
+
+### Trace Sampling
+
+By default, all requests are traced (100% sampling). For high-traffic production:
+
+```python
+# In src/config/opentelemetry_config.py
+from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
+
+# Sample 10% of traces
+sampler = TraceIdRatioBased(0.1)
+tracer_provider = TracerProvider(resource=resource, sampler=sampler)
+```
+
+### Log Volume
+
+To reduce log volume in production:
+
+```python
+# In src/config/logging_config.py
+if Config.IS_PRODUCTION:
+    root_logger.setLevel(logging.WARNING)  # Only warnings and errors
+```
+
+### Batch Processing
+
+OpenTelemetry uses batch processing by default:
+- Spans are batched and sent every 5 seconds
+- Max batch size: 512 spans
+- This minimizes overhead on the main application
+
+## Security
+
+### Authentication
+
+If Loki/Tempo are exposed publicly, add authentication:
+
+```python
+# In src/config/opentelemetry_config.py
+otlp_exporter = OTLPSpanExporter(
+    endpoint=f"{tempo_endpoint}/v1/traces",
+    headers={"Authorization": f"Bearer {os.getenv('TEMPO_AUTH_TOKEN')}"}
+)
+
+# In src/config/logging_config.py
+import base64
+auth = base64.b64encode(f"{username}:{password}".encode()).decode()
+loki_handler = LokiLogHandler(
+    loki_url=Config.LOKI_PUSH_URL,
+    tags={...},
+    headers={"Authorization": f"Basic {auth}"}
+)
+```
+
+### Railway Private Networking
+
+Use Railway's internal networking for better security:
+
+```bash
+# No public URLs needed!
+TEMPO_OTLP_HTTP_ENDPOINT=http://tempo.railway.internal:4318
+LOKI_PUSH_URL=http://loki.railway.internal:3100/loki/api/v1/push
+```
+
+## Summary
+
+Your FastAPI application now sends:
+
+- ✅ **Metrics** → Prometheus → Grafana (via `/metrics` endpoint)
+- ✅ **Logs** → Loki → Grafana (via HTTP push API)
+- ✅ **Traces** → Tempo → Grafana (via OTLP HTTP)
+
+All three are correlated via trace IDs, enabling powerful debugging and observability workflows!
+
+## References
+
+- [OpenTelemetry Python Docs](https://opentelemetry.io/docs/instrumentation/python/)
+- [Grafana Tempo Docs](https://grafana.com/docs/tempo/latest/)
+- [Grafana Loki Docs](https://grafana.com/docs/loki/latest/)
+- [FastAPI Observability Dashboard](https://grafana.com/grafana/dashboards/16110)

--- a/src/config/logging_config.py
+++ b/src/config/logging_config.py
@@ -1,0 +1,246 @@
+"""
+Logging configuration with Grafana Loki integration.
+
+This module configures Python logging to send structured logs to Grafana Loki
+while maintaining console logging for local development.
+
+Features:
+- Structured JSON logging with trace correlation
+- Automatic Loki push integration
+- Environment-aware configuration
+- Trace ID injection for log-to-trace correlation
+"""
+
+import logging
+import sys
+from typing import Dict, Any, Optional
+
+from src.config.config import Config
+
+logger = logging.getLogger(__name__)
+
+
+class LokiLogHandler(logging.Handler):
+    """
+    Custom log handler that sends logs to Grafana Loki.
+
+    This handler formats logs as JSON with trace context and pushes them
+    to Loki via HTTP API.
+    """
+
+    def __init__(self, loki_url: str, tags: Dict[str, str]):
+        super().__init__()
+        self.loki_url = loki_url
+        self.tags = tags
+        self._session = None
+
+    def _get_session(self):
+        """Lazy-load HTTP session for sending logs."""
+        if self._session is None:
+            import httpx
+            self._session = httpx.Client(timeout=5.0)
+        return self._session
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """
+        Send log record to Loki.
+
+        Args:
+            record: LogRecord to send
+        """
+        try:
+            # Format the log message
+            log_entry = self.format(record)
+
+            # Get trace context if available
+            trace_id = getattr(record, 'trace_id', None)
+            span_id = getattr(record, 'span_id', None)
+
+            # Build Loki labels
+            labels = {**self.tags}
+            if trace_id:
+                labels['trace_id'] = trace_id
+            if hasattr(record, 'request_path'):
+                labels['path'] = record.request_path
+
+            # Build Loki push payload
+            # Format: {"streams": [{"stream": {...labels}, "values": [[timestamp_ns, log_line]]}]}
+            timestamp_ns = str(int(record.created * 1_000_000_000))
+            payload = {
+                "streams": [
+                    {
+                        "stream": labels,
+                        "values": [[timestamp_ns, log_entry]]
+                    }
+                ]
+            }
+
+            # Send to Loki
+            session = self._get_session()
+            response = session.post(self.loki_url, json=payload)
+            response.raise_for_status()
+
+        except Exception as e:
+            # Don't fail the application if logging fails
+            # Use handleError to avoid infinite recursion
+            self.handleError(record)
+
+    def close(self) -> None:
+        """Close HTTP session."""
+        if self._session:
+            self._session.close()
+        super().close()
+
+
+class TraceContextFilter(logging.Filter):
+    """
+    Logging filter that adds trace context to log records.
+
+    This filter enriches log records with OpenTelemetry trace and span IDs,
+    enabling correlation between logs and traces in Grafana.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """
+        Add trace context to log record.
+
+        Args:
+            record: LogRecord to enrich
+
+        Returns:
+            bool: Always True (don't filter out records)
+        """
+        try:
+            from src.config.opentelemetry_config import get_current_trace_id, get_current_span_id
+
+            trace_id = get_current_trace_id()
+            span_id = get_current_span_id()
+
+            if trace_id:
+                record.trace_id = trace_id
+            if span_id:
+                record.span_id = span_id
+
+        except Exception:
+            # Don't fail if we can't get trace context
+            pass
+
+        return True
+
+
+class StructuredFormatter(logging.Formatter):
+    """
+    JSON formatter for structured logging.
+
+    Formats log records as JSON with trace context and additional metadata.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        """
+        Format log record as JSON.
+
+        Args:
+            record: LogRecord to format
+
+        Returns:
+            str: JSON-formatted log entry
+        """
+        import json
+
+        log_data = {
+            "timestamp": self.formatTime(record),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        # Add trace context if available
+        if hasattr(record, 'trace_id'):
+            log_data['trace_id'] = record.trace_id
+        if hasattr(record, 'span_id'):
+            log_data['span_id'] = record.span_id
+
+        # Add exception info if present
+        if record.exc_info:
+            log_data['exception'] = self.formatException(record.exc_info)
+
+        # Add any extra fields
+        if hasattr(record, 'extra'):
+            log_data.update(record.extra)
+
+        return json.dumps(log_data)
+
+
+def configure_logging() -> bool:
+    """
+    Configure application logging with Loki integration.
+
+    Sets up:
+    - Console handler for local development
+    - Loki handler for production (if enabled)
+    - Trace context filter for log-to-trace correlation
+    - JSON formatting for structured logs
+
+    Returns:
+        bool: True if Loki integration was enabled, False otherwise
+    """
+    # Get root logger
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+
+    # Clear existing handlers
+    root_logger.handlers.clear()
+
+    # Add trace context filter to all loggers
+    trace_filter = TraceContextFilter()
+    root_logger.addFilter(trace_filter)
+
+    # Console handler (always enabled)
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setLevel(logging.INFO)
+
+    # Use simple format for console in development, JSON in production
+    if Config.IS_DEVELOPMENT:
+        console_formatter = logging.Formatter(
+            '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        )
+    else:
+        console_formatter = StructuredFormatter()
+
+    console_handler.setFormatter(console_formatter)
+    root_logger.addHandler(console_handler)
+
+    logger.info("📝 Console logging configured")
+
+    # Loki handler (optional)
+    loki_enabled = False
+    if Config.LOKI_ENABLED:
+        try:
+            loki_handler = LokiLogHandler(
+                loki_url=Config.LOKI_PUSH_URL,
+                tags={
+                    "app": Config.OTEL_SERVICE_NAME,
+                    "environment": Config.APP_ENV,
+                    "service": "gatewayz-api",
+                }
+            )
+            loki_handler.setLevel(logging.INFO)
+            loki_handler.setFormatter(StructuredFormatter())
+            root_logger.addHandler(loki_handler)
+
+            logger.info(f"✅ Loki logging enabled: {Config.LOKI_PUSH_URL}")
+            loki_enabled = True
+
+        except Exception as e:
+            logger.warning(f"⚠️  Failed to configure Loki logging: {e}")
+
+    else:
+        logger.info("⏭️  Loki logging disabled (LOKI_ENABLED=false)")
+
+    # Set log levels for noisy libraries
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("httpcore").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+    logging.getLogger("opentelemetry").setLevel(logging.WARNING)
+
+    return loki_enabled

--- a/src/config/opentelemetry_config.py
+++ b/src/config/opentelemetry_config.py
@@ -1,0 +1,206 @@
+"""
+OpenTelemetry configuration for distributed tracing and observability.
+
+This module configures OpenTelemetry to send traces to Tempo and integrates
+with the existing Prometheus metrics and logging infrastructure.
+
+Features:
+- Automatic FastAPI request tracing
+- HTTPX and Requests library instrumentation
+- Context propagation for distributed tracing
+- Integration with Railway/Grafana observability stack
+"""
+
+import logging
+import os
+from typing import Optional
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+from opentelemetry.instrumentation.requests import RequestsInstrumentor
+from opentelemetry.sdk.resources import Resource, SERVICE_NAME, SERVICE_VERSION, DEPLOYMENT_ENVIRONMENT
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+
+from src.config.config import Config
+
+logger = logging.getLogger(__name__)
+
+
+class OpenTelemetryConfig:
+    """
+    OpenTelemetry configuration and setup for the Gatewayz API.
+
+    This class handles initialization of:
+    - Trace provider with OTLP export to Tempo
+    - FastAPI automatic instrumentation
+    - HTTP client instrumentation (httpx, requests)
+    - Resource attributes (service name, version, environment)
+    """
+
+    _initialized = False
+    _tracer_provider: Optional[TracerProvider] = None
+
+    @classmethod
+    def initialize(cls) -> bool:
+        """
+        Initialize OpenTelemetry tracing if enabled.
+
+        Returns:
+            bool: True if initialization succeeded, False if disabled or failed
+        """
+        if cls._initialized:
+            logger.debug("OpenTelemetry already initialized")
+            return True
+
+        if not Config.TEMPO_ENABLED:
+            logger.info("⏭️  OpenTelemetry tracing disabled (TEMPO_ENABLED=false)")
+            return False
+
+        try:
+            logger.info("🔭 Initializing OpenTelemetry tracing...")
+
+            # Create resource with service metadata
+            resource = Resource.create({
+                SERVICE_NAME: Config.OTEL_SERVICE_NAME,
+                SERVICE_VERSION: "2.0.3",
+                DEPLOYMENT_ENVIRONMENT: Config.APP_ENV,
+                "service.namespace": "gatewayz",
+                "telemetry.sdk.language": "python",
+            })
+
+            # Create tracer provider
+            cls._tracer_provider = TracerProvider(resource=resource)
+
+            # Configure OTLP exporter to Tempo
+            tempo_endpoint = Config.TEMPO_OTLP_HTTP_ENDPOINT
+            logger.info(f"   Tempo endpoint: {tempo_endpoint}")
+
+            otlp_exporter = OTLPSpanExporter(
+                endpoint=f"{tempo_endpoint}/v1/traces",
+                headers={},  # Add authentication headers if needed
+            )
+
+            # Add span processor for exporting traces
+            cls._tracer_provider.add_span_processor(
+                BatchSpanProcessor(otlp_exporter)
+            )
+
+            # In development, also log traces to console
+            if Config.IS_DEVELOPMENT:
+                cls._tracer_provider.add_span_processor(
+                    BatchSpanProcessor(ConsoleSpanExporter())
+                )
+                logger.info("   Console trace export enabled (development mode)")
+
+            # Set global tracer provider
+            trace.set_tracer_provider(cls._tracer_provider)
+
+            # Instrument HTTP clients for automatic tracing
+            HTTPXClientInstrumentor().instrument()
+            RequestsInstrumentor().instrument()
+            logger.info("   HTTP client instrumentation enabled")
+
+            cls._initialized = True
+            logger.info("✅ OpenTelemetry tracing initialized successfully")
+            return True
+
+        except Exception as e:
+            logger.error(f"❌ Failed to initialize OpenTelemetry: {e}", exc_info=True)
+            return False
+
+    @classmethod
+    def instrument_fastapi(cls, app) -> None:
+        """
+        Instrument a FastAPI application with OpenTelemetry.
+
+        This adds automatic tracing for all FastAPI routes and includes:
+        - Request/response tracing
+        - Route matching information
+        - HTTP method and status code
+        - Exception tracking
+
+        Args:
+            app: FastAPI application instance to instrument
+        """
+        if not cls._initialized or not Config.TEMPO_ENABLED:
+            logger.debug("Skipping FastAPI instrumentation (tracing not enabled)")
+            return
+
+        try:
+            FastAPIInstrumentor.instrument_app(app)
+            logger.info("✅ FastAPI application instrumented with OpenTelemetry")
+        except Exception as e:
+            logger.error(f"❌ Failed to instrument FastAPI: {e}", exc_info=True)
+
+    @classmethod
+    def shutdown(cls) -> None:
+        """
+        Gracefully shutdown OpenTelemetry and flush any pending spans.
+
+        Should be called during application shutdown to ensure all traces
+        are exported before the application exits.
+        """
+        if not cls._initialized:
+            return
+
+        try:
+            logger.info("🛑 Shutting down OpenTelemetry...")
+            if cls._tracer_provider:
+                cls._tracer_provider.shutdown()
+            logger.info("✅ OpenTelemetry shutdown complete")
+        except Exception as e:
+            logger.error(f"❌ Error during OpenTelemetry shutdown: {e}", exc_info=True)
+        finally:
+            cls._initialized = False
+            cls._tracer_provider = None
+
+    @classmethod
+    def get_tracer(cls, name: str) -> trace.Tracer:
+        """
+        Get a tracer for creating custom spans.
+
+        Args:
+            name: Name of the tracer (typically __name__ of the calling module)
+
+        Returns:
+            OpenTelemetry Tracer instance
+        """
+        return trace.get_tracer(name)
+
+
+# Helper function to get current trace context
+def get_current_trace_id() -> Optional[str]:
+    """
+    Get the current trace ID as a hex string.
+
+    Returns:
+        str: Trace ID in hex format (32 characters), or None if no active span
+    """
+    try:
+        span = trace.get_current_span()
+        span_context = span.get_span_context()
+        if span_context.is_valid:
+            return format(span_context.trace_id, '032x')
+    except Exception:
+        pass
+    return None
+
+
+def get_current_span_id() -> Optional[str]:
+    """
+    Get the current span ID as a hex string.
+
+    Returns:
+        str: Span ID in hex format (16 characters), or None if no active span
+    """
+    try:
+        span = trace.get_current_span()
+        span_context = span.get_span_context()
+        if span_context.is_valid:
+            return format(span_context.span_id, '016x')
+    except Exception:
+        pass
+    return None

--- a/src/middleware/trace_context_middleware.py
+++ b/src/middleware/trace_context_middleware.py
@@ -1,0 +1,96 @@
+"""
+Middleware for adding trace context to request logs.
+
+This middleware enriches all request logs with OpenTelemetry trace and span IDs,
+enabling seamless navigation from logs to traces in Grafana.
+"""
+
+import logging
+from typing import Callable
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
+
+from src.config.opentelemetry_config import get_current_trace_id, get_current_span_id
+
+logger = logging.getLogger(__name__)
+
+
+class TraceContextMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware that adds trace context to request logs.
+
+    For each incoming request:
+    1. Extracts the current trace ID and span ID from OpenTelemetry
+    2. Logs the request with trace context for correlation
+    3. Adds trace headers to the response
+
+    This enables:
+    - Clicking from logs to traces in Grafana
+    - Distributed tracing across services
+    - Request correlation in observability tools
+    """
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        """
+        Process request and add trace context to logs.
+
+        Args:
+            request: Incoming HTTP request
+            call_next: Next middleware/handler in the chain
+
+        Returns:
+            HTTP response with trace headers
+        """
+        # Get trace context
+        trace_id = get_current_trace_id()
+        span_id = get_current_span_id()
+
+        # Create log context with trace IDs
+        log_extra = {
+            "path": request.url.path,
+            "method": request.method,
+            "client_host": request.client.host if request.client else None,
+        }
+
+        if trace_id:
+            log_extra["trace_id"] = trace_id
+        if span_id:
+            log_extra["span_id"] = span_id
+
+        # Log request with trace context
+        logger.info(
+            f"{request.method} {request.url.path}",
+            extra=log_extra
+        )
+
+        # Process request
+        try:
+            response = await call_next(request)
+
+            # Add trace headers to response for client-side tracing
+            if trace_id:
+                response.headers["X-Trace-Id"] = trace_id
+            if span_id:
+                response.headers["X-Span-Id"] = span_id
+
+            # Log response with trace context
+            logger.info(
+                f"{request.method} {request.url.path} - {response.status_code}",
+                extra={
+                    **log_extra,
+                    "status_code": response.status_code,
+                }
+            )
+
+            return response
+
+        except Exception as e:
+            # Log error with trace context
+            logger.error(
+                f"{request.method} {request.url.path} - Error: {str(e)}",
+                extra=log_extra,
+                exc_info=True
+            )
+            raise


### PR DESCRIPTION
## Summary
- Adds end-to-end observability for Gatewayz API by integrating OpenTelemetry with Tempo (tracing), Loki (logging), and Prometheus (metrics).
- Introduces config, middleware, and documentation to enable rapid observability on Railway.
- Updates environment defaults and adds quickstart/setup docs for OpenTelemetry.

## Changes
### Observability Integration
- OpenTelemetry setup and instrumentation
  - src/config/opentelemetry_config.py: Initialize tracer provider, export traces to Tempo via OTLP HTTP, instrument FastAPI, HTTPX, and Requests, and provide helpers to fetch current trace/span IDs.
  - Instrumentation is optional behind TEMPO_ENABLED and opens a console exporter in development.
- Logging with Loki
  - src/config/logging_config.py: New LokiLogHandler for structured JSON logs pushed to Loki, a trace-context filter, and a JSON formatter.
  - configure_logging() wires console logging (and Loki, if enabled) with trace correlation data injected into logs.
- Trace context propagation in FastAPI requests
  - src/middleware/trace_context_middleware.py: Middleware to append trace_id/span_id to request logs and response headers, enabling log-to-trace navigation.

### FastAPI App and Lifecycle
- src/main.py
  - Initialize Loki/OpenTelemetry logging at startup and add TraceContextMiddleware for correlation.
  - Integrate OpenTelemetry initialization into app startup and ensure graceful shutdown via OpenTelemetry shutdown.

### Documentation & Examples
- docs/OBSERVABILITY_QUICKSTART.md: New quickstart guide to enable Tempo, Loki, and Prometheus with Railway internal networking.
- docs/OPENTELEMETRY_SETUP.md: Comprehensive OpenTelemetry setup guide detailing configuration, instrumentation, and dashboards.

### Config & Defaults
- .env.example: Added environment variables for observability
  - OTEL_SERVICE_NAME for service metadata
  - TEMPO_ENABLED, TEMPO_OTLP_HTTP_ENDPOINT for tracing
  - LOKI_ENABLED, LOKI_PUSH_URL for logging
  - PROMETHEUS_ENABLED / PROMETHEUS_SCRAPE_ENABLED for metrics

## How to test
- Local development
  - Ensure TEMPO_ENABLED and LOKI_ENABLED are true to observe traces and logs locally (Tempo/Loki endpoints can be local or mocked).
  - Check /metrics is exposed (Prometheus) and scrape targets are healthy.
  - Verify console logs appear and Loki pushes are performed when enabled.
- Railway deployment
  - Deploy with Railway networking as recommended in the docs.
  - Use quickstart in OBSERVABILITY_QUICKSTART.md to configure internal endpoints:
    - TEMPO_OTLP_HTTP_ENDPOINT=http://tempo.railway.internal:4318
    - LOKI_PUSH_URL=http://loki.railway.internal:3100/loki/api/v1/push
  - Open Grafana dashboards to verify:
    - Tempo traces for requests
    - Loki logs with trace_id correlation
    - Prometheus metrics (fastapi_requests_total, etc.)

## Notes
- This change scaffolds observability and is designed to be opt-in via environment variables (TEMPO_ENABLED, LOKI_ENABLED).
- In development mode, traces can also be output to the console for easier local debugging.
- No breaking changes to existing application routes; tracing and logging are additive.

## Related files touched
- src/config/opentelemetry_config.py
- src/config/logging_config.py
- src/middleware/trace_context_middleware.py
- src/main.py
- docs/OBSERVABILITY_QUICKSTART.md
- docs/OPENTELEMETRY_SETUP.md
- .env.example


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/02a5819b-8392-4e0a-9f3a-ced85b0dbf4f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional OpenTelemetry (Tempo) tracing and Loki structured logging with Prometheus metrics wiring, plus middleware, startup/shutdown hooks, env vars, and setup docs.
> 
> - **Backend Observability**:
>   - **Tracing**: Add OpenTelemetry setup exporting to Tempo via OTLP HTTP in `src/config/opentelemetry_config.py` (FastAPI, HTTPX, Requests instrumentation; helpers for `trace_id`/`span_id`; graceful shutdown).
>   - **Logging**: Introduce structured JSON logging and Grafana Loki push via `LokiLogHandler`, `TraceContextFilter`, and `StructuredFormatter` in `src/config/logging_config.py`; `configure_logging()` enables console + optional Loki.
>   - **Middleware**: Add `src/middleware/trace_context_middleware.py` to inject trace context into request/response logs and headers.
>   - **App wiring**: Update `src/main.py` to initialize logging, add trace-context middleware, initialize/instrument OpenTelemetry on startup, and shut it down on app stop; expose `/metrics`.
> - **Config & Environment**:
>   - Extend `.env.example` with observability vars: `OTEL_SERVICE_NAME`, `TEMPO_ENABLED`, `TEMPO_OTLP_HTTP_ENDPOINT`, `LOKI_ENABLED`, `LOKI_PUSH_URL`, `PROMETHEUS_ENABLED`, `PROMETHEUS_SCRAPE_ENABLED`.
> - **Documentation**:
>   - Add `docs/OBSERVABILITY_QUICKSTART.md` and `docs/OPENTELEMETRY_SETUP.md` with Railway/internal vs public endpoint config, verification steps, queries, and dashboards.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2ebee420ec031132f38ab7f0bdcdc06ad995ee1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->