### PR TITLE
Fix gateway health dashboard: update endpoints and thresholds

### DIFF
--- a/scripts/diagnostic/check_and_fix_gateway_models.py
+++ b/scripts/diagnostic/check_and_fix_gateway_models.py
@@ -80,7 +80,7 @@ GATEWAY_CONFIG = {
     },
     'chutes': {
         'name': 'Chutes',
-        'url': 'https://api.chutes.ai/v1/models',
+        'url': 'https://llm.chutes.ai/v1/models',
         'api_key_env': 'CHUTES_API_KEY',
         'api_key': getattr(Config, 'CHUTES_API_KEY', None),
         'cache': _chutes_models_cache,
@@ -152,7 +152,7 @@ GATEWAY_CONFIG = {
     },
     'novita': {
         'name': 'Novita',
-        'url': 'https://api.novita.ai/v3/models',
+        'url': 'https://api.novita.ai/v3/openai/models',
         'api_key_env': 'NOVITA_API_KEY',
         'api_key': Config.NOVITA_API_KEY,
         'cache': _novita_models_cache,
@@ -183,7 +183,7 @@ GATEWAY_CONFIG = {
         'api_key_env': 'NEAR_API_KEY',
         'api_key': Config.NEAR_API_KEY,
         'cache': _near_models_cache,
-        'min_expected_models': 5,
+        'min_expected_models': 4,
         'header_type': 'bearer'
     },
     'fal': {

--- a/scripts/healthcheck_all_models.py
+++ b/scripts/healthcheck_all_models.py
@@ -91,7 +91,7 @@ GATEWAY_CONFIG = {
     },
     'chutes': {
         'name': 'Chutes',
-        'url': 'https://api.chutes.ai/v1/models',
+        'url': 'https://llm.chutes.ai/v1/models',
         'api_key_env': 'CHUTES_API_KEY',
         'api_key': getattr(Config, 'CHUTES_API_KEY', None),
         'cache': _chutes_models_cache,
@@ -163,7 +163,7 @@ GATEWAY_CONFIG = {
     },
     'novita': {
         'name': 'Novita',
-        'url': 'https://api.novita.ai/v3/models',
+        'url': 'https://api.novita.ai/v3/openai/models',
         'api_key_env': 'NOVITA_API_KEY',
         'api_key': Config.NOVITA_API_KEY,
         'cache': _novita_models_cache,
@@ -194,7 +194,7 @@ GATEWAY_CONFIG = {
         'api_key_env': 'NEAR_API_KEY',
         'api_key': Config.NEAR_API_KEY,
         'cache': _near_models_cache,
-        'min_expected_models': 5,
+        'min_expected_models': 4,
         'header_type': 'bearer'
     },
 }

--- a/src/services/gateway_health_service.py
+++ b/src/services/gateway_health_service.py
@@ -67,7 +67,7 @@ GATEWAY_CONFIG = {
     },
     "chutes": {
         "name": "Chutes",
-        "url": "https://api.chutes.ai/v1/models",
+        "url": "https://llm.chutes.ai/v1/models",
         "api_key_env": "CHUTES_API_KEY",
         "api_key": getattr(Config, "CHUTES_API_KEY", None),
         "cache": _chutes_models_cache,
@@ -139,7 +139,7 @@ GATEWAY_CONFIG = {
     },
     "novita": {
         "name": "Novita",
-        "url": "https://api.novita.ai/v3/models",
+        "url": "https://api.novita.ai/v3/openai/models",
         "api_key_env": "NOVITA_API_KEY",
         "api_key": Config.NOVITA_API_KEY,
         "cache": _novita_models_cache,
@@ -170,7 +170,7 @@ GATEWAY_CONFIG = {
         "api_key_env": "NEAR_API_KEY",
         "api_key": Config.NEAR_API_KEY,
         "cache": _near_models_cache,
-        "min_expected_models": 5,
+        "min_expected_models": 4,
         "header_type": "bearer",
     },
     "fal": {


### PR DESCRIPTION
## Summary
- Aligns gateway health checks with current provider endpoints and model counts to prevent dashboard failures.
- Updates ensure the health dashboard queries the correct model endpoints and uses the right minimum model expectations.

## Changes
- Core Configuration
  - chutes: URL updated to https://llm.chutes.ai/v1/models
  - novita: URL updated to https://api.novita.ai/v3/openai/models
  - near: min_expected_models updated from 5 to 4
- Health Check Scripts
  - scripts/healthcheck_all_models.py: updated gateway URLs and min_expected_models
  - src/services/gateway_health_service.py: updated gateway URLs and min_expected_models
  - scripts/diagnostic/check_and_fix_gateway_models.py: updated gateway URLs and min_expected_models

## Test plan
- Run the gateway health dashboard health checks and verify green status
- Confirm NEAR shows 4 expected models
- Validate that chutes and novita endpoints are reachable and return expected model listings
- Ensure there are no mismatches or 404s in health checks after the changes

## Notes
- Changes are configuration-only (URLs and counts); no behavioral logic was modified beyond syncing with updated provider endpoints.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/95d82abf-d20b-462b-b3e0-a14a971c52a8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Chutes and Novita model endpoints and lowers NEAR min_expected_models to 4 across health scripts and gateway service.
> 
> - **Gateway config updates**:
>   - **Endpoints**:
>     - `chutes`: `https://llm.chutes.ai/v1/models` (was `https://api.chutes.ai/v1/models`).
>     - `novita`: `https://api.novita.ai/v3/openai/models` (was `https://api.novita.ai/v3/models`).
>   - **Thresholds**:
>     - `near`: `min_expected_models` set to `4` (was `5`).
> - **Files touched**:
>   - `scripts/diagnostic/check_and_fix_gateway_models.py`
>   - `scripts/healthcheck_all_models.py`
>   - `src/services/gateway_health_service.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e4ccb7ddca5501b479f079365affafd2caa7b76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->