### PR TITLE
Integrate Near AI pricing API for dynamic model pricing

### DIFF
--- a/src/data/manual_pricing.json
+++ b/src/data/manual_pricing.json
@@ -86,36 +86,40 @@
       "prompt": "1.00",
       "completion": "2.50",
       "request": "0",
-      "image": "0"
+      "image": "0",
+      "context_length": 128000
     },
     "openai/gpt-oss-120b": {
       "prompt": "0.20",
       "completion": "0.60",
       "request": "0",
-      "image": "0"
+      "image": "0",
+      "context_length": 131000
     },
     "Qwen/Qwen3-30B-A3B-Instruct-2507": {
       "prompt": "0.15",
       "completion": "0.45",
       "request": "0",
-      "image": "0"
+      "image": "0",
+      "context_length": 262000
     },
     "zai-org/GLM-4.6": {
       "prompt": "0.75",
       "completion": "2.00",
       "request": "0",
-      "image": "0"
+      "image": "0",
+      "context_length": 200000
     }
   },
   "_metadata": {
-    "last_updated": "2025-11-12",
-    "note": "Manual pricing data for providers that don't expose pricing via API",
+    "last_updated": "2025-11-13",
+    "note": "Manual pricing data for providers that don't expose pricing via API. Near AI pricing is now fetched dynamically from API but kept here as fallback.",
     "sources": [
       "https://deepinfra.com/pricing",
       "https://featherless.ai/pricing",
       "https://chutes.ai/pricing",
       "https://console.anyscale.com/services (Alpaca Network via Anyscale)",
-      "https://cloud.near.ai/models"
+      "https://cloud-api.near.ai/v1/model/list (Near AI - dynamic API)"
     ],
     "currency": "USD",
     "units": "per 1M tokens (unless specified otherwise)"

--- a/test_near_model_list_api.py
+++ b/test_near_model_list_api.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Test Near AI model list endpoint to verify pricing data is available.
+"""
+
+import json
+import os
+import sys
+
+try:
+    import httpx
+    USE_HTTPX = True
+except ImportError:
+    try:
+        import requests
+        USE_HTTPX = False
+    except ImportError:
+        print("ERROR: Neither httpx nor requests library available")
+        sys.exit(1)
+
+NEAR_API_KEY = os.getenv("NEAR_API_KEY")
+NEAR_MODEL_LIST_URL = "https://cloud-api.near.ai/v1/model/list"
+
+def test_model_list_endpoint():
+    """Test the /v1/model/list endpoint and verify pricing data"""
+    print("=" * 80)
+    print("  Near AI Model List API Test")
+    print("=" * 80)
+
+    if not NEAR_API_KEY:
+        print("\n❌ NEAR_API_KEY not found in environment")
+        print("   Set it with: export NEAR_API_KEY='your-key'")
+        return 1
+
+    print(f"\n✅ API Key found: ...{NEAR_API_KEY[-8:]}")
+    print(f"   Endpoint: {NEAR_MODEL_LIST_URL}")
+
+    headers = {
+        "Authorization": f"Bearer {NEAR_API_KEY}",
+        "Content-Type": "application/json"
+    }
+
+    try:
+        print("\n📡 Fetching model list...")
+
+        if USE_HTTPX:
+            response = httpx.get(NEAR_MODEL_LIST_URL, headers=headers, timeout=20.0)
+        else:
+            response = requests.get(NEAR_MODEL_LIST_URL, headers=headers, timeout=20.0)
+
+        print(f"   Status Code: {response.status_code}")
+
+        if response.status_code != 200:
+            print(f"\n❌ Failed to fetch models")
+            print(f"   Response: {response.text[:500]}")
+            return 1
+
+        data = response.json()
+        models = data.get("models", [])
+
+        if not models:
+            print("\n❌ No models found in response")
+            print(f"   Response keys: {list(data.keys())}")
+            return 1
+
+        print(f"\n✅ Successfully fetched {len(models)} models")
+        print("\n" + "=" * 80)
+        print("  Model Pricing Verification")
+        print("=" * 80)
+
+        all_have_pricing = True
+
+        for i, model in enumerate(models, 1):
+            model_id = model.get("modelId", "unknown")
+            input_cost = model.get("inputCostPerToken", {})
+            output_cost = model.get("outputCostPerToken", {})
+            metadata = model.get("metadata", {})
+
+            print(f"\n{i}. {model_id}")
+            print(f"   Display Name: {metadata.get('displayName', 'N/A')}")
+            print(f"   Context Length: {metadata.get('contextLength', 'N/A'):,}" if metadata.get('contextLength') else "   Context Length: N/A")
+
+            # Check pricing
+            if input_cost and output_cost:
+                input_amount = input_cost.get("amount", 0)
+                input_scale = input_cost.get("scale", -9)
+                output_amount = output_cost.get("amount", 0)
+                output_scale = output_cost.get("scale", -9)
+
+                # Convert to per million tokens
+                input_per_million = input_amount * (10 ** (6 + input_scale))
+                output_per_million = output_amount * (10 ** (6 + output_scale))
+
+                print(f"   Pricing:")
+                print(f"     Input:  ${input_per_million:.2f} per million tokens")
+                print(f"     Output: ${output_per_million:.2f} per million tokens")
+                print(f"   ✅ Pricing available")
+            else:
+                print(f"   ❌ No pricing data")
+                all_have_pricing = False
+
+        print("\n" + "=" * 80)
+        print("  Summary")
+        print("=" * 80)
+
+        if all_have_pricing:
+            print(f"\n✅ SUCCESS: All {len(models)} models have pricing data")
+            print("\nRecommendation:")
+            print("  • The Near AI API provides complete pricing information")
+            print("  • Your integration should successfully extract pricing dynamically")
+            print("  • No need for manual pricing fallback for these models")
+            return 0
+        else:
+            print(f"\n⚠️  WARNING: Some models missing pricing data")
+            print("\nRecommendation:")
+            print("  • Consider keeping manual pricing fallback for incomplete data")
+            return 1
+
+    except Exception as e:
+        print(f"\n❌ Error: {type(e).__name__}: {e}")
+        import traceback
+        traceback.print_exc()
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(test_model_list_endpoint())

--- a/test_near_models_fetch.py
+++ b/test_near_models_fetch.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Integration test for Near AI models fetch with actual code"""
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+
+import logging
+from src.services.models import normalize_near_model
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+logger = logging.getLogger(__name__)
+
+def test_normalize_near_model():
+    """Test the actual normalize_near_model function"""
+    print("\n" + "="*60)
+    print("Testing normalize_near_model function")
+    print("="*60 + "\n")
+
+    # Test with new API format (modelId + inputCostPerToken/outputCostPerToken)
+    test_cases = [
+        {
+            "name": "New API format with modelId",
+            "input": {
+                "modelId": "deepseek-ai/DeepSeek-V3.1",
+                "inputCostPerToken": {"amount": 1, "scale": -6},
+                "outputCostPerToken": {"amount": 2.5, "scale": -6},
+                "metadata": {
+                    "displayName": "DeepSeek V3.1",
+                    "description": "Advanced reasoning model",
+                    "contextLength": 128000
+                }
+            },
+            "expected_prompt": "1.0",
+            "expected_completion": "2.5",
+        },
+        {
+            "name": "Legacy API format with id",
+            "input": {
+                "id": "openai/gpt-oss-120b",
+                "pricing": {
+                    "prompt": "0.20",
+                    "completion": "0.60"
+                },
+                "metadata": {
+                    "context_length": 131000
+                }
+            },
+            "expected_prompt": "0.20",
+            "expected_completion": "0.60",
+        },
+        {
+            "name": "Different scale value (-9)",
+            "input": {
+                "modelId": "test/model",
+                "inputCostPerToken": {"amount": 100, "scale": -9},
+                "outputCostPerToken": {"amount": 200, "scale": -9},
+                "metadata": {"contextLength": 100000}
+            },
+            "expected_prompt": "0.1",
+            "expected_completion": "0.2",
+        },
+    ]
+
+    all_passed = True
+
+    for test_case in test_cases:
+        print(f"Test: {test_case['name']}")
+        result = normalize_near_model(test_case['input'])
+
+        if not result:
+            logger.error(f"  ❌ FAILED: normalize_near_model returned None")
+            all_passed = False
+            print()
+            continue
+
+        pricing = result.get("pricing", {})
+        prompt_price = pricing.get("prompt")
+        completion_price = pricing.get("completion")
+
+        print(f"  Expected prompt: ${test_case['expected_prompt']}/M")
+        print(f"  Got prompt: ${prompt_price}/M")
+        print(f"  Expected completion: ${test_case['expected_completion']}/M")
+        print(f"  Got completion: ${completion_price}/M")
+
+        if prompt_price == test_case["expected_prompt"] and completion_price == test_case["expected_completion"]:
+            logger.info(f"  ✅ SUCCESS")
+        else:
+            logger.error(f"  ❌ FAILED: Pricing mismatch")
+            all_passed = False
+
+        print()
+
+    print("="*60)
+    if all_passed:
+        print("✅ All tests passed!")
+        return 0
+    else:
+        print("❌ Some tests failed")
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(test_normalize_near_model())

--- a/test_near_pricing_integration.py
+++ b/test_near_pricing_integration.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Test script to verify Near AI pricing integration"""
+
+import sys
+import logging
+
+# Setup logging
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+logger = logging.getLogger(__name__)
+
+# Mock data from the Near AI API
+mock_near_api_response = {
+    "models": [
+        {
+            "modelId": "deepseek-ai/DeepSeek-V3.1",
+            "inputCostPerToken": {"amount": 1, "scale": -6},
+            "outputCostPerToken": {"amount": 2.5, "scale": -6},
+            "metadata": {
+                "displayName": "DeepSeek V3.1",
+                "description": "Advanced reasoning model with hybrid thinking mode",
+                "contextLength": 128000
+            }
+        },
+        {
+            "modelId": "openai/gpt-oss-120b",
+            "inputCostPerToken": {"amount": 0.2, "scale": -6},
+            "outputCostPerToken": {"amount": 0.6, "scale": -6},
+            "metadata": {
+                "displayName": "GPT OSS 120B",
+                "description": "High-performance open source model",
+                "contextLength": 131000
+            }
+        },
+        {
+            "modelId": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "inputCostPerToken": {"amount": 0.15, "scale": -6},
+            "outputCostPerToken": {"amount": 0.45, "scale": -6},
+            "metadata": {
+                "displayName": "Qwen3 30B A3B Instruct",
+                "description": "Efficient instruction-following model",
+                "contextLength": 262000
+            }
+        },
+        {
+            "modelId": "zai-org/GLM-4.6",
+            "inputCostPerToken": {"amount": 0.75, "scale": -6},
+            "outputCostPerToken": {"amount": 2.0, "scale": -6},
+            "metadata": {
+                "displayName": "GLM-4.6",
+                "description": "Zhipu AI's latest generation model",
+                "contextLength": 200000
+            }
+        }
+    ]
+}
+
+def normalize_near_model(near_model: dict) -> dict:
+    """Test version of the normalize function"""
+    model_id = near_model.get("modelId")
+    if not model_id:
+        return None
+
+    slug = f"near/{model_id}"
+    metadata = near_model.get("metadata", {})
+
+    display_name = metadata.get("displayName", model_id)
+    description = metadata.get("description", f"Near AI hosted model {model_id}.")
+    context_length = metadata.get("contextLength", 0)
+
+    pricing = {
+        "prompt": None,
+        "completion": None,
+        "request": None,
+        "image": None,
+    }
+
+    # Extract pricing from Near AI API response
+    input_cost = near_model.get("inputCostPerToken", {})
+    output_cost = near_model.get("outputCostPerToken", {})
+
+    if input_cost and isinstance(input_cost, dict):
+        input_amount = input_cost.get("amount", 0)
+        input_scale = input_cost.get("scale", -9)
+        # Convert to per million tokens
+        if input_amount > 0:
+            pricing["prompt"] = str(input_amount * (10 ** (6 + input_scale)))
+
+    if output_cost and isinstance(output_cost, dict):
+        output_amount = output_cost.get("amount", 0)
+        output_scale = output_cost.get("scale", -9)
+        # Convert to per million tokens
+        if output_amount > 0:
+            pricing["completion"] = str(output_amount * (10 ** (6 + output_scale)))
+
+    return {
+        "id": slug,
+        "name": display_name,
+        "description": description,
+        "context_length": context_length,
+        "pricing": pricing,
+    }
+
+def test_pricing_extraction():
+    """Test that pricing is correctly extracted from Near AI API response"""
+    print("\n" + "="*60)
+    print("Testing Near AI Pricing Integration")
+    print("="*60 + "\n")
+
+    models = mock_near_api_response["models"]
+    success = True
+
+    for model in models:
+        normalized = normalize_near_model(model)
+        if not normalized:
+            logger.error(f"Failed to normalize model: {model.get('modelId')}")
+            success = False
+            continue
+
+        model_id = model.get("modelId")
+        pricing = normalized.get("pricing", {})
+
+        print(f"Model: {normalized['name']}")
+        print(f"  ID: {normalized['id']}")
+        print(f"  Context Length: {normalized['context_length']:,} tokens")
+        print(f"  Pricing:")
+        print(f"    Input: ${pricing.get('prompt', 'N/A')} per million tokens")
+        print(f"    Output: ${pricing.get('completion', 'N/A')} per million tokens")
+
+        # Verify pricing is extracted
+        if not pricing.get("prompt") or not pricing.get("completion"):
+            logger.error(f"  ❌ FAILED: Pricing not extracted for {model_id}")
+            success = False
+        else:
+            logger.info(f"  ✅ SUCCESS: Pricing extracted correctly")
+
+        print()
+
+    print("="*60)
+    if success:
+        print("✅ All tests passed!")
+        return 0
+    else:
+        print("❌ Some tests failed")
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(test_pricing_extraction())


### PR DESCRIPTION
### Summary
- Adds dynamic pricing support by integrating Near AI pricing API for model pricing
- Fetches Near AI model list from /v1/model/list and normalizes pricing data
- Supports new Near AI pricing format (inputCostPerToken / outputCostPerToken) with per-Million-token pricing; retains backward-compatible fallback pricing
- Updates manual pricing data to include context lengths and Near API as a data source
- Introduces tests to validate Near API pricing extraction and integration

### Changes
#### Backend
- Fetch and normalize Near AI models from Near API
  - Use endpoint: https://cloud-api.near.ai/v1/model/list (formerly /v1/models)
  - Parse models from payload.models (fallbacks to known models if API is unavailable)
- normalize_near_model enhancements
  - Support new fields: modelId, inputCostPerToken, outputCostPerToken, metadata (including displayName, description, contextLength)
  - Compute pricing in per-million-tokens units by converting input/output costs using amount and scale (per token to per million tokens)
  - Preserve backward compatibility by falling back to legacy pricing data when needed
  - Extract and apply context_length from metadata.contextLength (fallbacks supported)
  - Build description with security notes and model metadata for better discoverability
- Data handling and compatibility
  - Updated normalization to gracefully handle both new API format and legacy format
  - Adjusted model slug generation to 

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e9e9a5bc-8615-43d5-afed-f518e4198dfd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fetch Near AI models from /v1/model/list with pricing, normalize new fields and pricing conversion, add fallbacks, and update manual pricing with context lengths.
> 
> - **Backend (Near AI)**:
>   - Fetch models from `https://cloud-api.near.ai/v1/model/list` (replaces `/v1/models`); parse `payload.models` and cache results.
>   - Enhance `normalize_near_model` to support `modelId`, `metadata.displayName/description/contextLength`, and convert `inputCostPerToken`/`outputCostPerToken` to per‑million pricing; fallback to legacy `pricing` and `id` fields.
>   - Expand fallback Near models with pricing and `metadata.contextLength`.
> - **Data**:
>   - Update `src/data/manual_pricing.json` Near entries to include `context_length`; refresh `_metadata.last_updated` and add Near API source URL.
> - **Tests**:
>   - Add `test_near_model_list_api.py` to validate API response and pricing presence.
>   - Add `test_near_models_fetch.py` to verify normalization and pricing conversion across formats/scales.
>   - Add `test_near_pricing_integration.py` to confirm pricing extraction from mocked API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e8be2dedbd2d85766b3c88e4385b887037f9f7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->