### PR TITLE
Normalize case handling for Portkey/provider/model IDs across components

### DIFF
--- a/src/services/image_generation_client.py
+++ b/src/services/image_generation_client.py
@@ -49,15 +49,16 @@ def make_portkey_image_request(
         if virtual_key:
             headers["x-portkey-virtual-key"] = virtual_key
         # Method 2: Use @provider format (Portkey SDK style)
-        elif provider and provider.startswith("@"):
+        # Normalize provider to lowercase for case-insensitive @ prefix checking
+        elif provider and provider.lower().startswith("@"):
             # Use config-based provider format
             import json
 
-            config = {"provider": provider}  # e.g., "@openai", "@stability-ai"
+            config = {"provider": provider.lower()}  # e.g., "@openai", "@stability-ai"
             headers["x-portkey-config"] = json.dumps(config)
         # Method 3: Legacy provider header
         elif provider:
-            headers["x-portkey-provider"] = provider
+            headers["x-portkey-provider"] = provider.lower()
         else:
             raise ValueError(
                 "Either virtual_key or provider must be specified for Portkey image generation"

--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -616,25 +616,28 @@ def detect_provider_from_model_id(model_id: str, preferred_provider: Optional[st
     if model_id.startswith("accounts/fireworks/models/"):
         return "fireworks"
 
+    # Normalize to lowercase for consistency in all @ prefix checks
+    normalized_model = model_id.lower()
+
     # Check for Google Vertex AI models first (before Portkey check)
     if model_id.startswith("projects/") and "/models/" in model_id:
         return "google-vertex"
-    if model_id.startswith("@google/models/") and any(
-        pattern in model_id.lower()
+    if normalized_model.startswith("@google/models/") and any(
+        pattern in normalized_model
         for pattern in ["gemini-2.5", "gemini-2.0", "gemini-1.5", "gemini-1.0"]
     ):
         # Patterns like "@google/models/gemini-2.5-flash"
         return "google-vertex"
     if (
         any(
-            pattern in model_id.lower()
+            pattern in normalized_model
             for pattern in ["gemini-2.5", "gemini-2.0", "gemini-1.5", "gemini-1.0"]
         )
         and "/" not in model_id
     ):
         # Simple patterns like "gemini-2.5-flash", "gemini-2.0-flash" or "gemini-1.5-pro"
         return "google-vertex"
-    if model_id.startswith("google/") and "gemini" in model_id.lower():
+    if model_id.startswith("google/") and "gemini" in normalized_model:
         # Patterns like "google/gemini-2.5-flash" or "google/gemini-2.0-flash-001"
         # These can go to either Vertex AI or OpenRouter
         # Check if Vertex AI credentials are available
@@ -659,9 +662,10 @@ def detect_provider_from_model_id(model_id: str, preferred_provider: Optional[st
             return "openrouter"
 
     # Portkey format is @org/model (must have / to be valid)
-    if model_id.startswith("@") and "/" in model_id:
+    # Normalize to lowercase for case-insensitive @ prefix detection
+    if normalized_model.startswith("@") and "/" in model_id:
         # Only Portkey if not a Google format
-        if not model_id.startswith("@google/models/"):
+        if not normalized_model.startswith("@google/models/"):
             return "portkey"
 
     # Check all mappings to see if this model exists

--- a/src/services/portkey_client.py
+++ b/src/services/portkey_client.py
@@ -32,24 +32,29 @@ def _format_portkey_model(model: str, slug: Optional[str]) -> str:
     if not trimmed:
         raise ValueError("Model name is required for Portkey requests")
 
-    # Already namespaced
-    if trimmed.startswith("@"):
-        return trimmed
+    # Normalize for @ prefix checking (case-insensitive)
+    trimmed_lower = trimmed.lower()
+
+    # Already namespaced (case-insensitive check)
+    if trimmed_lower.startswith("@"):
+        # Return as-is (preserving original case) since Portkey expects lowercase for model IDs
+        return trimmed.lower()
 
     if "/" in trimmed:
         prefix, _ = trimmed.split("/", 1)
-        if prefix.startswith("@"):
-            return trimmed
-        if slug and prefix == slug:
-            return f"@{trimmed}"
+        if prefix.lower().startswith("@"):
+            # Return with proper lowercasing for Portkey format
+            return f"@{trimmed.lower()}"
+        if slug and prefix.lower() == slug.lower():
+            return f"@{trimmed.lower()}"
         # Assume caller supplied provider slug without '@'
-        return f"@{trimmed}"
+        return f"@{trimmed.lower()}"
 
     if slug:
-        return f"@{slug}/{trimmed}"
+        return f"@{slug.lower()}/{trimmed.lower()}"
 
     # Fallback: return raw model, Portkey will attempt to resolve default
-    return trimmed
+    return trimmed.lower()
 
 
 def get_portkey_client(provider: Optional[str] = None, virtual_key: Optional[str] = None) -> OpenAI:


### PR DESCRIPTION
## Summary
- Normalize case handling for Portkey/provider/model IDs to improve compatibility with diverse model identifiers (e.g., Cerebras/Qwen-3-32B)
- Ensure provider hints (@-formatted) are treated case-insensitively, with lowercase normalization where appropriate
- Standardize Portkey model formatting to lowercase for consistency across the codebase

## Changes

### Image generation
- src/services/image_generation_client.py
  - Treats provider prefix "@" checks as case-insensitive by lowercasing provider when creating Portkey config/header entries
  - Normalize provider checks to lowercase for consistent Portkey handling

### Model detection
- src/services/model_transformations.py
  - Normalize model_id to lowercase for all provider-format checks
  - Use a lowercased normalized_model for pattern checks (Google Vertex, Gemini, Portkey)
  - Ensure @ prefix handling does not miss valid Portkey models due to case differences

### Portkey client
- src/services/portkey_client.py
  - _format_portkey_model now enforces case-insensitive normalization
  - Returns lowercased Portkey IDs to ensure consistency
  - Handles case-insensitive detection of @ prefixes and slug matches
  - Ensures generated Portkey strings are lowercase where appropriate

## Rationale
- Case-sensitivity can cause misclassification of models and incorrect Portkey headers when inputs come from varied sources. Lowercasing and normalization reduce edge-case failures and improve reliability when investigating model deployments like Cerebras/Qwen-3-32B.

## Test plan
- [ ] Validate detect_provider_from_model_id with mixed-case inputs (e.g., "@Google/Models/GEMINI-2.5-FLASH", "google/gemini-2.5-flash", "GEMINI-2.5")
- [ ] Validate _format_portkey_model with mixed-case inputs (e.g., "OpenAI/GEMINI-2.0", "@OPENAI/GEMINI-2.0", "gemini-2.0-flash")
- [ ] Ensure image generation requests include properly lowercased x-portkey-config/provider headers
- [ ] Run existing tests to ensure no regressions with lowercase inputs

## Notes
- No public API changes; this is internal normalization to improve consistency and reliability across providers and model identifiers.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/3f679c43-5b4c-4874-b114-5a1a92f6e11d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make provider hints and model IDs case-insensitive and normalize to lowercase across Portkey clients, image generation, and provider detection.
> 
> - **Portkey**:
>   - `_format_portkey_model` now treats `@` prefixes and slugs case-insensitively and returns lowercased Portkey IDs.
>   - Lowercase normalization when adding `x-portkey-provider`/`x-portkey-config` headers in `src/services/image_generation_client.py`.
> - **Provider Detection** (`src/services/model_transformations.py`):
>   - Introduce `normalized_model = model_id.lower()` and use it for `@` prefix and Gemini/Google checks.
>   - Portkey detection updated to case-insensitive `@` handling while excluding `@google/models/`.
> - **Consistency**:
>   - Standardize handling of `@provider` formats and model paths to be case-insensitive with lowercase normalization throughout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c8c673790176439a768b8ebf88887b3fdc1d364. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->