### PR TITLE
Load AI model pricing and catalog data

### DIFF
--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -211,6 +211,10 @@ def track_trial_usage(*args, **kwargs):
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
+# Log module initialization to help debug route loading
+logger.info("🔄 Chat module initialized - router created")
+logger.info(f"   Router type: {type(router)}")
+
 DEFAULT_PROVIDER_TIMEOUT = 30
 PROVIDER_TIMEOUTS = {
     "huggingface": 120,
@@ -526,6 +530,9 @@ async def stream_generator(
         yield f"data: {json.dumps(error_chunk)}\n\n"
         yield "data: [DONE]\n\n"
 
+
+# Log route registration for debugging
+logger.info("📍 Registering /v1/chat/completions endpoint")
 
 @router.post("/v1/chat/completions", tags=["chat"])
 @traced(name="chat_completions", type="llm")
@@ -2180,3 +2187,8 @@ async def unified_responses(
                 await rate_limit_mgr.release_concurrency(api_key)
             except Exception as exc:
                 logger.debug("Failed to release concurrency for %s: %s", mask_key(api_key), exc)
+
+
+# Log successful module load - this should appear in startup logs if chat.py loads correctly
+logger.info("✅ Chat module fully loaded - all routes registered successfully")
+logger.info(f"   Total routes in router: {len(router.routes)}")


### PR DESCRIPTION
Added logging at three key points in chat.py to diagnose why /v1/chat/completions returns 404:
- Module initialization (when router is created)
- Route registration (before defining /v1/chat/completions)
- Module completion (after all routes are defined)

This will help identify if the chat module is being imported and if routes are being registered properly.

Related to 404 errors on /v1/chat/completions endpoint in production.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add startup and route-registration logging in `src/routes/chat.py` to verify router initialization and endpoint availability.
> 
> - **Backend — `src/routes/chat.py`**:
>   - Add module initialization logs (router created, router type).
>   - Log before registering `POST /v1/chat/completions`.
>   - Log successful module load with total routes registered.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae231b290559aa2a7db1ba2365d4ab3439301736. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->