### PR TITLE
Fix onboarding/referral emails by refreshing Resend API key

### DIFF
--- a/src/enhanced_notification_service.py
+++ b/src/enhanced_notification_service.py
@@ -374,6 +374,9 @@ The {self.app_name} Team
                 logger.warning("❌ Resend API key not configured, skipping email notification")
                 return False
 
+            # Ensure API key is set before each send (in case it changed)
+            resend.api_key = self.resend_api_key
+
             # Use Resend SDK
             logger.info("Sending email via Resend SDK...")
             response = resend.Emails.send(

--- a/src/services/notification.py
+++ b/src/services/notification.py
@@ -316,6 +316,9 @@ class NotificationService:
                 logger.warning("Resend API key not configured, skipping email notification")
                 return False
 
+            # Ensure API key is set before each send (in case it changed)
+            resend.api_key = self.resend_api_key
+
             # Prepare email data for Resend
             email_params = {
                 "from": self.from_email,


### PR DESCRIPTION
## Summary
- Ensures the latest Resend API key is applied before every email send to onboarding and referral flows.
- Addresses failures when the API key rotates or changes between sends.

## Changes

### Core Functionality
- In enhanced_notification_service.py, assign `resend.api_key = self.resend_api_key` prior to sending via the Resend SDK.
- In src/services/notification.py, assign `resend.api_key = self.resend_api_key` prior to sending via the Resend SDK.

### Why
- API keys can rotate at runtime; reapplying the key before each send prevents misdelivery and ensures reliable email delivery.

### Files Updated
- src/enhanced_notification_service.py
- src/services/notification.py

## Testing Plan
- [x] Validate onboarding and referral emails are delivered when API key is rotated at runtime.
- [x] Verify no emails are sent if the API key is not configured.
- [x] Ensure existing email flows still work with the key refresh logic.

## Notes
- No user-facing changes; this is a reliability improvement for internal email delivery via Resend.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/35e990e5-c696-4b29-bd4e-ae5591ebde60

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refreshes the Resend API key immediately before sending emails in both notification services to ensure current credentials are used.
> 
> - **Backend**
>   - **Email Sending**:
>     - In `src/enhanced_notification_service.py` (`send_email_notification`), set `resend.api_key = self.resend_api_key` before calling `resend.Emails.send`.
>     - In `src/services/notification.py` (`send_email_notification`), set `resend.api_key = self.resend_api_key` before calling `resend.Emails.send`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48e24be60432213e14dc29685558e5d462dee8af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->