### PR TITLE
Fix missing key_version column error in remote schema

### DIFF
--- a/supabase/migrations/20251009030427_remote_schema.sql
+++ b/supabase/migrations/20251009030427_remote_schema.sql
@@ -121,7 +121,9 @@ CREATE TABLE IF NOT EXISTS "public"."api_keys_new" (
     "last_used_at" timestamp with time zone,
     "created_at" timestamp with time zone DEFAULT "now"(),
     "updated_at" timestamp with time zone DEFAULT "now"(),
-    "encrypted_key" "text"
+    "encrypted_key" "text",
+    "key_version" integer,
+    "last4" "text"
 );
 
 


### PR DESCRIPTION
## Summary
- Adds key_version column to api_keys_new
- Adds last4 column to api_keys_new
- Minor formatting cleanup for update_updated_at_column trigger in remote schema

## Changes

### Database migrations
- supabase/migrations/20251009030427_remote_schema.sql
  - Add `key_version` integer column to `api_keys_new`
  - Add `last4` text column to `api_keys_new`
  - Normalize and fix formatting of the `update_updated_at_column` trigger block (standardized `AS $$ ... $$` quoting)

### Rationale
- Resolves the missing key_version column error by introducing the expected column on the new API keys table
- Keeps compatibility with existing logic while improving SQL readability and stability

## Test plan
- Run the migrations and verify the new columns exist on public.api_keys_new with correct types (`integer` for key_version, `text` for last4)
- Ensure no syntax errors in the remote schema migration and trigger definitions
- Execute any tests or queries that reference `key_version` to confirm successful interaction
- Validate that existing functionality involving `encrypted_key` remains unaffected


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/1b606cbf-2934-44aa-b3e7-65f15fcef8ab

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `key_version` and `last4` columns to `public.api_keys_new` and standardize the `update_updated_at_column` function block formatting.
> 
> - **Database migration** (`supabase/migrations/20251009030427_remote_schema.sql`):
>   - **`public.api_keys_new`**:
>     - Add `key_version` (integer)
>     - Add `last4` (text)
>   - **Trigger function**:
>     - Normalize formatting/quoting of `public.update_updated_at_column()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aecd706639206b0cbec91724497d039d7d7dd4c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->