### PR TITLE
Include huggingface gateway in model fetch candidate list

### DIFF
--- a/src/services/models.py
+++ b/src/services/models.py
@@ -2766,6 +2766,9 @@ def fetch_specific_model(provider_name: str, model_name: str, gateway: str = Non
             if "openrouter" not in candidate_gateways:
                 candidate_gateways.append("openrouter")
 
+            if "huggingface" not in candidate_gateways:
+                candidate_gateways.append("huggingface")
+
         fetchers = {
             "openrouter": fetch_specific_model_from_openrouter,
             "portkey": fetch_specific_model_from_portkey,


### PR DESCRIPTION
## Summary
- Fix: Include huggingface as a candidate gateway when fetching specific models to prevent missing model pages.

## Changes

### Core Functionality
- In `fetch_specific_model`, ensure "huggingface" is appended to `candidate_gateways` when it’s not already present, alongside existing handling for "openrouter".

### Behavior Impact
- Improves reliability of model page creation for models hosted on HuggingFace by ensuring the gateway is considered during fetch.

### Files Modified
- `src/services/models.py`

## Test plan
- [x] Fetch a model that lives on HuggingFace; verify it uses the HuggingFace gateway (no 404 model page)
- [x] Ensure no regressions for OpenRouter and PortKey pathways
- [x] Code review: confirm idempotency of adding HuggingFace to `candidate_gateways` (no duplicates)

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/be1c894b-5319-42ee-a814-4e7fb74dd603

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `fetch_specific_model` always considers the Hugging Face gateway when resolving a specific model.
> 
> - **Model fetch routing**:
>   - Update `fetch_specific_model` in `src/services/models.py` to append `huggingface` to `candidate_gateways` (if missing), ensuring models on Hugging Face are considered during lookup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93a880e7ebee87b5e159e381b27db720abbad145. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->