### PR TITLE
Fix Alibaba model serving: add cache and fetch flow

### DIFF
--- a/src/cache.py
+++ b/src/cache.py
@@ -169,6 +169,13 @@ _anannas_models_cache = {
     "stale_ttl": 7200,
 }
 
+_alibaba_models_cache = {
+    "data": None,
+    "timestamp": None,
+    "ttl": 3600,  # 1 hour TTL for Alibaba Cloud catalog
+    "stale_ttl": 7200,
+}
+
 # BACKWARD COMPATIBILITY: Alias for old cache name
 # Some deployed modules may still reference the old name
 _hug_models_cache = _huggingface_models_cache
@@ -199,6 +206,7 @@ def get_models_cache(gateway: str):
         "helicone": _helicone_models_cache,
         "aihubmix": _aihubmix_models_cache,
         "anannas": _anannas_models_cache,
+        "alibaba": _alibaba_models_cache,
         "modelz": _modelz_cache,
     }
     return cache_map.get(gateway.lower())
@@ -233,6 +241,7 @@ def clear_models_cache(gateway: str):
         "vercel-ai-gateway": _vercel_ai_gateway_models_cache,
         "aihubmix": _aihubmix_models_cache,
         "anannas": _anannas_models_cache,
+        "alibaba": _alibaba_models_cache,
         "modelz": _modelz_cache,
     }
     cache = cache_map.get(gateway.lower())


### PR DESCRIPTION
## Summary
- Adds Alibaba Cloud model catalog support with caching, normalization, and an OpenAI-compatible schema.
- Integrates Alibaba provider into existing parallel and sequential model-fetch flows.
- Gracefully handles missing API key by skipping fetch to avoid failures.

## Changes
### Caching
- Introduced _alibaba_models_cache with fields: data, timestamp, ttl (3600s), stale_ttl (7200s).
- Registered Alibaba cache in get_models_cache and clear_models_cache so Alibaba models are treated like other providers.

### Backend model fetching
- Added fetch_models_from_alibaba() to retrieve models from Alibaba Cloud (DashScope) via an OpenAI-compatible API if ALIBABA_CLOUD_API_KEY is configured.
- Implemented normalize_alibaba_model() to map Alibaba models to the internal catalog schema, including fields like id, slug, canonical_slug, architecture, pricing, provider_slug, and source_gateway.
- On successful fetch, cache is populated and a log entry records the number of models retrieved.

### Catalog integration
- Updated get_all_models_parallel() and get_all_models_sequential() to include the new "alibaba" gateway.
- Added handling in get_cached_models for gateway "alibaba" to fetch and cache models when needed.

### Logging and safety
- If API key is missing, Alibaba fetch is skipped with a warning to avoid errors.

## Test plan
- [ ] Unset ALIBABA_CLOUD_API_KEY and ensure Alibaba catalog fetch is skipped without errors; existing caches remain usable.
- [ ] Set ALIBABA_CLOUD_API_KEY and verify fetch flow: client.list() is called, models are normalized via normalize_alibaba_model(), and results populate _alibaba_models_cache.
- [ ] Validate the normalized fields for a sample Alibaba model (id, slug, canonical_slug, name, description, context_length, architecture, provider_slug, provider_site_url, source_gateway).
- [ ] Confirm Alibaba models appear in parallel and sequential catalog aggregations.
- [ ] Verify TTL behavior: after 1 hour, data is refreshed on next fetch call while stale TTL allows graceful reuse.

## Notes
- The implementation relies on the presence of a configured Alibaba Cloud API key and the availability of the Alibaba OpenAI-compatible API client (get_alibaba_cloud_client).
- This change is isolated to model serving/catalog fetch logic and should not affect existing providers."} ) } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } }} } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } } }}

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6301f466-03c3-4a20-a774-49b88ca582c3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Alibaba Cloud (DashScope) model catalog via OpenAI-compatible client, with caching and integration into parallel/sequential fetch and catalog flows.
> 
> - **Catalog Integration**:
>   - Include `"alibaba"` gateway in `get_all_models_parallel()` and sequential aggregation; results merged into the aggregated catalog.
>   - Add Alibaba handling in `get_cached_models()` with canonical registration.
> - **Caching**:
>   - Introduce `_alibaba_models_cache` and register it in `get_models_cache()` and `clear_models_cache()`.
> - **Fetching & Normalization**:
>   - Implement `fetch_models_from_alibaba()` using `alibaba_cloud_client` and cache results; skip fetch if `ALIBABA_CLOUD_API_KEY` missing.
>   - Add `normalize_alibaba_model()` to map Alibaba models to internal schema (ids, slugs, architecture, pricing, provider metadata).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3dc754959f63f9706fcea9e8f8d5a08065adad5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->