### PR TITLE
Add PostHog error tracking with Python SDK integration

### DIFF
--- a/docs/POSTHOG_ERROR_TRACKING.md
+++ b/docs/POSTHOG_ERROR_TRACKING.md
@@ -1,0 +1,294 @@
+# PostHog Error Tracking Integration
+
+## Overview
+
+This document describes the PostHog error tracking integration for the Gatewayz Universal Inference API. The integration provides automatic exception capture and manual error reporting capabilities.
+
+## Features
+
+- **Automatic Exception Capture**: All unhandled exceptions are automatically captured and sent to PostHog
+- **Manual Exception Capture**: Ability to manually capture and report specific exceptions
+- **User Context**: Exceptions include user identification when available
+- **Request Context**: Exception reports include request path, method, and other relevant metadata
+- **Graceful Degradation**: If PostHog is not configured or fails, the application continues to function normally
+
+## Configuration
+
+### Environment Variables
+
+The following environment variables are required for PostHog error tracking:
+
+```bash
+# Required
+POSTHOG_API_KEY=phc_iz1i6TdtphwFCtQfK2tWxsoythvgLNcxJJO9zpNmxZf
+
+# Optional (defaults to https://us.i.posthog.com)
+POSTHOG_HOST=https://us.i.posthog.com
+
+# Optional (for debugging)
+POSTHOG_DEBUG=false
+```
+
+### Setup
+
+1. Add the environment variables to your `.env` file or deployment environment
+2. The PostHog service is automatically initialized on application startup
+3. Error tracking is enabled by default when `POSTHOG_API_KEY` is set
+
+## Implementation Details
+
+### PostHog Service (`src/services/posthog_service.py`)
+
+The PostHog service is a singleton that manages the PostHog client and provides methods for event capture and error tracking.
+
+#### Key Features:
+
+- **Exception Autocapture**: Enabled via `enable_exception_autocapture=True` parameter
+- **Async Mode**: Uses async mode for better performance (`sync_mode=False`)
+- **Graceful Degradation**: Handles missing API key and initialization errors gracefully
+
+#### Methods:
+
+##### `initialize()`
+Initializes the PostHog client with exception autocapture enabled.
+
+##### `capture_exception(exception, distinct_id, properties)`
+Manually captures an exception and sends it to PostHog.
+
+**Parameters:**
+- `exception` (Exception): The exception object to capture
+- `distinct_id` (str, optional): User identifier (defaults to "system")
+- `properties` (dict, optional): Additional context properties
+
+**Example:**
+```python
+from src.services.posthog_service import posthog_service
+
+try:
+    # Some code that might raise an exception
+    risky_operation()
+except Exception as e:
+    posthog_service.capture_exception(
+        exception=e,
+        distinct_id="user_123",
+        properties={
+            "context": "processing_payment",
+            "payment_id": "pay_123"
+        }
+    )
+    # Handle the exception
+```
+
+### FastAPI Exception Handler (`src/main.py`)
+
+The global exception handler in FastAPI has been enhanced to automatically capture all unhandled exceptions.
+
+#### Features:
+
+- **Automatic User Identification**: Extracts user ID from request state or authorization header
+- **Request Context**: Includes request path, method, error type, and error message
+- **Fallback Behavior**: If PostHog capture fails, the error is logged but doesn't affect response
+
+#### Exception Properties Captured:
+
+- `path`: Request URL path
+- `method`: HTTP method (GET, POST, etc.)
+- `error_type`: Exception class name
+- `error_message`: Exception message
+
+## Testing
+
+### Unit Tests
+
+Comprehensive unit tests are available in `tests/services/test_posthog_service.py`:
+
+```bash
+pytest tests/services/test_posthog_service.py -v
+```
+
+Tests cover:
+- PostHog initialization with exception autocapture
+- Manual exception capture with distinct_id
+- Default distinct_id handling
+- Graceful handling when PostHog is not initialized
+
+### Manual Testing
+
+To test error tracking in development:
+
+1. Set up PostHog API key in your environment:
+   ```bash
+   export POSTHOG_API_KEY="your_api_key"
+   export POSTHOG_HOST="https://us.i.posthog.com"
+   ```
+
+2. Start the development server:
+   ```bash
+   python src/main.py
+   ```
+
+3. Trigger an error:
+   ```bash
+   # This endpoint doesn't exist, so it will trigger an error
+   curl -X GET http://localhost:8000/trigger-error
+   ```
+
+4. Check PostHog dashboard for the captured exception
+
+## Usage Examples
+
+### Example 1: Capturing Exceptions in Route Handlers
+
+```python
+from fastapi import APIRouter, HTTPException
+from src.services.posthog_service import posthog_service
+
+router = APIRouter()
+
+@router.post("/process")
+async def process_data(data: dict):
+    try:
+        # Process data
+        result = process_complex_operation(data)
+        return {"result": result}
+    except ValueError as e:
+        # Capture the exception with context
+        posthog_service.capture_exception(
+            exception=e,
+            distinct_id=data.get("user_id", "anonymous"),
+            properties={
+                "operation": "process_complex_operation",
+                "data_keys": list(data.keys())
+            }
+        )
+        raise HTTPException(status_code=400, detail=str(e))
+```
+
+### Example 2: Capturing Exceptions in Service Layer
+
+```python
+from src.services.posthog_service import posthog_service
+
+def process_payment(user_id: str, amount: float):
+    try:
+        # Payment processing logic
+        charge = stripe.Charge.create(amount=amount, currency="usd")
+        return charge
+    except stripe.error.CardError as e:
+        # Capture payment errors
+        posthog_service.capture_exception(
+            exception=e,
+            distinct_id=user_id,
+            properties={
+                "amount": amount,
+                "error_code": e.code,
+                "error_type": "card_error"
+            }
+        )
+        raise
+```
+
+### Example 3: Capturing Exceptions in Background Tasks
+
+```python
+from fastapi import BackgroundTasks
+from src.services.posthog_service import posthog_service
+
+def send_notification_email(user_id: str, email: str):
+    try:
+        # Send email
+        send_email(email, "Notification")
+    except Exception as e:
+        # Capture background task errors
+        posthog_service.capture_exception(
+            exception=e,
+            distinct_id=user_id,
+            properties={
+                "task": "send_notification_email",
+                "email": email
+            }
+        )
+
+@router.post("/notify")
+async def notify_user(user_id: str, email: str, background_tasks: BackgroundTasks):
+    background_tasks.add_task(send_notification_email, user_id, email)
+    return {"status": "notification_queued"}
+```
+
+## Best Practices
+
+1. **Include Context**: Always include relevant context in the `properties` parameter
+2. **User Identification**: Use actual user IDs when available for better tracking
+3. **Don't Over-Capture**: Only capture exceptions that need attention, not expected errors
+4. **Privacy**: Don't include sensitive information (passwords, tokens) in properties
+5. **Error Handling**: Don't let PostHog failures affect your application logic
+
+## Monitoring
+
+### PostHog Dashboard
+
+View captured exceptions in the PostHog dashboard:
+1. Navigate to your PostHog project
+2. Go to "Exceptions" or "Error Tracking" section
+3. Filter by distinct_id, error_type, or custom properties
+
+### Metrics to Monitor
+
+- **Error Rate**: Number of exceptions per time period
+- **Error Types**: Distribution of exception types
+- **User Impact**: Number of unique users affected
+- **Request Paths**: Which endpoints are generating errors
+
+## Troubleshooting
+
+### PostHog Not Capturing Exceptions
+
+1. Check that `POSTHOG_API_KEY` is set:
+   ```bash
+   echo $POSTHOG_API_KEY
+   ```
+
+2. Check application logs for PostHog initialization:
+   ```
+   PostHog initialized successfully with exception autocapture (host: ...)
+   ```
+
+3. Verify PostHog SDK version:
+   ```bash
+   pip show posthog
+   ```
+   Minimum version: 3.7.0
+
+4. Enable debug mode:
+   ```bash
+   export POSTHOG_DEBUG=true
+   ```
+
+### Exceptions Not Appearing in Dashboard
+
+1. Check if PostHog is initialized:
+   - Look for initialization message in logs
+   - Check for any initialization errors
+
+2. Verify API key is correct:
+   - Check PostHog project settings
+   - Ensure API key has write permissions
+
+3. Check for network issues:
+   - Verify connectivity to PostHog host
+   - Check firewall rules
+
+## Related Documentation
+
+- [PostHog Error Tracking Documentation](https://posthog.com/docs/error-tracking)
+- [PostHog Python SDK Documentation](https://posthog.com/docs/libraries/python)
+- [FastAPI Exception Handling](https://fastapi.tiangolo.com/tutorial/handling-errors/)
+
+## Change Log
+
+### 2025-11-21
+- Enabled exception autocapture in PostHog initialization
+- Added `capture_exception` method to PostHog service
+- Updated FastAPI global exception handler to capture errors
+- Added comprehensive unit tests for error tracking
+- Created documentation for error tracking integration

--- a/tests/services/test_posthog_service.py
+++ b/tests/services/test_posthog_service.py
@@ -5,7 +5,6 @@ import pytest
 from unittest.mock import Mock, patch, MagicMock, AsyncMock
 
 
-
 class TestPosthogService:
     """Test Posthog Service service functionality"""
 
@@ -18,3 +17,86 @@ class TestPosthogService:
         """Test module exports"""
         from src.services import posthog_service
         assert hasattr(posthog_service, '__name__')
+
+    @patch('src.services.posthog_service.Posthog')
+    @patch.dict('os.environ', {'POSTHOG_API_KEY': 'test_key', 'POSTHOG_HOST': 'https://test.posthog.com'})
+    def test_initialize_with_exception_autocapture(self, mock_posthog):
+        """Test that PostHog initializes with exception autocapture enabled"""
+        from src.services.posthog_service import PostHogService
+
+        service = PostHogService()
+        service.initialize()
+
+        # Verify PostHog was initialized with correct parameters
+        mock_posthog.assert_called_once_with(
+            'test_key',
+            host='https://test.posthog.com',
+            debug=False,
+            sync_mode=False,
+            enable_exception_autocapture=True
+        )
+
+    @patch('src.services.posthog_service.Posthog')
+    @patch.dict('os.environ', {'POSTHOG_API_KEY': 'test_key'})
+    def test_capture_exception_success(self, mock_posthog):
+        """Test successful exception capture"""
+        from src.services.posthog_service import PostHogService
+
+        # Setup mock client
+        mock_client = Mock()
+        mock_posthog.return_value = mock_client
+
+        service = PostHogService()
+        service.initialize()
+
+        # Test exception capture
+        test_exception = ValueError("Test error")
+        service.capture_exception(
+            exception=test_exception,
+            distinct_id="user_123",
+            properties={"context": "test"}
+        )
+
+        # Verify capture_exception was called
+        mock_client.capture_exception.assert_called_once_with(
+            test_exception,
+            distinct_id="user_123",
+            properties={"context": "test"}
+        )
+
+    @patch('src.services.posthog_service.Posthog')
+    @patch.dict('os.environ', {'POSTHOG_API_KEY': 'test_key'})
+    def test_capture_exception_default_distinct_id(self, mock_posthog):
+        """Test exception capture with default distinct_id"""
+        from src.services.posthog_service import PostHogService
+
+        # Setup mock client
+        mock_client = Mock()
+        mock_posthog.return_value = mock_client
+
+        service = PostHogService()
+        service.initialize()
+
+        # Test exception capture without distinct_id
+        test_exception = RuntimeError("Test error")
+        service.capture_exception(exception=test_exception)
+
+        # Verify capture_exception was called with 'system' as default
+        mock_client.capture_exception.assert_called_once_with(
+            test_exception,
+            distinct_id="system",
+            properties={}
+        )
+
+    def test_capture_exception_when_not_initialized(self):
+        """Test that capture_exception handles uninitialized client gracefully"""
+        from src.services.posthog_service import PostHogService
+
+        service = PostHogService()
+        service.client = None  # Simulate uninitialized state
+
+        # Should not raise an exception
+        test_exception = ValueError("Test error")
+        service.capture_exception(exception=test_exception, distinct_id="user_123")
+
+        # No assertion needed - just verify no exception is raised


### PR DESCRIPTION
## Summary
- Adds PostHog Python SDK-based error tracking to the Gatewayz backend
- Automatic capture of unhandled FastAPI exceptions and manual capture via a new API
- Graceful degradation: if PostHog is unavailable or misconfigured, the app continues to function
- Comprehensive tests for the new error tracking flow

## Changes
### Documentation
- Added docs/POSTHOG_ERROR_TRACKING.md detailing integration overview, configuration, usage, testing, and troubleshooting

### Backend
- src/services/posthog_service.py
  - Initialize PostHog client with exception autocapture enabled (`enable_exception_autocapture=True`) and async mode
  - New `capture_exception(exception, distinct_id=None, properties=None)` method to manually report exceptions
  - Default `distinct_id` to "system" if not provided
  - Improved logging around initialization and capture
- src/main.py
  - Global exception handler now reports unhandled exceptions to PostHog
  - Attempts to derive a user identity from request state or hashed auth header; includes request path, method, error type, and error message in props
  - Fail-safe: if reporting fails, logs a warning and returns the original 500 response

### Tests
- tests/services/test_posthog_service.py
  - Added tests for:
    - Initialization with exception autocapture
    - Successful `capture_exception` with provided `distinct_id` and properties
    - Default `distinct_id` when none is provided
    - Behavior when PostHog client is not initialized (graceful no-op)

## Testing plan
- Unit tests
  - Run: `pytest tests/services/test_posthog_service.py -v`
  - Validates initialization parameters, capture behavior, default distinct_id, and no-op when uninitialized
- Manual testing
  1. Set environment variables for PostHog:
     - `POSTHOG_API_KEY` (required)
     - `POSTHOG_HOST` (optional, defaults to https://us.i.posthog.com)
     - `POSTHOG_DEBUG` (optional)
  2. Start the server and trigger an error to verify it appears in PostHog
  3. Use the captured data to confirm correct context (path, method, error_type, error_message, distinct_id)

## Usage notes
- Required: `POSTHOG_API_KEY`
- Optional: `POSTHOG_HOST` (default https://us.i.posthog.com)
- Debugging: set `POSTHOG_DEBUG=true` to enable verbose PostHog SDK logs
- Do not include sensitive data in `properties` (privacy best practices)

## Rationale
- Centralized error tracking improves observability without impacting normal operation
- Automatic autocapture ensures common errors are captured with minimal code changes
- Manual `capture_exception` supports targeted reporting from custom components

## Related documentation
- New: docs/POSTHOG_ERROR_TRACKING.md
- PostHog Python SDK docs
- FastAPI exception handling guides

## Change Log
- 2025-11-21: Enabled autocapture, added capture method, updated exception handling, added unit tests and documentation


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6e667e4b-5195-4034-afbd-acaa42e2d845

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates PostHog error tracking with autocapture and manual capture, wires FastAPI global exception handler, and adds docs/tests.
> 
> - **Backend**:
>   - `src/services/posthog_service.py`: Initialize PostHog with `enable_exception_autocapture=True` and async mode; add `capture_exception(exception, distinct_id=None, properties=None)` with default `distinct_id="system"`; improved logs.
>   - `src/main.py`: Global exception handler now reports unhandled errors to PostHog with request/user context (path, method, error type/message); fail-safe logging on capture errors.
> - **Docs**:
>   - Add `docs/POSTHOG_ERROR_TRACKING.md` covering setup, usage, testing, and troubleshooting.
> - **Tests**:
>   - `tests/services/test_posthog_service.py`: Tests for initialization with autocapture, manual exception capture (with/without `distinct_id`), and graceful no-op when uninitialized.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5050f6cb3b99aee74ba6c6c7b6827babe13dc8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->