### PR TITLE
Investigate why this is happening

### DIFF
--- a/.github/workflows/monitor-deployment.yml
+++ b/.github/workflows/monitor-deployment.yml
@@ -22,10 +22,6 @@ jobs:
         run: |
           npm install -g @railway/cli
 
-      - name: Authenticate with Railway
-        run: |
-          railway login
-
       - name: Check production health
         id: prod-health
         continue-on-error: true
@@ -151,10 +147,6 @@ jobs:
       - name: Install Railway CLI
         run: |
           npm install -g @railway/cli
-
-      - name: Authenticate with Railway
-        run: |
-          railway login
 
       - name: Collect production metrics
         continue-on-error: true


### PR DESCRIPTION
The workflow was attempting to run 'railway login' which fails in non-interactive CI environments. When RAILWAY_TOKEN is set as an environment variable, the Railway CLI automatically uses it for authentication, so the login step is unnecessary and causes errors.

Fixes the 'Cannot login in non-interactive mode' error in the Monitor Deployment Health workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the interactive `railway login` step from the monitor-deployment workflow, relying on `RAILWAY_TOKEN` for authentication.
> 
> - **CI/Workflow** (`.github/workflows/monitor-deployment.yml`):
>   - Remove interactive `railway login` steps from health check and metrics jobs.
>   - Continue using token-based auth via `RAILWAY_TOKEN` for Railway CLI commands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdcc6e12b3db2c980565f8ddbd94472bc313350d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->