### PR TITLE
Add missing prometheus_client dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ dependencies = [
     # Analytics (lightweight)
     "statsig-python-core==0.10.2",
     "posthog==6.7.8",
+    "prometheus-client==0.21.0",
+    "sentry-sdk[fastapi]>=2.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
…l compatibility

Added missing dependencies to pyproject.toml that were causing Vercel deployment failures:
- prometheus-client==0.21.0 (required by src/main.py and prometheus_metrics.py)
- sentry-sdk[fastapi]>=2.0.0 (required by src/main.py)

These packages were present in requirements.txt but missing from pyproject.toml, which caused ModuleNotFoundError during Vercel serverless deployments.

Fixes deployment error: "ModuleNotFoundError: No module named 'prometheus_client'"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add missing `prometheus-client` and `sentry-sdk[fastapi]` to `[project.dependencies]` in `pyproject.toml`.
> 
> - **Dependencies**:
>   - Add `prometheus-client==0.21.0` to `pyproject.toml` under `[project.dependencies]`.
>   - Add `sentry-sdk[fastapi]>=2.0.0` to `pyproject.toml` under `[project.dependencies]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18b2c3fec9be62df9a06ccd00afdb1c34e260367. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->