### PR TITLE
Publicize model-health endpoint to fix 503/504 errors

### DIFF
--- a/src/routes/model_health.py
+++ b/src/routes/model_health.py
@@ -14,7 +14,7 @@ from src.db import model_health as model_health_db
 from src.security.deps import get_optional_user  # Optional auth for monitoring
 
 logger = logging.getLogger(__name__)
-router = APIRouter(dependencies=[Depends(get_optional_user)])
+router = APIRouter()
 
 
 @router.get("/v1/model-health", tags=["monitoring"])


### PR DESCRIPTION
## Summary
- Makes the `/v1/model-health` endpoint publicly accessible by removing the optional user dependency
- Aims to resolve intermittent 503/504 errors observed in the chat service health checks by decoupling health probes from authentication

## Changes

### Routing
- **src/routes/model_health.py**: Remove optional auth dependency from APIRouter
  - Before: `router = APIRouter(dependencies=[Depends(get_optional_user)])`
  - After:  `router = APIRouter()`

### Rationale
- Health checks should not depend on authentication services, which can be degraded and cause cascading 503/504 errors during monitoring

## Test plan
- [x] Access `/v1/model-health` without authentication and receive 200 OK
- [x] Run chat service health probes to ensure no 503/504 errors attributable to health endpoint
- [x] Verify monitoring dashboards can reach the health endpoint without auth



🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/5c406ac3-e18e-4964-a3be-0bc19470d1f2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the router-level optional auth dependency in `src/routes/model_health.py` to make `/v1/model-health` routes publicly accessible.
> 
> - **Routing (monitoring)**:
>   - Remove global dependency `Depends(get_optional_user)` from `router = APIRouter(...)` in `src/routes/model_health.py`, making all `/v1/model-health` endpoints public while retaining per-endpoint optional dependency parameters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb879d44ba8971003150d1003c832f10c8e4b58f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->