### PR TITLE
Investigate and resolve API downtime with lazy Supabase client

### DIFF
--- a/src/config/supabase_config.py
+++ b/src/config/supabase_config.py
@@ -88,11 +88,15 @@ class _LazySupabaseClient:
     while deferring client initialization until first use.
     """
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str):
+        # Don't delegate dunder attributes to avoid triggering initialization
+        # during introspection (e.g., by unittest.mock or hasattr checks)
+        if name.startswith("_"):
+            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
         return getattr(get_supabase_client(), name)
 
     def __repr__(self):
-        return f"<LazySupabaseClient proxy for {get_supabase_client()!r}>"
+        return "<LazySupabaseClient proxy>"
 
 
 supabase = _LazySupabaseClient()


### PR DESCRIPTION
## Summary
- Reworked Supabase client initialization to lazy-load, mitigating API downtime during startup and import.
- Keeps existing import paths working while deferring heavy initialization until first access.

## Changes
### Core
- Replaced eager client initialization (supabase = property(get_client)) with a lazy proxy:
  - Added `_LazySupabaseClient` that delegates attribute access to `get_supabase_client()`.
  - `supabase = _LazySupabaseClient()` to replace the previous eager initialization.
  - Implemented `__getattr__` to proxy all calls and `__repr__` for debuggability.
- Import-time side effects are removed, reducing startup latency and risk of downtime during boot.

### Compatibility
- Maintains the same public API for `from src.config.supabase_config import supabase`.
- No breaking changes for consumers; initialization now happens on first use.

## Rationale
- Downtime could be caused by heavy or failing initialization at import time. Lazy-loading defers initialization until the client is actually needed, improving startup resilience and overall uptime.

## Test Plan
- [x] Import modules that reference `supabase` without triggering initialization.
- [x] Access `supabase.<method>` to trigger lazy initialization and verify it forwards correctly.
- [x] Ensure there are no import-time side effects or errors.
- [x] Run existing tests to confirm no regressions.

## Additional Context / Next Steps
- Consider adding logging around lazy initialization to aid troubleshooting.
- If needed, provide a toggle to force eager initialization in specific environments (e.g., CI or special deployments).


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4555b7c5-c600-4259-bfe5-3f1b288636fb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces eager Supabase client with a lazy proxy that initializes on first use while preserving the `supabase` import API.
> 
> - **Config (`src/config/supabase_config.py`)**:
>   - Replace `supabase = property(get_client)` with lazy proxy `supabase = _LazySupabaseClient()`.
>     - Add `_LazySupabaseClient` with `__getattr__` delegating to `get_supabase_client()` and `__repr__` for debugging.
>   - Maintains existing import path (`from src.config.supabase_config import supabase`) while deferring initialization to first attribute access.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac305fa2991c084e9c51e4cd52024043692d3780. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->