### PR TITLE
Fix Supabase auth by adding apikey headers to custom httpx client

### DIFF
--- a/src/config/supabase_config.py
+++ b/src/config/supabase_config.py
@@ -48,8 +48,13 @@ def get_supabase_client() -> Client:
         # Configure HTTP client with better connection pooling for HTTP/2
         # This helps prevent connection resets under high concurrency
         # IMPORTANT: base_url must be set so postgrest relative paths resolve correctly
+        # IMPORTANT: headers must include apikey and Authorization for Supabase auth
         httpx_client = httpx.Client(
             base_url=postgrest_base_url,
+            headers={
+                "apikey": Config.SUPABASE_KEY,
+                "Authorization": f"Bearer {Config.SUPABASE_KEY}",
+            },
             timeout=httpx.Timeout(120.0, connect=10.0),  # 120s total, 10s connect timeout
             limits=httpx.Limits(
                 max_connections=100,  # Maximum total connections in the pool


### PR DESCRIPTION
## Summary

- Fixed authentication failure where all database operations were returning "No API key found in request" errors
- The root cause was the custom httpx client injected for HTTP/2 connection pooling was missing the `apikey` and `Authorization` headers
- Added the required auth headers to the httpx client configuration

## Problem

After recent changes to add `base_url` to the httpx client (commit 79cc5f2), Supabase database operations started failing with:

```
ERROR - Error getting user by Privy ID: {'message': 'No API key found in request', 'hint': 'No `apikey` request header or url param was found.'}
```

## Root Cause

When we replace `_supabase_client.postgrest.session` with our custom httpx client, the authentication headers that the Supabase SDK normally injects are lost. The SDK adds `apikey` and `Authorization: Bearer <key>` headers to all requests, but our custom client didn't have these.

## Solution

Added the required authentication headers to the custom httpx client:

```python
httpx_client = httpx.Client(
    base_url=postgrest_base_url,
    headers={
        "apikey": Config.SUPABASE_KEY,
        "Authorization": f"Bearer {Config.SUPABASE_KEY}",
    },
    # ... rest of config
)
```

## Test plan

- [x] Added unit tests to verify httpx client includes auth headers
- [x] Added unit tests to verify httpx client includes base_url
- [ ] Verify auth works in production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `apikey` and `Authorization` headers to the custom `httpx.Client` used by Supabase and adds tests verifying headers and `base_url`.
> 
> - **Config (Supabase)**:
>   - Update `src/config/supabase_config.py` to set `httpx.Client` headers with `apikey` and `Authorization: Bearer <key>` alongside existing `base_url`, timeouts, limits, and HTTP/2.
>   - Continue injecting the configured client into `postgrest.session`.
> - **Tests**:
>   - Add tests in `tests/config/test_supabase_config.py` to verify the `httpx.Client` includes auth headers and the correct `base_url`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61bed64e398c76421491ebea9b7916f935d06d47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->