### PR TITLE
Add ai-sdk-completions alias endpoint and tests

### DIFF
--- a/src/routes/ai_sdk.py
+++ b/src/routes/ai_sdk.py
@@ -5,7 +5,9 @@ This route provides a dedicated endpoint for Vercel AI SDK requests.
 The endpoint is compatible with the AI SDK client interface and routes
 requests through the Vercel AI Gateway for actual model execution.
 
-Endpoint: POST /api/chat/ai-sdk
+Endpoints:
+- POST /api/chat/ai-sdk
+- POST /api/chat/ai-sdk-completions (alias)
 """
 
 import asyncio
@@ -93,6 +95,7 @@ def _build_request_kwargs(request: AISDKChatRequest) -> dict:
     return {k: v for k, v in kwargs.items() if v is not None}
 
 
+@router.post("/api/chat/ai-sdk-completions", tags=["ai-sdk"], response_model=AISDKChatResponse)
 @router.post("/api/chat/ai-sdk", tags=["ai-sdk"], response_model=AISDKChatResponse)
 async def ai_sdk_chat_completion(request: AISDKChatRequest):
     """


### PR DESCRIPTION
## Summary
- Adds alias endpoint /api/chat/ai-sdk-completions for the AI SDK, resolving internal server error when clients request completions variant.
- Endpoint mirrors existing /api/chat/ai-sdk behavior to ensure compatibility.
- Updated tests to verify endpoint existence and functional parity.

## Changes

### Backend
- **AI SDK route**: In `src/routes/ai_sdk.py`, register POST `/api/chat/ai-sdk-completions` as an alias to the same handler, and update endpoint docs to reflect both endpoints.

### Tests
- **Tests for AI SDK**: In `tests/routes/test_ai_sdk.py`
  - Added `test_ai_sdk_completions_endpoint_exists` to ensure the completions endpoint is registered (OPTIONS allowed or method not allowed).
  - Added `test_ai_sdk_completions_endpoint_works` to verify the completions variant behaves identically to the main endpoint using mocks:
    - `validate_ai_sdk_api_key`, `make_ai_sdk_request_openai`, and `process_ai_sdk_response` are mocked.
    - POST to `/api/chat/ai-sdk-completions` with example payload and asserts status 200 and expected structure and content (e.g., `"Hello from completions!"`).

## Test plan
- [x] Run pytest for `tests/routes/test_ai_sdk.py`
- [x] Verify OPTIONS on both endpoints returns 200 or 405
- [x] Verify completions endpoint returns identical response structure and content as main endpoint

## Notes
- This change ensures the AI SDK completions path is available and stable, addressing potential internal server errors when clients use the completions variant.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/94ee5fe4-fdf1-412c-8551-0beaa4851816

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds POST /api/chat/ai-sdk-completions as an alias to the existing AI SDK chat endpoint and adds tests to verify its existence and parity.
> 
> - **Backend**:
>   - Register alias endpoint `POST /api/chat/ai-sdk-completions` pointing to the same handler as `POST /api/chat/ai-sdk` in `src/routes/ai_sdk.py`.
>   - Update module docstring to list both endpoints.
> - **Tests**:
>   - Add `test_ai_sdk_completions_endpoint_exists` to confirm the alias route is registered.
>   - Add `test_ai_sdk_completions_endpoint_works` to validate functional parity with the main endpoint using mocks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fe9e433548dd47fc906e1257e7c42cf2440b78f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->