### PR TITLE
Clarifai OpenAI API integration: fix endpoints and mappings

### DIFF
--- a/src/services/clarifai_client.py
+++ b/src/services/clarifai_client.py
@@ -1,12 +1,20 @@
 """
 Clarifai client for LLM inference integration.
 
-This client uses the official Clarifai Python SDK to interact with language models
-available on the Clarifai platform. It supports both standard LLM models and
-specialized models for reasoning and multimodal tasks.
+This client uses Clarifai's OpenAI-compatible API endpoint to interact with
+language models available on the Clarifai platform. It supports both standard
+LLM models and specialized models for reasoning and multimodal tasks.
 
 Clarifai provides access to models like Claude, GPT-4, Llama, Mistral, and others
-through a unified API.
+through a unified OpenAI-compatible API.
+
+API Documentation: https://docs.clarifai.com/compute/inference/open-ai/
+
+Model ID Format:
+    Models should be specified using Clarifai's URL format:
+    - Full URL: https://clarifai.com/{user_id}/{app_id}/models/{model_id}
+    - Abbreviated: {user_id}/{app_id}/models/{model_id}
+    Example: "openai/chat-completion/models/gpt-4o"
 """
 
 import logging
@@ -37,7 +45,7 @@ def make_clarifai_request_openai(messages, model, **kwargs):
 
     Args:
         messages: List of message objects in OpenAI format
-        model: Model ID (e.g., "claude-3.5-sonnet" or with user/app prefix)
+        model: Model ID in Clarifai format (e.g., "openai/chat-completion/models/gpt-4o")
         **kwargs: Additional parameters like max_tokens, temperature, etc.
 
     Returns:
@@ -66,7 +74,7 @@ def make_clarifai_request_openai_stream(messages, model, **kwargs):
 
     Args:
         messages: List of message objects in OpenAI format
-        model: Model ID (e.g., "claude-3.5-sonnet" or with user/app prefix)
+        model: Model ID in Clarifai format (e.g., "openai/chat-completion/models/gpt-4o")
         **kwargs: Additional parameters like max_tokens, temperature, etc.
 
     Returns:

--- a/src/services/connection_pool.py
+++ b/src/services/connection_pool.py
@@ -393,15 +393,18 @@ def get_chutes_pooled_client() -> OpenAI:
 
 
 def get_clarifai_pooled_client() -> OpenAI:
-    """Get pooled client for Clarifai."""
+    """Get pooled client for Clarifai.
+
+    Uses Clarifai's OpenAI-compatible API endpoint.
+    See: https://docs.clarifai.com/compute/inference/open-ai/
+    """
     if not Config.CLARIFAI_API_KEY:
         raise ValueError("Clarifai API key not configured")
 
     return get_pooled_client(
         provider="clarifai",
-        base_url="https://api.clarifai.com/v1",
+        base_url="https://api.clarifai.com/v2/ext/openai/v1",
         api_key=Config.CLARIFAI_API_KEY,
-        default_headers={"X-Clarifai-PAT": Config.CLARIFAI_API_KEY},
     )
 
 

--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -627,28 +627,38 @@ def get_model_id_mapping(provider: str) -> dict[str, str]:
             "qwen-plus-latest": "qwen-plus",
         },
         "clarifai": {
-            # Clarifai supports many models through its unified API
-            # Most models pass through directly using their standard naming
-            # Anthropic models
-            "anthropic/claude-3-opus": "claude-3-opus",
-            "anthropic/claude-3.5-sonnet": "claude-3.5-sonnet",
-            "claude-3-opus": "claude-3-opus",
-            "claude-3.5-sonnet": "claude-3.5-sonnet",
-            # OpenAI models
-            "openai/gpt-4": "gpt-4",
-            "openai/gpt-4-turbo": "gpt-4-turbo",
-            "gpt-4": "gpt-4",
-            "gpt-4-turbo": "gpt-4-turbo",
-            # Meta Llama models
-            "meta-llama/llama-3.1-70b": "llama-3.1-70b-instruct",
-            "meta-llama/llama-3-70b": "llama-3-70b-instruct",
-            "llama-3.1-70b": "llama-3.1-70b-instruct",
-            "llama-3-70b": "llama-3-70b-instruct",
-            # Mistral models
-            "mistralai/mistral-7b": "mistral-7b-instruct",
-            "mistralai/mixtral-8x7b": "mixtral-8x7b-instruct",
-            "mistral-7b": "mistral-7b-instruct",
-            "mixtral-8x7b": "mixtral-8x7b-instruct",
+            # Clarifai OpenAI-compatible API requires full model URLs or abbreviated paths
+            # Format: https://clarifai.com/{user_id}/{app_id}/models/{model_id}
+            # Or abbreviated: {user_id}/{app_id}/models/{model_id}
+            # See: https://docs.clarifai.com/compute/inference/open-ai/
+            #
+            # OpenAI models (via Clarifai)
+            "openai/gpt-4o": "openai/chat-completion/models/gpt-4o",
+            "openai/gpt-4-turbo": "openai/chat-completion/models/gpt-4-turbo",
+            "openai/gpt-4": "openai/chat-completion/models/gpt-4",
+            "gpt-4o": "openai/chat-completion/models/gpt-4o",
+            "gpt-4-turbo": "openai/chat-completion/models/gpt-4-turbo",
+            "gpt-4": "openai/chat-completion/models/gpt-4",
+            # GPT-OSS (Clarifai's open-source GPT)
+            "gpt-oss-120b": "openai/chat-completion/models/gpt-oss-120b",
+            "openai/gpt-oss-120b": "openai/chat-completion/models/gpt-oss-120b",
+            # Anthropic Claude models (via Clarifai)
+            "anthropic/claude-3-opus": "anthropic/completion/models/claude-3-opus",
+            "anthropic/claude-3.5-sonnet": "anthropic/completion/models/claude-3-5-sonnet",
+            "anthropic/claude-3-sonnet": "anthropic/completion/models/claude-3-sonnet",
+            "claude-3-opus": "anthropic/completion/models/claude-3-opus",
+            "claude-3.5-sonnet": "anthropic/completion/models/claude-3-5-sonnet",
+            "claude-3-sonnet": "anthropic/completion/models/claude-3-sonnet",
+            # Meta Llama models (via Clarifai)
+            "meta-llama/llama-3.1-70b": "meta/llama-2/models/llama-3-1-70b-instruct",
+            "meta-llama/llama-3-70b": "meta/llama-2/models/llama-3-70b-instruct",
+            "llama-3.1-70b": "meta/llama-2/models/llama-3-1-70b-instruct",
+            "llama-3-70b": "meta/llama-2/models/llama-3-70b-instruct",
+            # Mistral models (via Clarifai)
+            "mistralai/mistral-7b": "mistralai/completion/models/mistral-7b-instruct",
+            "mistralai/mixtral-8x7b": "mistralai/completion/models/mixtral-8x7b-instruct",
+            "mistral-7b": "mistralai/completion/models/mistral-7b-instruct",
+            "mixtral-8x7b": "mistralai/completion/models/mixtral-8x7b-instruct",
         },
         "xai": {
             # XAI Grok models - pass-through format


### PR DESCRIPTION
## Summary
- Align Clarifai integration with OpenAI-compatible API endpoint
- Update model ID handling to Clarifai's URL/abbreviated format
- Update connection pool to use Clarifai OpenAI endpoint
- Extend model ID mappings for Clarifai provider to OpenAI-compatible paths

## Changes
### Clarifai client
- Updated docstrings to reflect Clarifai OpenAI-compatible API usage
- Clarified model ID format guidance and added example formats (full URL or abbreviated path)
- Included API documentation link: https://docs.clarifai.com/compute/inference/open-ai/

### Connection pool
- get_clarifai_pooled_client now targets Clarifai OpenAI endpoint
  base_url updated to https://api.clarifai.com/v2/ext/openai/v1
- Updated docstring to reference the OpenAI-compatible API docs

### Model transformations
- Reworked Clarifai provider mappings to use OpenAI-compatible model paths
- Added mappings for common OpenAI-compatible models via Clarifai, e.g.:
  - openai/gpt-4o -> openai/chat-completion/models/gpt-4o
  - openai/gpt-4-turbo -> openai/chat-completion/models/gpt-4-turbo
  - openai/gpt-4 -> openai/chat-completion/models/gpt-4
  - gpt-4o, gpt-4-turbo, gpt-4, gpt-oss-120b and equivalents
- Included mappings for Claude, Meta Llama, and Mistral variants via Clarifai
- Added clarifai-specific note: model IDs should be full Clarifai URL paths or abbreviated user/app/models paths

## Rationale
- Ensures requests are routed to Clarifai’s OpenAI-compatible endpoint and that model identifiers resolve correctly under the new API.
- Makes model resolution explicit and aligned with Clarifai’s documentation.

## Potential impacts
- Callers must provide Clarifai OpenAI-formatted model IDs (URLs or abbreviated paths) when using the Clarifai provider.
- Base URL change may affect existing deployments if they relied on the old endpoint.

## Testing plan
- [x] Validate that get_clarifai_pooled_client returns a client with the new base URL
- [x] Validate that model ID mappings resolve to Clarifai OpenAI-compatible paths
- [ ] Run an integration test against Clarifai OpenAI endpoint (requires credentials)
- [ ] Quick smoke test to ensure request construction uses the new endpoint and IDs correctly


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/54716a80-d392-434c-a204-eaf1e33d43bd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns Clarifai integration to the OpenAI-compatible API and rewrites Clarifai model mappings to use Clarifai URL/abbreviated paths.
> 
> - **Clarifai integration**:
>   - **Client**: Update docs and examples to use Clarifai’s OpenAI-compatible API; clarify required model ID format (full URL or `{user}/{app}/models/{model}`); add API docs link.
>   - **Connection Pool**: Point `get_clarifai_pooled_client` to `https://api.clarifai.com/v2/ext/openai/v1` and refresh docstring.
>   - **Model Transformations**: Replace Clarifai mappings with OpenAI-compatible Clarifai paths for `openai/*` (e.g., `gpt-4o`), `anthropic/*` (Claude), Meta Llama, Mistral; add `gpt-oss-120b` support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c83913370cb08fc1583765785826683c26b83fbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->