### PR TITLE
Fix model API fetch errors by updating route prefix

### DIFF
--- a/src/routes/models_catalog_management.py
+++ b/src/routes/models_catalog_management.py
@@ -41,7 +41,7 @@ from src.db.providers_db import get_provider_by_id, get_provider_by_slug
 logger = logging.getLogger(__name__)
 
 router = APIRouter(
-    prefix="/models",
+    prefix="/catalog/models-db",
     tags=["Models Catalog Management"],
 )
 


### PR DESCRIPTION
## Summary
- Diagnoses and fixes model fetching errors by adjusting the models catalog route path.

## Changes

### Core Functionality
- Updated the APIRouter prefix from "/models" to "/catalog/models-db" in `src/routes/models_catalog_management.py`.

### Backwards Compatibility
- The old "/models" route is no longer exposed by this router. Clients should use "/catalog/models-db".

### Risks
- Minimal; only routing path changed and should not affect business logic.

## Test plan
- [x] Verify GET /catalog/models-db returns the expected list of models.
- [x] Verify that the old GET /models endpoint is no longer served (404).
- [x] End-to-end fetch from client code uses the new path without errors.


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/15de14d3-3358-493f-9ef5-c1bd2701c7ac

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the models catalog router prefix from `/models` to `/catalog/models-db`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42fbe5731e88fcdd40daff38dd40b64778502cd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR fixes model fetching errors by updating the APIRouter prefix in `src/routes/models_catalog_management.py` from `/models` to `/catalog/models-db`. This change standardizes the routing structure to match expected path conventions in the codebase and resolves fetch failures that were occurring with the previous path. The modification only affects the route prefix while maintaining all endpoint functionality intact. This appears to be aligning the route structure with other catalog-related endpoints in the system for consistency.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|-------|---------|
| src/routes/models_catalog_management.py | 4/5 | Updates APIRouter prefix from "/models" to "/catalog/models-db" - introduces breaking change |

<h3>Confidence score: 4/5</h3>


- This PR introduces a breaking change that requires client code updates but appears necessary to fix fetch errors
- Score reflects the breaking nature of the change and potential impact on existing integrations using the old path
- Pay close attention to ensuring all client applications and frontend code are updated to use the new path structure

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->