### PR TITLE
Rate-limit health checks and guard Prometheus remote_write

### DIFF
--- a/src/services/model_health_monitor.py
+++ b/src/services/model_health_monitor.py
@@ -718,5 +718,15 @@ class ModelHealthMonitor:
         }
 
 
-# Global health monitor instance
-health_monitor = ModelHealthMonitor()
+# Global health monitor instance with rate-limited configuration
+# This prevents hitting provider rate limits by:
+# - Checking models in small batches (20 at a time)
+# - Adding 15-second delay between batches (4 batches/min max)
+# - Running checks every 5 minutes by default
+# This is especially important for OpenRouter's 4 model switches/minute limit
+health_monitor = ModelHealthMonitor(
+    check_interval=300,  # Check every 5 minutes
+    batch_size=20,  # Process 20 models per batch
+    batch_interval=15.0,  # 15 second delay between batches (4 batches/min)
+    fetch_chunk_size=100,  # Fetch models in chunks of 100
+)


### PR DESCRIPTION
## Summary
- Introduces rate-limited health checks to avoid provider rate limits by batching and scheduled intervals.
- Guards the Prometheus remote_write path by raising a clear error to prevent incorrect protobuf usage and directs toward the proper approach.

## Changes
### Health Monitoring
- Update the global health monitor initialization to statically rate-limit checks:
  - check_interval: 300 seconds (every 5 minutes)
  - batch_size: 20 models per batch
  - batch_interval: 15.0 seconds between batches (4 batches/min)
  - fetch_chunk_size: 100 models per fetch

### Prometheus Remote Write
- Replace the current protobuf serialization path with a NotImplementedError to prevent sending incorrectly formatted data.
- Added detailed inline guidance explaining the mismatch between OpenMetrics text format and the required Prometheus remote_write protobuf format, and suggesting proper alternatives (library-based WriteRequest or using /metrics scraping).

## Rationale
- Rate-limiting the health checks helps avoid hitting provider limits (e.g., OpenRouter's 4-model/minute limit) while still keeping health data fresh.
- The existing remote_write implementation attempted to send OpenMetrics text where a protobuf WriteRequest is required, leading to illegal wire types. This change prevents silent incorrect data transmission and communicates a clear path forward.

## How to test
- Health monitor:
  - Ensure the global health_monitor is created with the new parameters.
  - Verify that health checks are performed in batches of 20 with ~15 seconds between batches and that checks run every ~5 minutes.
- Prometheus remote_write:
  - Trigger metrics serialization path and observe NotImplementedError being raised with guidance to use /metrics scraping or a proper remote_write implementation.
  - If remote_write is intended to be disabled, set PROMETHEUS_ENABLED=false and verify metrics are scraped via /metrics instead.

## Notes / Impact
- This change effectively disables remote_write serialization until a proper protobuf WriteRequest path is implemented. Users relying on remote_write should switch to scraping /metrics or await a proper implementation.
- Consider documenting the new health check throttling in any operator dashboards or runbooks.


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/3e5a4450-f16c-41c0-91c5-e6dcc2099c39

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rate-limits model health checks and disables incorrect Prometheus remote_write serialization with clear guidance.
> 
> - **Monitoring**:
>   - Configure global `health_monitor` in `src/services/model_health_monitor.py` with rate limits: `check_interval=300`, `batch_size=20`, `batch_interval=15.0`, `fetch_chunk_size=100`.
> - **Metrics / Prometheus**:
>   - In `src/services/prometheus_remote_write.py`, replace OpenMetrics-based serialization with `NotImplementedError` to prevent invalid remote_write payloads; add guidance on proper protobuf `WriteRequest` approach or using `/metrics` scraping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b26d995a5418433030d534ab23f38bd0961a287. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR implements two critical operational fixes to address rate limiting and monitoring issues. The changes introduce rate-limited health checks for the model monitoring system, implementing batched processing (20 models per batch with 15-second delays) and reducing check frequency to every 5 minutes to avoid hitting provider rate limits like OpenRouter's 4 model switches per minute restriction. The PR also fixes a critical bug in the Prometheus remote_write implementation that was incorrectly sending OpenMetrics text format instead of the required protobuf WriteRequest format, which caused "illegal wireType 7" errors. Rather than attempting a complex fix, the implementation is temporarily disabled with a clear NotImplementedError that provides guidance on proper implementation approaches, following the fail-fast principle to prevent data corruption.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|-------|----------|
| `src/services/model_health_monitor.py` | 5/5 | Adds rate-limited configuration to global health monitor with batching parameters |
| `src/services/prometheus_remote_write.py` | 4/5 | Replaces broken protobuf serialization with NotImplementedError and implementation guidance |

<h3>Confidence score: 4/5</h3>


- This PR addresses critical operational issues and is generally safe to merge with proper monitoring
- Score reflects the temporary disabling of remote_write functionality which may impact monitoring setups that rely on it, and the need to verify the new health check intervals don't cause service degradation
- Pay close attention to `src/services/prometheus_remote_write.py` to understand the monitoring impact and ensure alternative monitoring approaches are in place

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API as "FastAPI App"
    participant HealthMonitor as "ModelHealthMonitor"
    participant PrometheusWriter as "PrometheusRemoteWriter"
    participant Providers as "AI Providers"
    participant Prometheus as "Prometheus Server"
    
    User->>API: "Start Application"
    API->>HealthMonitor: "Initialize with rate-limited config"
    Note over HealthMonitor: "batch_size: 20, check_interval: 300s, batch_interval: 15s"
    API->>PrometheusWriter: "init_prometheus_remote_write()"
    PrometheusWriter->>PrometheusWriter: "Check protobuf dependencies"
    PrometheusWriter-->>API: "Initialization complete"
    
    API->>HealthMonitor: "start_monitoring()"
    HealthMonitor->>HealthMonitor: "Start monitoring loop"
    
    loop "Every 5 minutes"
        HealthMonitor->>HealthMonitor: "_perform_health_checks()"
        HealthMonitor->>HealthMonitor: "_get_models_to_check()"
        Note over HealthMonitor: "Get models from 17 gateways"
        
        loop "Process in batches of 20"
            HealthMonitor->>Providers: "HTTP health check requests"
            Note over HealthMonitor,Providers: "Batch of 20 models"
            Providers-->>HealthMonitor: "Response (success/failure)"
            HealthMonitor->>HealthMonitor: "_update_health_data()"
            Note over HealthMonitor: "Wait 15 seconds between batches"
        end
        
        HealthMonitor->>HealthMonitor: "_update_provider_metrics()"
        HealthMonitor->>HealthMonitor: "_update_system_metrics()"
    end
    
    User->>API: "Request metrics push"
    API->>PrometheusWriter: "push_metrics()"
    PrometheusWriter->>PrometheusWriter: "_serialize_metrics_to_protobuf()"
    PrometheusWriter-->>API: "NotImplementedError: Use /metrics scraping instead"
    Note over PrometheusWriter: "Prevents incorrect protobuf usage"
    
    User->>API: "Access /metrics endpoint"
    API-->>User: "OpenMetrics text format"
    Note over API,User: "Proper metrics scraping approach"
    
    User->>API: "Shutdown Application"
    API->>HealthMonitor: "stop_monitoring()"
    API->>PrometheusWriter: "shutdown_prometheus_remote_write()"
    PrometheusWriter->>PrometheusWriter: "Cancel push tasks"
    PrometheusWriter-->>API: "Shutdown complete"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->