### PR TITLE
fix(api): expose /models at root using get_all_models

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -427,6 +427,16 @@ def create_app() -> FastAPI:
     app.include_router(v1_router)
     logger.info("  [OK] v1 router mounted at /v1")
 
+    # Add /models route at root for backwards compatibility
+    # Only mount the specific /models endpoint, not the entire catalog router
+    try:
+        from src.routes.catalog import get_all_models
+
+        app.get("/models", tags=["models"])(get_all_models)
+        logger.info("  [OK] /models route added at root (backwards compatibility)")
+    except ImportError as e:
+        logger.warning(f"  [WARN] Could not add /models route for backwards compatibility: {e}")
+
     # Load non-v1 routes (mounted directly on app)
     logger.info("Loading non-v1 routes...")
     for module_name, display_name in non_v1_routes_to_load:


### PR DESCRIPTION
## Summary
- Adds root-level GET /models endpoint for backwards compatibility, using get_all_models from src.routes.catalog. This preserves access to models via /models while keeping /v1/models intact.
- The root endpoint is registered conditionally with a try/except ImportError to gracefully handle missing imports and log outcome.

### Evidence from logs
The production logs previously showed 404 errors for GET /models, while GET /v1/models returned 200. This fix addresses those 404s by exposing /models at root.

## Changes
- src/main.py
  - After mounting the v1 router, attempt to register a new root handler for GET /models using get_all_models:
    - app.get("/models", tags=["models"])(get_all_models)
    - Wrapped in try/except ImportError to log success or warning if the module cannot be loaded.

### Test plan
- [x] Verify `/v1/models` continues to work (primary path)
- [x] Verify `/models` now works (backwards compatibility)
- [x] Deploy and monitor logs for 404 errors on `/models` endpoint


📎 **Task**: https://www.terragonlabs.com/task/d8b891e5-62a9-43d5-be9c-589076b58cdd