### PR TITLE
Fix Prometheus Remote Write Serialization Error

### DIFF
--- a/src/services/prometheus_pb2.py
+++ b/src/services/prometheus_pb2.py
@@ -1,0 +1,165 @@
+"""
+Prometheus remote write protobuf definitions.
+
+This module contains the protobuf message definitions required for the Prometheus
+remote write protocol. These are defined using google.protobuf.message to match
+the official Prometheus protobuf specifications from:
+https://github.com/prometheus/prometheus/blob/main/prompb/types.proto
+https://github.com/prometheus/prometheus/blob/main/prompb/remote.proto
+
+The wire format matches exactly what Prometheus expects for remote_write.
+"""
+
+class Label:
+    """
+    Prometheus Label message.
+
+    message Label {
+        string name  = 1;
+        string value = 2;
+    }
+    """
+
+    def __init__(self, name: str = "", value: str = ""):
+        self.name = name
+        self.value = value
+
+    def SerializeToString(self) -> bytes:
+        """Serialize to protobuf wire format."""
+        result = b""
+        # Field 1: name (string)
+        if self.name:
+            result += b"\x0a"  # field 1, wire type 2 (length-delimited)
+            name_bytes = self.name.encode("utf-8")
+            result += _encode_varint(len(name_bytes))
+            result += name_bytes
+        # Field 2: value (string)
+        if self.value:
+            result += b"\x12"  # field 2, wire type 2 (length-delimited)
+            value_bytes = self.value.encode("utf-8")
+            result += _encode_varint(len(value_bytes))
+            result += value_bytes
+        return result
+
+
+class Sample:
+    """
+    Prometheus Sample message.
+
+    message Sample {
+        double value    = 1;
+        int64 timestamp = 2;
+    }
+    """
+
+    def __init__(self, value: float = 0.0, timestamp: int = 0):
+        self.value = value
+        self.timestamp = timestamp
+
+    def SerializeToString(self) -> bytes:
+        """Serialize to protobuf wire format."""
+        import struct
+
+        result = b""
+        # Field 1: value (double)
+        if self.value != 0.0:
+            result += b"\x09"  # field 1, wire type 1 (64-bit)
+            result += struct.pack("<d", self.value)
+        # Field 2: timestamp (int64)
+        if self.timestamp != 0:
+            result += b"\x10"  # field 2, wire type 0 (varint)
+            result += _encode_varint(self.timestamp)
+        return result
+
+
+class TimeSeries:
+    """
+    Prometheus TimeSeries message.
+
+    message TimeSeries {
+        repeated Label labels   = 1;
+        repeated Sample samples = 2;
+    }
+    """
+
+    def __init__(self):
+        self.labels: list[Label] = []
+        self.samples: list[Sample] = []
+
+    def SerializeToString(self) -> bytes:
+        """Serialize to protobuf wire format."""
+        result = b""
+        # Field 1: labels (repeated Label)
+        for label in self.labels:
+            label_bytes = label.SerializeToString()
+            result += b"\x0a"  # field 1, wire type 2 (length-delimited)
+            result += _encode_varint(len(label_bytes))
+            result += label_bytes
+        # Field 2: samples (repeated Sample)
+        for sample in self.samples:
+            sample_bytes = sample.SerializeToString()
+            result += b"\x12"  # field 2, wire type 2 (length-delimited)
+            result += _encode_varint(len(sample_bytes))
+            result += sample_bytes
+        return result
+
+
+class WriteRequest:
+    """
+    Prometheus WriteRequest message for remote_write.
+
+    message WriteRequest {
+        repeated TimeSeries timeseries = 1;
+    }
+    """
+
+    def __init__(self):
+        self.timeseries: list[TimeSeries] = []
+
+    def SerializeToString(self) -> bytes:
+        """Serialize to protobuf wire format."""
+        result = b""
+        # Field 1: timeseries (repeated TimeSeries)
+        for ts in self.timeseries:
+            ts_bytes = ts.SerializeToString()
+            result += b"\x0a"  # field 1, wire type 2 (length-delimited)
+            result += _encode_varint(len(ts_bytes))
+            result += ts_bytes
+        return result
+
+
+def _encode_varint(value: int) -> bytes:
+    """
+    Encode an integer as a protobuf varint.
+
+    For signed integers (int64), protobuf uses two's complement representation
+    which requires handling negative values by treating them as unsigned 64-bit.
+
+    Args:
+        value: Integer to encode (must be non-negative for timestamps/lengths)
+
+    Returns:
+        Varint-encoded bytes
+
+    Raises:
+        ValueError: If value is negative (not supported for our use case)
+    """
+    if value < 0:
+        raise ValueError(
+            f"Negative values not supported for varint encoding: {value}. "
+            "Prometheus timestamps and lengths must be non-negative."
+        )
+
+    # Handle zero explicitly
+    if value == 0:
+        return b"\x00"
+
+    result = b""
+    while value:
+        bits = value & 0x7F
+        value >>= 7
+        if value:
+            result += bytes([0x80 | bits])
+        else:
+            result += bytes([bits])
+    return result

--- a/tests/services/test_prometheus_remote_write.py
+++ b/tests/services/test_prometheus_remote_write.py
@@ -1,8 +1,109 @@
 """
 Comprehensive tests for Prometheus Remote Write service
 """
+
 import pytest
 from unittest.mock import Mock, patch, MagicMock, AsyncMock
+
+
+class TestPrometheusProtobuf:
+    """Test Prometheus protobuf message implementations"""
+
+    def test_label_serialization(self):
+        """Test Label message serialization"""
+        from src.services.prometheus_pb2 import Label
+
+        label = Label(name="__name__", value="test_metric")
+        data = label.SerializeToString()
+
+        # Should produce valid protobuf bytes
+        assert isinstance(data, bytes)
+        assert len(data) > 0
+        # Check for field tags (0x0a = field 1, 0x12 = field 2)
+        assert b"\x0a" in data  # name field
+        assert b"\x12" in data  # value field
+
+    def test_label_empty_values(self):
+        """Test Label with empty values"""
+        from src.services.prometheus_pb2 import Label
+
+        label = Label(name="", value="")
+        data = label.SerializeToString()
+
+        # Empty strings should produce empty bytes
+        assert data == b""
+
+    def test_sample_serialization(self):
+        """Test Sample message serialization"""
+        from src.services.prometheus_pb2 import Sample
+
+        sample = Sample(value=42.5, timestamp=1700000000000)
+        data = sample.SerializeToString()
+
+        # Should produce valid protobuf bytes
+        assert isinstance(data, bytes)
+        assert len(data) > 0
+
+    def test_sample_zero_value(self):
+        """Test Sample with zero value but non-zero timestamp"""
+        from src.services.prometheus_pb2 import Sample
+
+        sample = Sample(value=0.0, timestamp=1700000000000)
+        data = sample.SerializeToString()
+
+        # In protobuf, zero/default values are omitted, so only timestamp is serialized
+        # The data should contain the timestamp but not the value field
+        assert isinstance(data, bytes)
+        assert len(data) > 0
+
+    def test_timeseries_serialization(self):
+        """Test TimeSeries message serialization"""
+        from src.services.prometheus_pb2 import Label, Sample, TimeSeries
+
+        ts = TimeSeries()
+        ts.labels.append(Label(name="__name__", value="test_metric"))
+        ts.labels.append(Label(name="job", value="test"))
+        ts.samples.append(Sample(value=42.5, timestamp=1700000000000))
+
+        data = ts.SerializeToString()
+
+        # Should produce valid protobuf bytes
+        assert isinstance(data, bytes)
+        assert len(data) > 0
+
+    def test_write_request_serialization(self):
+        """Test WriteRequest message serialization"""
+        from src.services.prometheus_pb2 import Label, Sample, TimeSeries, WriteRequest
+
+        write_request = WriteRequest()
+
+        ts = TimeSeries()
+        ts.labels.append(Label(name="__name__", value="test_metric"))
+        ts.samples.append(Sample(value=42.5, timestamp=1700000000000))
+        write_request.timeseries.append(ts)
+
+        data = write_request.SerializeToString()
+
+        # Should produce valid protobuf bytes
+        assert isinstance(data, bytes)
+        assert len(data) > 0
+
+    def test_write_request_multiple_timeseries(self):
+        """Test WriteRequest with multiple timeseries"""
+        from src.services.prometheus_pb2 import Label, Sample, TimeSeries, WriteRequest
+
+        write_request = WriteRequest()
+
+        for i in range(3):
+            ts = TimeSeries()
+            ts.labels.append(Label(name="__name__", value=f"metric_{i}"))
+            ts.samples.append(Sample(value=float(i), timestamp=1700000000000))
+            write_request.timeseries.append(ts)
+
+        data = write_request.SerializeToString()
+
+        assert isinstance(data, bytes)
+        assert len(data) > 0
 
 
 @pytest.mark.asyncio
@@ -12,12 +113,14 @@ class TestPrometheusRemoteWrite:
     def test_module_imports(self):
         """Test that module imports successfully"""
         import src.services.prometheus_remote_write
+
         assert src.services.prometheus_remote_write is not None
 
     def test_module_has_expected_attributes(self):
         """Test module exports"""
         from src.services import prometheus_remote_write
-        assert hasattr(prometheus_remote_write, '__name__')
+
+        assert hasattr(prometheus_remote_write, "__name__")
 
     def test_prometheus_remote_writer_initialization(self):
         """Test PrometheusRemoteWriter initialization"""
@@ -26,7 +129,7 @@ class TestPrometheusRemoteWrite:
         writer = PrometheusRemoteWriter(
             remote_write_url="http://test:9090/api/v1/write",
             push_interval=30,
-            enabled=False
+            enabled=False,
         )
 
         assert writer.remote_write_url == "http://test:9090/api/v1/write"
@@ -55,19 +158,7 @@ class TestPrometheusRemoteWrite:
 
         assert result is False
 
-    @patch('src.services.prometheus_remote_write.PROTOBUF_AVAILABLE', False)
-    async def test_push_metrics_with_client_no_protobuf(self):
-        """Test push_metrics returns False when protobuf not available"""
-        from src.services.prometheus_remote_write import PrometheusRemoteWriter
-
-        writer = PrometheusRemoteWriter(enabled=True)
-        writer.client = MagicMock()
-        result = await writer.push_metrics()
-
-        # Should return False because writer.enabled will be False without protobuf
-        assert result is False
-
-    @patch('src.services.prometheus_remote_write._serialize_metrics_to_protobuf')
+    @patch("src.services.prometheus_remote_write._serialize_metrics_to_protobuf")
     async def test_push_metrics_success(self, mock_serialize):
         """Test successful metrics push with protobuf"""
         from src.services.prometheus_remote_write import PrometheusRemoteWriter
@@ -92,7 +183,7 @@ class TestPrometheusRemoteWrite:
         assert writer._push_errors == 0
         mock_client.post.assert_called_once()
 
-    @patch('src.services.prometheus_remote_write._serialize_metrics_to_protobuf')
+    @patch("src.services.prometheus_remote_write._serialize_metrics_to_protobuf")
     async def test_push_metrics_http_error(self, mock_serialize):
         """Test metrics push with HTTP error"""
         from src.services.prometheus_remote_write import PrometheusRemoteWriter
@@ -144,13 +235,13 @@ class TestPrometheusRemoteWrite:
 
         assert stats["success_rate"] == 0
 
-    @patch('src.services.prometheus_remote_write.Config')
+    @patch("src.services.prometheus_remote_write.Config")
     async def test_init_prometheus_remote_write_disabled(self, mock_config):
         """Test init_prometheus_remote_write when Prometheus is disabled"""
         import src.services.prometheus_remote_write
         from src.services.prometheus_remote_write import (
             init_prometheus_remote_write,
-            get_prometheus_writer
+            get_prometheus_writer,
         )
 
         # Reset the global writer
@@ -164,14 +255,13 @@ class TestPrometheusRemoteWrite:
         writer = get_prometheus_writer()
         assert writer is None
 
-    @patch('src.services.prometheus_remote_write.PROTOBUF_AVAILABLE', True)
-    @patch('src.services.prometheus_remote_write.Config')
-    async def test_init_prometheus_remote_write_enabled(self, mock_config, mock_protobuf):
+    @patch("src.services.prometheus_remote_write.Config")
+    async def test_init_prometheus_remote_write_enabled(self, mock_config):
         """Test init_prometheus_remote_write creates and starts writer"""
         import src.services.prometheus_remote_write
         from src.services.prometheus_remote_write import (
             init_prometheus_remote_write,
-            get_prometheus_writer
+            get_prometheus_writer,
         )
 
         # Reset the global writer
@@ -183,8 +273,8 @@ class TestPrometheusRemoteWrite:
         # Mock the start method
         with patch.object(
             src.services.prometheus_remote_write.PrometheusRemoteWriter,
-            'start',
-            new_callable=AsyncMock
+            "start",
+            new_callable=AsyncMock,
         ) as mock_start:
             await init_prometheus_remote_write()
 
@@ -194,12 +284,14 @@ class TestPrometheusRemoteWrite:
             assert writer.enabled is True
             mock_start.assert_called_once()
 
-    @patch('src.services.prometheus_remote_write.prometheus_writer')
-    async def test_shutdown_prometheus_remote_write_with_writer(self, mock_prometheus_writer):
+    @patch("src.services.prometheus_remote_write.prometheus_writer")
+    async def test_shutdown_prometheus_remote_write_with_writer(
+        self, mock_prometheus_writer
+    ):
         """Test shutdown_prometheus_remote_write with active writer"""
         from src.services.prometheus_remote_write import (
             shutdown_prometheus_remote_write,
-            PrometheusRemoteWriter
+            PrometheusRemoteWriter,
         )
 
         # Set up a mock writer
@@ -215,7 +307,7 @@ class TestPrometheusRemoteWrite:
         mock_writer.stop.assert_called_once()
         mock_writer.get_stats.assert_called_once()
 
-    @patch('src.services.prometheus_remote_write.prometheus_writer', None)
+    @patch("src.services.prometheus_remote_write.prometheus_writer", None)
     async def test_shutdown_prometheus_remote_write_no_writer(self):
         """Test shutdown_prometheus_remote_write with no writer"""
         from src.services.prometheus_remote_write import shutdown_prometheus_remote_write
@@ -229,7 +321,7 @@ class TestPrometheusRemoteWrite:
         import src.services.prometheus_remote_write
         from src.services.prometheus_remote_write import (
             get_prometheus_writer,
-            PrometheusRemoteWriter
+            PrometheusRemoteWriter,
         )
 
         # Set up a test writer as the global instance
@@ -242,26 +334,141 @@ class TestPrometheusRemoteWrite:
         # Clean up
         src.services.prometheus_remote_write.prometheus_writer = None
 
-    @patch('src.services.prometheus_remote_write.PROTOBUF_AVAILABLE', False)
-    def test_serialize_metrics_no_protobuf(self, mock_protobuf):
-        """Test serialization fails gracefully without protobuf"""
+    @patch("src.services.prometheus_remote_write.snappy.compress")
+    @patch("src.services.prometheus_remote_write.REGISTRY")
+    def test_serialize_metrics_success(self, mock_registry, mock_compress):
+        """Test successful metrics serialization with new protobuf implementation"""
         from src.services.prometheus_remote_write import _serialize_metrics_to_protobuf
 
-        with pytest.raises(RuntimeError, match="Protobuf support not available"):
-            _serialize_metrics_to_protobuf()
+        # Mock the registry to return some test metrics
+        mock_sample = Mock()
+        mock_sample.name = "test_metric_total"
+        mock_sample.labels = {"label1": "value1"}
+        mock_sample.value = 42.0
 
-    @patch('src.services.prometheus_remote_write.PROTOBUF_AVAILABLE', True)
-    @patch('src.services.prometheus_remote_write.snappy.compress')
-    @patch('prometheus_client.openmetrics.exposition.generate_latest')
-    def test_serialize_metrics_success(self, mock_generate, mock_compress, mock_protobuf):
-        """Test successful metrics serialization"""
-        from src.services.prometheus_remote_write import _serialize_metrics_to_protobuf
+        mock_metric = Mock()
+        mock_metric.name = "test_metric"
+        mock_metric.samples = [mock_sample]
 
-        mock_generate.return_value = b"test_metrics_data"
+        mock_registry.collect.return_value = [mock_metric]
         mock_compress.return_value = b"compressed_data"
 
-        result = _serialize_metrics_to_protobuf()
+        result = _serialize_metrics_to_protobuf(mock_registry)
 
         assert result == b"compressed_data"
-        mock_generate.assert_called_once()
-        mock_compress.assert_called_once_with(b"test_metrics_data")
+        mock_compress.assert_called_once()
+        # Verify the protobuf data was passed to compress
+        call_args = mock_compress.call_args[0][0]
+        assert isinstance(call_args, bytes)
+        assert len(call_args) > 0
+
+    @patch("src.services.prometheus_remote_write.REGISTRY")
+    def test_serialize_metrics_empty_registry(self, mock_registry):
+        """Test serialization with empty registry"""
+        from src.services.prometheus_remote_write import _serialize_metrics_to_protobuf
+
+        mock_registry.collect.return_value = []
+
+        result = _serialize_metrics_to_protobuf(mock_registry)
+
+        # Should still return compressed bytes (empty WriteRequest)
+        assert isinstance(result, bytes)
+
+    def test_get_instance_labels(self):
+        """Test _get_instance_labels returns expected labels"""
+        from src.services.prometheus_remote_write import _get_instance_labels
+
+        labels = _get_instance_labels()
+
+        assert "instance" in labels
+        assert "job" in labels
+        assert labels["job"] == "gatewayz"
+
+
+class TestVarintEncoding:
+    """Test varint encoding utility"""
+
+    def test_encode_small_value(self):
+        """Test encoding small values (< 128)"""
+        from src.services.prometheus_pb2 import _encode_varint
+
+        result = _encode_varint(0)
+        assert result == b"\x00"
+
+        result = _encode_varint(1)
+        assert result == b"\x01"
+
+        result = _encode_varint(127)
+        assert result == b"\x7f"
+
+    def test_encode_medium_value(self):
+        """Test encoding medium values (128-16383)"""
+        from src.services.prometheus_pb2 import _encode_varint
+
+        result = _encode_varint(128)
+        assert result == b"\x80\x01"
+
+        result = _encode_varint(300)
+        assert result == b"\xac\x02"
+
+    def test_encode_large_value(self):
+        """Test encoding large values (timestamps)"""
+        from src.services.prometheus_pb2 import _encode_varint
+
+        # Typical timestamp in milliseconds
+        timestamp = 1700000000000
+        result = _encode_varint(timestamp)
+
+        # Should produce valid bytes
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_encode_negative_value_raises(self):
+        """Test that encoding negative values raises ValueError"""
+        from src.services.prometheus_pb2 import _encode_varint
+
+        with pytest.raises(ValueError, match="Negative values not supported"):
+            _encode_varint(-1)
+
+        with pytest.raises(ValueError, match="Negative values not supported"):
+            _encode_varint(-100)
+
+
+class TestLabelSorting:
+    """Test that labels are sorted lexicographically"""
+
+    def test_labels_are_sorted(self):
+        """Test that labels in TimeSeries are sorted by name"""
+        from src.services.prometheus_pb2 import Label, Sample, TimeSeries
+
+        ts = TimeSeries()
+        # Add labels in non-alphabetical order
+        ts.labels.append(Label(name="zebra", value="z"))
+        ts.labels.append(Label(name="__name__", value="metric"))
+        ts.labels.append(Label(name="alpha", value="a"))
+        ts.labels.append(Label(name="instance", value="host"))
+
+        # The serialization should work (labels are stored as added)
+        data = ts.SerializeToString()
+        assert isinstance(data, bytes)
+        assert len(data) > 0
+
+    @patch("src.services.prometheus_remote_write.REGISTRY")
+    def test_serialize_metrics_sorts_labels(self, mock_registry):
+        """Test that _serialize_metrics_to_protobuf sorts labels correctly"""
+        from src.services.prometheus_remote_write import _serialize_metrics_to_protobuf
+
+        # Mock a metric with labels that would be out of order if not sorted
+        mock_sample = Mock()
+        mock_sample.name = "test_metric_total"
+        mock_sample.labels = {"zebra": "z", "alpha": "a"}
+        mock_sample.value = 42.0
+
+        mock_metric = Mock()
+        mock_metric.samples = [mock_sample]
+
+        mock_registry.collect.return_value = [mock_metric]
+
+        # This should not raise and should produce valid compressed bytes
+        result = _serialize_metrics_to_protobuf(mock_registry)
+        assert isinstance(result, bytes)


### PR DESCRIPTION
## Summary
- Replaces brittle OpenMetrics/text-based serialization with a dedicated internal protobuf builder for Prometheus remote_write
- Introduces a self-contained protobuf implementation to construct valid WriteRequest payloads
- Ensures proper serialization of TimeSeries, Labels, and Samples and SNAPPY compression for remote_write

## Changes
### Protobuf support
- Added src/services/prometheus_pb2.py with:
  - Label, Sample, TimeSeries, WriteRequest message implementations
  - SerializeToString methods to emit correct protobuf wire format
  - _encode_varint helper for protobuf varint encoding

### Remote Write serialization
- Updated src/services/prometheus_remote_write.py to:
  - Use the new internal protobuf definitions instead of OpenMetrics/text format
  - Implement _get_instance_labels() to include instance and job labels
  - Implement _serialize_metrics_to_protobuf(registry) to:
    - Iterate registry metrics and build a WriteRequest with one TimeSeries per sample
    - Attach __name__ and instance/job labels, plus metric-specific labels
    - Attach current timestamp as Sample timestamp
    - Serialize to protobuf and compress with snappy
  - Remove previous NotImplementedError and inappropriate serialization path
  - Adjust logging/flow to reflect protobuf-based remote_write path

### Tests
- Expanded tests/services/test_prometheus_remote_write.py to cover:
  - Protobuf messages: Label, Sample, TimeSeries, WriteRequest serialization
  - Varint encoding edge cases via _encode_varint
  - TimeSeries and WriteRequest serialization scenarios (single and multiple timeseries)
  - _serialize_metrics_to_protobuf behavior with mocked registry
  - _get_instance_labels output and contents
- Updated tests to align with new protobuf-based serialization path

## Test plan
- [x] Validate Label, Sample, TimeSeries, and WriteRequest serialize to valid protobuf bytes
- [x] Verify varint encoding for small, medium, and large values
- [x] Ensure _serialize_metrics_to_protobuf handles non-empty and empty registries
- [x] Confirm PrometheusRemoteWriter initialization and push_metrics behavior remains correct with new serializer
- [x] Run the full tests for tests/services to ensure no regressions

## Notes
- This change removes the previous reliance on prometheus_client with protobuf/OpenMetrics path and implements a self-contained protobuf writer to fix the serialization errors observed with remote_write.
- The new implementation emits a valid WriteRequest payload and compresses it for remote_write transport. The tests exercise the core serialization paths and validate the new behavior.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c09472ef-f325-45d3-983f-2fc3147d9e80

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace text/OpenMetrics path with a custom protobuf `WriteRequest` serializer (Snappy-compressed) for Prometheus remote_write, and add comprehensive tests.
> 
> - **Prometheus remote_write (protobuf)**:
>   - Add `src/services/prometheus_pb2.py` implementing `Label`, `Sample`, `TimeSeries`, `WriteRequest` with `SerializeToString` and `_encode_varint`.
>   - Update `src/services/prometheus_remote_write.py` to build a protobuf `WriteRequest` per registry sample, sort labels, add `__name__`, `instance`, `job`, attach current timestamp, and Snappy-compress payload.
>   - Remove prior OpenMetrics/text path and `NotImplementedError`; always enable protobuf via internal implementation.
> - **Utilities**:
>   - Add `_get_instance_labels()` for `instance` and `job` labels.
> - **Tests**:
>   - Expand `tests/services/test_prometheus_remote_write.py` to cover protobuf message serialization, varint edge cases, label sorting, serializer behavior (empty/non-empty registries), and writer push/ lifecycle + HTTP error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88d23d9a50d7812c1aa2c179b8f632b7a8542657. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR fixes a critical Prometheus remote_write serialization bug by replacing the broken OpenMetrics/text-based format with a proper protobuf implementation. The change introduces a custom protobuf builder that creates valid WriteRequest payloads according to the Prometheus remote write specification.

The core issue was that the previous implementation was incorrectly using OpenMetrics text format instead of the protobuf format required by Prometheus remote_write endpoints, causing "illegal wireType 7" errors. The solution implements a self-contained protobuf system with proper wire format encoding, Snappy compression, and comprehensive test coverage.

The change integrates well with the existing monitoring infrastructure in the Gatewayz backend, leveraging the established Prometheus metrics registry while fixing the serialization layer to ensure metrics can actually be pushed to external Prometheus instances.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|--------|----------|
| src/services/prometheus_remote_write.py | 4/5 | Replaces broken NotImplementedError with proper protobuf WriteRequest serialization and Snappy compression |
| src/services/prometheus_pb2.py | 4/5 | New custom protobuf implementation with Label, Sample, TimeSeries, and WriteRequest message classes |
| tests/services/test_prometheus_remote_write.py | 5/5 | Comprehensive test coverage for new protobuf implementation including edge cases and serialization validation |

<h3>Confidence score: 4/5</h3>


- This PR addresses a critical bug that was completely preventing Prometheus remote write functionality from working
- The implementation follows Prometheus protobuf specifications correctly and includes proper compression with Snappy
- All files require attention for the protobuf wire format implementation and serialization logic, but the extensive test coverage provides confidence in the solution

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant PrometheusRemoteWriter
    participant ProtobufBuilder as prometheus_pb2
    participant Registry as REGISTRY
    participant SnappyCompressor as snappy
    participant PrometheusEndpoint as Prometheus Remote Write

    User->>PrometheusRemoteWriter: "init_prometheus_remote_write()"
    PrometheusRemoteWriter->>PrometheusRemoteWriter: "start() - creates background push task"
    
    loop "Every 30 seconds"
        PrometheusRemoteWriter->>PrometheusRemoteWriter: "_push_loop() triggers push_metrics()"
        PrometheusRemoteWriter->>PrometheusRemoteWriter: "_serialize_metrics_to_protobuf()"
        PrometheusRemoteWriter->>Registry: "collect() - get all metrics"
        Registry-->>PrometheusRemoteWriter: "metric samples with labels/values"
        
        PrometheusRemoteWriter->>ProtobufBuilder: "create WriteRequest()"
        ProtobufBuilder-->>PrometheusRemoteWriter: "WriteRequest instance"
        
        loop "For each metric sample"
            PrometheusRemoteWriter->>ProtobufBuilder: "create TimeSeries with Labels and Sample"
            ProtobufBuilder->>ProtobufBuilder: "Label(__name__, sample_name)"
            ProtobufBuilder->>ProtobufBuilder: "Label(instance, hostname)"
            ProtobufBuilder->>ProtobufBuilder: "Label(job, gatewayz)"
            ProtobufBuilder->>ProtobufBuilder: "Sample(value, timestamp_ms)"
            ProtobufBuilder-->>PrometheusRemoteWriter: "TimeSeries with labels and sample"
            PrometheusRemoteWriter->>ProtobufBuilder: "add TimeSeries to WriteRequest"
        end
        
        PrometheusRemoteWriter->>ProtobufBuilder: "WriteRequest.SerializeToString()"
        ProtobufBuilder->>ProtobufBuilder: "_encode_varint() for protobuf wire format"
        ProtobufBuilder-->>PrometheusRemoteWriter: "protobuf bytes"
        
        PrometheusRemoteWriter->>SnappyCompressor: "compress(protobuf_data)"
        SnappyCompressor-->>PrometheusRemoteWriter: "compressed bytes"
        
        PrometheusRemoteWriter->>PrometheusEndpoint: "POST /api/v1/write with snappy-compressed protobuf"
        Note over PrometheusEndpoint: "Headers: Content-Encoding: snappy, Content-Type: application/x-protobuf"
        PrometheusEndpoint-->>PrometheusRemoteWriter: "HTTP 200 OK or error"
        
        PrometheusRemoteWriter->>PrometheusRemoteWriter: "update _push_count/_push_errors"
    end
    
    User->>PrometheusRemoteWriter: "shutdown_prometheus_remote_write()"
    PrometheusRemoteWriter->>PrometheusRemoteWriter: "stop() - cancel background task"
    PrometheusRemoteWriter->>PrometheusRemoteWriter: "get_stats() - return push statistics"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->