### PR TITLE
Increase default max_tokens to 4096 in proxy schemas

### DIFF
--- a/src/schemas/proxy.py
+++ b/src/schemas/proxy.py
@@ -31,7 +31,7 @@ class Message(BaseModel):
 class ProxyRequest(BaseModel):
     model: str
     messages: list[Message]
-    max_tokens: int | None = 950
+    max_tokens: int | None = 4096
     temperature: float | None = 1.0
     top_p: float | None = 1.0
     frequency_penalty: float | None = 0.0
@@ -80,7 +80,7 @@ class ResponseRequest(BaseModel):
 
     model: str
     input: list[InputMessage]  # Replaces 'messages' in chat/completions
-    max_tokens: int | None = 950
+    max_tokens: int | None = 4096
     temperature: float | None = 1.0
     top_p: float | None = 1.0
     frequency_penalty: float | None = 0.0


### PR DESCRIPTION
## Summary
- Increases default max_tokens for ProxyRequest and ResponseRequest from 950 to 4096 to support longer prompts/responses.

## Changes
### Core Functionality
- Update default in `src/schemas/proxy.py`:
  - `ProxyRequest.max_tokens: int | None = 4096`
  - `ResponseRequest.max_tokens: int | None = 4096`
### Validation
- Existing behavior preserved: explicit `max_tokens` overrides the default.

## Test plan
- [x] Validate requests without `max_tokens` use 4096
- [x] Validate explicit `max_tokens` values override the default
- [x] Ensure compatibility with client SDKs that rely on the default

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/00636a49-6ce5-45c7-b150-8d1e45700078

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase default max_tokens from 950 to 4096 for ProxyRequest and ResponseRequest to support longer outputs.
> 
> - **Schemas**:
>   - Increase default `max_tokens` to `4096` in `ProxyRequest` and `ResponseRequest` (`src/schemas/proxy.py`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f3bb3fa931e51a2768538d60ce3e136b38ddb81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR increases the default `max_tokens` value from 950 to 4096 in two Pydantic schema classes (`ProxyRequest` and `ResponseRequest`) within the proxy schemas module. This change addresses a common limitation where the previous default was insufficient for many real-world use cases involving longer prompts or responses. The modification maintains backward compatibility as explicit `max_tokens` values will still override the default, and the field remains optional. This change aligns with modern AI model capabilities and provides a better out-of-the-box experience for users who don't explicitly configure this parameter.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|--------|-----------|
| src/schemas/proxy.py | 5/5 | Increased default max_tokens from 950 to4096in ProxyRequest and ResponseRequest schemas |

<h3>Confidence score: 5/5</h3>


- This PR is extremely safe to merge with virtually no risk of breaking existing functionality
- Score reflects simple parameter change that maintains backward compatibility and follows established patterns
- No files require special attention as this is a straightforward default value adjustment

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant "Gateway API" as API
    participant "Proxy Schema" as Schema
    participant "LLM Provider" as Provider

    User->>API: "POST /v1/chat/completions (without max_tokens)"
    API->>Schema: "Validate ProxyRequest"
    Schema->>Schema: "Apply default max_tokens=4096"
    Schema->>API: "Validated request with max_tokens=4096"
    API->>Provider: "Forward request with max_tokens=4096"
    Provider->>API: "Return response"
    API->>User: "Return response"

    User->>API: "POST /v1/responses (without max_tokens)"
    API->>Schema: "Validate ResponseRequest"
    Schema->>Schema: "Apply default max_tokens=4096"
    Schema->>API: "Validated request with max_tokens=4096"
    API->>Provider: "Forward request with max_tokens=4096"
    Provider->>API: "Return response"
    API->>User: "Return response"

    User->>API: "POST /v1/chat/completions (with explicit max_tokens=2048)"
    API->>Schema: "Validate ProxyRequest"
    Schema->>Schema: "Use explicit max_tokens=2048"
    Schema->>API: "Validated request with max_tokens=2048"
    API->>Provider: "Forward request with max_tokens=2048"
    Provider->>API: "Return response"
    API->>User: "Return response"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->