### PR TITLE
Fix healthcheck failures by backgrounding startup tasks

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -14,15 +14,15 @@
           "liveness": {
             "enabled": true,
             "interval": 30,
-            "timeout": 10,
-            "initialDelay": 30,
+            "timeout": 30,
+            "initialDelay": 60,
             "path": "/health"
           },
           "readiness": {
             "enabled": true,
             "interval": 10,
-            "timeout": 5,
-            "initialDelay": 10,
+            "timeout": 30,
+            "initialDelay": 45,
             "path": "/health"
           }
         },
@@ -33,7 +33,7 @@
               "liveness": {
                 "enabled": true,
                 "interval": 30,
-                "timeout": 10,
+                "timeout": 30,
                 "initialDelay": 60
               }
             }
@@ -44,8 +44,8 @@
               "liveness": {
                 "enabled": true,
                 "interval": 30,
-                "timeout": 10,
-                "initialDelay": 30
+                "timeout": 30,
+                "initialDelay": 45
               }
             }
           }

--- a/src/services/tempo_otlp.py
+++ b/src/services/tempo_otlp.py
@@ -23,7 +23,7 @@ from src.config.opentelemetry_config import instrument_fastapi_application
 logger = logging.getLogger(__name__)
 
 
-def check_tempo_endpoint_reachable(endpoint: str, timeout: float = 2.0) -> bool:
+def check_tempo_endpoint_reachable(endpoint: str, timeout: float = 1.0) -> bool:
     """
     Check if the Tempo OTLP endpoint is reachable.
 


### PR DESCRIPTION
## Summary
Healthcheck failures and error logs were observed due to startup tasks blocking readiness and liveness probes. This PR moves heavy initialization steps to background tasks, trims startup retries, and tunes health probes to reduce false positives during startup. It also shortens the tempo endpoint check timeout for quicker responsiveness.

## Changes
### Infrastructure / Config
- railway.json
  - Increase liveness timeout from 10s to 30s and initialDelay from 30s to 60s
  - Increase readiness timeout from 5s to 30s and initialDelay from 10s to 45s
  - Other inline probe configurations adjusted to align with the slower startup window

### Backend startup flow
- src/services/startup.py
  - Reduce startup retries: max_retries from 3 to 2
  - Shorten retry delay: retry_delay from 2.0s to 1.0s
  - Move Tempo OTLP tracing initialization to a background task
  - Move Prometheus remote write initialization to a background task
  - Move pre-warming of provider connections to a background task
  - Move autonomous error monitoring initialization to a background task
  - Health checks and readiness should no longer be blocked by these initializations

### Telemetry
- src/services/tempo_otlp.py
  - Check tempo endpoint reachability timeout reduced from 2.0s to 1.0s to improve responsiveness of health checks

## Rationale
- Non-blocking health checks: By running expensive/long-running startup tasks in the background, liveness and readiness probes no longer fail due to slow initialization.
- Faster startup: Reducing retry behavior helps the service reach a healthy state quicker once the background tasks complete.
- Improved observability: Background tasks log their status without delaying readiness signals.

## Testing plan
- Deploy branch terragon/fix-healthcheck-failure-5ajrw0 and observe health endpoints during startup
- Verify liveness/readiness probes no longer report failures while background tasks initialize
- Confirm Tempo OTLP, Prometheus remote write, and provider warmup complete in the background without blocking API readiness
- Validate tempo endpoint reachability timeout behavior is using 1.0s as configured
- Check logs for successful background initializations (e.g., "Tempo/OTLP tracing initialized", "Prometheus remote write initialized", "Autonomous error monitoring started") and ensure no regression in normal operation

## Notes
- Some background tasks may still be in progress after the service reports healthy; this is expected and logged accordingly. If needed, we can add startup task health checks later to explicitly monitor background task completion.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/5abf8592-080a-4a80-9e0a-cefa12e9811e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Backgrounds heavy startup tasks, trims DB init retries, increases Railway probe timeouts, and shortens Tempo endpoint check.
> 
> - **Backend startup (`src/services/startup.py`)**:
>   - Add tracked background tasks with cleanup on shutdown.
>   - Move initialization of `Tempo OTLP` exporter, `Prometheus` remote write, provider warmup, and autonomous error monitoring to background tasks.
>   - Initialize FastAPI instrumentation synchronously.
>   - Reduce Supabase init retries: `max_retries 3→2`, `retry_delay 2.0s→1.0s`.
> - **Infra (`railway.json`)**:
>   - Increase `gateway-api` healthcheck timeouts/initialDelays (liveness `timeout 10→30`, `initialDelay 30→60`; readiness `timeout 5→30`, `initialDelay 10→45`).
>   - Align prod/staging liveness timeouts/delays accordingly.
> - **Telemetry (`src/services/tempo_otlp.py`)**:
>   - Shorten Tempo endpoint reachability timeout `2.0s→1.0s`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93eb0c40df9a8214fe7e72b28d3a79643c400943. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR addresses healthcheck failures during application startup by implementing a background task strategy for heavy initialization operations. The changes move four expensive startup tasks (Tempo OTLP tracing, Prometheus remote write, provider connection warming, and autonomous error monitoring) to run asynchronously without blocking health probes. Additionally, the Railway deployment configuration is updated with more generous timeout and initial delay settings to accommodate the new startup architecture. The database initialization retry parameters are reduced to speed up the critical path to service readiness, and the Tempo endpoint timeout is shortened for faster responsiveness.

The changes follow the repository's established patterns for async operations and service initialization found in `src/services/startup.py`. This architectural improvement aligns with cloud-native best practices where health checks must succeed within tight timeouts while allowing non-critical initialization to complete in the background.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|-------|----------|
| railway.json | 5/5 | Updated health check timeouts and delays to accommodate background startup tasks |
| src/services/startup.py | 4/5 | Moved heavy initialization tasks to background and reduced retry parameters |
| src/services/tempo_otlp.py | 5/5 | Reduced tempo endpoint timeout from 2.0s to 1.0s for faster responsiveness |

<h3>Confidence score: 4/5</h3>


- This PR is safe to merge with low risk as it implements a well-established pattern for handling startup tasks in cloud environments
- Score reflects solid implementation but potential for race conditions if background tasks fail silently or if dependent services expect these initializations to complete before health checks pass
- Pay close attention to src/services/startup.py to ensure proper error handling in background tasks

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Railway as "Railway Platform"
    participant App as "FastAPI App"
    participant BG as "Background Tasks"
    participant Health as "Health Endpoints"
    participant DB as "Supabase DB"
    participant Tempo
    participant Prometheus
    participant Providers as "AI Providers"
    participant Monitor as "Error Monitor"

    User->>Railway: "Deploy Application"
    Railway->>App: "Start uvicorn server"
    
    Note over App: "Startup begins with lifespan manager"
    
    App->>App: "Validate critical env vars"
    App->>DB: "Initialize Supabase client (2 retries, 1s delay)"
    alt DB Success
        DB-->>App: "Connection established"
        App->>App: "Log: DB initialized"
    else DB Failure
        DB-->>App: "Connection failed"
        App->>App: "Start in DEGRADED MODE"
        App->>App: "Send warning to Sentry"
    end
    
    App->>App: "Initialize Fal.ai cache"
    
    Note over App,BG: "Heavy tasks moved to background"
    
    App->>BG: "create_task(init_tempo_background)"
    App->>BG: "create_task(init_prometheus_background)"
    App->>BG: "create_task(warmup_connections_background)"
    App->>BG: "create_task(init_error_monitoring_background)"
    
    App->>App: "Initialize response cache"
    App->>Health: "Health endpoints ready"
    
    Note over App: "App reports healthy - startup complete"
    
    Railway->>Health: "Liveness probe (30s timeout, 60s delay)"
    Health-->>Railway: "200 OK"
    
    Railway->>Health: "Readiness probe (30s timeout, 45s delay)"
    Health-->>Railway: "200 OK"
    
    Note over BG: "Background tasks run in parallel"
    
    par Background Initialization
        BG->>Tempo: "Check endpoint reachability (1s timeout)"
        alt Tempo Available
            Tempo-->>BG: "Connection OK"
            BG->>BG: "Initialize OTLP tracing"
            BG->>App: "Log: Tempo/OTLP initialized"
        else Tempo Unavailable
            Tempo-->>BG: "Connection failed"
            BG->>App: "Log: Tempo initialization warning"
        end
    and
        BG->>Prometheus: "Initialize remote write"
        Prometheus-->>BG: "Initialization complete"
        BG->>App: "Log: Prometheus remote write initialized"
    and
        BG->>Providers: "Warm up connections"
        Providers-->>BG: "Connections warmed"
        BG->>App: "Log: Provider connections warmed"
    and
        BG->>Monitor: "Initialize autonomous monitoring"
        Monitor-->>BG: "Monitor started"
        BG->>App: "Log: Error monitoring started"
    end
    
    User->>Health: "API requests"
    Health-->>User: "Responses (app fully operational)"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->