### PR TITLE
Removed is active query

### DIFF
--- a/health-service/main.py
+++ b/health-service/main.py
@@ -224,30 +224,27 @@ async def _get_intelligent_monitor_counts() -> tuple[int, int, int]:
     try:
         from src.config.supabase_config import supabase
 
-        # Get count of all active models from the CATALOG table (not health tracking)
+        # Get count of all models from the CATALOG table (not health tracking)
         # The 'models' table contains all 9000+ models
         models_response = (
             supabase.table("models")
             .select("id", count="exact")
-            .eq("is_active", True)
             .execute()
         )
         models_count = models_response.count or 0
 
-        # Get distinct provider count from the providers table
+        # Get provider count from the providers table
         providers_response = (
             supabase.table("providers")
             .select("id", count="exact")
-            .eq("is_active", True)
             .execute()
         )
         providers_count = providers_response.count or 0
 
-        # Get distinct gateway count from the gateways table
+        # Get gateway count from the gateways table
         gateways_response = (
             supabase.table("gateways")
             .select("id", count="exact")
-            .eq("is_active", True)
             .execute()
         )
         gateways_count = gateways_response.count or 0


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR modifies the health service's counting logic by removing `is_active` query filters from three database operations. The change shifts from counting only active entities to counting all entities in the models, providers, and gateways tables. This appears to be addressing an issue where the health monitoring system was not returning accurate counts, potentially because the `is_active` field either doesn't exist in these tables or was filtering out entities that should be included in health metrics.

The modification aligns the counting behavior with the likely intention of providing comprehensive health statistics about all available resources rather than just currently active ones. This could be part of fixing health monitoring accuracy where the system needs visibility into the full catalog of models, providers, and gateways for proper operational oversight.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|-------|----------|
| health-service/main.py | 4/5 | Removes `is_active` filters from database count queries for models, providers, and gateways |

<h3>Confidence score: 4/5</h3>


- This PR is safe to merge with minimal risk as it's a straightforward filter removal
- Score reflects simple query modification without complex logic changes, though the behavioral change could impact monitoring dashboards that depend on these counts
- No files require special attention beyond understanding the monitoring implications

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant HealthService as "Health Service (FastAPI)"
    participant IntelligentMonitor as "Intelligent Health Monitor"
    participant SimpleMonitor as "Simple Health Monitor"
    participant AvailabilityService as "Availability Service"
    participant Database as "Supabase Database"
    participant Redis as "Redis Cache"

    User->>HealthService: "Start Health Service"
    
    Note over HealthService: "Application Startup (lifespan)"
    HealthService->>Database: "Validate environment & Redis connection"
    Database-->>HealthService: "Connection established"
    
    alt "USE_INTELLIGENT_MONITOR = true"
        HealthService->>IntelligentMonitor: "start_monitoring()"
        IntelligentMonitor-->>HealthService: "Success/Failure"
        alt "Intelligent monitor fails"
            HealthService->>SimpleMonitor: "start_monitoring() [fallback]"
            SimpleMonitor-->>HealthService: "Fallback started"
        end
    else "USE_INTELLIGENT_MONITOR = false"
        HealthService->>SimpleMonitor: "start_monitoring()"
        SimpleMonitor-->>HealthService: "Simple monitor started"
    end
    
    HealthService->>AvailabilityService: "start_monitoring()"
    AvailabilityService-->>HealthService: "Availability monitoring started"

    User->>HealthService: "GET /status"
    HealthService->>Database: "_get_intelligent_monitor_counts()"
    Database-->>HealthService: "models_count, providers_count, gateways_count"
    HealthService-->>User: "Status with counts and monitor type"

    User->>HealthService: "GET /metrics" 
    alt "intelligent monitor active"
        HealthService->>Database: "_get_intelligent_monitor_summary()"
        Database-->>HealthService: "health summary with recent models"
    else "simple monitor active"
        HealthService->>SimpleMonitor: "get_health_summary()"
        SimpleMonitor-->>HealthService: "health summary from memory"
    end
    HealthService-->>User: "Health metrics summary"

    User->>HealthService: "POST /check/trigger"
    alt "intelligent monitor active"
        HealthService->>IntelligentMonitor: "_get_models_for_checking()"
        IntelligentMonitor-->>HealthService: "models list"
        loop "for each model (limit 10)"
            HealthService->>IntelligentMonitor: "_check_model_health(model)"
            IntelligentMonitor->>Database: "Update health status"
        end
    else "simple monitor active"
        HealthService->>SimpleMonitor: "_perform_health_checks()"
        SimpleMonitor->>Redis: "Update health cache"
    end
    HealthService-->>User: "Health check triggered"

    User->>HealthService: "GET /cache/stats"
    HealthService->>Redis: "Check cache availability and data"
    Redis-->>HealthService: "Cache statistics"
    HealthService-->>User: "Cache stats response"

    Note over HealthService: "Application Shutdown (lifespan)"
    HealthService->>AvailabilityService: "stop_monitoring()"
    alt "intelligent monitor active"
        HealthService->>IntelligentMonitor: "stop_monitoring()"
    else "simple monitor active"  
        HealthService->>SimpleMonitor: "stop_monitoring()"
    end
    HealthService->>Database: "cleanup_supabase_client()"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->