### PR TITLE
../AGENTS.md

### DIFF
--- a/health-service/main.py
+++ b/health-service/main.py
@@ -222,29 +222,32 @@ async def _get_intelligent_monitor_counts() -> tuple[int, int, int]:
     try:
         from src.config.supabase_config import supabase
 
-        # Get count of all models from the CATALOG table
-        # The 'models' table contains all 9000+ models
+        # Get count of all models from the latest_models table
         try:
             models_response = (
-                supabase.table("models")
-                .select("*", count="exact")
+                supabase.table("latest_models")
+                .select("id", count="exact", head=True)
                 .execute()
             )
-            models_count = models_response.count or 0
+            models_count = models_response.count if models_response.count is not None else 0
+            logger.info(f"Models catalog query successful: {models_count} models")
         except Exception as e:
-            logger.warning(f"Failed to get models count: {e}")
+            logger.error(f"Failed to get models count from catalog: {e}")
             models_count = 0
 
-        # Get provider count from the providers table
+        # Get distinct provider count from latest_models table
         try:
+            # Fetch provider column and count distinct values
             providers_response = (
-                supabase.table("providers")
-                .select("*", count="exact")
+                supabase.table("latest_models")
+                .select("provider")
                 .execute()
             )
-            providers_count = providers_response.count or 0
+            providers = set(row.get("provider") for row in (providers_response.data or []) if row.get("provider"))
+            providers_count = len(providers)
+            logger.info(f"Providers count from latest_models: {providers_count} distinct providers")
         except Exception as e:
-            logger.warning(f"Failed to get providers count: {e}")
+            logger.error(f"Failed to get providers count: {e}")
             providers_count = 0
 
         # Get gateway count - gateways are defined in GATEWAY_CONFIG, not a database table
@@ -396,17 +399,19 @@ async def _get_intelligent_monitor_summary() -> dict:
     try:
         from src.config.supabase_config import supabase
 
-        # Get total counts from catalog tables
+        # Get total counts from latest_models table
         try:
-            catalog_models = supabase.table("models").select("*", count="exact").execute()
+            catalog_models = supabase.table("latest_models").select("id", count="exact", head=True).execute()
             total_models = catalog_models.count or 0
         except Exception as e:
             logger.warning(f"Failed to get models count: {e}")
             total_models = 0
             
         try:
-            catalog_providers = supabase.table("providers").select("*", count="exact").execute()
-            total_providers = catalog_providers.count or 0
+            # Get distinct providers from latest_models
+            providers_response = supabase.table("latest_models").select("provider").execute()
+            providers = set(row.get("provider") for row in (providers_response.data or []) if row.get("provider"))
+            total_providers = len(providers)
         except Exception as e:
             logger.warning(f"Failed to get providers count: {e}")
             total_providers = 0


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR fixes health monitoring count queries by migrating from legacy `models` and `providers` tables to the `latest_models` table. The changes affect two critical health service files that calculate total model and provider counts for system dashboards. The intelligent health monitor now uses a more efficient count-only query with `head=True` for model counts and calculates distinct provider counts from the unified catalog. This migration appears to be part of a database consolidation effort where separate catalog tables have been merged into a single authoritative `latest_models` table, requiring the health monitoring system to adapt its counting logic accordingly.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|-------|-----------|
| src/services/intelligent_health_monitor.py | 4/5 | Updated health monitoring to query latest_models table instead of legacy models/providers tables for accurate system statistics |
| health-service/main.py | 4/5 | Modified health service count queries to use latest_models table with head=True optimization and manual provider counting |

<h3>Confidence score: 4/5</h3>


- This PR is safe to merge with low risk as it primarily fixes data accuracy by using the correct database tables
- Score reflects that the changes are straightforward database query updates with proper error handling and fallbacks, though the database schema migration context adds some complexity 
- Pay close attention to both health monitoring files to ensure the latest_models table structure matches expectations and fallback logic works correctly

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as User
    participant FastAPI as FastAPI App
    participant LifespanManager as Lifespan Manager
    participant RedisConfig as Redis Config
    participant IntelligentMonitor as Intelligent Health Monitor
    participant SimpleMonitor as Simple Health Monitor
    participant AvailabilityService as Availability Service
    participant Supabase as Supabase
    participant Redis as Redis Cache
    participant MonitoringLoop as Monitoring Loop
    participant Gateway as External Gateway

    User->>FastAPI: "Start Health Service"
    FastAPI->>LifespanManager: "startup()"
    
    Note over LifespanManager: Log startup configuration
    LifespanManager->>RedisConfig: "get_redis_client()"
    RedisConfig-->>LifespanManager: "Redis client or None"
    
    alt USE_INTELLIGENT_MONITOR == true
        LifespanManager->>IntelligentMonitor: "start_monitoring()"
        IntelligentMonitor->>IntelligentMonitor: "Create monitoring tasks"
        IntelligentMonitor->>MonitoringLoop: "Start _monitoring_loop()"
        
        Note over MonitoringLoop: Main monitoring loop starts
        loop Every 30 seconds
            MonitoringLoop->>Supabase: "Get models needing check"
            Supabase-->>MonitoringLoop: "List of models"
            
            loop For each model batch
                MonitoringLoop->>Gateway: "POST /chat/completions"
                Gateway-->>MonitoringLoop: "Health check response"
                MonitoringLoop->>Supabase: "Update health tracking"
                MonitoringLoop->>Supabase: "Insert health history"
            end
            
            MonitoringLoop->>Redis: "Publish health cache"
        end
    else
        LifespanManager->>SimpleMonitor: "start_monitoring()"
        Note over SimpleMonitor: Falls back to simple monitor
    end
    
    LifespanManager->>AvailabilityService: "start_monitoring()"
    AvailabilityService->>AvailabilityService: "Start availability tracking"
    
    Note over LifespanManager: Service fully started
    LifespanManager-->>FastAPI: "Service ready"
    
    User->>FastAPI: "GET /status"
    FastAPI->>Supabase: "Query model counts"
    Supabase-->>FastAPI: "Model statistics"
    FastAPI-->>User: "Service status with counts"
    
    User->>FastAPI: "POST /check/trigger"
    FastAPI->>IntelligentMonitor: "Manual health check trigger"
    IntelligentMonitor->>Gateway: "Immediate health checks"
    Gateway-->>IntelligentMonitor: "Check results"
    IntelligentMonitor->>Supabase: "Update health data"
    FastAPI-->>User: "Health check triggered"
    
    User->>FastAPI: "Shutdown signal"
    FastAPI->>LifespanManager: "shutdown()"
    LifespanManager->>IntelligentMonitor: "stop_monitoring()"
    LifespanManager->>AvailabilityService: "stop_monitoring()"
    LifespanManager->>Supabase: "cleanup_supabase_client()"
    LifespanManager-->>FastAPI: "Shutdown complete"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->