### PR TITLE
Fix health monitor counts to query full catalog tables

### DIFF
--- a/src/services/intelligent_health_monitor.py
+++ b/src/services/intelligent_health_monitor.py
@@ -794,18 +794,12 @@ class IntelligentHealthMonitor:
                     total_models = tracked_models
                 
             try:
-                # Get distinct providers from openrouter_models table
-                providers_response = supabase.table("openrouter_models").select("top_provider").execute()
-                providers = set(row.get("top_provider") for row in (providers_response.data or []) if row.get("top_provider"))
-                total_providers = len(providers) if providers else tracked_providers
+                # Get all providers from providers table
+                providers_response = supabase.table("providers").select("id", count="exact", head=True).execute()
+                total_providers = providers_response.count or tracked_providers
             except Exception as e:
-                logger.warning(f"Failed to get providers from 'openrouter_models' table: {e}, trying providers table")
-                try:
-                    providers_response = supabase.table("providers").select("id", count="exact", head=True).execute()
-                    total_providers = providers_response.count or tracked_providers
-                except Exception as e2:
-                    logger.warning(f"Failed to get providers catalog count: {e2}")
-                    total_providers = tracked_providers
+                logger.warning(f"Failed to get providers catalog count: {e}")
+                total_providers = tracked_providers
                 
             # Get gateway count from GATEWAY_CONFIG (not a database table)
             try:


### PR DESCRIPTION
- Query openrouter_models for all 9000+ models (not just top 80)
- Query providers table for all 3000+ providers (not distinct)
- /status endpoint shows tracked counts (337 models, X providers, 17 gateways)
- /health/system endpoint shows catalog totals (9000+ models, 3000+ providers, 17 gateways)
- /health/models and /health/providers include metadata with both totals and tracked counts
- Redis cache published with correct catalog totals
- Added pagination for provider counting from tracked models

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR fixes health monitoring endpoints to correctly report catalog totals versus tracked counts. The main issue was that health endpoints were querying limited datasets (top 80 models, distinct providers from model data) instead of the full catalog tables. The fix ensures that the `/status` endpoint shows tracked counts (models actively monitored - around 337 models and providers), while `/health/system` shows complete catalog totals (9000+ models from `openrouter_models`, 3000+ providers from `providers` table). The changes modify the provider counting logic to directly query the `providers` table instead of extracting distinct providers from `openrouter_models`, which was only showing ~80 providers instead of the full 3000+. Pagination was added to handle large datasets efficiently when counting tracked providers.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|-------|----------|
| src/services/intelligent_health_monitor.py | 4/5 | Simplified provider counting to query full `providers` table instead of distinct values from `openrouter_models` |
| health-service/main.py | 4/5 | Updated health endpoints to distinguish catalog totals vs tracked counts, added pagination for provider counting |

<h3>Confidence score: 4/5</h3>


- This PR addresses a clear reporting issue and should provide more accurate health monitoring data
- Score reflects good implementation with proper error handling and pagination, but concerns about potential performance impact of querying large catalog tables
- Pay close attention to both files to ensure the catalog vs tracked count distinction is properly implemented and tested

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant HealthService as "Health Service"
    participant IntelligentMonitor as "Intelligent Health Monitor"
    participant Database as "Supabase Database"
    participant Redis as "Redis Cache"
    participant Gateways as "Gateway APIs"

    User->>HealthService: "GET /status"
    HealthService->>HealthService: "Check active monitor type"
    
    alt Intelligent Monitor Active
        HealthService->>Database: "Query model_health_tracking table"
        Note over Database: "Get tracked models count"
        Database-->>HealthService: "Return tracked models"
        
        HealthService->>Database: "Query providers with pagination"
        Note over Database: "Get distinct providers from tracked models"
        Database-->>HealthService: "Return tracked providers"
        
        HealthService->>IntelligentMonitor: "Get gateway count from GATEWAY_CONFIG"
        IntelligentMonitor-->>HealthService: "Return gateway count"
    else Simple Monitor Active
        HealthService->>HealthService: "Get counts from memory cache"
    end
    
    HealthService-->>User: "Return status with tracked counts"

    User->>HealthService: "GET /health/system"
    HealthService->>HealthService: "Call _get_intelligent_monitor_counts()"
    
    HealthService->>Database: "Query openrouter_models table (catalog)"
    Note over Database: "9000+ models from full catalog"
    Database-->>HealthService: "Return total models count"
    
    HealthService->>Database: "Query providers table (catalog)"
    Note over Database: "3000+ providers from full catalog"
    Database-->>HealthService: "Return total providers count"
    
    HealthService->>IntelligentMonitor: "Get gateway count from GATEWAY_CONFIG"
    IntelligentMonitor-->>HealthService: "Return gateway count"
    
    HealthService-->>User: "Return system health with catalog totals"

    Note over HealthService: "Background Health Monitoring Process"
    
    IntelligentMonitor->>Database: "Query models due for checking"
    Database-->>IntelligentMonitor: "Return models to check"
    
    loop For each model batch
        IntelligentMonitor->>Gateways: "Send health check request"
        Gateways-->>IntelligentMonitor: "Return response/status"
        
        IntelligentMonitor->>Database: "Update model_health_tracking"
        IntelligentMonitor->>Database: "Insert model_health_history"
    end
    
    IntelligentMonitor->>Database: "Query aggregated health data"
    Database-->>IntelligentMonitor: "Return health statistics"
    
    IntelligentMonitor->>Redis: "Publish health data to cache"
    Note over Redis: "Cache system, providers, and models health"
    Redis-->>IntelligentMonitor: "Confirm cached"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->