### PR TITLE
Add detailed logging for catalog count queries

### DIFF
--- a/src/services/intelligent_health_monitor.py
+++ b/src/services/intelligent_health_monitor.py
@@ -783,22 +783,25 @@ class IntelligentHealthMonitor:
             # Get total counts from openrouter_models table (not just tracked)
             try:
                 catalog_models_response = supabase.table("openrouter_models").select("id", count="exact", head=True).execute()
-                total_models = catalog_models_response.count or tracked_models
+                total_models = catalog_models_response.count if catalog_models_response.count is not None else tracked_models
+                logger.info(f"Got {total_models} total models from openrouter_models table")
             except Exception as e:
                 logger.warning(f"Failed to get models from 'openrouter_models' table: {e}, trying models table")
                 try:
                     catalog_models_response = supabase.table("models").select("id", count="exact", head=True).execute()
-                    total_models = catalog_models_response.count or tracked_models
+                    total_models = catalog_models_response.count if catalog_models_response.count is not None else tracked_models
+                    logger.info(f"Got {total_models} total models from models table")
                 except Exception as e2:
-                    logger.warning(f"Failed to get models catalog count: {e2}")
+                    logger.warning(f"Failed to get models catalog count: {e2}, using tracked count: {tracked_models}")
                     total_models = tracked_models
                 
             try:
                 # Get all providers from providers table
                 providers_response = supabase.table("providers").select("id", count="exact", head=True).execute()
-                total_providers = providers_response.count or tracked_providers
+                total_providers = providers_response.count if providers_response.count is not None else tracked_providers
+                logger.info(f"Got {total_providers} total providers from providers table")
             except Exception as e:
-                logger.warning(f"Failed to get providers catalog count: {e}")
+                logger.warning(f"Failed to get providers catalog count: {e}, using tracked count: {tracked_providers}")
                 total_providers = tracked_providers
                 
             # Get gateway count from GATEWAY_CONFIG (not a database table)


### PR DESCRIPTION
- Log when catalog counts are successfully retrieved
- Log which table is being used (openrouter_models vs models)
- Log fallback to tracked counts with reason
- Better debugging for health count issues

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds enhanced logging capabilities to debug health count display issues in the health monitoring system. The changes focus on two key areas:

1. **Improved serverless environment support** in `config.py` by adding fallback mechanisms for read-only file systems (like Vercel/Lambda), which detects serverless environments and gracefully falls back to using `/tmp` when directory creation fails in the main filesystem.

2. **Detailed catalog count query logging** in `intelligent_health_monitor.py` to track which database tables are being used (`openrouter_models` vs `models`) and when fallback counts are applied. The changes also fix a subtle bug where legitimate zero counts would be incorrectly replaced with tracked counts due to Python's falsy evaluation.

These changes integrate well with the existing health monitoring architecture, maintaining compatibility while improving observability and serverless deployment reliability.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|--------|-----------|
| src/config/config.py | 4/5 | Added serverless-aware file system handling with fallback to /tmp when directory creation fails |
| src/services/intelligent_health_monitor.py | 4/5 | Enhanced catalog count query logging and fixed None vs falsy value handling for accurate count reporting |

<h3>Confidence score: 4/5</h3>


- This PR is safe to merge with minimal risk as it primarily adds logging and fixes edge cases
- Score reflects solid defensive programming practices and improved observability without breaking existing functionality
- Pay close attention to the serverless detection logic in config.py to ensure it works across all deployment environments

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant HealthService as "Intelligent Health Monitor"
    participant DB as "Supabase Database"
    participant Redis as "Redis Cache"
    participant Gateway as "AI Gateway (OpenRouter/etc)"
    
    User->>HealthService: "start_monitoring()"
    HealthService->>HealthService: "Initialize worker ID & semaphore"
    HealthService->>HealthService: "Start background monitoring loops"
    
    loop "Monitoring Loop (every 30s)"
        HealthService->>DB: "Query models due for checking"
        DB-->>HealthService: "Return models list with priorities"
        HealthService->>Redis: "Acquire distributed locks for models"
        Redis-->>HealthService: "Return available models to check"
        
        loop "Batch Processing"
            par "Concurrent Health Checks"
                HealthService->>Gateway: "POST /chat/completions (test payload)"
                Gateway-->>HealthService: "Response with status/timing"
            and 
                HealthService->>Gateway: "POST /chat/completions (test payload)"
                Gateway-->>HealthService: "Response with status/timing"
            end
            
            HealthService->>DB: "Update model_health_tracking table"
            HealthService->>DB: "Insert into model_health_history table"
            
            alt "Health Check Failed"
                HealthService->>DB: "Create/update incident record"
            else "Health Check Succeeded"
                HealthService->>DB: "Resolve active incidents"
            end
        end
        
        HealthService->>DB: "Query aggregated health data"
        DB-->>HealthService: "Return models & providers data"
        HealthService->>DB: "Get catalog counts from openrouter_models"
        DB-->>HealthService: "Return total model count"
        HealthService->>Redis: "Cache health data for API consumption"
    end
    
    loop "Tier Update Loop (hourly)"
        HealthService->>DB: "Call update_model_tier() function"
        DB-->>HealthService: "Update monitoring tiers based on usage"
    end
    
    loop "Metrics Aggregation (every 5min)"
        HealthService->>HealthService: "Aggregate hourly metrics"
    end
    
    User->>HealthService: "check_model_on_demand(provider, model, gateway)"
    HealthService->>Gateway: "Immediate health check request"
    Gateway-->>HealthService: "Response"
    HealthService->>DB: "Process and store result"
    HealthService-->>User: "Return HealthCheckResult"
    
    User->>HealthService: "stop_monitoring()"
    HealthService->>HealthService: "Cancel all background tasks"
    HealthService->>HealthService: "Clean shutdown"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->