### PR TITLE
Fix health endpoints response format to match frontend expectations

### DIFF
--- a/src/routes/health.py
+++ b/src/routes/health.py
@@ -182,9 +182,12 @@ async def get_providers_health(
             if gateway:
                 cached = [p for p in cached if p.get("gateway") == gateway]
             
-            # Return with metadata
+            # Return format that frontend expects
             return {
                 "data": cached,
+                "providers": cached,  # Also include as 'providers' for compatibility
+                "total_providers": total_providers,
+                "tracked_providers": tracked_providers,
                 "metadata": {
                     "total_providers": total_providers,
                     "tracked_providers": tracked_providers,
@@ -196,6 +199,9 @@ async def get_providers_health(
         logger.debug("No providers health in cache - health-service may not be running")
         return {
             "data": [],
+            "providers": [],
+            "total_providers": total_providers,
+            "tracked_providers": 0,
             "metadata": {
                 "total_providers": total_providers,
                 "tracked_providers": 0,
@@ -212,6 +218,9 @@ async def get_providers_health(
         )
         return {
             "data": [],
+            "providers": [],
+            "total_providers": 0,
+            "tracked_providers": 0,
             "metadata": {
                 "total_providers": 0,
                 "tracked_providers": 0,
@@ -265,9 +274,12 @@ async def get_models_health(
             if status:
                 cached = [m for m in cached if m.get("status") == status]
             
-            # Return with metadata
+            # Return format that frontend expects
             return {
                 "data": cached,
+                "models": cached,  # Also include as 'models' for compatibility
+                "total_models": total_models,
+                "tracked_models": tracked_models,
                 "metadata": {
                     "total_models": total_models,
                     "tracked_models": tracked_models,
@@ -279,6 +291,9 @@ async def get_models_health(
         logger.debug("No models health in cache - health-service may not be running")
         return {
             "data": [],
+            "models": [],
+            "total_models": total_models,
+            "tracked_models": 0,
             "metadata": {
                 "total_models": total_models,
                 "tracked_models": 0,
@@ -295,6 +310,9 @@ async def get_models_health(
         )
         return {
             "data": [],
+            "models": [],
+            "total_models": 0,
+            "tracked_models": 0,
             "metadata": {
                 "total_models": 0,
                 "tracked_models": 0,


### PR DESCRIPTION
- /health/models returns data, models, total_models, tracked_models, and metadata
- /health/providers returns data, providers, total_providers, tracked_providers, and metadata
- Frontend can extract data from any of these fields for compatibility
- Includes catalog totals (9000+ models, 3000+ providers) alongside tracked counts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR modifies the health endpoints (`/health/models` and `/health/providers`) to return data in multiple field formats for frontend compatibility. The changes duplicate the cached model/provider data in both `data` and `models`/`providers` fields, ensuring the frontend can access the information regardless of which field name it expects. Additionally, the PR adds top-level count fields (`total_models`, `tracked_models`, `total_providers`, `tracked_providers`) and metadata objects containing the same information with timestamps.

The changes are applied consistently across all response paths (success, cache miss, and error scenarios) to maintain API consistency. This appears to be a defensive programming approach to handle different frontend implementations or migration scenarios where components might expect different response structures.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|-------|----------|
| src/routes/health.py | 4/5| Modified health endpoints to return duplicate data fields and count summaries for frontend compatibility |

<h3>Confidence score: 4/5</h3>


- This PR is safe to merge with minimal risk as it only adds additional response fields without removing existing functionality
- Score reflects that the changes are additive and maintain backward compatibility, though they introduce some data duplication which could be considered a code smell
- Pay close attention to the response format changes to ensure they align with frontend expectations and don't cause confusion in future maintenance

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API
    participant HealthService
    participant Redis
    participant Database
    participant Logger

    User->>API: "GET /health/models?gateway=x"
    API->>Redis: "get_models_health()"
    Redis-->>API: "cached models data"
    
    alt "Cache has data"
        API->>API: "Filter by gateway/provider/status"
        API->>API: "Build response with data, models, totals"
        API-->>User: "{ data: [], models: [], total_models, tracked_models, metadata }"
    else "Cache empty"
        API->>Logger: "log warning about health-service"
        API-->>User: "{ data: [], models: [], total_models: 0, tracked_models: 0 }"
    end

    User->>API: "GET /health/providers?gateway=x"
    API->>Redis: "get_providers_health()"
    Redis-->>API: "cached providers data"
    
    alt "Cache has data"
        API->>API: "Filter by gateway if specified"
        API->>API: "Build response with data, providers, totals"
        API-->>User: "{ data: [], providers: [], total_providers, tracked_providers, metadata }"
    else "Cache empty"
        API->>Logger: "log warning about health-service"
        API-->>User: "{ data: [], providers: [], total_providers: 0, tracked_providers: 0 }"
    end

    User->>API: "GET /health/system"
    API->>Redis: "get_system_health()"
    Redis-->>API: "cached system data"
    
    alt "Cache has data"
        API-->>User: "SystemHealthResponse with metrics"
    else "Cache empty"
        API->>Logger: "log warning about health-service"
        API-->>User: "SystemHealthResponse with zero values"
    end

    Note over HealthService,Redis: "Health-service populates Redis cache independently"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))

<!-- /greptile_comment -->