### PR TITLE
Raise burst_limit default to 100 and add fix docs

### DIFF
--- a/docs/fixes/BACKEND_ERRORS_FIX_2025-12-11.md
+++ b/docs/fixes/BACKEND_ERRORS_FIX_2025-12-11.md
@@ -46,13 +46,23 @@ The `burst_limit` configuration was incorrectly set to `10` instead of `100`.
 
 **Files Changed**: `src/db/rate_limits.py`
 
-```python
-# AFTER (src/db/rate_limits.py:411)
-"burst_limit": config.get("burst_limit", 100),  # ✅ FIXED
+**All 4 locations updated** (lines 411, 426, 479, 491):
 
-# AFTER (src/db/rate_limits.py:426)
-"burst_limit": 100,  # ✅ FIXED
+```python
+# Location 1: get_rate_limit_config() - database config (line 411)
+"burst_limit": config.get("burst_limit", 100),  # ✅ FIXED (was 10)
+
+# Location 2: get_rate_limit_config() - fallback default (line 426)
+"burst_limit": 100,  # ✅ FIXED (was 10)
+
+# Location 3: update_rate_limit_config() - UPDATE query (line 479)
+"burst_limit": config.get("burst_limit", 100),  # ✅ FIXED (was 10)
+
+# Location 4: update_rate_limit_config() - INSERT query (line 491)
+"burst_limit": config.get("burst_limit", 100),  # ✅ FIXED (was 10)
 ```
+
+**Critical**: Locations 3 & 4 were identified by Sentry AI bot as causing config updates via API to revert to the old default of 10, effectively undoing the fix. All locations must be updated to prevent regression.
 
 **Result**:
 - With `burst_limit=100`: Refill rate = 100/60 = 1.666 tokens/second

--- a/src/db/rate_limits.py
+++ b/src/db/rate_limits.py
@@ -476,7 +476,7 @@ def update_rate_limit_config(api_key: str, config: dict[str, Any]) -> bool:
                         {
                             "max_requests": config.get("requests_per_hour", 1000),
                             "max_tokens": config.get("tokens_per_hour", 1000000),
-                            "burst_limit": config.get("burst_limit", 10),
+                            "burst_limit": config.get("burst_limit", 100),
                             "concurrency_limit": config.get("concurrency_limit", 50),
                             "window_size": config.get("window_size_seconds", 60),
                             "updated_at": datetime.now(timezone.utc).isoformat(),
@@ -488,7 +488,7 @@ def update_rate_limit_config(api_key: str, config: dict[str, Any]) -> bool:
                             "api_key_id": api_key_id,
                             "max_requests": config.get("requests_per_hour", 1000),
                             "max_tokens": config.get("tokens_per_hour", 1000000),
-                            "burst_limit": config.get("burst_limit", 10),
+                            "burst_limit": config.get("burst_limit", 100),
                             "concurrency_limit": config.get("concurrency_limit", 50),
                             "window_size": config.get("window_size_seconds", 60),
                         }


### PR DESCRIPTION
## Summary
- Fix: Raise the default burst_limit from 10 to 100 in the rate limiter to resolve erroneous 429 Too Many Requests on valid requests to `/v1/chat/completions`.
- Documentation: Added a detailed fix note at `docs/fixes/BACKEND_ERRORS_FIX_2025-12-11.md` describing the issue, root cause, fix, and validation steps.

## Changes
- src/db/rate_limits.py
  - Update get_rate_limit_config to use a default burst_limit of 100 instead of 10 in both the per-api-key config and the fallback/default config:
    - `"burst_limit": config.get("burst_limit", 100)`
    - `"burst_limit": 100`
- src/db/rate_limits.py
  - update_rate_limit_config to use 100 as the default for burst_limit in both update and insert operations:
    - `"burst_limit": config.get("burst_limit", 100)`
- docs/fixes/BACKEND_ERRORS_FIX_2025-12-11.md
  - Added new documentation detailing:
    - Issue: 429 rate limit errors on valid requests
    - Root cause: Burst limiter configured with a low value (10)
    - Fix: Raised to 100 and its impact
    - Verification steps and testing plan

## Rationale
- The rate limiter relies on a burst token bucket. A burst_limit of 10 yields a refill rate of 10/60 ≈ 0.166 tokens/second, effectively capping bursts to roughly 1 every 6 seconds. This caused throttling for valid traffic and affected all new API keys starting with 0 tokens due to the fallback limiter.
- Raising burst_limit to 100 increases the refill rate to ≈1.666 tokens/second, allowing about 100 requests in bursts and reducing false positives on normal traffic.

## Verification & Testing Plan
- Confirm configuration:
  - burst_limit is now 100 by default in `get_rate_limit_config` for both existing and new API keys.
- Functional validation:
  - Simulate rapid requests to `/v1/chat/completions` with a single API key and verify that requests are not rate-limited prematurely.
  - Verify that a sequence of 50–100 concurrent or near-concurrent requests succeeds without 429s under typical traffic patterns.
- Observability:
  - Monitor logs for 429 errors before/after deploy and ensure a reduction in false positives.
  - If available, check burst token depletion metrics and refill rates to ensure realistic burst handling.

## Deployment & Impact
- No database migrations required; this is a code-only change.
- No configuration changes needed; default value updated in code.
- Immediate effect on next deployment.
- Risk is low: increases capacity for bursts and does not decrease existing protections.

## Related Issues
- 429 errors observed on `/v1/chat/completions` despite low concurrent usage
- Warnings like "Rate limit alerts table not available" (cosmetic / unrelated)

## Follow-up Actions
- [ ] Deploy fix to production
- [ ] Add integration tests for burst limiting
- [ ] Add monitoring/dashboard for burst token usage and refill rates
- [ ] Document rate limit tuning guidelines in project docs

---

**Fixed by**: Terragon AI Agent
**Date**: December 11, 2025
**Branch**: terragon/fix-backend-errors-ovaubi
**Reviews**: Pending

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

> [!NOTE]
> Increase burst_limit default from 10 to 100 in rate limiter config and add a detailed fix note to docs.
> 
> - **Backend**:
>   - Update `get_rate_limit_config` in `src/db/rate_limits.py` to use `"burst_limit": config.get("burst_limit", 100)` and fallback `"burst_limit": 100`.
> - **Docs**:
>   - Add `docs/fixes/BACKEND_ERRORS_FIX_2025-12-11.md` detailing the 429 issue, root cause, fix, and verification steps.
>
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08bd064fc401382b36eeb20b618bf91295e1074e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

📎 **Task**: https://www.terragonlabs.com/task/c8a624e9-6610-4767-b28c-f48f756c541a