### PR TITLE
fix(backend): validate session_id range and fix Redis metrics

### DIFF
--- a/src/services/redis_metrics.py
+++ b/src/services/redis_metrics.py
@@ -152,8 +152,8 @@ class RedisMetrics:
             # 7. Update health score
             await self._update_health_score_pipe(pipe, provider, success)
 
-            # Execute all operations atomically
-            await pipe.execute()
+            # Execute all operations atomically (sync operation, no await needed)
+            pipe.execute()
 
             logger.debug(
                 f"Recorded metrics: {provider}/{model} - "


### PR DESCRIPTION
## Summary
Fixes critical production errors discovered in Sentry and Railway logs from the last 24 hours:

- **Session ID Integer Overflow**: PostgreSQL integer range validation
- **Redis Metrics Error**: Remove incorrect await on synchronous pipeline execution

## Issues Fixed

### 1. Session ID Integer Overflow
**Error Log:**
```
❌ get_chat_session(session=-1765547418850, user=1) failed with non-retryable error: 
{'code': '22003', 'details': None, 'hint': None, 'message': 'value "-1765547418850" is out of range for type integer'}
```

**Root Cause:**  
- PostgreSQL `integer` type has range: -2,147,483,648 to 2,147,483,647
- Client sent session_id: -1,765,547,418,850 (beyond 32-bit integer range)
- Database rejected the value causing chat history operations to fail

**Solution:**
- Added validation before all database operations involving session_id
- Invalid session_ids are logged with warnings and ignored gracefully
- Applied to 5 locations across /v1/chat/completions and /v1/responses endpoints

### 2. Redis Metrics Await Expression Error
**Error Log:**
```
⚠️ Failed to record Redis metrics: object list can't be used in 'await' expression
```

**Root Cause:**  
- Redis client (`redis.Redis`) is synchronous, not async
- `pipe.execute()` returns a list directly, not an awaitable
- Code incorrectly used `await pipe.execute()`

**Solution:**
- Removed incorrect `await` keyword from `pipe.execute()` call in `src/services/redis_metrics.py:156`
- Added comment clarifying it's a sync operation

## Changes Made

### `src/routes/chat.py`
- Added session_id validation in 5 locations:
  1. `/v1/chat/completions` - before fetching history (line 1310)
  2. `/v1/chat/completions` - before saving history (line 2128)  
  3. `/v1/chat/completions` streaming - before saving history (line 838)
  4. `/v1/responses` - before fetching history (line 2418)
  5. `/v1/responses` - before saving history (line 3183)

### `src/services/redis_metrics.py`
- Fixed `await pipe.execute()` → `pipe.execute()` (line 156)

## Testing
- ✅ Python syntax validation passed for both files
- ✅ No breaking changes to API behavior
- ✅ Error handling improved with detailed logging

## Impact
- **Before:** Database errors crashed chat history operations
- **After:** Invalid session_ids are handled gracefully with warnings
- **Before:** Redis metrics recording failed silently  
- **After:** Metrics recording works correctly

## Related Issues
- Addresses errors found in Railway deployment logs from Dec 12, 2025
- No duplicate fixes found in recent PRs (#600, #598, #597, #595, #594)

## Checklist
- [x] Code changes follow project conventions
- [x] No breaking changes to API
- [x] Error handling improved
- [x] Detailed logging added
- [x] Files syntax-validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds PostgreSQL-range validation for session_id across chat endpoints and fixes Redis metrics by removing an incorrect await on pipeline execute.
> 
> - **Backend**:
>   - **Chat history safety (`src/routes/chat.py`)**:
>     - Validate `session_id` within PostgreSQL `integer` range before fetching or saving history in `/v1/chat/completions` (streaming and non-streaming) and `/v1/responses`.
>     - On invalid `session_id`, log warning and skip history usage/saves.
>   - **Redis metrics (`src/services/redis_metrics.py`)**:
>     - Replace `await pipe.execute()` with synchronous `pipe.execute()` in `record_request()`; clarify via comment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 314cbf99a4ed1beccb0ff549f3963e1e166a06af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

📎 **Task**: https://www.terragonlabs.com/task/d39278b9-e60f-4951-813f-2183c86bbc7e

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR addresses two critical production errors identified in the backend monitoring logs. The first fix prevents PostgreSQL integer overflow crashes by validating session_id values against PostgreSQL's 32-bit integer range (-2,147,483,648 to 2,147,483,647) before database operations. When clients send session IDs outside this range, the system now logs a warning and gracefully continues without chat history functionality instead of crashing. The second fix resolves a Redis metrics recording issue where synchronous pipeline execution was incorrectly awaited, causing "object list can't be used in 'await' expression" errors.

The session_id validation is strategically applied at five critical points across the chat completions and responses endpoints, ensuring comprehensive coverage of all database operations involving session IDs. This follows the codebase's established pattern of graceful degradation when encountering invalid data, maintaining API functionality while preventing system crashes from malformed client input.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|-------|-----------|
| src/routes/chat.py | 5/5 | Added session_id validation at 5 critical database operation points to prevent PostgreSQL integer overflow crashes |
| src/services/redis_metrics.py | 5/5 | Removed incorrect `await` keyword from synchronous Redis pipeline execution to fix metrics recording |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk as it implements defensive programming practices and fixes clear production errors
- Score reflects straightforward error handling improvements with proper logging and no breaking changes to existing API behavior  
- No files require special attention as both changes are well-targeted bug fixes with clear error handling

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API as FastAPI Router
    participant Auth as Authentication
    participant DB as Database
    participant Redis as Redis Metrics
    participant Provider as AI Provider
    participant Background as Background Tasks

    User->>API: POST /v1/chat/completions
    API->>Auth: get_optional_api_key()
    Auth-->>API: api_key (or None for anonymous)
    
    alt Authenticated User
        API->>DB: get_user(api_key)
        DB-->>API: user data
        API->>DB: validate_trial_access(api_key)
        DB-->>API: trial status
        API->>DB: enforce_plan_limits(user_id, 0, environment)
        DB-->>API: plan check result
    else Anonymous User
        API->>API: Skip user validation
    end

    alt Session ID provided and authenticated
        Note over API: Validate session_id within PostgreSQL integer range
        alt Valid session_id
            API->>DB: get_chat_session(session_id, user_id)
            DB-->>API: chat history
            API->>API: Inject history into messages
        else Invalid session_id
            API->>API: Log warning, skip history
        end
    end

    API->>Provider: make_provider_request(messages, model, options)
    Provider-->>API: response/stream

    alt Streaming Response
        API-->>User: StreamingResponse (SSE)
        API->>Background: Schedule background processing
        Note over Background: Process credits, metrics, history asynchronously
    else Non-streaming Response
        API->>API: Process response
        alt Authenticated User
            API->>DB: deduct_credits(api_key, cost)
            DB-->>API: success
        end
        API->>Redis: record_request(provider, model, metrics)
        Note over Redis: Fix: Remove incorrect await from pipe.execute()
        API-->>User: JSON Response
    end

    alt Background Processing (Streaming)
        Background->>DB: deduct_credits(api_key, cost)
        Background->>Redis: record_request(provider, model, metrics)
        alt Valid session_id and authenticated
            Background->>DB: save_chat_message(session_id, messages)
        else Invalid session_id
            Background->>Background: Skip history save with warning
        end
    end
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->