### PR TITLE
Audit and test all models; preserve OpenRouter meta-model IDs

### DIFF
--- a/tests/services/test_model_availability_comprehensive.py
+++ b/tests/services/test_model_availability_comprehensive.py
@@ -10,7 +10,6 @@ Tests cover:
 """
 
 import pytest
-from unittest.mock import patch
 from datetime import datetime, timedelta
 import os
 import time

--- a/tests/services/test_model_transformations_comprehensive.py
+++ b/tests/services/test_model_transformations_comprehensive.py
@@ -8,7 +8,6 @@ Tests cover:
 - Edge cases and error handling
 """
 
-import pytest
 from unittest.mock import patch
 import os
 

--- a/tests/services/test_provider_clients.py
+++ b/tests/services/test_provider_clients.py
@@ -285,10 +285,9 @@ class TestGoogleVertexClient:
         result = _sanitize_system_content(123)
         assert result == "123"
 
-    @patch.dict(os.environ, {}, clear=False)
+    @patch.dict(os.environ, {"GOOGLE_PROJECT_ID": "", "GOOGLE_VERTEX_LOCATION": ""}, clear=False)
     def test_prepare_vertex_environment_missing_project(self):
         """Test environment preparation fails without project ID"""
-        # Clear the relevant env vars
         with patch('src.services.google_vertex_client.Config') as mock_config:
             mock_config.GOOGLE_PROJECT_ID = None
             mock_config.GOOGLE_VERTEX_LOCATION = "us-central1"


### PR DESCRIPTION
## Summary
- Adds OpenRouter meta-model preservation in model ID transformation and expands test coverage for model availability, transformations, and provider clients.
- Preserves OpenRouter meta-model IDs (e.g., openrouter/auto, openrouter/bodybuilder) by not stripping the openrouter/ prefix for those meta-models.
- Introduces comprehensive tests across model availability, transformation logic, and provider clients to harden routing and mappings.

## Changes
### Core
- src/services/model_transformations.py
  - Define OPENROUTER_META_MODELS = {"openrouter/auto", "openrouter/bodybuilder"} to explicitly mark OpenRouter meta-models that must be preserved as full IDs.
  - Update transformation logic so that, for OpenRouter, only non-meta models have the leading "openrouter/" prefix stripped. Meta-models are preserved with their full IDs.
  - Improve logging to clearly indicate when an OpenRouter meta-model is preserved vs. when the prefix is stripped.
  - Retain existing behavior for Near prefixes and other providers to maintain backward compatibility.

### Tests
- tests/services/test_model_availability_comprehensive.py
  - Adds comprehensive tests for CircuitBreaker state transitions, AvailabilityConfig defaults/customization, ModelAvailability dataclass, ModelAvailabilityService functionality, maintenance mode management, and async monitoring lifecycle.
  - Verifies availability summary metrics, best available model selection, and OpenRouter gateway statistics.

- tests/services/test_model_transformations_comprehensive.py
  - Adds extensive tests for model alias resolution, provider detection, normalization, and various provider-specific transformation scenarios.
  - Covers OpenRouter meta-model preservation, Claude Sonnet transformations, Groq-specific mappings, Google Vertex Gemini variants, HuggingFace/mixed-case handling, Near/AIMO/Morpheus prefix stripping, and edge-case inputs.
  - Validates get_model_id_mapping across providers, and overrides for special providers.

- tests/services/test_provider_clients.py
  - Adds broad coverage for provider client modules (import integrity, default models, supported parameters, and basic client initialization/fallback paths).
  - Includes targeted tests for Cerebras, Groq, Google Vertex, HuggingFace, and a wide range of additional provider clients to ensure module imports and basic behaviors without requiring external API access.

- The tests rely on environment flags (e.g., APP_ENV and TESTING) to simulate a testing environment and avoid real external calls where appropriate.

## Rationale
- This change hardens model handling across providers by ensuring meta-models are preserved when transforming IDs, reducing potential mismatches and misrouting.
- The expanded test suites validate critical system behaviors (circuit breakers, availability, fallbacks, maintenance mode, and async monitoring) and exercise a broad matrix of model IDs and provider mappings to catch regressions early.

## Test plan
- Run the full test suite locally:
  - pytest -q
- Expected outcomes:
  - All new tests pass and provide coverage for model availability, transformations, and provider clients.
  - Transformation logic correctly preserves OpenRouter meta-models and strips only non-meta prefixes.
  - Circuit breaker transitions and availability summaries behave as designed under varied scenarios.

## Notes
- No database migrations or external service changes required for these tests.
- If any test fails due to environment-specific mappings, adjust OPENROUTER_AUTO_FALLBACKS, MODEL_PROVIDER_OVERRIDES, or related mappings accordingly to align with your deployment configurations.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---
> [!NOTE]
> Preserves OpenRouter meta-model IDs during transformation and adds comprehensive tests for model availability, transformations, and provider clients.
> 
> - **Core (model transformations)**:
>   - Preserve OpenRouter meta-model IDs (`openrouter/auto`, `openrouter/bodybuilder`) by not stripping the `openrouter/` prefix; improved logs.
> - **Tests**:
>   - **Model Availability**: Circuit breaker transitions, availability checks, fallback selection, summaries, maintenance mode, and async monitoring.
>   - **Model Transformations**: Aliases, provider detection, normalization, provider-specific mappings (Fireworks, OpenRouter, Groq, Google Vertex, HuggingFace, Near, AIMO, Morpheus), OpenRouter meta-model preservation, auto fallbacks, and edge cases.
>   - **Provider Clients**: Import integrity and basic functionality across many clients (Cerebras, Groq, Google Vertex, OpenRouter, HuggingFace, etc.); validation of defaults and helpers (e.g., pricing normalization).
+
+<!-- Task link preserved from PR context -->
+<!-- Task: https://www.terragonlabs.com/task/b1824e1b-365c-4121-b486-778ecd6c9a5a -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens tests by simulating circuit-breaker recovery without sleeping and tightening provider client expectations (Cerebras, Google Vertex), plus minor test cleanups.
> 
> - **Tests**:
>   - **Model Availability / Circuit Breaker**:
>     - Simulate recovery timeout by adjusting `last_failure_time` instead of using `time.sleep`, validating OPEN → HALF_OPEN transition.
>   - **Provider Clients**:
>     - `cerebras_client`: expect `get_cerebras_client()` to raise `ValueError` when API key missing; `_normalize_cerebras_model` now falls back to `name` when `id` is missing.
>     - `google_vertex_client`: enforce environment validation; error when `GOOGLE_PROJECT_ID` absent (with explicit empty env vars).
>   - **Model Transformations**:
>     - Minor test refinements/cleanup; assertions maintained for OpenRouter/meta-model handling and mappings.
>   - **Misc**:
>     - Remove unused imports and tighten assertions across suites.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f9faa1732ef3bf6ebe43ee03017d7018e720b64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->