### PR TITLE
fix(near): add Kimi-K2-Thinking model and support reasoning content

### DIFF
--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -581,6 +581,11 @@ def get_model_id_mapping(provider: str) -> dict[str, str]:
             "zai-org/glm-4.6": "zai-org/GLM-4.6",
             "glm-4.6-fp8": "zai-org/GLM-4.6",
             "glm-4.6": "zai-org/GLM-4.6",
+
+            # Moonshot AI Kimi models (thinking/reasoning)
+            "moonshotai/kimi-k2-thinking": "moonshotai/Kimi-K2-Thinking",
+            "kimi-k2-thinking": "moonshotai/Kimi-K2-Thinking",
+            "kimi-k2": "moonshotai/Kimi-K2-Thinking",
         },
         "alpaca-network": {
             # Alpaca Network uses Anyscale infrastructure with DeepSeek models

--- a/src/services/models.py
+++ b/src/services/models.py
@@ -1933,6 +1933,14 @@ def fetch_models_from_near():
                 "outputCostPerToken": {"amount": 2.0, "scale": -6},  # $2.00 per million tokens
                 "metadata": {"contextLength": 200000},
             },
+            {
+                "id": "moonshotai/Kimi-K2-Thinking",
+                "modelId": "moonshotai/Kimi-K2-Thinking",
+                "owned_by": "Moonshot AI",
+                "inputCostPerToken": {"amount": 0.6, "scale": -6},  # $0.60 per million tokens
+                "outputCostPerToken": {"amount": 2.4, "scale": -6},  # $2.40 per million tokens
+                "metadata": {"contextLength": 128000},
+            },
         ]
 
         normalized_models = [normalize_near_model(model) for model in fallback_models if model]


### PR DESCRIPTION
## Summary
- Adds the new `moonshotai/Kimi-K2-Thinking` model to Near AI's fallback model list
- Adds model transformation mappings for Kimi-K2 variants (case-insensitive lookup)
- Fixes `extract_message_with_tools` to handle reasoning/thinking models where `content` may be `null` but `reasoning` or `reasoning_content` fields contain the response
- Properly extracts and exposes `reasoning_content` field in API responses

## Background
Near AI added a new model (`moonshotai/Kimi-K2-Thinking`) that wasn't in our catalog. Additionally, thinking/reasoning models (like Kimi-K2-Thinking and openai/gpt-oss-120b) return responses differently - they may return `content: null` with the response in `reasoning` or `reasoning_content` fields, especially with low `max_tokens` settings.

## Test plan
- [x] Tested all 5 Near AI models via direct API calls:
  - `deepseek-ai/DeepSeek-V3.1` ✓
  - `openai/gpt-oss-120b` ✓
  - `Qwen/Qwen3-30B-A3B-Instruct-2507` ✓
  - `zai-org/GLM-4.6` ✓
  - `moonshotai/Kimi-K2-Thinking` ✓ (new)
- [x] Unit tested `extract_message_with_tools` with various message formats
- [x] Ran existing test suite (43 tests passing for near_client and models)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `moonshotai/Kimi-K2-Thinking` to Near AI and updates message extraction to surface `reasoning_content` when `content` is null.
> 
> - **Models (Near AI)**:
>   - Add `moonshotai/Kimi-K2-Thinking` to fallback catalog with pricing and context metadata.
> - **Model ID Transformations**:
>   - Map Kimi variants to `moonshotai/Kimi-K2-Thinking` (`moonshotai/kimi-k2-thinking`, `kimi-k2-thinking`, `kimi-k2`).
> - **Response Processing**:
>   - Update `extract_message_with_tools` to handle thinking models: accept `content=None`, extract `reasoning`/`reasoning_content`, and expose as `reasoning_content` in output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8b683b5cff70b945090cc1802216af3fdbbd84f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds support for Moonshot AI's new reasoning model `moonshotai/Kimi-K2-Thinking` to the Near AI provider and enhances message extraction to handle thinking/reasoning models properly. The changes introduce model ID transformations for various Kimi-K2 input formats, add the new model to Near AI's fallback catalog with appropriate pricing ($0.60/$2.40 per million input/output tokens) and context length (128K), and update the message extraction logic in `extract_message_with_tools` to surface reasoning content when the standard `content` field is null. This addresses a specific issue with thinking models that return their actual responses in `reasoning` or `reasoning_content` fields rather than the standard `content` field, ensuring API consumers receive the model's actual output instead of empty content.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|-------|----------|
| src/services/model_transformations.py | 5/5 | Adds three case-insensitive model ID mappings for Kimi-K2 variants following established patterns |
| src/services/models.py | 4/5 | Adds the new Kimi-K2-Thinking model to Near AI's fallback catalog with pricing and metadata |
| src/services/anthropic_transformer.py | 4/5 | Updates message extraction to handle reasoning models where content is null but reasoning fields contain responses |

<h3>Confidence score: 4/5</h3>


- This PR addresses a clear integration issue with new reasoning models and follows established patterns in the codebase
- Score reflects solid implementation but minor concerns about handling edge cases in message extraction logic and potential impact on existing functionality
- Pay close attention to src/services/anthropic_transformer.py for the reasoning content extraction logic and ensure thorough testing with various response formats

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API as "GatewayZ API"
    participant ModelTransform as "Model Transformations"
    participant NearClient as "Near AI Client"
    participant AnthropicTransformer as "Anthropic Transformer"
    
    User->>API: "POST /chat/completions with moonshotai/Kimi-K2-Thinking"
    API->>ModelTransform: "transform_model_id(moonshotai/Kimi-K2-Thinking, near)"
    ModelTransform->>ModelTransform: "Apply alias mapping: kimi-k2 -> moonshotai/Kimi-K2-Thinking"
    ModelTransform->>API: "Return: moonshotai/Kimi-K2-Thinking"
    API->>NearClient: "Forward request to Near AI"
    NearClient->>NearClient: "Send to https://cloud-api.near.ai/v1/chat/completions"
    NearClient-->>API: "Response with content=null, reasoning_content='thinking process'"
    API->>AnthropicTransformer: "extract_message_with_tools(choice_message)"
    AnthropicTransformer->>AnthropicTransformer: "Check content is null, extract reasoning field"
    AnthropicTransformer->>AnthropicTransformer: "Set content='' and add reasoning_content to message"
    AnthropicTransformer->>API: "Return message with reasoning_content exposed"
    API->>User: "Response with reasoning_content field for thinking models"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->