### PR TITLE
Fix health-service JSON error by correcting model_health_tracking query

### DIFF
--- a/health-service/main.py
+++ b/health-service/main.py
@@ -372,9 +372,10 @@ async def get_status():
             try:
                 from src.config.supabase_config import supabase
                 # Get tracked models count
+                # Note: model_health_tracking has composite PK (provider, model), no 'id' column
                 tracked_models_response = (
                     supabase.table("model_health_tracking")
-                    .select("id", count="exact", head=True)
+                    .select("*", count="exact", head=True)
                     .execute()
                 )
                 models_count = tracked_models_response.count or 0


### PR DESCRIPTION
## Summary
- Fix health-service JSON generation error by correcting the model_health_tracking query in get_status.

## Changes

### Health Service
- In health-service/main.py, changed the select call from `.select("id", count="exact", head=True)` to `.select("*", count="exact", head=True)` when querying `model_health_tracking`.
- Added a clarifying comment: `model_health_tracking` uses a composite PK (provider, model) and has no `id` column.

## Rationale
- Selecting the `id` column caused a JSON generation error due to the column not existing in this table. Selecting all columns (`*`) aligns with the table schema and allows correct counting of tracked models.

## Test plan
- [x] Run health-service `get_status` and verify the API returns valid JSON without errors.
- [x] Verify `models_count` is returned as an integer in the response.
- [x] Ensure behavior is correct when there are no entries in `model_health_tracking` (should be 0).


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/5f5d666b-5472-473a-a07b-465bae8441bd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes the tracked models query in intelligent monitor status by selecting `*` (no `id` column) to prevent JSON errors and return correct counts.
> 
> - **Health Service**
>   - Update `health-service/main.py` `get_status` (intelligent monitor path): change `supabase.table("model_health_tracking").select("id", ...)` to `.select("*", ...)` to match composite PK schema and enable accurate tracked model counting.
>   - Add clarifying comment noting `model_health_tracking` has no `id` column.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e615fdea1b0c885362e2c911056748f8475bbb8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR fixes a runtime JSON generation error in the health service by correcting a database query to the `model_health_tracking` table. The issue was that the original code attempted to select an "id" column from a table that uses a composite primary key (provider, model) instead of an auto-incrementing ID column. The fix changes the select statement from `.select("id", count="exact", head=True)` to `.select("*", count="exact", head=True)` and adds a clarifying comment explaining the table structure. This change allows the health service to properly count tracked models without encountering database errors when Supabase tries to generate the JSON response.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|-------|----------|
| health-service/main.py |5/5 | Fixed database query by selecting all columns instead of non-existent "id" column to prevent JSON errors |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk as it fixes a clear runtime error with a straightforward database query correction
- Score reflects a simple, well-understood fix that addresses a specific database schema mismatch with proper documentation added
- No files require special attention as this is a single-line query fix with added documentation

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant HealthService as Health Service API
    participant IntelligentMonitor as Intelligent Health Monitor
    participant Supabase as Supabase Database
    participant Redis as Redis Cache
    
    User->>HealthService: "GET /status"
    HealthService->>HealthService: "Check _active_monitor_type"
    
    alt Intelligent Monitor Active
        HealthService->>Supabase: "SELECT * FROM model_health_tracking (count=exact)"
        Note over Supabase: Fixed: Was SELECT id, now SELECT * for composite PK table
        Supabase-->>HealthService: "Return models count"
        
        HealthService->>Supabase: "SELECT provider FROM model_health_tracking (with pagination)"
        Supabase-->>HealthService: "Return provider data in batches"
        
        HealthService->>HealthService: "Calculate distinct providers count"
        
        HealthService->>HealthService: "Get gateways count from GATEWAY_CONFIG"
        
        HealthService-->>User: "Return status with models_tracked, providers_tracked, gateways_tracked"
        
    else Simple Monitor Active
        HealthService->>HealthService: "Get counts from memory (health_data, provider_data, gateway_data)"
        HealthService-->>User: "Return status with in-memory counts"
        
    else No Monitor Active
        HealthService-->>User: "Return 503 degraded status"
    end
    
    Note over HealthService,Supabase: Background: Intelligent Monitor continuously updates model_health_tracking
    IntelligentMonitor->>Supabase: "INSERT/UPDATE model_health_tracking records"
    IntelligentMonitor->>Redis: "Cache health metrics"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->