### PR TITLE
Add Clarifai model loading and caching support

### DIFF
--- a/src/cache.py
+++ b/src/cache.py
@@ -190,6 +190,13 @@ _cloudflare_workers_ai_models_cache = {
     "stale_ttl": 7200,
 }
 
+_clarifai_models_cache = {
+    "data": None,
+    "timestamp": None,
+    "ttl": 3600,  # 1 hour TTL for Clarifai catalog
+    "stale_ttl": 7200,
+}
+
 # BACKWARD COMPATIBILITY: Alias for old cache name
 # Some deployed modules may still reference the old name
 _hug_models_cache = _huggingface_models_cache
@@ -227,6 +234,7 @@ def get_models_cache(gateway: str):
         "alibaba": _alibaba_models_cache,
         "onerouter": _onerouter_models_cache,
         "cloudflare-workers-ai": _cloudflare_workers_ai_models_cache,
+        "clarifai": _clarifai_models_cache,
         "modelz": _modelz_cache,
     }
     return cache_map.get(gateway.lower())
@@ -264,6 +272,7 @@ def clear_models_cache(gateway: str):
         "alibaba": _alibaba_models_cache,
         "onerouter": _onerouter_models_cache,
         "cloudflare-workers-ai": _cloudflare_workers_ai_models_cache,
+        "clarifai": _clarifai_models_cache,
         "modelz": _modelz_cache,
     }
     cache = cache_map.get(gateway.lower())


### PR DESCRIPTION
## Summary
- Adds Clarifai model loading and caching to the gateway model catalog
- Exposes a new gateway identifier `clarifai` to fetch and serve Clarifai models alongside other providers

## Changes

### Caching
- Introduced `_clarifai_models_cache` in `src/cache.py` with:
  - data, timestamp, ttl of 3600s (1 hour), stale_ttl of 7200s
- Registered the Clarifai cache in model cache lookups:
  - `get_models_cache` and `clear_models_cache` now include the `clarifai` entry

### Clarifai integration
- Added `fetch_models_from_clarifai()` in `src/services/clarifai_client.py`
  - Uses Clarifai API key from `Config.CLARIFAI_API_KEY`
  - Calls Clarifai OpenAI-compatible models endpoint and handles response
  - Transforms Clarifai models into the internal catalog format (id, slug, name, description, context_length, architecture, pricing, provider_slug, source_gateway)
  - Caches transformed models in `_clarifai_models_cache` with TTL handling
  - Graceful error handling: logs issues and returns an empty list when API key is missing or requests fail

### Model loading / registry
- Updated `src/services/models.py` to integrate Clarifai into the catalog flow:
  - Imports `_clarifai_models_cache` and uses `fetch_models_from_clarifai` when gateway is `clarifai`
  - Registers canonical records for Clarifai results
  - Exposes Clarifai in both parallel and sequential model loading paths
  - Ensures `get_all_models_parallel` and `get_all_models_sequential` include `clarifai` alongside other providers (e.g., `google-vertex`, `cloudflare-workers-ai`)

### Configuration
- Clarifai API key is required to fetch models. If not configured, the fetch path returns an empty model list and logs a warning.

## Why
- Resolves a loading gap for platform-specific model catalogs by introducing a dedicated Clarifai integration with caching, reducing API calls and improving reliability when querying model metadata.

## Testing plan
- [x] Configure CLARIFAI_API_KEY and trigger model loading for the `clarifai` gateway; verify returned catalogs.
- [x] Validate 1-hour TTL behavior for cached Clarifai models; ensure cache refresh occurs after TTL.
- [x] Confirm graceful fallback to an empty list when API key is missing or requests fail.
- [x] Ensure canonical registry updates correctly for Clarifai models and that downstream aggregations include Clarifai models.

## Notes
- No breaking changes to existing gateways.
- Logging provides visibility into fetch outcomes and error conditions.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b67efdf6-8f11-43e4-b03c-6ad43826ef2c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `clarifai` gateway with model fetch + cache, and integrates it into parallel/sequential catalog assembly and canonical registry.
> 
> - **Caching**
>   - Add `_clarifai_models_cache` with TTL/stale TTL in `src/cache.py` and register it in `get_models_cache`/`clear_models_cache`.
> - **Clarifai integration**
>   - Implement `fetch_models_from_clarifai()` in `src/services/clarifai_client.py` (uses `CLARIFAI_API_KEY`, OpenAI-compatible models endpoint, normalizes fields, caches results, graceful error handling).
> - **Catalog assembly**
>   - In `src/services/models.py`:
>     - Include `clarifai` in gateways for `get_all_models_parallel()` and aggregation in `get_all_models_sequential()`.
>     - Wire `clarifai` branch in `get_cached_models()` with cache check, fetch, and `_register_canonical_records`.
>     - Also aggregate additional gateways in sequential list: `onerouter`, `google-vertex`, `cloudflare-workers-ai`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d23a43386c7033ec8333f19e58ff2e12a266d31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR introduces Clarifai as a new AI model provider in the Gatewayz universal inference gateway. The changes follow the established architectural pattern used for other providers by adding a complete integration stack: caching infrastructure, API client implementation, and model catalog registration. The implementation adds a `fetch_models_from_clarifai()` function that calls Clarifai's OpenAI-compatible models endpoint, transforms the response to match the internal catalog format, and caches results with a 1-hour TTL. The Clarifai provider is registered in both parallel and sequential model loading pipelines alongside existing providers like Google Vertex and Cloudflare Workers AI, ensuring it participates in the unified model discovery system that aggregates models from all supported providers.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|--------|----------|
| src/cache.py | 5/5 | Added `_clarifai_models_cache` configuration with 1-hour TTL and registered it in cache management functions |
| src/services/clarifai_client.py | 4/5 | Implemented `fetch_models_from_clarifai()` with API integration, model transformation, and caching logic |
| src/services/models.py | 4/5 | Integrated Clarifai into both parallel and sequential model loading pipelines with proper cache handling |

<h3>Confidence score: 4/5</h3>


- This PR is generally safe to merge with well-structured provider integration following established patterns
- Score reflects some concerns with hardcoded pricing data (all zeros) and generic model descriptions that may not accurately represent Clarifai's actual model capabilities and costs
- Pay close attention to the Clarifai client implementation for potential API response handling issues and consider validating the hardcoded pricing assumptions

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant FastAPI as "FastAPI Service"
    participant Cache as "Cache Layer"
    participant ClarifaiClient as "Clarifai Client"
    participant ClarifaiAPI as "Clarifai API"
    participant Registry as "Canonical Registry"

    User->>FastAPI: "Request model catalog (clarifai gateway)"
    FastAPI->>Cache: "Check _clarifai_models_cache"
    
    alt Cache is fresh (within 1-hour TTL)
        Cache->>FastAPI: "Return cached models"
        Cache->>Registry: "Register canonical records"
        FastAPI->>User: "Return cached model list"
    else Cache expired/empty
        FastAPI->>ClarifaiClient: "Call fetch_models_from_clarifai()"
        
        alt API key configured
            ClarifaiClient->>ClarifaiAPI: "GET /v2/ext/openai/v1/models"
            ClarifaiAPI->>ClarifaiClient: "Return models data"
            ClarifaiClient->>ClarifaiClient: "Transform to catalog format"
            ClarifaiClient->>Cache: "Cache models with timestamp"
            ClarifaiClient->>Registry: "Register canonical records"
            ClarifaiClient->>FastAPI: "Return transformed models"
            FastAPI->>User: "Return fresh model list"
        else No API key
            ClarifaiClient->>Cache: "Cache empty list"
            ClarifaiClient->>FastAPI: "Return empty list"
            FastAPI->>User: "Return empty model list"
        end
    end
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))

<!-- /greptile_comment -->