### PR TITLE
Fix Fireworks streaming error by normalizing output_text to text

### DIFF
--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -2419,6 +2419,13 @@ async def unified_responses(
                                 transformed_content.append(
                                     {"type": "text", "text": item.get("text", "")}
                                 )
+                            elif item.get("type") == "output_text":
+                                # Transform Responses API output_text to standard text format
+                                # This handles cases where clients send assistant messages with
+                                # output_text content type from previous response conversations
+                                transformed_content.append(
+                                    {"type": "text", "text": item.get("text", "")}
+                                )
                             elif item.get("type") == "input_image_url":
                                 transformed_content.append(
                                     {"type": "image_url", "image_url": item.get("image_url", {})}
@@ -2427,8 +2434,9 @@ async def unified_responses(
                                 # Already in correct format
                                 transformed_content.append(item)
                             else:
-                                logger.warning(f"Unknown content type: {item.get('type')}")
-                                transformed_content.append(item)
+                                logger.warning(f"Unknown content type: {item.get('type')}, skipping")
+                                # Skip unknown types instead of passing them through to avoid
+                                # provider API errors like "Unexpected content chunk type"
                         else:
                             logger.warning(f"Invalid content item (not a dict): {type(item)}")
 


### PR DESCRIPTION
## Summary
- Fix Fireworks streaming error by normalizing output_text content type to text in unified_responses
- Skip unknown content types to prevent provider API errors

## Changes
### Core Functionality
- In `src/routes/chat.py` unified_responses, transform items with type "output_text" into standard text format
- Warn and skip unknown content types instead of passing them through to the provider to avoid errors like "Unexpected content chunk type"

### Tests
- Add test `test_unified_responses_with_output_text_transformation` in `tests/routes/test_chat_comprehensive.py` to ensure `output_text` is transformed to `text` for continued conversations

### Validation
- Improves compatibility with prior Responses API content types and prevents Fireworks streaming errors

## Test plan
- [x] Run full test suite
- [x] Verify `test_unified_responses_with_output_text_transformation` passes
- [ ] Manual end-to-end verification of streaming flow

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9eba20d5-c05f-4725-9f37-39a68ab84e55

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize `output_text` to `text` in `/v1/responses` input transformation and skip unknown content types; add a test to validate behavior.
> 
> - **Backend**
>   - **`src/routes/chat.py`**: In `unified_responses`, transform content items of type `output_text` to standard `text`; log and skip unknown content types to avoid provider errors.
> - **Tests**
>   - **`tests/routes/test_chat_comprehensive.py`**: Add `test_unified_responses_with_output_text_transformation` to verify `output_text` is converted to `text` and request succeeds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfb96fedafceb38c087d676dfac23ad92ab42438. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR fixes a streaming error in the Fireworks provider by implementing content type normalization in the unified responses endpoint. The core change transforms `output_text` content types to standard `text` format and skips unknown content types instead of passing them through to providers. This addresses compatibility issues where clients send assistant messages containing `output_text` content from previous Responses API conversations, which causes "Unexpected content chunk type" errors when providers expect standard text formatting. The fix includes defensive programming by logging warnings for unknown content types rather than failing. A comprehensive test validates the transformation behavior for conversation continuation scenarios.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|--------|----------|
| `src/routes/chat.py` | 4/5 | Fixes streaming error by transforming output_text to text format in unified_responses and skipping unknown content types |
| `tests/routes/test_chat_comprehensive.py` | 5/5 | Adds test to validate output_text to text transformation for conversation continuation scenarios |

<h3>Confidence score: 4/5</h3>


- This PR is safe to merge with minimal risk as it fixes a specific streaming error and improves error handling
- Score reflects a targeted bug fix with good test coverage, though the core transformation logic could benefit from more detailed edge case handling
- Pay close attention to the content type transformation logic in src/routes/chat.py to ensure all legacy content types are properly handled

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Router as /v1/responses
    participant Validation as Input Validation
    participant Transform as Content Transform
    participant Provider as Upstream Provider
    participant Response as Response Builder

    User->>Router: "POST /v1/responses with output_text content"
    Router->>Validation: "Validate request and auth"
    Validation->>Router: "Validation passed"
    
    Router->>Transform: "Transform input messages"
    
    loop For each input message
        Transform->>Transform: "Check content type"
        alt content type is output_text
            Transform->>Transform: "Transform to standard text format"
            Note over Transform: output_text -> text
        else content type is unknown
            Transform->>Transform: "Log warning and skip item"
            Note over Transform: Prevents provider errors
        else content type is valid
            Transform->>Transform: "Keep as-is"
        end
    end
    
    Transform->>Router: "Return transformed messages"
    Router->>Provider: "Send request with normalized content"
    Provider->>Router: "Return response"
    Router->>Response: "Build unified response format"
    Response->>User: "Return successful response"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->