### PR TITLE
fix(onerouter): add provider prefix to model IDs for UI display

### DIFF
--- a/src/services/onerouter_client.py
+++ b/src/services/onerouter_client.py
@@ -221,8 +221,12 @@ def fetch_models_from_onerouter():
             # Get model name with proper fallback (handle None values)
             model_name = model.get("name") or model_id
 
+            # Build the full model ID with onerouter prefix for consistent display
+            # This ensures models are grouped under "OneRouter" in the UI
+            full_model_id = f"onerouter/{model_id}"
+
             transformed_model = {
-                "id": model_id,
+                "id": full_model_id,
                 "slug": model_id,
                 "canonical_slug": model_id,
                 "name": model_name,

--- a/tests/services/test_onerouter_client.py
+++ b/tests/services/test_onerouter_client.py
@@ -386,7 +386,9 @@ class TestFetchModelsFromOneRouter:
 
             # Verify models were returned
             assert len(models) == 2
-            assert models[0]["id"] == "gemini-2.0-flash"
+            # Model IDs should have onerouter/ prefix for proper UI grouping
+            assert models[0]["id"] == "onerouter/gemini-2.0-flash"
+            assert models[0]["slug"] == "gemini-2.0-flash"  # slug remains without prefix
             assert models[0]["context_length"] == 1048576
             assert models[0]["max_completion_tokens"] == 8192
             assert models[0]["pricing"]["prompt"] == "0.10"
@@ -394,7 +396,8 @@ class TestFetchModelsFromOneRouter:
             assert "images" in models[0]["architecture"]["input_modalities"]
             assert models[0]["architecture"]["modality"] == "text+image->text"
 
-            assert models[1]["id"] == "deepseek-v3-250324"
+            assert models[1]["id"] == "onerouter/deepseek-v3-250324"
+            assert models[1]["slug"] == "deepseek-v3-250324"  # slug remains without prefix
             assert models[1]["context_length"] == 16384
             assert models[1]["max_completion_tokens"] == 65536
             assert models[1]["pricing"]["prompt"] == "1.14"
@@ -571,7 +574,8 @@ class TestFetchModelsFromOneRouter:
 
             # Only valid model should be included
             assert len(models) == 1
-            assert models[0]["id"] == "valid-model"
+            assert models[0]["id"] == "onerouter/valid-model"
+            assert models[0]["slug"] == "valid-model"
 
     def test_fetch_models_http_error_with_caching(self):
         """Test HTTP error handling and verify cache is still updated"""


### PR DESCRIPTION
## Summary
- Add 'onerouter/' prefix to model IDs for proper grouping in UI
- The slug field retains the original invoke_name for API calls

This fix ensures OneRouter models are properly displayed and grouped under "OneRouter" in the model selector UI.

## Changes
- `src/services/onerouter_client.py`: Add `onerouter/` prefix to model IDs
- `tests/services/test_onerouter_client.py`: Update tests for new ID format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prefixes OneRouter model IDs with `onerouter/` for UI grouping while keeping `slug` unchanged, and updates tests accordingly.
> 
> - **OneRouter models**:
>   - Prefix `id` with `onerouter/` (via `full_model_id`) for consistent UI grouping; retain original `slug`/`canonical_slug`.
> - **Tests**:
>   - Update assertions to the new `id` format and verify `slug` remains unprefixed.
>   - Improve HTTP error test mocking for `HTTPStatusError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51a91e0cb5bb88aa032f10bc5d5253a0735b058a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds the 'onerouter/' prefix to OneRouter model IDs for improved UI grouping while preserving API functionality. The change ensures OneRouter models appear under the "OneRouter" provider section in the frontend model selector, enhancing user experience. The modification only affects the display `id` field - the `slug` and `canonical_slug` fields retain the original model identifiers needed for API calls to OneRouter, maintaining backward compatibility.

The change follows the established pattern used by other providers in the codebase for consistent model organization. This is a UI improvement that doesn't alter the underlying API routing logic or functionality.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|-------|----------|
| `src/services/onerouter_client.py` | 5/5 | Adds 'onerouter/' prefix to model ID field while preserving original slug for API calls |
| `tests/services/test_onerouter_client.py` | 4/5 | Updates test assertions for new model ID format and improves HTTP error mocking |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk - it's a straightforward UI improvement with no breaking changes
- Score reflects thorough testing, simple changes, and proper test coverage - the modification is isolated to display formatting while preserving API compatibility
- No files require special attention - both changes are well-implemented and properly tested

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant UI as "Model Selector UI"
    participant API as "Gatewayz API"
    participant OneRouter as "OneRouter Client"
    participant Cache as "Models Cache"
    participant OneRouterAPI as "OneRouter API"

    User->>UI: "Request model list for selector"
    UI->>API: "GET /models"
    API->>OneRouter: "fetch_models_from_onerouter()"
    
    alt Cache Miss or Expired
        OneRouter->>OneRouterAPI: "GET /api/display_models/"
        OneRouterAPI-->>OneRouter: "Return models data"
        OneRouter->>OneRouter: "Transform model data"
        Note over OneRouter: Add 'onerouter/' prefix to model IDs<br/>Keep original invoke_name as slug
        OneRouter->>Cache: "Cache transformed models"
        OneRouter-->>API: "Return prefixed models"
    else Cache Hit
        OneRouter->>Cache: "Get cached models"
        OneRouter-->>API: "Return cached models"
    end
    
    API-->>UI: "Return models with onerouter/ prefix"
    UI->>UI: "Group models by provider prefix"
    UI-->>User: "Display OneRouter models grouped under 'OneRouter' section"
    
    User->>UI: "Select onerouter/gemini-2.0-flash"
    UI->>API: "POST /chat with model: onerouter/gemini-2.0-flash"
    API->>API: "Extract slug from model ID"
    Note over API: Use slug 'gemini-2.0-flash' for API call
    API->>OneRouter: "make_onerouter_request_openai(model='gemini-2.0-flash')"
    OneRouter->>OneRouterAPI: "POST /chat/completions with model='gemini-2.0-flash'"
    OneRouterAPI-->>OneRouter: "Return completion response"
    OneRouter-->>API: "Return processed response"
    API-->>UI: "Return chat completion"
    UI-->>User: "Display AI response"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->