### PR TITLE
fix(referral): add missing fields for frontend referral stats display

### DIFF
--- a/src/services/referral.py
+++ b/src/services/referral.py
@@ -580,17 +580,25 @@ def get_referral_stats(user_id: int) -> dict[str, Any] | None:
 
             referral_details.append(
                 {
+                    "id": ref_user["id"],  # Frontend expects 'id' for React key prop
                     "user_id": ref_user["id"],
+                    "referee_id": ref_user["id"],  # Frontend normalizes to referee_id
                     "username": ref_user.get("username", "Unknown"),
                     "email": ref_user.get("email", "Unknown"),
-                    "date": ref_user.get("created_at"),  # Use 'date' for frontend compatibility
+                    "referee_email": ref_user.get("email", "Unknown"),  # Frontend expects referee_email
+                    "created_at": ref_user.get("created_at"),  # Frontend expects created_at
+                    "date": ref_user.get("created_at"),
                     "signed_up_at": ref_user.get("created_at"),
                     "status": "completed" if bonus_info else "pending",
                     "bonus_earned": bonus_info.get("bonus_earned", 0) if bonus_info else 0,
                     "bonus_date": bonus_info.get("bonus_date") if bonus_info else None,
+                    "completed_at": bonus_info.get("bonus_date") if bonus_info else None,  # Frontend expects completed_at
                     "reward": (
                         bonus_info.get("bonus_earned", 0) if bonus_info else 0
-                    ),  # Use 'reward' for frontend compatibility
+                    ),
+                    "reward_amount": (
+                        bonus_info.get("bonus_earned", 0) if bonus_info else REFERRAL_BONUS
+                    ),  # Frontend expects reward_amount, default to REFERRAL_BONUS for pending
                 }
             )
 


### PR DESCRIPTION
## Summary
- Added missing fields to referral stats API response that the frontend expects
- Fields added: `id`, `referee_id`, `referee_email`, `created_at`, `completed_at`, `reward_amount`
- This fixes new sign-ups not appearing on the /settings/referrals page

## Test plan
- [x] All existing referral tests pass
- [ ] Verify referrals page shows new sign-ups correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds frontend-expected fields to referral stats entries to enable proper display of new sign-ups and rewards.
> 
> - **Backend (referral stats)**:
>   - Update `get_referral_stats` response objects to include:
>     - `id`, `referee_id`, `referee_email`, `created_at`, `completed_at`, `reward_amount` (defaults to `REFERRAL_BONUS` when pending)
>   - Preserve existing fields (`date`, `reward`, `bonus_earned`, `bonus_date`, etc.) and harmonize values (e.g., `date`/`signed_up_at` from `created_at`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e322d110614a6f3c21ea67cb55a1c2b90229695d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Added missing fields to referral stats API response (`id`, `referee_id`, `referee_email`, `created_at`, `completed_at`, `reward_amount`) to fix frontend display issues with new sign-ups not appearing on settings page
- Preserved all existing fields for backward compatibility while adding frontend-expected field names alongside original field names
- Enhanced reward amount logic to default to `REFERRAL_BONUS` constant for pending referrals while maintaining existing bonus calculations for completed ones

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/services/referral.py | Enhanced `get_referral_stats` method to include frontend-expected fields (`id`, `referee_id`, `referee_email`, `created_at`, `completed_at`, `reward_amount`) while maintaining backward compatibility |

<h3>Confidence score: 4/5</h3>


- This PR is safe to merge with minimal risk as it only adds new response fields without changing existing logic or breaking backward compatibility
- Score reflects straightforward field additions with good backward compatibility design, though there's minor field duplication that could be cleaner
- No files require special attention as the changes are isolated to a single service method with clear intent

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API
    participant ReferralService
    participant SupabaseClient
    participant EmailService

    User->>API: "POST /signup with referral_code"
    API->>ReferralService: "track_referral_signup(code, user_id)"
    ReferralService->>SupabaseClient: "Get referrer by code"
    SupabaseClient-->>ReferralService: "Return referrer data"
    ReferralService->>SupabaseClient: "Create pending referral record"
    ReferralService->>SupabaseClient: "Set referred_by_code on user"
    ReferralService->>EmailService: "send_referral_signup_notification()"
    EmailService-->>ReferralService: "Notification sent"
    ReferralService-->>API: "Return success"
    API-->>User: "Signup complete"

    User->>API: "POST /purchase (first purchase $10+)"
    API->>ReferralService: "apply_referral_bonus(user_id, code, amount)"
    ReferralService->>SupabaseClient: "Update referral status to completed"
    ReferralService->>SupabaseClient: "Add credits to referee"
    ReferralService->>SupabaseClient: "Add credits to referrer"
    ReferralService->>EmailService: "send_referral_bonus_notification()"
    EmailService-->>ReferralService: "Notifications sent"
    ReferralService-->>API: "Return bonus data"
    API-->>User: "Purchase complete with bonus"

    User->>API: "GET /referral/stats"
    API->>ReferralService: "get_referral_stats(user_id)"
    ReferralService->>SupabaseClient: "Get user data and referral code"
    ReferralService->>SupabaseClient: "Get referred users by code"
    ReferralService->>SupabaseClient: "Get completed referrals"
    ReferralService-->>API: "Return stats with referral details"
    API-->>User: "Display referral stats"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->