### PR TITLE
refactor: add in-memory caches for usage and trial; UTC updates in tests

### DIFF
--- a/tests/db/test_api_keys.py
+++ b/tests/db/test_api_keys.py
@@ -2,7 +2,7 @@
 import sys
 import types
 import importlib
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 import pytest
 
 MODULE_PATH = "src.db.api_keys"  # <-- change if your file lives elsewhere
@@ -71,7 +71,7 @@ class _Table:
             if "id" not in r:
                 r["id"] = len(self.store[self.name]) + 1
             if "created_at" not in r:
-                r["created_at"] = datetime.now(timezone.utc).isoformat()
+                r["created_at"] = datetime.now(UTC).isoformat()
             self.store[self.name].append(r)
         return self
 
@@ -261,7 +261,7 @@ def test_create_api_key_schema_cache_error_fallback(monkeypatch, mod, fake_supab
 
 def test_get_user_api_keys_builds_fields(mod, fake_supabase):
     # load 2 keys
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     fake_supabase.table("api_keys_new").insert([
         {
             "user_id": 7,
@@ -319,7 +319,7 @@ def test_delete_api_key_new_and_legacy(mod, fake_supabase):
 
 def test_validate_api_key_prefers_api_keys_then_fallback(monkeypatch, mod, fake_supabase):
     # 1) Found in api_keys_new table and active with not-expired
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     fake_supabase.table("api_keys_new").insert({
         "id": 11,
         "user_id": 777,
@@ -436,7 +436,7 @@ def test_validate_api_key_permissions(mod, fake_supabase):
 
 
 def test_get_api_key_by_id(mod, fake_supabase):
-    exp = (datetime.now(timezone.utc) + timedelta(days=3)).isoformat()
+    exp = (datetime.now(UTC) + timedelta(days=3)).isoformat()
     fake_supabase.table("api_keys_new").insert({
         "id": 123, "user_id": 4, "key_name": "K",
         "api_key": "gw_live_K", "is_active": True, "max_requests": 100,

--- a/tests/db/test_chat_history.py
+++ b/tests/db/test_chat_history.py
@@ -1,5 +1,5 @@
 import pytest
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 
 # =========================
 # In-memory Supabase stub
@@ -173,7 +173,7 @@ def sb(monkeypatch):
     return stub
 
 def iso_now():
-    return datetime.now(timezone.utc).isoformat()
+    return datetime.now(UTC).isoformat()
 
 # =========================
 # Tests
@@ -197,7 +197,7 @@ def test_create_and_get_session_with_messages(sb):
 def test_get_user_chat_sessions_pagination_and_sort(sb):
     import src.db.chat_history as ch
     # seed sessions with different updated_at
-    base = datetime.now(timezone.utc)
+    base = datetime.now(UTC)
     for i in range(5):
         s = {
             "user_id": 2,

--- a/tests/db/test_chat_history_deduplication.py
+++ b/tests/db/test_chat_history_deduplication.py
@@ -6,7 +6,7 @@ Uses the same in-memory Supabase stub as test_chat_history.py for consistency.
 """
 
 import pytest
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 
 # =========================
 # In-memory Supabase stub (same as test_chat_history.py)
@@ -79,7 +79,7 @@ class _Insert:
                 next_id += 1
             # Ensure created_at is set if not provided
             if "created_at" not in row:
-                row["created_at"] = datetime.now(timezone.utc).isoformat()
+                row["created_at"] = datetime.now(UTC).isoformat()
             self.store[self.table].append(row)
             inserted.append(row.copy())
         return _Result(inserted)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -7,7 +7,7 @@ of API endpoints using HTTP requests.
 
 import asyncio
 import os
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from unittest.mock import AsyncMock, Mock
 
 import pytest

--- a/tests/integration/test_auth_referral_integration.py
+++ b/tests/integration/test_auth_referral_integration.py
@@ -14,7 +14,7 @@ Flow tested:
 """
 import os
 import pytest
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from unittest.mock import patch, Mock, MagicMock, call
 from fastapi.testclient import TestClient
 from fastapi import BackgroundTasks
@@ -61,7 +61,7 @@ def test_auth_users(supabase_client, test_prefix):
             "email": email,
             "credits": int(credits),  # Database expects integer, not float
             "api_key": api_key,
-            "created_at": datetime.now(timezone.utc).isoformat(),
+            "created_at": datetime.now(UTC).isoformat(),
         }
 
         # Try to add has_made_first_purchase, but don't fail if column doesn't exist

--- a/tests/integration/test_chat_history_edge_cases.py
+++ b/tests/integration/test_chat_history_edge_cases.py
@@ -14,7 +14,7 @@ Tests cover:
 
 import pytest
 import asyncio
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, UTC
 from unittest.mock import Mock, patch, AsyncMock
 from typing import List, Dict, Any
 
@@ -52,12 +52,12 @@ def mock_supabase_client():
             if isinstance(data, list):
                 for item in data:
                     item['id'] = len(self.storage[self.table_name]) + 1
-                    item['created_at'] = datetime.now(timezone.utc).isoformat()
+                    item['created_at'] = datetime.now(UTC).isoformat()
                     self.storage[self.table_name].append(item)
                 return MockResult(data=data)
             else:
                 data['id'] = len(self.storage[self.table_name]) + 1
-                data['created_at'] = datetime.now(timezone.utc).isoformat()
+                data['created_at'] = datetime.now(UTC).isoformat()
                 self.storage[self.table_name].append(data)
                 return MockResult(data=[data])
 
@@ -134,8 +134,8 @@ def sample_session(mock_supabase_client, sample_user):
         'title': 'Test Session',
         'model': 'openai/gpt-4',
         'is_active': True,
-        'created_at': datetime.now(timezone.utc).isoformat(),
-        'updated_at': datetime.now(timezone.utc).isoformat()
+        'created_at': datetime.now(UTC).isoformat(),
+        'updated_at': datetime.now(UTC).isoformat()
     }
     result = mock_supabase_client.table('chat_sessions').insert(session_data).execute()
     return result.data[0]

--- a/tests/routes/test_auth_v2.py
+++ b/tests/routes/test_auth_v2.py
@@ -9,7 +9,7 @@ This test file uses proper mocking strategies for FastAPI route testing:
 """
 
 import pytest
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 # Note: Do NOT import 'from src.main import app' here!
 # The app must be imported AFTER mocking in the fixture to ensure mocks are applied
 
@@ -194,14 +194,14 @@ def client(sb, monkeypatch):
 
     def mock_create_enhanced_user(username, email, auth_method, privy_user_id=None, credits=10):
         # Create user (let stub auto-assign ID)
-        trial_expires_at = datetime.now(timezone.utc).isoformat()
+        trial_expires_at = datetime.now(UTC).isoformat()
         user_data = {
             'username': username,
             'email': email,
             'credits': credits,
             'privy_user_id': privy_user_id,
             'auth_method': auth_method.value if hasattr(auth_method, 'value') else str(auth_method),
-            'created_at': datetime.now(timezone.utc).isoformat(),
+            'created_at': datetime.now(UTC).isoformat(),
             'subscription_status': 'trial',
             'trial_expires_at': trial_expires_at,
             'tier': 'basic',
@@ -681,7 +681,7 @@ def test_request_password_reset_user_not_found(client, sb):
 def test_reset_password_with_valid_token(client, sb):
     """Test resetting password with valid token"""
     # Create valid token
-    expires_at = datetime.now(timezone.utc).replace(hour=23, minute=59)
+    expires_at = datetime.now(UTC).replace(hour=23, minute=59)
     sb.table('password_reset_tokens').insert({
         'id': '1',
         'token': 'valid_token_123',
@@ -711,7 +711,7 @@ def test_reset_password_with_invalid_token(client, sb):
 def test_reset_password_with_expired_token(client, sb):
     """Test resetting password with expired token"""
     # Create expired token
-    expires_at = datetime.now(timezone.utc).replace(year=2020)
+    expires_at = datetime.now(UTC).replace(year=2020)
     sb.table('password_reset_tokens').insert({
         'id': '1',
         'token': 'expired_token_123',
@@ -728,7 +728,7 @@ def test_reset_password_with_expired_token(client, sb):
 
 def test_reset_password_with_used_token(client, sb):
     """Test resetting password with already used token"""
-    expires_at = datetime.now(timezone.utc).replace(hour=23, minute=59)
+    expires_at = datetime.now(UTC).replace(hour=23, minute=59)
     sb.table('password_reset_tokens').insert({
         'id': '1',
         'token': 'used_token_123',

--- a/tests/routes/test_chat_comprehensive.py
+++ b/tests/routes/test_chat_comprehensive.py
@@ -17,7 +17,7 @@ import json
 import asyncio
 from fastapi.testclient import TestClient
 from unittest.mock import MagicMock, AsyncMock, patch
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 
 import src.config.supabase_config
 import src.db.users as users_module
@@ -490,7 +490,7 @@ def client(sb, monkeypatch):
             if trial_end:
                 if isinstance(trial_end, str):
                     trial_end = datetime.fromisoformat(trial_end.replace('Z', '+00:00'))
-                is_expired = datetime.now(timezone.utc) > trial_end
+                is_expired = datetime.now(UTC) > trial_end
             else:
                 is_expired = False
 
@@ -772,7 +772,7 @@ def test_chat_completions_trial_user_success(client, sb):
         "api_key": "test-trial-key",
         "credits": 0.0,
         "is_trial": True,
-        "trial_expires_at": (datetime.now(timezone.utc) + timedelta(days=7)).isoformat()
+        "trial_expires_at": (datetime.now(UTC) + timedelta(days=7)).isoformat()
     }).execute()
 
     response = client.post(
@@ -795,7 +795,7 @@ def test_chat_completions_trial_expired(client, sb):
         "api_key": "test-expired-trial",
         "credits": 0.0,
         "is_trial": True,
-        "trial_expires_at": (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        "trial_expires_at": (datetime.now(UTC) - timedelta(days=1)).isoformat()
     }).execute()
 
     response = client.post(

--- a/tests/services/test_aimo_resilience.py
+++ b/tests/services/test_aimo_resilience.py
@@ -8,7 +8,7 @@ Tests cover:
 """
 
 import pytest
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from unittest.mock import MagicMock, patch, call
 import httpx
 
@@ -68,7 +68,7 @@ class TestAIMOStaleWhileRevalidate:
         """Fresh cache within TTL should be returned."""
         test_data = [{"id": "model-1", "name": "Test Model"}]
         _aimo_models_cache["data"] = test_data
-        _aimo_models_cache["timestamp"] = datetime.now(timezone.utc)
+        _aimo_models_cache["timestamp"] = datetime.now(UTC)
         _aimo_models_cache["ttl"] = 3600
 
         result = _fresh_cached_models(_aimo_models_cache, "aimo")
@@ -81,7 +81,7 @@ class TestAIMOStaleWhileRevalidate:
         test_data = [{"id": "model-1"}]
         _aimo_models_cache["data"] = test_data
         _aimo_models_cache["ttl"] = 0.1  # Very short TTL
-        _aimo_models_cache["timestamp"] = datetime.now(timezone.utc)
+        _aimo_models_cache["timestamp"] = datetime.now(UTC)
 
         time.sleep(0.2)  # Wait for cache to expire
 
@@ -92,7 +92,7 @@ class TestAIMOStaleWhileRevalidate:
         """Should return data within fresh TTL."""
         test_data = [{"id": "model-1"}]
         _aimo_models_cache["data"] = test_data
-        _aimo_models_cache["timestamp"] = datetime.now(timezone.utc)
+        _aimo_models_cache["timestamp"] = datetime.now(UTC)
         _aimo_models_cache["ttl"] = 3600
         _aimo_models_cache["stale_ttl"] = 7200
 
@@ -107,7 +107,7 @@ class TestAIMOStaleWhileRevalidate:
         _aimo_models_cache["data"] = test_data
         _aimo_models_cache["ttl"] = 0.1  # Very short TTL
         _aimo_models_cache["stale_ttl"] = 10.0  # Long stale TTL
-        _aimo_models_cache["timestamp"] = datetime.now(timezone.utc)
+        _aimo_models_cache["timestamp"] = datetime.now(UTC)
 
         time.sleep(0.2)  # Expire fresh cache but within stale window
 
@@ -122,7 +122,7 @@ class TestAIMOStaleWhileRevalidate:
         _aimo_models_cache["data"] = test_data
         _aimo_models_cache["ttl"] = 0.1
         _aimo_models_cache["stale_ttl"] = 0.2
-        _aimo_models_cache["timestamp"] = datetime.now(timezone.utc)
+        _aimo_models_cache["timestamp"] = datetime.now(UTC)
 
         time.sleep(0.3)  # Wait for both to expire
 
@@ -222,7 +222,7 @@ class TestAIMORetryLogic:
         # Set up stale cached data
         stale_data = [{"id": "stale-model-1"}]
         _aimo_models_cache["data"] = stale_data
-        _aimo_models_cache["timestamp"] = datetime.now(timezone.utc)
+        _aimo_models_cache["timestamp"] = datetime.now(UTC)
         _aimo_models_cache["ttl"] = 1
         _aimo_models_cache["stale_ttl"] = 100000
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -8,7 +8,7 @@ Tests cover all cache management functions including:
 """
 
 import pytest
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from unittest.mock import patch, MagicMock
 import src.cache as cache_module
 
@@ -146,7 +146,7 @@ class TestClearModelsCacheFunction:
         """Test clearing OpenRouter cache"""
         # Set up cache with data
         cache_module._models_cache["data"] = {"model": "data"}
-        cache_module._models_cache["timestamp"] = datetime.now(timezone.utc)
+        cache_module._models_cache["timestamp"] = datetime.now(UTC)
 
         # Clear cache
         cache_module.clear_models_cache("openrouter")
@@ -159,7 +159,7 @@ class TestClearModelsCacheFunction:
     def test_clear_models_cache_case_insensitive(self):
         """Test cache clearing is case insensitive"""
         cache_module._models_cache["data"] = {"test": "data"}
-        cache_module._models_cache["timestamp"] = datetime.now(timezone.utc)
+        cache_module._models_cache["timestamp"] = datetime.now(UTC)
 
         cache_module.clear_models_cache("OPENROUTER")
 
@@ -183,7 +183,7 @@ class TestClearModelsCacheFunction:
             cache = cache_module.get_models_cache(gateway)
             if cache:
                 cache["data"] = {"test": "data"}
-                cache["timestamp"] = datetime.now(timezone.utc)
+                cache["timestamp"] = datetime.now(UTC)
 
         # Clear all
         for gateway in gateways:
@@ -204,7 +204,7 @@ class TestClearProvidersCacheFunction:
         """Test clearing providers cache"""
         # Set up cache
         cache_module._provider_cache["data"] = {"providers": ["openrouter"]}
-        cache_module._provider_cache["timestamp"] = datetime.now(timezone.utc)
+        cache_module._provider_cache["timestamp"] = datetime.now(UTC)
 
         # Clear cache
         cache_module.clear_providers_cache()
@@ -239,7 +239,7 @@ class TestModelzCacheFunctions:
     def test_clear_modelz_cache(self):
         """Test clearing Modelz cache"""
         cache_module._modelz_cache["data"] = {"token": "data"}
-        cache_module._modelz_cache["timestamp"] = datetime.now(timezone.utc)
+        cache_module._modelz_cache["timestamp"] = datetime.now(UTC)
 
         cache_module.clear_modelz_cache()
 
@@ -254,7 +254,7 @@ class TestCacheFreshness:
         """Test cache is fresh when within TTL"""
         cache = {
             "data": {"model": "test"},
-            "timestamp": datetime.now(timezone.utc),
+            "timestamp": datetime.now(UTC),
             "ttl": 3600,
             "stale_ttl": 7200
         }
@@ -264,7 +264,7 @@ class TestCacheFreshness:
     def test_cache_not_fresh_expired(self):
         """Test cache is not fresh when TTL exceeded"""
         # Set timestamp to 2 hours ago
-        old_time = datetime.now(timezone.utc) - timedelta(hours=2)
+        old_time = datetime.now(UTC) - timedelta(hours=2)
         cache = {
             "data": {"model": "test"},
             "timestamp": old_time,
@@ -282,7 +282,7 @@ class TestCacheFreshness:
         """
         cache = {
             "data": None,
-            "timestamp": datetime.now(timezone.utc),
+            "timestamp": datetime.now(UTC),
             "ttl": 3600,
             "stale_ttl": 7200
         }
@@ -293,7 +293,7 @@ class TestCacheFreshness:
         """Test cache is fresh when data is empty list [] (valid cached value)"""
         cache = {
             "data": [],
-            "timestamp": datetime.now(timezone.utc),
+            "timestamp": datetime.now(UTC),
             "ttl": 3600,
             "stale_ttl": 7200
         }
@@ -315,7 +315,7 @@ class TestCacheFreshness:
         """Test cache with empty dict is still fresh if timestamp valid"""
         cache = {
             "data": {},
-            "timestamp": datetime.now(timezone.utc),
+            "timestamp": datetime.now(UTC),
             "ttl": 3600,
             "stale_ttl": 7200
         }
@@ -327,7 +327,7 @@ class TestCacheFreshness:
         """Test cache freshness with custom TTL value"""
         cache = {
             "data": {"model": "test"},
-            "timestamp": datetime.now(timezone.utc),
+            "timestamp": datetime.now(UTC),
             "ttl": 600,  # 10 minutes
             "stale_ttl": 1200
         }
@@ -337,7 +337,7 @@ class TestCacheFreshness:
     def test_cache_freshness_boundary_condition(self):
         """Test cache at TTL boundary (just expired)"""
         # Set timestamp to exactly TTL seconds ago + 1 second
-        old_time = datetime.now(timezone.utc) - timedelta(seconds=3601)
+        old_time = datetime.now(UTC) - timedelta(seconds=3601)
         cache = {
             "data": {"model": "test"},
             "timestamp": old_time,
@@ -354,7 +354,7 @@ class TestCacheStaleness:
     def test_cache_stale_but_usable(self):
         """Test cache is usable in stale window"""
         # Set timestamp to 90 minutes ago (between TTL and stale_ttl)
-        old_time = datetime.now(timezone.utc) - timedelta(minutes=90)
+        old_time = datetime.now(UTC) - timedelta(minutes=90)
         cache = {
             "data": {"model": "test"},
             "timestamp": old_time,
@@ -368,7 +368,7 @@ class TestCacheStaleness:
         """Test fresh cache is not considered stale"""
         cache = {
             "data": {"model": "test"},
-            "timestamp": datetime.now(timezone.utc),
+            "timestamp": datetime.now(UTC),
             "ttl": 3600,
             "stale_ttl": 7200
         }
@@ -378,7 +378,7 @@ class TestCacheStaleness:
     def test_cache_expired_beyond_stale_window(self):
         """Test cache beyond stale window is not usable"""
         # Set timestamp to 3 hours ago (beyond stale_ttl)
-        old_time = datetime.now(timezone.utc) - timedelta(hours=3)
+        old_time = datetime.now(UTC) - timedelta(hours=3)
         cache = {
             "data": {"model": "test"},
             "timestamp": old_time,
@@ -396,7 +396,7 @@ class TestCacheStaleness:
         """
         cache = {
             "data": None,
-            "timestamp": datetime.now(timezone.utc),
+            "timestamp": datetime.now(UTC),
             "ttl": 3600,
             "stale_ttl": 7200
         }
@@ -407,7 +407,7 @@ class TestCacheStaleness:
     def test_cache_stale_with_empty_list(self):
         """Test stale check with empty list [] (valid cached value)"""
         # Set timestamp to 90 minutes ago (between TTL and stale_ttl)
-        old_time = datetime.now(timezone.utc) - timedelta(minutes=90)
+        old_time = datetime.now(UTC) - timedelta(minutes=90)
         cache = {
             "data": [],
             "timestamp": old_time,
@@ -431,7 +431,7 @@ class TestCacheStaleness:
     def test_cache_stale_custom_ttl(self):
         """Test stale window with custom TTL"""
         # 35 minutes ago with 30 min TTL and 60 min stale (stale but usable)
-        old_time = datetime.now(timezone.utc) - timedelta(minutes=35)
+        old_time = datetime.now(UTC) - timedelta(minutes=35)
         cache = {
             "data": {"model": "test"},
             "timestamp": old_time,
@@ -444,7 +444,7 @@ class TestCacheStaleness:
     def test_cache_stale_boundary_ttl(self):
         """Test at TTL boundary (just became stale)"""
         # Set timestamp to exactly TTL seconds ago
-        old_time = datetime.now(timezone.utc) - timedelta(seconds=3600)
+        old_time = datetime.now(UTC) - timedelta(seconds=3600)
         cache = {
             "data": {"model": "test"},
             "timestamp": old_time,
@@ -457,7 +457,7 @@ class TestCacheStaleness:
     def test_cache_stale_boundary_stale_ttl(self):
         """Test at stale_ttl boundary (just expired from stale window)"""
         # Set timestamp to exactly stale_ttl seconds ago
-        old_time = datetime.now(timezone.utc) - timedelta(seconds=7200)
+        old_time = datetime.now(UTC) - timedelta(seconds=7200)
         cache = {
             "data": {"model": "test"},
             "timestamp": old_time,
@@ -474,7 +474,7 @@ class TestShouldRevalidateInBackground:
     def test_should_revalidate_stale_but_usable(self):
         """Test revalidation needed for stale but usable cache"""
         # Set timestamp to 90 minutes ago
-        old_time = datetime.now(timezone.utc) - timedelta(minutes=90)
+        old_time = datetime.now(UTC) - timedelta(minutes=90)
         cache = {
             "data": {"model": "test"},
             "timestamp": old_time,
@@ -488,7 +488,7 @@ class TestShouldRevalidateInBackground:
         """Test no revalidation needed for fresh cache"""
         cache = {
             "data": {"model": "test"},
-            "timestamp": datetime.now(timezone.utc),
+            "timestamp": datetime.now(UTC),
             "ttl": 3600,
             "stale_ttl": 7200
         }
@@ -497,7 +497,7 @@ class TestShouldRevalidateInBackground:
 
     def test_should_not_revalidate_expired_cache(self):
         """Test no revalidation for cache beyond stale window"""
-        old_time = datetime.now(timezone.utc) - timedelta(hours=3)
+        old_time = datetime.now(UTC) - timedelta(hours=3)
         cache = {
             "data": {"model": "test"},
             "timestamp": old_time,
@@ -521,7 +521,7 @@ class TestShouldRevalidateInBackground:
     def test_should_revalidate_logic_combination(self):
         """Test revalidation logic (not fresh AND stale usable)"""
         # Just past TTL but within stale window
-        old_time = datetime.now(timezone.utc) - timedelta(minutes=65)
+        old_time = datetime.now(UTC) - timedelta(minutes=65)
         cache = {
             "data": {"model": "test"},
             "timestamp": old_time,
@@ -611,9 +611,9 @@ class TestInitializeFalCache:
         cache_module._fal_models_cache["data"] = None
         cache_module._fal_models_cache["timestamp"] = None
 
-        before = datetime.now(timezone.utc)
+        before = datetime.now(UTC)
         cache_module.initialize_fal_cache_from_catalog()
-        after = datetime.now(timezone.utc)
+        after = datetime.now(UTC)
 
         timestamp = cache_module._fal_models_cache["timestamp"]
         assert timestamp is not None
@@ -631,7 +631,7 @@ class TestCacheIntegration:
 
         # Populate
         cache_module._models_cache["data"] = [{"id": "model1"}]
-        cache_module._models_cache["timestamp"] = datetime.now(timezone.utc)
+        cache_module._models_cache["timestamp"] = datetime.now(UTC)
 
         # Check fresh
         assert cache_module.is_cache_fresh(cache_module._models_cache) is True
@@ -647,10 +647,10 @@ class TestCacheIntegration:
         """Test that clearing one gateway doesn't affect others"""
         # Populate both caches
         cache_module._models_cache["data"] = ["openrouter_model"]
-        cache_module._models_cache["timestamp"] = datetime.now(timezone.utc)
+        cache_module._models_cache["timestamp"] = datetime.now(UTC)
 
         cache_module._featherless_models_cache["data"] = ["featherless_model"]
-        cache_module._featherless_models_cache["timestamp"] = datetime.now(timezone.utc)
+        cache_module._featherless_models_cache["timestamp"] = datetime.now(UTC)
 
         # Clear only openrouter
         cache_module.clear_models_cache("openrouter")
@@ -674,18 +674,18 @@ class TestCacheIntegration:
         }
 
         # Fresh state
-        cache["timestamp"] = datetime.now(timezone.utc)
+        cache["timestamp"] = datetime.now(UTC)
         assert cache_module.is_cache_fresh(cache) is True
         assert cache_module.is_cache_stale_but_usable(cache) is False
 
         # Stale but usable state
-        cache["timestamp"] = datetime.now(timezone.utc) - timedelta(minutes=90)
+        cache["timestamp"] = datetime.now(UTC) - timedelta(minutes=90)
         assert cache_module.is_cache_fresh(cache) is False
         assert cache_module.is_cache_stale_but_usable(cache) is True
         assert cache_module.should_revalidate_in_background(cache) is True
 
         # Expired state
-        cache["timestamp"] = datetime.now(timezone.utc) - timedelta(hours=3)
+        cache["timestamp"] = datetime.now(UTC) - timedelta(hours=3)
         assert cache_module.is_cache_fresh(cache) is False
         assert cache_module.is_cache_stale_but_usable(cache) is False
         assert cache_module.should_revalidate_in_background(cache) is False
@@ -694,14 +694,14 @@ class TestCacheIntegration:
         """Test caches with different TTL configurations"""
         short_ttl_cache = {
             "data": {"test": "data"},
-            "timestamp": datetime.now(timezone.utc) - timedelta(minutes=16),
+            "timestamp": datetime.now(UTC) - timedelta(minutes=16),
             "ttl": 900,  # 15 minutes
             "stale_ttl": 1800
         }
 
         long_ttl_cache = {
             "data": {"test": "data"},
-            "timestamp": datetime.now(timezone.utc) - timedelta(minutes=16),
+            "timestamp": datetime.now(UTC) - timedelta(minutes=16),
             "ttl": 3600,  # 1 hour
             "stale_ttl": 7200
         }


### PR DESCRIPTION
## Summary
- Adds in-memory caches for usage data and trial validation to reduce database queries
- Introduces cache management helpers (clear, invalidate, stats)
- Updates tests to consistently use UTC (replacing timezone imports)
- Adds unit tests for streaming endpoint (tests/routes/test_stream_generator.py)
- Improves startup sequence to initialize Google Vertex AI models in background
- Refines referral background logging behavior

## Changes
- Implemented usage cache in src/db/plans.py (TTL, cache utils, and cached access)
- Implemented trial validation cache in src/services/trial_validation.py (TTL, cache utils, and cached access)
- Background initialization for Google Vertex AI models in src/services/startup.py
- Logging tweaks for referral background in src/routes/auth.py
- Tests updated to UTC across multiple test suites:
  - tests/db/test_api_keys.py
  - tests/db/test_chat_history.py
  - tests/db/test_chat_history_deduplication.py
  - tests/e2e/conftest.py
  - tests/integration/test_auth_referral_integration.py
  - tests/integration/test_chat_history_edge_cases.py
  - tests/routes/test_auth_v2.py
  - tests/routes/test_chat_comprehensive.py
  - tests/services/test_aimo_resilience.py
  - tests/test_cache.py
  - tests/db/test_plans.py (new tests for usage cache)
  - tests/services/test_trial_validation.py (cache tests)
- Added new test file: tests/routes/test_stream_generator.py (unit tests for stream_generator)

## Files Modified
- src/db/plans.py
- src/routes/auth.py
- src/services/startup.py
- src/services/trial_validation.py
- tests/db/test_api_keys.py
- tests/db/test_chat_history.py
- tests/db/test_chat_history_deduplication.py
- tests/db/test_plans.py
- tests/e2e/conftest.py
- tests/integration/test_auth_referral_integration.py
- tests/integration/test_chat_history_edge_cases.py
- tests/routes/test_auth_v2.py
- tests/routes/test_chat_comprehensive.py
- tests/routes/test_stream_generator.py
- tests/services/test_aimo_resilience.py
- tests/services/test_trial_validation.py
- tests/test_cache.py

## Testing
- The changes primarily impact internal caching layers and UTC handling. Existing tests were updated to UTC where they referenced timezone.utc, and new tests cover the new caching behavior and stream generation. Please run the full test suite to validate that all tests pass in your environment.

## Related
- Addresses performance and reliability improvements by introducing in-memory caches and more robust test-time handling. Task: https://www.terragonlabs.com/task/de7b9fda-21c5-4300-b037-8e5f36f673c9
