### PR TITLE
fix: address PR #650 review comments for datetime and sync script

### DIFF
--- a/tests/integration/test_e2e_coupon.py
+++ b/tests/integration/test_e2e_coupon.py
@@ -174,7 +174,7 @@ class TestCouponAdminEndpoints:
     def test_create_global_coupon(self, client, admin_api_key, test_prefix, cleanup_coupons):
         """Test creating a global promotional coupon"""
         code = f"GLOBAL{test_prefix}"
-        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat() + "Z"
+        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
 
         response = client.post(
             "/admin/coupons",
@@ -207,7 +207,7 @@ class TestCouponAdminEndpoints:
         """Test creating a user-specific coupon"""
         user = test_api_keys(credits=50.0, username_suffix="coupon_user")
         code = f"USER{test_prefix}"
-        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat() + "Z"
+        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
 
         response = client.post(
             "/admin/coupons",
@@ -237,7 +237,7 @@ class TestCouponAdminEndpoints:
     def test_create_coupon_invalid_negative_value(self, client, admin_api_key, test_prefix):
         """Test that negative coupon values are rejected"""
         code = f"INVALID{test_prefix}"
-        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat() + "Z"
+        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
 
         response = client.post(
             "/admin/coupons",
@@ -257,7 +257,7 @@ class TestCouponAdminEndpoints:
     def test_create_user_specific_without_assigned_user(self, client, admin_api_key, test_prefix):
         """Test that user-specific coupons require assigned_to_user_id"""
         code = f"INVALID{test_prefix}"
-        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat() + "Z"
+        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
 
         response = client.post(
             "/admin/coupons",
@@ -278,7 +278,7 @@ class TestCouponAdminEndpoints:
         """Test listing all coupons"""
         # Create a coupon first
         code = f"LIST{test_prefix}"
-        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat() + "Z"
+        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
 
         create_response = client.post(
             "/admin/coupons",
@@ -330,7 +330,7 @@ class TestCouponAdminEndpoints:
         """Test getting a specific coupon by ID"""
         # Create a coupon
         code = f"GETID{test_prefix}"
-        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat() + "Z"
+        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
 
         create_response = client.post(
             "/admin/coupons",
@@ -374,7 +374,7 @@ class TestCouponAdminEndpoints:
         """Test updating coupon fields"""
         # Create a coupon
         code = f"UPDATE{test_prefix}"
-        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat() + "Z"
+        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
 
         create_response = client.post(
             "/admin/coupons",
@@ -409,7 +409,7 @@ class TestCouponAdminEndpoints:
         """Test deactivating a coupon"""
         # Create a coupon
         code = f"DEACT{test_prefix}"
-        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat() + "Z"
+        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
 
         create_response = client.post(
             "/admin/coupons",
@@ -456,7 +456,7 @@ class TestCouponUserEndpoints:
 
         # Create a global coupon
         global_code = f"AVAIL{test_prefix}"
-        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat() + "Z"
+        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
 
         global_response = client.post(
             "/admin/coupons",
@@ -517,7 +517,7 @@ class TestCouponUserEndpoints:
 
         # Create a global coupon
         code = f"REDEEM{test_prefix}"
-        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat() + "Z"
+        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
 
         create_response = client.post(
             "/admin/coupons",
@@ -555,7 +555,7 @@ class TestCouponUserEndpoints:
 
         # Create a user-specific coupon
         code = f"SPECIFIC{test_prefix}"
-        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat() + "Z"
+        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
 
         create_response = client.post(
             "/admin/coupons",
@@ -592,7 +592,7 @@ class TestCouponUserEndpoints:
 
         # Create a global coupon
         code = f"TWICE{test_prefix}"
-        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat() + "Z"
+        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
 
         create_response = client.post(
             "/admin/coupons",
@@ -653,7 +653,7 @@ class TestCouponUserEndpoints:
 
         # Create an expired coupon
         code = f"EXPIRED{test_prefix}"
-        expired_date = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat() + "Z"
+        expired_date = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
 
         create_response = client.post(
             "/admin/coupons",
@@ -687,7 +687,7 @@ class TestCouponUserEndpoints:
 
         # Create a coupon
         code = f"DEACTIVATE{test_prefix}"
-        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat() + "Z"
+        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
 
         create_response = client.post(
             "/admin/coupons",
@@ -729,7 +729,7 @@ class TestCouponUserEndpoints:
 
         # Create and redeem a coupon
         code = f"HISTORY{test_prefix}"
-        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat() + "Z"
+        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
 
         create_response = client.post(
             "/admin/coupons",
@@ -792,7 +792,7 @@ class TestCouponAnalytics:
 
         # Create a coupon
         code = f"ANALYTICS{test_prefix}"
-        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat() + "Z"
+        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
 
         create_response = client.post(
             "/admin/coupons",
@@ -864,7 +864,7 @@ class TestCouponEdgeCases:
     def test_create_coupon_without_admin_key(self, client, test_prefix):
         """Test that creating coupons requires admin API key"""
         code = f"NOAUTH{test_prefix}"
-        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat() + "Z"
+        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
 
         response = client.post(
             "/admin/coupons",
@@ -899,7 +899,7 @@ class TestCouponEdgeCases:
 
         # Create coupon for user1
         code = f"USER1ONLY{test_prefix}"
-        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat() + "Z"
+        valid_until = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
 
         create_response = client.post(
             "/admin/coupons",

--- a/tests/security/test_db_security.py
+++ b/tests/security/test_db_security.py
@@ -472,7 +472,7 @@ class TestValidateSecureAPIKey:
         mock_get_audit.return_value = mock_audit_logger
 
         # Set expiration to past date
-        past_date = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat() + '+00:00'
+        past_date = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
         sample_api_key_data['expiration_date'] = past_date
 
         table_mock.execute.return_value = Mock(data=[sample_api_key_data])


### PR DESCRIPTION
## Summary

This PR addresses the review comments from PR #650 that were identified after the initial PR was merged.

## Issues Fixed

### 1. scripts/sync-superpowers.sh - Absolute Paths
**Problem**: Script used relative paths which would break when run outside project root.

**Fix**: 
- Added `SCRIPT_DIR` and `PROJECT_ROOT` computation
- All paths now use absolute paths
- Script works correctly from any directory

### 2. scripts/sync-superpowers.sh - Dynamic Branch Detection
**Problem**: Hardcoded `origin main` incompatible with repos using 'master' or other branch names.

**Fix**:
- Added dynamic branch detection via `git symbolic-ref refs/remotes/origin/HEAD`
- Falls back to "main" if detection fails
- Compatible with any default branch name

### 3. scripts/sync-superpowers.sh - Missing Exclusion
**Problem**: `settings.local.json` was not excluded, causing local settings to be deleted.

**Fix**:
- Added `--exclude='settings.local.json'` to rsync command
- Local Claude Code settings preserved during sync

### 4. Duplicate Timezone Suffixes
**Problem**: `datetime.now(timezone.utc).isoformat()` already includes `+00:00`, but code was appending `+ "Z"` or `+ '+00:00'`, creating malformed timestamps.

**Fix**:
- Removed all redundant timezone suffix concatenations
- Fixed 18 occurrences in `test_e2e_coupon.py`
- Fixed 1 occurrence in `test_db_security.py`

## Changes

```
Files Modified: 3
Lines Changed: +29, -23

scripts/sync-superpowers.sh:
  - Added absolute path resolution
  - Dynamic default branch detection
  - settings.local.json exclusion

tests/integration/test_e2e_coupon.py:
  - Removed 18 duplicate timezone suffixes

tests/security/test_db_security.py:
  - Removed 1 duplicate timezone suffix
```

## Testing

✅ All datetime operations produce proper ISO 8601 timestamps
✅ Sync script works from any directory
✅ Sync script preserves local settings
✅ Compatible with different default branch names

## Related

Addresses review comments: https://github.com/Alpaca-Network/gatewayz-backend/pull/650#pullrequestreview-3598764997

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>