### PR TITLE
fix(backend): handle None response in intelligent health monitor

### DIFF
--- a/src/services/intelligent_health_monitor.py
+++ b/src/services/intelligent_health_monitor.py
@@ -462,6 +462,14 @@ class IntelligentHealthMonitor:
                 .execute()
             )
 
+            # Handle case where response is None (e.g., Supabase client not initialized)
+            if current is None:
+                logger.warning(
+                    f"Supabase query returned None for health tracking on {result.model}. "
+                    "Skipping health result processing."
+                )
+                return
+
             current_data = current.data if current.data else {}
 
             # Calculate new values
@@ -608,6 +616,14 @@ class IntelligentHealthMonitor:
                 .maybe_single()
                 .execute()
             )
+
+            # Handle case where response is None (e.g., Supabase client not initialized)
+            if active is None:
+                logger.warning(
+                    f"Supabase query returned None for incident check on {result.model}. "
+                    "Skipping incident creation/update."
+                )
+                return
 
             if active.data:
                 # Update existing incident


### PR DESCRIPTION
## Summary
- Fixes AttributeError: 'NoneType' object has no attribute 'data' that occurred when Supabase queries returned None
- Adds null checks before accessing `.data` in `_create_or_update_incident` and `_process_health_check_result`
- Logs warning when None responses are encountered to aid debugging

## Test plan
- [x] Added unit tests for `_create_or_update_incident` handling None response
- [x] Added unit tests for `_process_health_check_result` handling None response
- [x] All 24 tests in `test_intelligent_health_monitor.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add None-response checks with warnings in `_process_health_check_result` and `_create_or_update_incident`, plus tests ensuring graceful handling.
> 
> - **Backend**:
>   - Add None-response guards after Supabase `maybe_single().execute()` in `src/services/intelligent_health_monitor.py`:
>     - `_process_health_check_result`: skip processing and log warning if query returns `None`.
>     - `_create_or_update_incident`: skip incident create/update and log warning if query returns `None`.
> - **Tests**:
>   - Add unit tests in `tests/test_intelligent_health_monitor.py` to verify warnings and no exceptions when Supabase returns `None` for both methods.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b930d330494d0d7ce6b5396c5239e628314d421. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Fixes critical production crash by adding null checks to prevent AttributeError when Supabase queries return None in `src/services/intelligent_health_monitor.py`
- Adds comprehensive unit tests in `tests/test_intelligent_health_monitor.py` to verify graceful handling of None responses with proper warning logging

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/services/intelligent_health_monitor.py | Adds null checks in `_create_or_update_incident` and `_process_health_check_result` to prevent crashes when Supabase returns None |
| tests/test_intelligent_health_monitor.py | Adds new test cases to verify proper None response handling with warning logs |

<h3>Confidence score: 4/5</h3>


- This PR is safe to merge with minimal risk as it implements defensive programming for a production crash
- Score reflects the narrow scope of the fix and comprehensive test coverage, though the root cause of why Supabase returns None is not addressed  
- Pay close attention to the intelligent health monitor service as this is a critical system component monitoring 10,000+ AI models

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Monitor as "IntelligentHealthMonitor"
    participant Supabase as "Supabase Database"
    participant Redis as "Redis Cache"
    participant Gateway as "Model Gateway"
    
    Monitor->>Monitor: "start_monitoring()"
    Monitor->>Monitor: "Start background monitoring loop"
    
    loop "Every 30 seconds"
        Monitor->>Supabase: "Get models due for checking"
        Supabase-->>Monitor: "Return models list"
        
        alt "Models found"
            loop "For each batch of models"
                Monitor->>Redis: "Acquire lock for model"
                Redis-->>Monitor: "Lock acquired"
                
                Monitor->>Gateway: "Send health check request"
                Gateway-->>Monitor: "Return response"
                
                Monitor->>Monitor: "Process health result"
                Monitor->>Supabase: "Update health tracking"
                Monitor->>Supabase: "Insert health history"
                
                alt "Health check failed"
                    Monitor->>Supabase: "Create/update incident"
                else "Health check succeeded"
                    Monitor->>Supabase: "Resolve incidents"
                end
            end
            
            Monitor->>Redis: "Publish health data to cache"
        else "No models to check"
            Monitor->>Redis: "Publish cached health data"
        end
    end
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->