### PR TITLE
fix(cloudflare): handle non-dict items in API model response

### DIFF
--- a/src/services/cloudflare_workers_ai_client.py
+++ b/src/services/cloudflare_workers_ai_client.py
@@ -481,6 +481,14 @@ async def fetch_models_from_cloudflare_api() -> list[dict[str, Any]]:
                     break
 
                 for model in result:
+                    # Skip any items that are not dictionaries (API response format may vary)
+                    if not isinstance(model, dict):
+                        logger.warning(
+                            "Skipping non-dict model entry in Cloudflare API response: %r",
+                            type(model).__name__,
+                        )
+                        continue
+
                     # Convert Cloudflare model format to our standard format
                     model_id = model.get("name", "")
                     if not model_id:


### PR DESCRIPTION
## Summary
- Fixes the `'list' object has no attribute 'get'` error occurring on `/v1/models/popular` endpoint
- Adds type checking in `fetch_models_from_cloudflare_api()` to skip non-dict items in the API response's result array
- Logs warnings when encountering unexpected item types for debugging

## Root Cause
The Cloudflare Workers AI API's `/accounts/{account_id}/ai/models/search` endpoint was returning items in the `result` array that were not dictionaries (e.g., lists, strings, None). When iterating over these items and calling `.get()`, it raised `AttributeError: 'list' object has no attribute 'get'`.

## Fix
Added `isinstance(model, dict)` check before processing each item in the result array. Non-dict items are now skipped with a warning log for visibility.

## Test plan
- [ ] New unit test `test_fetch_models_with_non_dict_items_in_result` covers mixed-type result arrays
- [ ] Existing tests still pass
- [ ] Verify `/v1/models/popular` endpoint no longer throws errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skip non-dict items in Cloudflare models API response during parsing and add a unit test covering mixed-type results.
> 
> - **Cloudflare Workers AI client**:
>   - In `fetch_models_from_cloudflare_api` (`src/services/cloudflare_workers_ai_client.py`), skip non-dict entries in the API `result` array and log a warning to avoid attribute errors when parsing models.
> - **Tests**:
>   - Add `test_fetch_models_with_non_dict_items_in_result` verifying mixed-type `result` arrays only yield valid dict-based models.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b5e709763d7f5cb621c3b7e4b56b4c70a3d2281. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Fixes AttributeError crash in `/v1/models/popular` endpoint by adding type checking to handle non-dict items in Cloudflare Workers AI API responses
- Adds defensive programming with `isinstance(model, dict)` check in `fetch_models_from_cloudflare_api()` to skip invalid response items and log warnings
- Includes comprehensive unit test `test_fetch_models_with_non_dict_items_in_result` that validates handling of mixed-type result arrays from the external API

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/services/cloudflare_workers_ai_client.py | Fixed runtime error by adding type validation before calling `.get()` on API response items |
| tests/services/test_cloudflare_workers_ai_client.py | Added test case validating proper handling of malformed API responses with mixed data types |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk as it implements defensive programming practices for external API response handling
- Score reflects a focused bug fix with proper error handling, comprehensive test coverage, and no breaking changes to existing functionality
- No files require special attention - the changes are straightforward defensive programming improvements with appropriate test coverage

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API as "/v1/models/popular"
    participant Service as "CloudflareService"
    participant HttpClient as "HttpxClient"
    participant CloudflareAPI as "Cloudflare API"
    
    User->>API: "GET /v1/models/popular"
    API->>Service: "fetch_models_from_cloudflare_api()"
    Service->>HttpClient: "create async client"
    HttpClient->>CloudflareAPI: "GET /ai/models/search"
    CloudflareAPI-->>HttpClient: "response with mixed result array"
    HttpClient-->>Service: "API response data"
    Service->>Service: "check if model is dict"
    Service->>Service: "skip non-dict items with warning"
    Service->>Service: "process valid dict models"
    Service-->>API: "return processed models list"
    API-->>User: "return popular models"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->