### PR TITLE
fix(models): enable redirect following for AIMO model fetch

### DIFF
--- a/src/services/models.py
+++ b/src/services/models.py
@@ -1674,7 +1674,9 @@ def fetch_models_from_aimo():
                     f"URL {url_idx + 1}/{len(urls_to_try)}: {url}"
                 )
 
-                response = httpx.get(url, headers=headers, timeout=timeout_config)
+                response = httpx.get(
+                    url, headers=headers, timeout=timeout_config, follow_redirects=True
+                )
                 response.raise_for_status()
 
                 payload = response.json()


### PR DESCRIPTION
## Summary

- Fixes HTTP 308 redirect handling when fetching models from AIMO Network
- The `httpx` library does not follow redirects by default (unlike `requests`), so when the HTTP fallback URLs were tried, the server's 308 redirect to HTTPS was treated as an error
- Added `follow_redirects=True` to the `httpx.get()` call in `fetch_models_from_aimo()`

## Root Cause

The Sentry error showed:
```
Failed to fetch models from AIMO after all retries: HTTP 308 at http://aimo.network/api/v1/models
```

When the code tried HTTP fallback URLs (after HTTPS failed), the AIMO server returned HTTP 308 (Permanent Redirect) to redirect back to HTTPS. However, `httpx.get()` doesn't follow redirects by default, so `raise_for_status()` treated this as an HTTP error.

## Changes

- `src/services/models.py`: Added `follow_redirects=True` to the `httpx.get()` call
- `tests/services/test_aimo_resilience.py`: Added `TestRedirectHandling` class with tests to verify:
  - `follow_redirects=True` is passed to httpx
  - Authorization headers are preserved during redirects

## Test plan

- [x] All 20 AIMO resilience tests pass
- [x] New redirect handling tests verify the fix
- [ ] Deploy to staging and verify AIMO models are fetched successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **AIMO redirect handling**
> 
> - Set `follow_redirects=True` on `httpx.get` in `fetch_models_from_aimo()` to correctly follow HTTP→HTTPS 308 redirects
> - Add `TestRedirectHandling` in `tests/services/test_aimo_resilience.py` verifying 308 redirects are followed and `Authorization` headers are preserved
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b71afcd1feba11a25594417568675d7a10df0716. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Fixes HTTP 308 redirect handling in AIMO model fetching by adding `follow_redirects=True` to the `httpx.get()` call to properly handle server redirects from HTTP to HTTPS
- Adds comprehensive test coverage with `TestRedirectHandling` class to verify redirect following functionality and authorization header preservation during redirects

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| `src/services/models.py` | Added `follow_redirects=True` to httpx.get() call to fix HTTP 308 redirect handling when AIMO server redirects HTTP to HTTPS |
| `tests/services/test_aimo_resilience.py` | New TestRedirectHandling class with tests verifying redirect following and authorization header preservation |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk as it addresses a specific production issue with a well-targeted fix
- Score reflects the focused nature of the change (single parameter addition), comprehensive test coverage, and clear documentation of the root cause
- No files require special attention as both changes are straightforward and well-tested

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Models as models.py
    participant Cache as _aimo_models_cache
    participant HTTPX as httpx.get()
    participant AIMO as AIMO Network API
    
    Client->>Models: "get_cached_models('aimo')"
    Models->>Cache: "Check fresh cache"
    Cache-->>Models: "Cache expired/empty"
    
    Models->>Models: "fetch_models_from_aimo()"
    Models->>Models: "Build URLs list (HTTPS + HTTP fallback)"
    
    loop "For each URL (with retries)"
        Models->>HTTPX: "httpx.get(url, headers, timeout, follow_redirects=True)"
        HTTPX->>AIMO: "HTTP request to /api/v1/models"
        
        alt "Server returns HTTP 308 redirect"
            AIMO-->>HTTPX: "HTTP 308 Permanent Redirect to HTTPS"
            HTTPX->>AIMO: "Follow redirect automatically"
            AIMO-->>HTTPX: "200 OK with models data"
        else "Direct response"
            AIMO-->>HTTPX: "200 OK with models data"
        end
        
        HTTPX-->>Models: "Response with models"
        Models->>Models: "normalize_aimo_model() for each model"
        Models->>Cache: "Update cache with normalized models"
        Models-->>Client: "Return normalized models"
    end
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->