### PR TITLE
Fireworks model mapping fix

### DIFF
--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -14,11 +14,28 @@ logger = logging.getLogger(__name__)
 MODEL_PROVIDER_OVERRIDES = {
     "katanemo/arch-router-1.5b": "huggingface",
     "zai-org/glm-4.6-fp8": "near",
-    # DeepSeek V3.2 is NOT available on Fireworks, route to OpenRouter instead
-    # Fireworks only has deepseek-v3p1 (V3/V3.1) and deepseek-r1-0528 (R1)
+    # DeepSeek models NOT available on Fireworks - route to OpenRouter instead
+    # Fireworks ONLY has: deepseek-v3p1 (V3/V3.1) and deepseek-r1-0528 (R1)
+    # All other DeepSeek models must go to OpenRouter
+    # V3.2 - not on Fireworks
     "deepseek/deepseek-v3.2": "openrouter",
     "deepseek-ai/deepseek-v3.2": "openrouter",
     "deepseek-v3.2": "openrouter",
+    # V2/V2.5 - older versions, not on Fireworks
+    "deepseek/deepseek-v2": "openrouter",
+    "deepseek-ai/deepseek-v2": "openrouter",
+    "deepseek-v2": "openrouter",
+    "deepseek/deepseek-v2.5": "openrouter",
+    "deepseek-ai/deepseek-v2.5": "openrouter",
+    "deepseek-v2.5": "openrouter",
+    # DeepSeek Coder - not on Fireworks
+    "deepseek/deepseek-coder": "openrouter",
+    "deepseek-ai/deepseek-coder": "openrouter",
+    "deepseek-coder": "openrouter",
+    # DeepSeek Chat - the default chat model, on OpenRouter
+    "deepseek/deepseek-chat": "openrouter",
+    "deepseek-ai/deepseek-chat": "openrouter",
+    "deepseek-chat": "openrouter",
     # Note: Cerebras DOES support Llama models natively (3.1 and 3.3 series)
     # No override needed - let natural provider detection route to Cerebras
 }
@@ -413,11 +430,26 @@ def get_model_id_mapping(provider: str) -> dict[str, str]:
             # Other models
             "meta-llama/llama-3.1-70b": "meta-llama/llama-3.1-70b-instruct",
             "deepseek-ai/deepseek-v3": "deepseek/deepseek-chat",
-            # DeepSeek V3.2 - route to deepseek/deepseek-chat on OpenRouter
-            # Note: Fireworks does NOT have V3.2, only V3/V3.1 (deepseek-v3p1)
+            # DeepSeek models routed to OpenRouter (not available on Fireworks)
+            # V3.2 - not on Fireworks
             "deepseek/deepseek-v3.2": "deepseek/deepseek-chat",
             "deepseek-ai/deepseek-v3.2": "deepseek/deepseek-chat",
             "deepseek-v3.2": "deepseek/deepseek-chat",
+            # V2/V2.5 - older versions
+            "deepseek/deepseek-v2": "deepseek/deepseek-chat",
+            "deepseek-ai/deepseek-v2": "deepseek/deepseek-chat",
+            "deepseek-v2": "deepseek/deepseek-chat",
+            "deepseek/deepseek-v2.5": "deepseek/deepseek-chat",
+            "deepseek-ai/deepseek-v2.5": "deepseek/deepseek-chat",
+            "deepseek-v2.5": "deepseek/deepseek-chat",
+            # DeepSeek Coder
+            "deepseek/deepseek-coder": "deepseek/deepseek-coder",
+            "deepseek-ai/deepseek-coder": "deepseek/deepseek-coder",
+            "deepseek-coder": "deepseek/deepseek-coder",
+            # DeepSeek Chat (default chat model)
+            "deepseek/deepseek-chat": "deepseek/deepseek-chat",
+            "deepseek-ai/deepseek-chat": "deepseek/deepseek-chat",
+            "deepseek-chat": "deepseek/deepseek-chat",
             # Cerebras models explicitly routed through OpenRouter
             # (for users who request provider="openrouter" explicitly or failover scenarios)
             "cerebras/llama-3.3-70b": "meta-llama/llama-3.3-70b-instruct",


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-f30b970f-c6df-4064-86cf-15bba2de3258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f30b970f-c6df-4064-86cf-15bba2de3258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Routing correction for DeepSeek V3.2**
> 
> - Add provider overrides to route `deepseek/deepseek-v3.2` (and variants) to `openrouter`
> - Map OpenRouter `deepseek-v3.2` variants to `deepseek/deepseek-chat`
> - Clarify via comments that Fireworks lacks V3.2 (only V3/V3.1 and R1)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6ed992e646ba126357974516f4db1f764cf350a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Fixes routing issue for DeepSeek V3.2 models by adding provider overrides to route them to OpenRouter instead of Fireworks, since Fireworks doesn't support V3.2 variants
- Updates model mapping configuration to properly handle V3.2 model requests that were previously failing with 404 errors

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/services/model_transformations.py | Added provider overrides and OpenRouter mappings for DeepSeek V3.2 variants to prevent routing to Fireworks which doesn't support these models |

<h3>Confidence score: 4/5</h3>


- This PR is safe to merge with low risk as it fixes a legitimate routing issue for model requests
- Score reflects the targeted nature of the fix addressing a specific provider compatibility issue without affecting other model routing logic  
- Pay attention to `src/services/model_transformations.py` to verify the mapping logic aligns with actual provider capabilities

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Router as "Model Router"
    participant Alias as "Alias Resolver"
    participant Override as "Provider Override Check"
    participant Registry as "Multi-Provider Registry"
    participant Mapping as "Model Mapping"
    participant Provider as "Target Provider"

    User->>Router: "Request model_id + provider"
    Router->>Alias: "apply_model_alias(model_id)"
    Alias-->>Router: "canonical_model_id"
    
    Router->>Override: "Check MODEL_PROVIDER_OVERRIDES"
    alt Override exists
        Override-->>Router: "override_provider"
        Router->>Mapping: "get_model_id_mapping(override_provider)"
    else No override
        Router->>Registry: "Check multi-provider registry"
        alt Multi-provider model found
            Registry-->>Router: "provider_specific_model_id"
        else Single provider
            Router->>Mapping: "get_model_id_mapping(provider)"
        end
    end
    
    Mapping->>Mapping: "Transform model ID to provider format"
    Mapping-->>Router: "transformed_model_id"
    Router->>Provider: "API call with transformed_model_id"
    Provider-->>User: "Model response"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))

<!-- /greptile_comment -->