### PR TITLE
Vertex model name fix

### DIFF
--- a/docs/setup/VERTEX_AI_SETUP.md
+++ b/docs/setup/VERTEX_AI_SETUP.md
@@ -149,19 +149,25 @@ curl -X POST http://localhost:8000/v1/chat/completions \
 
 When using Google Vertex AI, the following Gemini models are supported:
 
-- `google/gemini-2.5-flash-lite-preview-09-2025`
-- `google/gemini-2.5-flash-preview-09-2025`
-- `google/gemini-2.5-pro-preview-09-2025`
+**Recommended (Stable GA):**
+- `google/gemini-2.5-pro` - Latest Pro model
+- `google/gemini-2.5-flash` - Latest Flash model (fast, cost-effective)
+- `google/gemini-2.5-flash-lite` - Lightweight Flash variant
 - `google/gemini-2.0-flash`
 - `google/gemini-2.0-flash-001`
 - `google/gemini-2.0-pro`
-- `google/gemini-1.5-pro`
-- `google/gemini-1.5-flash`
 - `google/gemini-1.0-pro`
 
+**Preview Aliases (map to stable versions):**
+- `google/gemini-2.5-pro-preview` → uses `gemini-2.5-pro`
+- `google/gemini-2.5-flash-preview` → uses `gemini-2.5-flash`
+
+**Note:** Dated preview versions (e.g., `gemini-2.5-pro-preview-09-2025`) have been retired from Vertex AI. These aliases now fall back to the stable GA versions.
+
 You can also use the shorter versions without the `google/` prefix:
+- `gemini-2.5-pro`
+- `gemini-2.5-flash`
 - `gemini-2.0-flash`
-- `gemini-1.5-pro`
 - etc.
 
 ## Troubleshooting

--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -125,10 +125,12 @@ def apply_model_alias(model_id: str | None) -> str | None:
     return model_id
 
 # Gemini model name constants to reduce duplication
+# NOTE: The dated preview model versions (e.g., gemini-2.5-pro-preview-09-2025) were retired
+# from Vertex AI and return 404 errors. We now map generic "preview" aliases to stable GA versions.
 GEMINI_3_FLASH_PREVIEW = "gemini-3-flash-preview"
-GEMINI_2_5_FLASH_LITE_PREVIEW = "gemini-2.5-flash-lite-preview-09-2025"
-GEMINI_2_5_FLASH_PREVIEW = "gemini-2.5-flash-preview-09-2025"
-GEMINI_2_5_PRO_PREVIEW = "gemini-2.5-pro-preview-09-2025"
+GEMINI_2_5_FLASH_LITE_PREVIEW = "gemini-2.5-flash-lite"  # Stable GA version (dated preview retired)
+GEMINI_2_5_FLASH_PREVIEW = "gemini-2.5-flash"  # Stable GA version (dated preview retired)
+GEMINI_2_5_PRO_PREVIEW = "gemini-2.5-pro"  # Stable GA version (dated preview retired)
 GEMINI_2_0_FLASH = "gemini-2.0-flash"
 GEMINI_2_0_PRO = "gemini-2.0-pro"
 GEMINI_1_5_PRO = "gemini-1.5-pro"
@@ -522,8 +524,8 @@ def get_model_id_mapping(provider: str) -> dict[str, str]:
             "gemini-2.5-flash-lite": "gemini-2.5-flash-lite",  # Use stable GA version
             "google/gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
             "@google/models/gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
-            # Preview version (only if explicitly requested)
-            "gemini-2.5-flash-lite-preview-09-2025": GEMINI_2_5_FLASH_LITE_PREVIEW,
+            # Preview versions (dated 09-2025 versions retired, fall back to stable GA)
+            "gemini-2.5-flash-lite-preview-09-2025": GEMINI_2_5_FLASH_LITE_PREVIEW,  # Falls back to stable
             "google/gemini-2.5-flash-lite-preview-09-2025": GEMINI_2_5_FLASH_LITE_PREVIEW,
             "@google/models/gemini-2.5-flash-lite-preview-09-2025": GEMINI_2_5_FLASH_LITE_PREVIEW,
             "gemini-2.5-flash-lite-preview-06-17": "gemini-2.5-flash-lite-preview-06-17",
@@ -532,9 +534,9 @@ def get_model_id_mapping(provider: str) -> dict[str, str]:
             "gemini-2.5-flash": "gemini-2.5-flash",  # Stable GA version for production
             "google/gemini-2.5-flash": "gemini-2.5-flash",
             "@google/models/gemini-2.5-flash": "gemini-2.5-flash",
-            # Preview version (only if explicitly requested)
-            "gemini-2.5-flash-preview-09-2025": GEMINI_2_5_FLASH_PREVIEW,
-            "gemini-2.5-flash-preview": GEMINI_2_5_FLASH_PREVIEW,
+            # Preview versions (dated 09-2025 versions retired, fall back to stable GA)
+            "gemini-2.5-flash-preview-09-2025": GEMINI_2_5_FLASH_PREVIEW,  # Falls back to stable
+            "gemini-2.5-flash-preview": GEMINI_2_5_FLASH_PREVIEW,  # Falls back to stable
             "google/gemini-2.5-flash-preview-09-2025": GEMINI_2_5_FLASH_PREVIEW,
             "@google/models/gemini-2.5-flash-preview-09-2025": GEMINI_2_5_FLASH_PREVIEW,
             # Image-specific models (GA version only - no preview version exists)
@@ -545,11 +547,11 @@ def get_model_id_mapping(provider: str) -> dict[str, str]:
             "gemini-2.5-pro": "gemini-2.5-pro",  # Use stable GA version
             "google/gemini-2.5-pro": "gemini-2.5-pro",
             "@google/models/gemini-2.5-pro": "gemini-2.5-pro",
-            # Preview version (only if explicitly requested)
-            "gemini-2.5-pro-preview-09-2025": GEMINI_2_5_PRO_PREVIEW,
+            # Preview versions (dated 09-2025 versions retired, fall back to stable GA)
+            "gemini-2.5-pro-preview-09-2025": GEMINI_2_5_PRO_PREVIEW,  # Falls back to stable
             "google/gemini-2.5-pro-preview-09-2025": GEMINI_2_5_PRO_PREVIEW,
             "@google/models/gemini-2.5-pro-preview-09-2025": GEMINI_2_5_PRO_PREVIEW,
-            "gemini-2.5-pro-preview": GEMINI_2_5_PRO_PREVIEW,
+            "gemini-2.5-pro-preview": GEMINI_2_5_PRO_PREVIEW,  # Falls back to stable
             "google/gemini-2.5-pro-preview": GEMINI_2_5_PRO_PREVIEW,
             "gemini-2.5-pro-preview-05-06": "gemini-2.5-pro-preview-05-06",
             "google/gemini-2.5-pro-preview-05-06": "gemini-2.5-pro-preview-05-06",

--- a/tests/integration/google_models_config.json
+++ b/tests/integration/google_models_config.json
@@ -1,16 +1,17 @@
 {
-  "timestamp": "2025-11-07",
+  "timestamp": "2025-12-23",
   "total_inputs": 40,
   "unique_models": 11,
   "constants": {
-    "GEMINI_2_5_FLASH_LITE_PREVIEW": "gemini-2.5-flash-lite-preview-09-2025",
-    "GEMINI_2_5_FLASH_PREVIEW": "gemini-2.5-flash-preview-09-2025",
-    "GEMINI_2_5_PRO_PREVIEW": "gemini-2.5-pro-preview-09-2025",
+    "GEMINI_2_5_FLASH_LITE_PREVIEW": "gemini-2.5-flash-lite",
+    "GEMINI_2_5_FLASH_PREVIEW": "gemini-2.5-flash",
+    "GEMINI_2_5_PRO_PREVIEW": "gemini-2.5-pro",
     "GEMINI_2_0_FLASH": "gemini-2.0-flash",
     "GEMINI_2_0_PRO": "gemini-2.0-pro",
     "GEMINI_1_5_PRO": "gemini-1.5-pro",
     "GEMINI_1_5_FLASH": "gemini-1.5-flash",
-    "GEMINI_1_0_PRO": "gemini-1.0-pro"
+    "GEMINI_1_0_PRO": "gemini-1.0-pro",
+    "_note": "Dated preview versions (09-2025) were retired from Vertex AI. Preview aliases now fall back to stable GA versions."
   },
   "unique_models_list": [
     "gemini-1.0-pro",

--- a/tests/services/test_google_vertex_client.py
+++ b/tests/services/test_google_vertex_client.py
@@ -437,10 +437,12 @@ class TestGoogleVertexModelIntegration:
         """Test that gemini models are properly detected when credentials are available"""
         from src.services.model_transformations import detect_provider_from_model_id
 
+        # Note: gemini-1.5 models are retired from Vertex AI (April-September 2025)
         models = [
+            "gemini-2.5-flash",
+            "gemini-2.5-pro",
             "gemini-2.0-flash",
-            "gemini-1.5-pro",
-            "google/gemini-1.5-flash",
+            "google/gemini-2.5-flash",
         ]
 
         for model in models:
@@ -479,12 +481,11 @@ class TestFetchModelsFromGoogleVertex:
         model_ids = [m["id"] for m in models]
 
         # Check for expected Gemini models
+        # Note: gemini-1.5 models are retired from Vertex AI (April-September 2025)
         expected_models = [
             "gemini-2.5-flash",
             "gemini-2.5-pro",
             "gemini-2.0-flash",
-            "gemini-1.5-pro",
-            "gemini-1.5-flash",
         ]
 
         for expected in expected_models:

--- a/tests/services/test_model_transformations.py
+++ b/tests/services/test_model_transformations.py
@@ -68,13 +68,18 @@ def test_detect_provider_from_model_id_existing_providers():
 
 @patch.dict('os.environ', {'GOOGLE_VERTEX_CREDENTIALS_JSON': '{"type":"service_account"}'})
 def test_detect_provider_google_vertex_models():
-    """Test that Google Vertex AI models are correctly detected when credentials are available"""
+    """Test that Google Vertex AI models are correctly detected when credentials are available
+
+    Note: gemini-1.5 models are retired from Vertex AI (April-September 2025) and
+    are not included in this test. They should be routed to OpenRouter instead.
+    """
     test_cases = [
         ("gemini-2.5-flash", "google-vertex"),
         ("gemini-2.0-flash", "google-vertex"),
-        ("gemini-1.5-pro", "google-vertex"),
+        ("gemini-2.5-pro", "google-vertex"),
         ("google/gemini-2.5-flash", "google-vertex"),
         ("google/gemini-2.0-flash", "google-vertex"),
+        ("google/gemini-2.5-pro-preview", "google-vertex"),  # Preview alias - falls back to stable
         ("@google/models/gemini-2.5-flash", "google-vertex"),  # Key test case - should NOT be portkey
         ("@google/models/gemini-2.0-flash", "google-vertex"),
     ]


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-9f4172b1-4556-4bf5-b54d-206f20a83b5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9f4172b1-4556-4bf5-b54d-206f20a83b5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Vertex AI Gemini model handling and documentation.
> 
> - Map `gemini-2.5-*-preview(-09-2025)` aliases to stable GA (`gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`) in `model_transformations.py`, avoiding 404s from retired dated previews
> - Keep support for `@google/models/*` and `google/gemini-*` inputs; provider detection routes Gemini 2.5/2.0/1.0 to Vertex when creds exist, excludes retired 1.5 from Vertex
> - Update Google Vertex model ID mappings (including preview aliases), and keep image/pro variants
> - Refresh docs (`VERTEX_AI_SETUP.md`) to recommend GA 2.5 models and note preview aliases fallback; add short `gemini-*` examples
> - Adjust tests and fixtures to reflect new mappings and retirement: update integration config JSON, revise provider detection and catalog expectations, and keep transformation/id handling consistent
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 458d72a885ded6a1ab2c24c44f9f5dea0d817a7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Updates Vertex AI Gemini model handling to fix404 errors by mapping retired dated preview models (`gemini-2.5-*-preview-09-2025`) to stable GA versions (`gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`)
- Removes support for retired Gemini 1.5 models from Vertex AI provider detection and routes them to OpenRouter instead, while adding support for newer Gemini 2.5/2.0 models
- Updates documentation in `VERTEX_AI_SETUP.md` to recommend stable GA models over deprecated preview versions and clarifies fallback behavior for preview aliases

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| `src/services/model_transformations.py` | Core model mapping logic updated to handle retired preview model aliases; critical for preventing API 404 errors but contains inconsistent constant usage |
| `tests/integration/google_models_config.json` | Test configuration with inconsistent mappings - constants map preview to 2.5 models but actual mappings show 2.5 resolving to 2.0 models |

<h3>Confidence score: 3/5</h3>


- This PR addresses a real production issue (404 errors from retired model endpoints) but contains several concerning inconsistencies that could cause issues
- Score reduced due to inconsistent model mappings between constants and actual transformations, potential breaking changes for users relying on specific dated models, and unclear test coverage verification
- Pay close attention to `google_models_config.json` for mapping inconsistencies and verify that all model transformation logic is consistent across the codebase

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API as "Gatewayz API"
    participant ModelTrans as "Model Transformations"
    participant VertexClient as "Vertex AI Client"
    participant GoogleAPI as "Google Vertex API"

    User->>API: "Request with google/gemini-2.5-pro-preview-09-2025"
    API->>ModelTrans: "apply_model_alias(model_id)"
    ModelTrans-->>API: "No alias found, returns original"
    API->>ModelTrans: "transform_model_id(model_id, 'google-vertex')"
    ModelTrans->>ModelTrans: "Check model mapping"
    Note over ModelTrans: "Maps preview-09-2025 to stable gemini-2.5-pro"
    ModelTrans-->>API: "gemini-2.5-pro"
    API->>VertexClient: "make_google_vertex_request_openai(model='gemini-2.5-pro')"
    VertexClient->>GoogleAPI: "Generate content with stable model"
    GoogleAPI-->>VertexClient: "Response"
    VertexClient-->>API: "Normalized OpenAI format"
    API-->>User: "Chat completion response"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->