### PR TITLE
Openrouter policy error

### DIFF
--- a/src/services/connection_pool.py
+++ b/src/services/connection_pool.py
@@ -302,7 +302,7 @@ def get_openrouter_pooled_client() -> OpenAI:
         api_key=Config.OPENROUTER_API_KEY,
         default_headers={
             "HTTP-Referer": Config.OPENROUTER_SITE_URL,
-            "X-TitleSection": Config.OPENROUTER_SITE_NAME,
+            "X-Title": Config.OPENROUTER_SITE_NAME,
         },
     )
 

--- a/tests/integration/test_end_to_end_normalization.py
+++ b/tests/integration/test_end_to_end_normalization.py
@@ -84,7 +84,7 @@ def test_openrouter_with_transform():
             api_key=OPENROUTER_API_KEY,
             default_headers={
                 'HTTP-Referer': os.getenv('OPENROUTER_SITE_URL', 'https://gatewayz.ai'),
-                'X-TitleSection': os.getenv('OPENROUTER_SITE_NAME', 'Gatewayz')
+                'X-Title': os.getenv('OPENROUTER_SITE_NAME', 'Gatewayz')
             }
         )
 

--- a/tests/integration/test_openrouter_direct.py
+++ b/tests/integration/test_openrouter_direct.py
@@ -23,7 +23,7 @@ def test_model():
             api_key=OPENROUTER_API_KEY,
             default_headers={
                 "HTTP-Referer": OPENROUTER_SITE_URL,
-                "X-TitleSection": OPENROUTER_SITE_NAME
+                "X-Title": OPENROUTER_SITE_NAME
             }
         )
 
@@ -56,7 +56,7 @@ def test_model():
             api_key=OPENROUTER_API_KEY,
             default_headers={
                 "HTTP-Referer": OPENROUTER_SITE_URL,
-                "X-TitleSection": OPENROUTER_SITE_NAME
+                "X-Title": OPENROUTER_SITE_NAME
             }
         )
 

--- a/tests/integration/test_provider_case_sensitivity.py
+++ b/tests/integration/test_provider_case_sensitivity.py
@@ -19,7 +19,7 @@ PROVIDERS = [
         'api_key': os.getenv('OPENROUTER_API_KEY'),
         'headers': {
             'HTTP-Referer': os.getenv('OPENROUTER_SITE_URL', 'https://gatewayz.ai'),
-            'X-TitleSection': os.getenv('OPENROUTER_SITE_NAME', 'Gatewayz')
+            'X-Title': os.getenv('OPENROUTER_SITE_NAME', 'Gatewayz')
         },
         'test_models': [
             ('meta-llama/llama-3.1-8b-instruct', 'meta-llama/Llama-3.1-8B-Instruct'),


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-034639ad-6209-403f-92ff-ab5ba7966d4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-034639ad-6209-403f-92ff-ab5ba7966d4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures OpenRouter requests are correctly formed and not blocked by data policy restrictions.
> 
> - Use `X-Title` instead of `X-TitleSection` in OpenRouter client headers across `connection_pool.py`, async client init, and integration tests
> - Add `_merge_extra_body` to inject `extra_body: { provider: { data_collection: "allow" } }`, preserving/allowing overrides; apply in `make_openrouter_request_openai`, `make_openrouter_request_openai_stream`, and async streaming
> - Add/adjust unit tests in `tests/services/test_openrouter_client.py` to assert header and `extra_body` merging behavior; update integration tests to match header change
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cdc2ff50a149490e54567562d027aa36bbc3d8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Fixes OpenRouter policy error by correcting header name from `X-TitleSection` to `X-Title` across the codebase and injecting `data_collection: "allow"` provider settings into all OpenRouter requests
- Adds `_merge_extra_body` helper function to preserve existing request parameters while adding required data policy overrides for OpenRouter API compliance
- Includes comprehensive test coverage for the new functionality and updates integration tests to match the corrected header specification

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| `src/services/openrouter_client.py` | Main OpenRouter client service; adds `_merge_extra_body` function and integrates it into all three request methods to inject required provider data collection settings |
| `tests/services/test_openrouter_client.py` | Unit tests for OpenRouter client; adds comprehensive test coverage for `_merge_extra_body` function and updates header assertions |
| `src/services/connection_pool.py` | Connection pooling service; corrects OpenRouter header from `X-TitleSection` to `X-Title` in default headers configuration |

<h3>Confidence score: 4/5</h3>


- This PR is generally safe to merge with good test coverage and clear fixes for OpenRouter API compliance
- Score lowered due to the impact on a critical external provider integration and the need to ensure the new data collection settings don't affect user expectations
- Pay close attention to `src/services/openrouter_client.py` for the provider settings injection logic and test thoroughly with OpenRouter endpoints

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant OpenRouterClient as "OpenRouter Client"
    participant ConnectionPool as "Connection Pool"
    participant OpenAI as "OpenAI Client"
    participant OpenRouter as "OpenRouter API"

    User->>OpenRouterClient: "make_openrouter_request_openai(messages, model, **kwargs)"
    OpenRouterClient->>OpenRouterClient: "_merge_extra_body(kwargs)"
    Note over OpenRouterClient: "Adds provider: {data_collection: 'allow'} to extra_body"
    OpenRouterClient->>ConnectionPool: "get_openrouter_pooled_client()"
    ConnectionPool->>ConnectionPool: "get_pooled_client(provider='openrouter')"
    Note over ConnectionPool: "Creates OpenAI client with X-Title header"
    ConnectionPool->>OpenAI: "OpenAI(base_url, api_key, headers)"
    ConnectionPool-->>OpenRouterClient: "pooled OpenAI client"
    OpenRouterClient->>OpenAI: "client.chat.completions.create(model, messages, **merged_kwargs)"
    OpenAI->>OpenRouter: "POST /chat/completions with data_collection=allow"
    OpenRouter-->>OpenAI: "response"
    OpenAI-->>OpenRouterClient: "response"
    OpenRouterClient->>OpenRouterClient: "process_openrouter_response(response)"
    OpenRouterClient-->>User: "processed response"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->