### PR TITLE
Supabase rate limit error handling

### DIFF
--- a/tests/db/test_plans.py
+++ b/tests/db/test_plans.py
@@ -2,7 +2,7 @@
 import sys
 import types
 import importlib
-from datetime import datetime, timezone, timezone
+from datetime import datetime, timezone, timedelta
 from unittest.mock import patch, MagicMock
 import pytest
 


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-8c560f8c-66cd-4351-a0af-7bba9afc4bae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8c560f8c-66cd-4351-a0af-7bba9afc4bae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a short-lived in-memory cache for user plan lookups to reduce concurrent Supabase queries and avoid Cloudflare 400s.
> 
> - Introduces `_get_user_plan_uncached` and wraps with cached `get_user_plan` (30s TTL)
> - Adds cache utilities: `clear_user_plan_cache`, `invalidate_user_plan_cache`, `get_user_plan_cache_stats`
> - Invalidates user plan cache in `assign_user_plan` and when expiring plans in `check_plan_entitlements`
> - Minor test fix: correct datetime imports in `tests/db/test_plans.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee7cf9b980c48b684e13d69972cf150842dedee0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Implements in-memory caching for user plan lookups with 30-second TTL to mitigate Supabase rate limiting errors causing 400 responses during high-traffic periods
- Refactors `get_user_plan()` into cached wrapper around new `_get_user_plan_uncached()` function, following existing usage data caching pattern in the same file
- Adds cache invalidation in plan modification functions (`assign_user_plan`, `check_plan_entitlements`) and fixes duplicate datetime import in test file

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/db/plans.py | Introduces comprehensive user plan caching system with 30s TTL, cache management utilities, and strategic invalidation points to address Supabase rate limit issues |
| tests/db/test_plans.py | Fixes duplicate timezone import and adds missing timedelta import required for test date operations |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk and effectively addresses a production rate limiting issue
- Score reflects well-implemented caching solution following established patterns, proper cache invalidation strategies, and minimal code complexity
- No files require special attention as both changes are straightforward: production caching fix and simple import correction

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API as "Gatewayz API"
    participant Cache as "User Plan Cache"
    participant Supabase as "Supabase Database"
    
    User->>API: "Request API call"
    API->>Cache: "Check user plan cache"
    alt Cache Hit
        Cache->>API: "Return cached plan data"
    else Cache Miss
        API->>Supabase: "Query user_plans table"
        Supabase->>API: "Return user plan data"
        API->>Supabase: "Query plans table"
        Supabase->>API: "Return plan details"
        API->>Cache: "Store plan data (30s TTL)"
        Cache->>API: "Confirm cache stored"
    end
    API->>User: "Return API response"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))

<!-- /greptile_comment -->