### PR TITLE
Fal provider handler missing

### DIFF
--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -1418,6 +1418,23 @@ async def chat_completions(
                 override_provider = override_provider.lower()
                 if override_provider == "hug":
                     override_provider = "huggingface"
+                # FAL models are for image/video generation only, not chat completions
+                if override_provider == "fal":
+                    logger.warning(
+                        "FAL model '%s' requested via chat completions endpoint - "
+                        "FAL models only support image/video generation",
+                        sanitize_for_logging(original_model),
+                    )
+                    raise HTTPException(
+                        status_code=400,
+                        detail=(
+                            f"Model '{original_model}' is a FAL image/video generation model and "
+                            "does not support chat completions. Please use the /v1/images/generations "
+                            "endpoint for image generation, or choose a chat-compatible model. "
+                            "FAL models support: text-to-image, text-to-video, image-to-video, and "
+                            "other media generation tasks. See https://fal.ai/models for details."
+                        ),
+                    )
                 if provider_locked and override_provider != provider:
                     logger.info(
                         "Skipping provider override for model %s: request locked provider to '%s'",
@@ -2536,6 +2553,23 @@ async def unified_responses(
             override_provider = override_provider.lower()
             if override_provider == "hug":
                 override_provider = "huggingface"
+            # FAL models are for image/video generation only, not chat completions
+            if override_provider == "fal":
+                logger.warning(
+                    "FAL model '%s' requested via responses endpoint - "
+                    "FAL models only support image/video generation",
+                    sanitize_for_logging(original_model),
+                )
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Model '{original_model}' is a FAL image/video generation model and "
+                        "does not support chat completions. Please use the /v1/images/generations "
+                        "endpoint for image generation, or choose a chat-compatible model. "
+                        "FAL models support: text-to-image, text-to-video, image-to-video, and "
+                        "other media generation tasks. See https://fal.ai/models for details."
+                    ),
+                )
             if provider_locked and override_provider != provider:
                 logger.info(
                     "Skipping provider override for model %s: request locked provider to '%s'",


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-1927a0b6-9178-4b2e-b24c-26b48ec50eac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1927a0b6-9178-4b2e-b24c-26b48ec50eac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Behavior change**
> 
> - Rejects `FAL`-detected models in `chat_completions` and `unified_responses` with `400 Bad Request`, logging a warning and returning a clear error that suggests using `/v1/images/generations` and links to FAL model docs.
> 
> **Tests**
> 
> - Adds tests ensuring FAL models (e.g., `fal-ai/veo3.1`, `fal-ai/stable-diffusion-v15`, `fal-ai/flux-pro/v1.1-ultra`, `fal-ai/sora-2/text-to-video`, `minimax/video-01`) are rejected with the expected error and guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f3c6352ee5b2ce8e6f7bb2cf7c0f348ae266457. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds validation to reject FAL provider models in chat completion endpoints with clear error messages directing users to image generation endpoints
- Implements provider detection checks in both `/v1/chat/completions` and `/v1/responses` endpoints to prevent inappropriate model usage
- Adds comprehensive test coverage for FAL model rejection behavior with multiple example model IDs from the FAL provider

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| `src/routes/chat.py` | Adds FAL provider validation with 400 error responses and helpful guidance messages for both chat completion endpoints |
| `tests/routes/test_chat.py` | Adds test coverage for FAL model rejection scenarios with proper error message validation |

<h3>Confidence score: 5/5</h3>


- This PR is extremely safe to merge with minimal risk as it only adds input validation
- Score reflects simple validation logic with comprehensive test coverage and no breaking changes to existing functionality
- No files require special attention as the changes are straightforward validation additions with proper error handling

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ChatRouter as "/v1/chat/completions"
    participant ModelTransforms as "detect_provider_from_model_id"
    
    User->>ChatRouter: "POST /v1/chat/completions with fal-ai/veo3.1"
    ChatRouter->>ModelTransforms: "detect_provider_from_model_id(fal-ai/veo3.1)"
    ModelTransforms-->>ChatRouter: "fal"
    ChatRouter->>ChatRouter: "Check if provider == 'fal'"
    ChatRouter-->>User: "400 Bad Request: FAL models only support image/video generation. Use /v1/images/generations endpoint"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->