### PR TITLE
FAL provider chat handler

### DIFF
--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -1626,6 +1626,21 @@ async def chat_completions(
                             request_model,
                             **optional,
                         )
+                    elif attempt_provider == "fal":
+                        # FAL models are for image/video generation, not chat completions
+                        # Return a clear error message directing users to the correct endpoint
+                        raise HTTPException(
+                            status_code=400,
+                            detail={
+                                "error": {
+                                    "message": f"Model '{request_model}' is a FAL.ai image/video generation model "
+                                    "and is not available through the chat completions endpoint. "
+                                    "Please use the /v1/images/generations endpoint with provider='fal' instead.",
+                                    "type": "invalid_request_error",
+                                    "code": "model_not_supported_for_chat",
+                                }
+                            },
+                        )
                     else:
                         # PERF: Use async streaming for OpenRouter (default provider)
                         # This is the most impactful optimization - prevents event loop blocking
@@ -1965,6 +1980,21 @@ async def chat_completions(
                         timeout=request_timeout,
                     )
                     processed = await _to_thread(process_onerouter_response, resp_raw)
+                elif attempt_provider == "fal":
+                    # FAL models are for image/video generation, not chat completions
+                    # Return a clear error message directing users to the correct endpoint
+                    raise HTTPException(
+                        status_code=400,
+                        detail={
+                            "error": {
+                                "message": f"Model '{request_model}' is a FAL.ai image/video generation model "
+                                "and is not available through the chat completions endpoint. "
+                                "Please use the /v1/images/generations endpoint with provider='fal' instead.",
+                                "type": "invalid_request_error",
+                                "code": "model_not_supported_for_chat",
+                            }
+                        },
+                    )
                 else:
                     resp_raw = await asyncio.wait_for(
                         _to_thread(
@@ -2659,6 +2689,21 @@ async def unified_responses(
                         stream = await _to_thread(
                             make_groq_request_openai_stream, messages, request_model, **optional
                         )
+                    elif attempt_provider == "fal":
+                        # FAL models are for image/video generation, not chat completions
+                        # Return a clear error message directing users to the correct endpoint
+                        raise HTTPException(
+                            status_code=400,
+                            detail={
+                                "error": {
+                                    "message": f"Model '{request_model}' is a FAL.ai image/video generation model "
+                                    "and is not available through the chat completions endpoint. "
+                                    "Please use the /v1/images/generations endpoint with provider='fal' instead.",
+                                    "type": "invalid_request_error",
+                                    "code": "model_not_supported_for_chat",
+                                }
+                            },
+                        )
                     else:
                         stream = await _to_thread(
                             make_openrouter_request_openai_stream,
@@ -3042,6 +3087,21 @@ async def unified_responses(
                         timeout=request_timeout,
                     )
                     processed = await _to_thread(process_groq_response, resp_raw)
+                elif attempt_provider == "fal":
+                    # FAL models are for image/video generation, not chat completions
+                    # Return a clear error message directing users to the correct endpoint
+                    raise HTTPException(
+                        status_code=400,
+                        detail={
+                            "error": {
+                                "message": f"Model '{request_model}' is a FAL.ai image/video generation model "
+                                "and is not available through the chat completions endpoint. "
+                                "Please use the /v1/images/generations endpoint with provider='fal' instead.",
+                                "type": "invalid_request_error",
+                                "code": "model_not_supported_for_chat",
+                            }
+                        },
+                    )
                 else:
                     resp_raw = await asyncio.wait_for(
                         _to_thread(

--- a/src/routes/messages.py
+++ b/src/routes/messages.py
@@ -598,6 +598,21 @@ async def anthropic_messages(
                         timeout=request_timeout,
                     )
                     processed = await _to_thread(process_vercel_ai_gateway_response, resp_raw)
+                elif attempt_provider == "fal":
+                    # FAL models are for image/video generation, not chat/messages
+                    # Return a clear error message directing users to the correct endpoint
+                    raise HTTPException(
+                        status_code=400,
+                        detail={
+                            "error": {
+                                "message": f"Model '{request_model}' is a FAL.ai image/video generation model "
+                                "and is not available through the messages endpoint. "
+                                "Please use the /v1/images/generations endpoint with provider='fal' instead.",
+                                "type": "invalid_request_error",
+                                "code": "model_not_supported_for_chat",
+                            }
+                        },
+                    )
                 else:
                     resp_raw = await asyncio.wait_for(
                         _to_thread(


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-543e322f-3ef9-4496-a89f-2cc4d3b84a7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-543e322f-3ef9-4496-a89f-2cc4d3b84a7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Clarifies unsupported provider usage**
> 
> - Adds explicit checks for `provider='fal'` in `chat.py` (chat/completions and responses) and `messages.py` (Anthropic messages), in both streaming and non-streaming paths
> - Returns HTTP 400 with `invalid_request_error` (`code`: `model_not_supported_for_chat`) and a message directing users to use `/v1/images/generations` with `provider='fal'`
> - No changes to other providers, routing, or request/response shapes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c8f2378f68f091bc6ea7460aaed46d2b36f7a22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds explicit error handling for FAL provider in chat endpoints to prevent incorrect usage and direct users to the appropriate image generation endpoint
- Implements consistent HTTP 400 error responses with detailed messages across both `src/routes/chat.py` and `src/routes/messages.py` in all streaming and non-streaming paths
- Enforces proper provider usage by clarifying that FAL models are specifically for image/video generation, not chat completions

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| `src/routes/chat.py` | Added FAL provider checks in four locations (streaming/non-streaming for both endpoints) that return HTTP 400 errors directing users to `/v1/images/generations` |
| `src/routes/messages.py` | Added FAL provider check in Anthropic Messages API routing with consistent error message and status code |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk as it only adds error handling without modifying existing functionality
- Score reflects straightforward error handling additions with consistent implementation across all affected endpoints and no breaking changes to core logic
- No files require special attention as the changes are purely additive error handling with clear, consistent patterns

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ChatAPI
    participant Auth
    participant ProviderRouter
    participant UpstreamProvider
    participant Database

    User->>ChatAPI: "POST /v1/chat/completions"
    ChatAPI->>Auth: "validate_api_key()"
    Auth-->>ChatAPI: "user_data"
    
    ChatAPI->>ChatAPI: "detect_provider_from_model_id()"
    ChatAPI->>ChatAPI: "check if provider == 'fal'"
    
    alt provider is FAL
        ChatAPI-->>User: "HTTP 400: Use /v1/images/generations instead"
    else provider is supported
        ChatAPI->>ProviderRouter: "route_to_provider(messages, model)"
        ProviderRouter->>UpstreamProvider: "make_request()"
        UpstreamProvider-->>ProviderRouter: "response"
        ProviderRouter-->>ChatAPI: "processed_response"
        
        ChatAPI->>Database: "record_usage(tokens, cost)"
        Database-->>ChatAPI: "success"
        
        ChatAPI-->>User: "chat_completion_response"
    end
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->