### PR TITLE
Alibaba cloud model mapping fix

### DIFF
--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -702,6 +702,22 @@ def get_model_id_mapping(provider: str) -> dict[str, str]:
             # Qwen Coder models
             "qwen/qwen-coder": "qwen-coder",
             "qwen-coder": "qwen-coder",
+            # Qwen 2.5 Coder models (specific versions)
+            "qwen/qwen-2.5-coder-32b-instruct": "qwen2.5-coder-32b-instruct",
+            "qwen/qwen2.5-coder-32b-instruct": "qwen2.5-coder-32b-instruct",
+            "qwen-2.5-coder-32b-instruct": "qwen2.5-coder-32b-instruct",
+            "qwen2.5-coder-32b-instruct": "qwen2.5-coder-32b-instruct",
+            "qwen/qwen-2.5-coder-32b": "qwen2.5-coder-32b-instruct",
+            "qwen/qwen-2.5-coder-7b-instruct": "qwen2.5-coder-7b-instruct",
+            "qwen/qwen2.5-coder-7b-instruct": "qwen2.5-coder-7b-instruct",
+            "qwen-2.5-coder-7b-instruct": "qwen2.5-coder-7b-instruct",
+            "qwen2.5-coder-7b-instruct": "qwen2.5-coder-7b-instruct",
+            "qwen/qwen-2.5-coder-7b": "qwen2.5-coder-7b-instruct",
+            "qwen/qwen-2.5-coder-14b-instruct": "qwen2.5-coder-14b-instruct",
+            "qwen/qwen2.5-coder-14b-instruct": "qwen2.5-coder-14b-instruct",
+            "qwen-2.5-coder-14b-instruct": "qwen2.5-coder-14b-instruct",
+            "qwen2.5-coder-14b-instruct": "qwen2.5-coder-14b-instruct",
+            "qwen/qwen-2.5-coder-14b": "qwen2.5-coder-14b-instruct",
 
             # Qwen reasoning models
             "qwen/qwq-32b-preview": "qwq-32b-preview",


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-37c43db5-0d28-4511-a598-81c1320ca60b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-37c43db5-0d28-4511-a598-81c1320ca60b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Alibaba Cloud model mapping updates**
> 
> - Adds mappings in `model_transformations.py` for Qwen 2.5 Coder models to DashScope native IDs: `qwen2.5-coder-32b-instruct`, `qwen2.5-coder-14b-instruct`, and `qwen2.5-coder-7b-instruct`
> - Supports multiple input aliases (e.g., `qwen/qwen-2.5-coder-*`, `qwen/qwen2.5-coder-*`, and shorthand names) all resolving to the correct `*-instruct` variants
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f16872a7ec40e7152cb6a876076c5e83fa0749ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds new model mappings for Qwen 2.5 Coder models (32B, 7B, 14B) in Alibaba Cloud provider configuration to support multiple input format aliases
- Maps various naming conventions (`qwen/qwen-2.5-coder-*`, `qwen2.5-coder-*`, etc.) to standardized DashScope API identifiers ending with `-instruct`
- Improves user experience by allowing flexible model naming while ensuring correct API integration with Alibaba Cloud's DashScope service

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| `src/services/model_transformations.py` | Added 16 new model mapping entries for Qwen 2.5 Coder variants to resolve multiple input aliases to canonical DashScope model IDs |

<h3>Confidence score: 4/5</h3>


- This PR is safe to merge with minimal risk as it only adds new model mapping entries without modifying existing functionality
- Score reflects straightforward configuration changes that follow established patterns in the codebase for provider model mappings
- Pay attention to `src/services/model_transformations.py` for potential duplicate key issues, though the mappings appear correctly structured

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API as "Chat Completions API"
    participant Transform as "transform_model_id()"
    participant Mapping as "get_model_id_mapping()"
    participant Provider as "Alibaba Cloud API"

    User->>API: "POST /chat/completions with model='qwen/qwen-2.5-coder-32b'"
    API->>Transform: "transform_model_id('qwen/qwen-2.5-coder-32b', 'alibaba-cloud')"
    Transform->>Transform: "apply_model_alias() - no alias found"
    Transform->>Transform: "normalize to lowercase"
    Transform->>Mapping: "get_model_id_mapping('alibaba-cloud')"
    Mapping-->>Transform: "{'qwen/qwen-2.5-coder-32b': 'qwen2.5-coder-32b-instruct', ...}"
    Transform->>Transform: "lookup 'qwen/qwen-2.5-coder-32b' in mapping"
    Transform-->>API: "return 'qwen2.5-coder-32b-instruct'"
    API->>Provider: "POST with model='qwen2.5-coder-32b-instruct'"
    Provider-->>API: "return chat completion response"
    API-->>User: "return response with transformed model ID"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->