### PR TITLE
Model id case transformation fix

### DIFF
--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -652,10 +652,9 @@ def get_model_id_mapping(provider: str) -> dict[str, str]:
             "glm-4.6-fp8": "zai-org/GLM-4.6",
             "glm-4.6": "zai-org/GLM-4.6",
 
-            # Moonshot AI Kimi models (thinking/reasoning)
-            "moonshotai/kimi-k2-thinking": "moonshotai/Kimi-K2-Thinking",
-            "kimi-k2-thinking": "moonshotai/Kimi-K2-Thinking",
-            "kimi-k2": "moonshotai/Kimi-K2-Thinking",
+            # Note: Kimi-K2-Thinking model is NOT available on Near AI
+            # Users requesting moonshotai/kimi-k2-thinking should use OpenRouter instead
+            # Near AI only has DeepSeek, Qwen, and GLM models currently
         },
         "alpaca-network": {
             # Alpaca Network uses Anyscale infrastructure with DeepSeek models

--- a/src/services/models.py
+++ b/src/services/models.py
@@ -1957,14 +1957,8 @@ def fetch_models_from_near():
                 "outputCostPerToken": {"amount": 2.0, "scale": -6},  # $2.00 per million tokens
                 "metadata": {"contextLength": 200000},
             },
-            {
-                "id": "moonshotai/Kimi-K2-Thinking",
-                "modelId": "moonshotai/Kimi-K2-Thinking",
-                "owned_by": "Moonshot AI",
-                "inputCostPerToken": {"amount": 0.6, "scale": -6},  # $0.60 per million tokens
-                "outputCostPerToken": {"amount": 2.4, "scale": -6},  # $2.40 per million tokens
-                "metadata": {"contextLength": 128000},
-            },
+            # Note: moonshotai/Kimi-K2-Thinking was removed - model is NOT available on Near AI
+            # Near AI only supports DeepSeek, Qwen, GLM, and GPT-OSS models currently
         ]
 
         normalized_models = [normalize_near_model(model) for model in fallback_models if model]


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-1e1f5583-1f17-41c8-975f-c7b90dcf7157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1e1f5583-1f17-41c8-975f-c7b90dcf7157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Near AI model catalog/mappings cleanup**
> 
> - Removed `moonshotai/Kimi-K2-Thinking` from Near AI fallback models in `models.py`
> - Dropped Near provider mappings for Kimi-K2-Thinking in `model_transformations.py`
> - Added comments clarifying Near AI currently supports DeepSeek, Qwen, GLM, and GPT-OSS; Kimi should be accessed via OpenRouter
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba592473fd1b5a659224176fb7e4a20d7a857664. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Removes invalid `moonshotai/Kimi-K2-Thinking` model mappings from Near AI provider configuration
- Adds clarifying comments indicating Kimi-K2-Thinking is not available on Near AI and should be accessed via OpenRouter
- Cleans up provider-model mappings to ensure accurate routing between providers and prevent 404 errors

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/services/models.py | Removed moonshotai/Kimi-K2-Thinking from Near AI fallback model catalog with explanatory comment |
| src/services/model_transformations.py | Removed Near AI transformation mappings for Kimi-K2-Thinking and added routing guidance comments |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk as it removes invalid model mappings that were causing routing errors
- Score reflects simple, well-documented cleanup changes that fix actual provider capability mismatches and improve system accuracy
- No files require special attention as both changes are straightforward mapping removals with clear documentation

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API as "API Gateway"
    participant MT as "Model Transformations"
    participant Models as "Models Service"
    participant NearClient as "Near AI Client"
    participant Cache as "Cache Layer"

    User->>API: "Request with near/qwen-3-30b"
    API->>MT: "transform_model_id(model_id, 'near')"
    MT->>MT: "apply_model_alias(model_id)"
    MT->>MT: "Strip 'near/' prefix"
    note over MT: "near/qwen-3-30b → qwen-3-30b"
    MT->>MT: "Check mapping for 'near' provider"
    MT->>MT: "Map to canonical: Qwen/Qwen3-30B-A3B-Instruct-2507"
    MT-->>API: "Transformed model ID"
    
    API->>Models: "get_cached_models('near')"
    Models->>Cache: "Check Near AI cache freshness"
    alt Cache is stale
        Models->>NearClient: "fetch_models_from_near()"
        NearClient->>NearClient: "Try Near AI API endpoint"
        alt API fails
            NearClient->>NearClient: "Use fallback model list"
            note over NearClient: "DeepSeek-V3.1, GPT-OSS-120B,<br/>Qwen3-30B, GLM-4.6<br/>(Kimi-K2 removed)"
        end
        NearClient->>Models: "normalize_near_model() for each"
        Models->>Cache: "Update cache with normalized models"
    end
    Models-->>API: "Near AI models catalog"
    API-->>User: "Model available for inference"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->