### PR TITLE
Model detail api path

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -373,6 +373,7 @@ def create_app() -> FastAPI:
 
     # Define non-v1 routes (loaded directly on app without prefix)
     non_v1_routes_to_load = [
+        ("api_models", "API Models Detail"),  # /api/models/detail endpoint for frontend
         ("health", "Health Check"),
         ("availability", "Model Availability"),
         ("ping", "Ping Service"),

--- a/src/routes/api_models.py
+++ b/src/routes/api_models.py
@@ -1,0 +1,189 @@
+"""
+API Models Routes
+
+This module provides the /api/models/detail endpoint for frontend compatibility.
+The frontend calls /api/models/detail with query parameters instead of the RESTful
+path-based endpoint /v1/models/{provider}/{model}.
+"""
+
+import logging
+from datetime import datetime, UTC
+
+from fastapi import APIRouter, HTTPException, Query
+
+from src.routes.catalog import (
+    annotate_provider_sources,
+    derive_providers_from_models,
+    merge_provider_lists,
+    normalize_developer_segment,
+    normalize_model_segment,
+)
+from src.services.models import (
+    enhance_model_with_huggingface_data,
+    enhance_model_with_provider_info,
+    fetch_specific_model,
+)
+from src.services.providers import enhance_providers_with_logos_and_sites, get_cached_providers
+from src.services.models import get_cached_models
+from src.utils.security_validators import sanitize_for_logging
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api", tags=["api-models"])
+
+
+@router.get("/models/detail")
+async def get_model_detail(
+    modelId: str | None = Query(None, description="Full model ID (e.g., 'z-ai/glm-4-7')"),
+    developer: str | None = Query(None, description="Developer/provider name (e.g., 'z-ai')"),
+    modelName: str | None = Query(None, description="Model name (e.g., 'glm-4-7')"),
+    include_huggingface: bool = Query(True, description="Include Hugging Face metrics if available"),
+    gateway: str | None = Query(None, description="Gateway to use for fetching model data"),
+):
+    """
+    Get specific model details using query parameters.
+
+    This endpoint provides compatibility with frontend clients that use query parameters
+    instead of the RESTful path-based endpoint /v1/models/{provider}/{model}.
+
+    The endpoint accepts either:
+    - modelId: Full model ID in format "developer/model-name"
+    - developer + modelName: Separate parameters for developer and model name
+
+    Examples:
+        GET /api/models/detail?modelId=z-ai/glm-4-7
+        GET /api/models/detail?developer=z-ai&modelName=glm-4-7
+        GET /api/models/detail?modelId=openai/gpt-4&gateway=openrouter
+    """
+    try:
+        # Determine provider_name and model_name from query parameters
+        provider_name = None
+        model_name = None
+
+        if modelId:
+            # Parse modelId to extract provider and model name
+            if "/" in modelId:
+                parts = modelId.split("/", 1)
+                provider_name = parts[0]
+                model_name = parts[1] if len(parts) > 1 else None
+            else:
+                # If no slash, treat the whole thing as model name
+                model_name = modelId
+        
+        # Use developer/modelName if provided (overrides parsed values)
+        if developer:
+            provider_name = developer
+        if modelName:
+            model_name = modelName
+
+        # Validate we have required parameters
+        if not provider_name or not model_name:
+            raise HTTPException(
+                status_code=400,
+                detail="Missing required parameters. Provide either 'modelId' (e.g., 'z-ai/glm-4-7') "
+                       "or both 'developer' and 'modelName' parameters."
+            )
+
+        # Normalize the parameters
+        provider_name = normalize_developer_segment(provider_name) or provider_name
+        model_name = normalize_model_segment(model_name) or model_name
+
+        logger.info(
+            "Fetching model detail: provider=%s, model=%s, gateway=%s",
+            sanitize_for_logging(provider_name),
+            sanitize_for_logging(model_name),
+            sanitize_for_logging(gateway) if gateway else "auto",
+        )
+
+        # Fetch model data from appropriate gateway
+        model_data = fetch_specific_model(provider_name, model_name, gateway)
+
+        if not model_data:
+            gateway_msg = f" from gateway '{gateway}'" if gateway else ""
+            raise HTTPException(
+                status_code=404,
+                detail=f"Model {provider_name}/{model_name} not found{gateway_msg}"
+            )
+
+        # Determine which gateway was used
+        detected_gateway = model_data.get("source_gateway", gateway or "all")
+
+        # Get enhanced providers data for all gateways
+        provider_groups: list[list[dict]] = []
+
+        # Always try to get OpenRouter providers for cross-reference
+        openrouter_providers = get_cached_providers()
+        if openrouter_providers:
+            enhanced_openrouter = annotate_provider_sources(
+                enhance_providers_with_logos_and_sites(openrouter_providers),
+                "openrouter",
+            )
+            provider_groups.append(enhanced_openrouter)
+
+        # Add providers from other gateways based on detected gateway
+        if detected_gateway in [
+            "featherless",
+            "deepinfra",
+            "chutes",
+            "groq",
+            "fireworks",
+            "together",
+            "cerebras",
+            "nebius",
+            "xai",
+            "novita",
+            "hug",
+            "aimo",
+            "near",
+            "fal",
+            "anannas",
+            "aihubmix",
+            "vercel-ai-gateway",
+            "onerouter",
+            "helicone",
+        ]:
+            # Get models from the detected gateway to derive providers
+            gateway_models = get_cached_models(detected_gateway)
+            if gateway_models:
+                derived_providers = derive_providers_from_models(gateway_models, detected_gateway)
+                annotated_providers = annotate_provider_sources(derived_providers, detected_gateway)
+                provider_groups.append(annotated_providers)
+
+        # Merge all provider data
+        enhanced_providers = merge_provider_lists(*provider_groups) if provider_groups else []
+
+        # Enhance with provider information and logos
+        if isinstance(model_data, dict):
+            model_data = enhance_model_with_provider_info(model_data, enhanced_providers)
+
+            # Then enhance with Hugging Face data if requested
+            if include_huggingface and model_data.get("hugging_face_id"):
+                model_data = enhance_model_with_huggingface_data(model_data)
+
+        # Extract provider list from model data for frontend compatibility
+        providers = []
+        if model_data.get("source_gateways"):
+            providers = model_data.get("source_gateways", [])
+        elif detected_gateway:
+            providers = [detected_gateway]
+
+        return {
+            "data": model_data,
+            "providers": providers,
+            "provider": provider_name,
+            "model": model_name,
+            "gateway": detected_gateway,
+            "include_huggingface": include_huggingface,
+            "timestamp": datetime.now(UTC).isoformat(),
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(
+            "Failed to get model detail for %s/%s: %s",
+            sanitize_for_logging(provider_name) if provider_name else "unknown",
+            sanitize_for_logging(model_name) if model_name else "unknown",
+            sanitize_for_logging(str(e)),
+        )
+        raise HTTPException(status_code=500, detail="Failed to get model data")

--- a/tests/routes/test_api_models.py
+++ b/tests/routes/test_api_models.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""
+Integration tests for /api/models/detail endpoint
+
+This endpoint provides frontend compatibility for fetching model details
+using query parameters instead of path parameters.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+
+from src.main import app
+
+client = TestClient(app)
+
+
+class TestApiModelsDetailEndpoint:
+    """Test /api/models/detail endpoint"""
+
+    @patch('src.routes.api_models.fetch_specific_model')
+    @patch('src.routes.api_models.get_cached_providers')
+    def test_get_model_detail_with_model_id(self, mock_providers, mock_fetch):
+        """Test getting model detail using modelId parameter"""
+        mock_providers.return_value = []
+        mock_fetch.return_value = {
+            "id": "z-ai/glm-4-7",
+            "name": "GLM-4-7",
+            "description": "Test model",
+            "source_gateway": "openrouter",
+        }
+
+        response = client.get("/api/models/detail?modelId=z-ai/glm-4-7")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["data"]["id"] == "z-ai/glm-4-7"
+        assert data["provider"] == "z-ai"
+        assert data["model"] == "glm-4-7"
+
+    @patch('src.routes.api_models.fetch_specific_model')
+    @patch('src.routes.api_models.get_cached_providers')
+    def test_get_model_detail_with_separate_params(self, mock_providers, mock_fetch):
+        """Test getting model detail using separate developer and modelName params"""
+        mock_providers.return_value = []
+        mock_fetch.return_value = {
+            "id": "openai/gpt-4",
+            "name": "GPT-4",
+            "source_gateway": "openrouter",
+        }
+
+        response = client.get("/api/models/detail?developer=openai&modelName=gpt-4")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["provider"] == "openai"
+        assert data["model"] == "gpt-4"
+
+    @patch('src.routes.api_models.fetch_specific_model')
+    @patch('src.routes.api_models.get_cached_providers')
+    def test_get_model_detail_with_all_params(self, mock_providers, mock_fetch):
+        """Test with both modelId and separate params (separate params take precedence)"""
+        mock_providers.return_value = []
+        mock_fetch.return_value = {
+            "id": "anthropic/claude-3",
+            "name": "Claude 3",
+            "source_gateway": "openrouter",
+        }
+
+        # When both are provided, developer/modelName override parsed values from modelId
+        response = client.get(
+            "/api/models/detail?modelId=wrong/model&developer=anthropic&modelName=claude-3"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["provider"] == "anthropic"
+        assert data["model"] == "claude-3"
+
+    @patch('src.routes.api_models.fetch_specific_model')
+    @patch('src.routes.api_models.get_cached_providers')
+    def test_get_model_detail_with_gateway(self, mock_providers, mock_fetch):
+        """Test getting model detail with specific gateway"""
+        mock_providers.return_value = []
+        mock_fetch.return_value = {
+            "id": "meta-llama/llama-2-70b",
+            "name": "Llama 2 70B",
+            "source_gateway": "deepinfra",
+        }
+
+        response = client.get(
+            "/api/models/detail?modelId=meta-llama/llama-2-70b&gateway=deepinfra"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["gateway"] == "deepinfra"
+
+    @patch('src.routes.api_models.fetch_specific_model')
+    def test_get_model_detail_not_found(self, mock_fetch):
+        """Test 404 when model not found"""
+        mock_fetch.return_value = None
+
+        response = client.get("/api/models/detail?modelId=nonexistent/model")
+
+        assert response.status_code == 404
+        data = response.json()
+        assert "not found" in data["detail"].lower()
+
+    def test_get_model_detail_missing_params(self):
+        """Test 400 when required parameters are missing"""
+        response = client.get("/api/models/detail")
+
+        assert response.status_code == 400
+        data = response.json()
+        assert "missing required parameters" in data["detail"].lower()
+
+    def test_get_model_detail_only_developer(self):
+        """Test 400 when only developer is provided"""
+        response = client.get("/api/models/detail?developer=openai")
+
+        assert response.status_code == 400
+
+    def test_get_model_detail_only_model_name(self):
+        """Test when only modelName is provided without developer"""
+        # modelName alone should fail because we need both
+        response = client.get("/api/models/detail?modelName=gpt-4")
+
+        assert response.status_code == 400
+
+    @patch('src.routes.api_models.fetch_specific_model')
+    @patch('src.routes.api_models.get_cached_providers')
+    def test_get_model_detail_with_huggingface(self, mock_providers, mock_fetch):
+        """Test including HuggingFace data"""
+        mock_providers.return_value = []
+        mock_fetch.return_value = {
+            "id": "meta-llama/Llama-2-7b",
+            "name": "Llama 2 7B",
+            "hugging_face_id": "meta-llama/Llama-2-7b-hf",
+            "source_gateway": "hug",
+        }
+
+        response = client.get(
+            "/api/models/detail?modelId=meta-llama/Llama-2-7b&include_huggingface=true"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["include_huggingface"] is True
+
+    @patch('src.routes.api_models.fetch_specific_model')
+    @patch('src.routes.api_models.get_cached_providers')
+    def test_get_model_detail_returns_providers_list(self, mock_providers, mock_fetch):
+        """Test that providers list is included in response"""
+        mock_providers.return_value = []
+        mock_fetch.return_value = {
+            "id": "openai/gpt-4",
+            "name": "GPT-4",
+            "source_gateway": "openrouter",
+            "source_gateways": ["openrouter", "deepinfra"],
+        }
+
+        response = client.get("/api/models/detail?modelId=openai/gpt-4")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "providers" in data
+        assert isinstance(data["providers"], list)
+        assert "openrouter" in data["providers"]
+
+    @patch('src.routes.api_models.fetch_specific_model')
+    @patch('src.routes.api_models.get_cached_providers')
+    def test_get_model_detail_url_encoded_model_id(self, mock_providers, mock_fetch):
+        """Test with URL-encoded modelId (as sent by frontend)"""
+        mock_providers.return_value = []
+        mock_fetch.return_value = {
+            "id": "z-ai/glm-4-7",
+            "name": "GLM-4-7",
+            "source_gateway": "openrouter",
+        }
+
+        # Frontend sends URL-encoded values like z-ai%2Fglm-4-7
+        # TestClient should handle this, but let's verify with explicit encoding
+        response = client.get("/api/models/detail?modelId=z-ai%2Fglm-4-7")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["provider"] == "z-ai"
+        assert data["model"] == "glm-4-7"
+
+    @patch('src.routes.api_models.fetch_specific_model')
+    @patch('src.routes.api_models.get_cached_providers')
+    def test_get_model_detail_with_complex_model_name(self, mock_providers, mock_fetch):
+        """Test with complex model names containing multiple slashes"""
+        mock_providers.return_value = []
+        mock_fetch.return_value = {
+            "id": "zai-org/glm-4-6",
+            "name": "GLM-4-6",
+            "source_gateway": "near",
+        }
+
+        response = client.get("/api/models/detail?modelId=zai-org/glm-4-6")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["provider"] == "zai-org"
+        assert data["model"] == "glm-4-6"
+
+
+class TestApiModelsDetailErrorHandling:
+    """Test error handling in /api/models/detail endpoint"""
+
+    @patch('src.routes.api_models.fetch_specific_model')
+    def test_internal_error_handling(self, mock_fetch):
+        """Test that internal errors return 500"""
+        mock_fetch.side_effect = Exception("Database error")
+
+        response = client.get("/api/models/detail?modelId=openai/gpt-4")
+
+        assert response.status_code == 500
+        data = response.json()
+        assert "failed to get model data" in data["detail"].lower()


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-1bc49d54-186b-4c64-bbcd-8498d1bcc404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1bc49d54-186b-4c64-bbcd-8498d1bcc404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Adds frontend-compatible model detail endpoint**
> 
> - New `GET /api/models/detail` in `src/routes/api_models.py` accepts `modelId` or `developer`+`modelName`, optional `gateway`, and `include_huggingface`
> - Enhances model data with provider info (logos/sites) and optional Hugging Face metrics; derives/merges providers across gateways and returns `providers` list
> - Error handling for missing params (400), not found (404), and internal errors (500); logs sanitized inputs
> - `src/main.py` loads new non-v1 route (`api_models`) alongside existing routes
> 
> **Tests**
> 
> - `tests/routes/test_api_models.py` covers query parsing precedence, gateway selection, HF inclusion, providers list, URL-encoded IDs, complex names, and error cases (400/404/500)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d17b9bc5c4c0bf24b762743301fb014c487c0b8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds new `GET /api/models/detail` endpoint that accepts query parameters (`modelId` or `developer`+`modelName`) to fetch model details for frontend consumption
- Enhances model data with provider information, logos/sites, and optional HuggingFace metrics while supporting multiple gateway selections
- Includes comprehensive test coverage for parameter validation, error handling, URL encoding, and edge cases

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/routes/api_models.py | New file containing frontend-compatible model detail endpoint with query parameter support and provider data enhancement |
| tests/routes/test_api_models.py | New comprehensive test suite covering parameter parsing, gateway selection, error scenarios, and edge cases |
| src/main.py | Added api_models router to non-v1 routes to enable the new frontend endpoint |

<h3>Confidence score: 4/5</h3>


- This PR adds a well-designed frontend-compatible API endpoint with minimal risk to existing functionality
- Score reflects solid implementation with comprehensive testing, but complexity in parameter handling and provider data merging requires careful review
- Pay close attention to `src/routes/api_models.py` for parameter validation logic and provider data enhancement patterns

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as User/Frontend
    participant Router as api_models router
    participant Catalog as catalog module
    participant Models as models service
    participant Providers as providers service
    
    User->>Router: "GET /api/models/detail?modelId=z-ai/glm-4-7"
    Router->>Router: "Parse modelId into provider/model"
    Router->>Router: "Normalize provider and model segments"
    Router->>Models: "fetch_specific_model(provider, model, gateway)"
    Models-->>Router: "Return model data"
    Router->>Providers: "get_cached_providers()"
    Providers-->>Router: "Return OpenRouter providers"
    Router->>Models: "get_cached_models(gateway)"
    Models-->>Router: "Return gateway models"
    Router->>Catalog: "derive_providers_from_models(models, gateway)"
    Catalog-->>Router: "Return derived providers"
    Router->>Catalog: "merge_provider_lists(provider_groups)"
    Catalog-->>Router: "Return enhanced providers"
    Router->>Models: "enhance_model_with_provider_info(model, providers)"
    Models-->>Router: "Return enhanced model"
    Router->>Models: "enhance_model_with_huggingface_data(model)"
    Models-->>Router: "Return model with HF data"
    Router->>User: "Return model detail with providers list"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->