### PR TITLE
fix(startup): reduce startup time to pass Railway healthcheck

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -8,10 +8,10 @@ restartPolicyMaxRetries = 10
 
 # Health check configuration for Railway
 # The /health endpoint returns 200 when the service is healthy
-# Timeout increased to 30s to allow for app initialization
-# Initial delay increased to 60s to match railway.json configuration
-# Note: Service takes ~15-20s to start due to connection warmup
+# Healthcheck timeout increased to 120s to handle cold starts with slow external services
+# Initial delay set to 30s - app should be ready quickly, but give buffer for container startup
+# Note: Startup optimizations applied to Statsig (5s timeout) and Supabase (10s timeout)
 healthcheckPath = "/health"
-healthcheckTimeout = 30
+healthcheckTimeout = 120
 healthcheckInterval = 30
-initialDelaySeconds = 60
+initialDelaySeconds = 30

--- a/src/config/supabase_config.py
+++ b/src/config/supabase_config.py
@@ -92,7 +92,7 @@ def get_supabase_client() -> Client:
                 "apikey": Config.SUPABASE_KEY,
                 "Authorization": f"Bearer {Config.SUPABASE_KEY}",
             },
-            timeout=httpx.Timeout(45.0, connect=10.0),  # Increased from 30s to 45s for complex queries
+            timeout=httpx.Timeout(10.0, connect=5.0),  # Reduced for faster startup; complex queries handled by request-level timeout
             limits=httpx.Limits(
                 max_connections=max_conn,
                 max_keepalive_connections=keepalive_conn,
@@ -105,8 +105,8 @@ def get_supabase_client() -> Client:
             supabase_url=Config.SUPABASE_URL,
             supabase_key=Config.SUPABASE_KEY,
             options=ClientOptions(
-                postgrest_client_timeout=45,  # 45 second timeout (increased for complex queries)
-                storage_client_timeout=45,  # Consistent with httpx timeout
+                postgrest_client_timeout=10,  # 10 second timeout for startup; individual requests can override
+                storage_client_timeout=30,  # Storage operations may need longer
                 schema="public",
                 headers={"X-Client-Info": "gatewayz-backend/1.0"},
             ),

--- a/src/main.py
+++ b/src/main.py
@@ -595,16 +595,18 @@ def create_app() -> FastAPI:
             except Exception as db_e:
                 logger.warning(f"    Database initialization warning: {db_e}")
 
-            # Set default admin user
-            try:
-                from src.config.supabase_config import get_supabase_client
-                from src.db.roles import UserRole, update_user_role
+            # Set default admin user in background (don't block startup)
+            async def setup_admin_user_background():
+                try:
+                    from src.config.supabase_config import get_supabase_client
+                    from src.db.roles import UserRole, update_user_role
 
-                ADMIN_EMAIL = Config.ADMIN_EMAIL
+                    ADMIN_EMAIL = Config.ADMIN_EMAIL
 
-                if not ADMIN_EMAIL:
-                    logger.warning("    ADMIN_EMAIL not configured in environment variables")
-                else:
+                    if not ADMIN_EMAIL:
+                        logger.debug("ADMIN_EMAIL not configured - skipping admin setup")
+                        return
+
                     client = get_supabase_client()
                     result = (
                         client.table("users").select("id, role").eq("email", ADMIN_EMAIL).execute()
@@ -622,10 +624,12 @@ def create_app() -> FastAPI:
                             )
                             logger.info(f"   Set {ADMIN_EMAIL} as admin")
                         else:
-                            logger.info(f"  ℹ  {ADMIN_EMAIL} is already admin")
+                            logger.debug(f"{ADMIN_EMAIL} is already admin")
 
-            except Exception as admin_e:
-                logger.warning(f"    Admin setup warning: {admin_e}")
+                except Exception as admin_e:
+                    logger.warning(f"Admin setup warning: {admin_e}")
+
+            asyncio.create_task(setup_admin_user_background())
 
             # Initialize analytics services (Statsig, PostHog, and Braintrust)
             try:


### PR DESCRIPTION
## Summary

The backend deployment was failing because the app took 7+ minutes to start, while the Railway healthcheck only waited 30-60 seconds. This was causing chat to fail because:
1. The new code with the chat message sequence fix wasn't being deployed
2. The old deployment was still running but experiencing timeouts

### Root Causes Identified and Fixed:

- **Statsig SDK** `initialize().wait()` blocked indefinitely → added 5s timeout
- **Supabase client** had 45s connection timeout → reduced to 10s  
- **Admin user setup** made blocking DB calls → moved to background task
- **Railway healthcheck** timeout was too short → increased to 120s

### Changes:
| File | Change |
|------|--------|
| `src/services/statsig_service.py` | Added 5s timeout to Statsig initialization |
| `src/config/supabase_config.py` | Reduced httpx timeout from 45s→10s |
| `src/main.py` | Moved admin user setup to background task |
| `railway.toml` | Increased healthcheckTimeout to 120s |

## Test Plan

- [ ] Verify syntax is correct (all files compile)
- [ ] Verify deployment passes healthcheck within 60s
- [ ] Verify chat functionality works after deployment
- [ ] Monitor for Statsig/Supabase warnings in logs (graceful degradation)

## Related Issues

- Fixes chat failure caused by database trigger error (migration in #667)
- Fixes 4 failed Railway deployments from Dec 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves startup reliability and healthcheck pass rates by minimizing blocking calls and tuning timeouts.
> 
> - Adds a 5s timeout to Statsig `initialize().wait()` with degraded-mode fallback in `src/services/statsig_service.py`
> - Lowers Supabase client timeouts (`httpx` 10s/5s connect; `postgrest_client_timeout` 10s; `storage_client_timeout` 30s) and retains HTTP/2 pooling in `src/config/supabase_config.py`
> - Moves default admin user setup to a non-blocking background task via `asyncio.create_task()` in `src/main.py`
> - Updates `railway.toml` healthcheck config: `healthcheckTimeout=120`, `initialDelaySeconds=30` (with clarified comments)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfc12ae9cd3e182da38291bc68024ba3bda7f0c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Fixes Railway deployment failures by optimizing FastAPI application startup time from 7+ minutes to under 60 seconds
- Addresses blocking operations in `src/services/statsig_service.py`, `src/config/supabase_config.py`, and `src/main.py` that were preventing healthchecks from passing
- Adjusts Railway healthcheck timeout configuration in `railway.toml` from 30s to 120s while reducing initial delay

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| `src/services/statsig_service.py` | Added 5-second timeout to Statsig initialization with graceful degradation to prevent indefinite blocking |
| `src/config/supabase_config.py` | Reduced connection timeouts: httpx 45s→10s, postgrest 45s→10s, storage 45s→30s for faster startup |
| `src/main.py` | Moved admin user setup to background task using `asyncio.create_task()` to avoid blocking startup |
| `railway.toml` | Increased healthcheckTimeout from 30s to 120s and reduced initialDelaySeconds from 60s to 30s |

<h3>Confidence score: 4/5</h3>


- This PR addresses critical deployment issues and is relatively safe to merge with proper monitoring
- Score reflects well-targeted fixes for specific blocking operations, though timeout values are somewhat arbitrary and may need adjustment
- Pay close attention to `src/services/statsig_service.py` for potential graceful degradation issues and monitor application logs post-deployment

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Railway as "Railway Platform"
    participant App as "FastAPI Application"
    participant Statsig as "Statsig SDK"
    participant Supabase as "Supabase Client"
    participant Admin as "Admin User Setup"
    participant Background as "Background Tasks"

    note over Railway: "Deployment starts"
    Railway->>App: "Start container with start.sh"
    
    note over App: "FastAPI startup event begins"
    App->>App: "Validate configuration"
    
    App->>Supabase: "Initialize client with 10s timeout"
    alt Success within 10s
        Supabase-->>App: "Connection successful"
    else Timeout after 10s
        Supabase-->>App: "Timeout - degraded mode"
    end
    
    App->>Background: "Create admin user setup task"
    Background->>Admin: "Setup admin user asynchronously"
    
    App->>Statsig: "Initialize with 5s timeout"
    alt Success within 5s
        Statsig-->>App: "Initialization complete"
    else Timeout after 5s
        Statsig-->>App: "Timeout - degraded mode"
    end
    
    App->>Background: "Start analytics & cache warming"
    
    App->>App: "Application ready"
    
    note over Railway: "healthcheckTimeout=120s, initialDelaySeconds=30s"
    Railway->>App: "GET /health (after 30s)"
    App-->>Railway: "200 OK"
    
    note over Railway: "Healthcheck passes, deployment successful"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->