### PR TITLE
fix(vertex): strip google/ prefix from model IDs to prevent 404 errors

### DIFF
--- a/src/services/google_vertex_client.py
+++ b/src/services/google_vertex_client.py
@@ -294,7 +294,8 @@ def transform_google_vertex_model_id(model_id: str) -> str:
     The full URL path is constructed in the API call functions.
 
     Args:
-        model_id: Model identifier (e.g., 'gemini-2.0-flash', 'gemini-1.5-pro')
+        model_id: Model identifier (e.g., 'gemini-2.0-flash', 'gemini-1.5-pro',
+                  'google/gemini-2.0-flash')
 
     Returns:
         Simple model name (e.g., 'gemini-2.5-flash-lite')
@@ -303,6 +304,10 @@ def transform_google_vertex_model_id(model_id: str) -> str:
     if model_id.startswith("projects/"):
         # Extract model name from projects/.../models/{model}
         return model_id.split("/models/")[-1]
+
+    # Strip provider prefix (e.g., 'google/gemini-2.0-flash' -> 'gemini-2.0-flash')
+    if model_id.startswith("google/"):
+        return model_id[7:]  # len("google/") == 7
 
     # Otherwise, return as-is
     return model_id


### PR DESCRIPTION
## Summary
- Fixed `transform_google_vertex_model_id` to strip the `google/` prefix from model IDs
- When model IDs like `google/gemini-3-pro-preview` were passed, the URL was malformed as `publishers/google/models/google/gemini-3-pro-preview`
- The Vertex REST API returned HTTP 404 for these invalid paths

## Test plan
- [x] Added `test_transform_google_prefix` to test the transform function with prefixed model IDs
- [x] Added `test_rest_request_strips_google_prefix_from_model_id` to verify URL construction
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes malformed Vertex REST URLs by normalizing model IDs.
> 
> - Updates `transform_google_vertex_model_id` to strip `google/` provider prefix (and continue handling full resource names)
> - Adds `test_transform_google_prefix` and `test_rest_request_strips_google_prefix_from_model_id` to validate prefix stripping and correct `publishers/google/models/{model}` URL paths
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e5cc7094f8e9837355a7e21a1b4c2500a1ebb34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Fixes a critical bug in Google Vertex AI integration by stripping `google/` provider prefix from model IDs to prevent HTTP 404 errors caused by malformed REST API URLs
- Updates `transform_google_vertex_model_id` function to normalize model IDs like `google/gemini-3-pro-preview` to `gemini-3-pro-preview` before URL construction
- Adds comprehensive test coverage with two new test cases to validate prefix stripping and URL construction in the complete request flow

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/services/google_vertex_client.py | Fixed model ID transformation by adding `google/` prefix stripping logic to prevent URL duplication |
| tests/services/test_google_vertex_client.py | Added two new test cases to validate prefix stripping and end-to-end URL construction |

<h3>Confidence score: 5/5</h3>


- This PR is extremely safe to merge with minimal risk as it fixes a clear bug with a targeted solution
- Score reflects a well-contained fix with comprehensive test coverage and clear problem identification - the solution directly addresses the root cause of 404 errors without introducing complexity or breaking changes
- No files require special attention as the fix is straightforward and well-tested

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant VertexClient as "Google Vertex Client"
    participant Transform as "transform_google_vertex_model_id"
    participant LocationDetector as "_get_model_location"
    participant RESTClient as "REST API Client"
    participant VertexAPI as "Google Vertex AI API"

    User->>VertexClient: "make_google_vertex_request_openai(model='google/gemini-3-pro-preview')"
    VertexClient->>Transform: "transform_google_vertex_model_id('google/gemini-3-pro-preview')"
    Transform->>Transform: "Strip 'google/' prefix"
    Transform-->>VertexClient: "gemini-3-pro-preview"
    VertexClient->>LocationDetector: "_get_model_location('gemini-3-pro-preview')"
    LocationDetector->>LocationDetector: "Check if 'gemini-3' in model name"
    LocationDetector-->>VertexClient: "global"
    VertexClient->>RESTClient: "_make_google_vertex_request_rest(model='gemini-3-pro-preview')"
    RESTClient->>RESTClient: "Build URL: publishers/google/models/gemini-3-pro-preview"
    RESTClient->>VertexAPI: "POST /publishers/google/models/gemini-3-pro-preview:generateContent"
    VertexAPI-->>RESTClient: "HTTP 200 + response data"
    RESTClient-->>VertexClient: "Normalized OpenAI response"
    VertexClient-->>User: "Chat completion response"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->