### PR TITLE
fix(providers): correct DeepSeek model mappings and routing

### DIFF
--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -36,6 +36,14 @@ MODEL_PROVIDER_OVERRIDES = {
     "deepseek/deepseek-chat": "openrouter",
     "deepseek-ai/deepseek-chat": "openrouter",
     "deepseek-chat": "openrouter",
+    # DeepSeek Chat V3 variants - non-standard names users sometimes request
+    # These should route to OpenRouter's deepseek-chat or be aliased to V3
+    "deepseek/deepseek-chat-v3-0324": "openrouter",
+    "deepseek-ai/deepseek-chat-v3-0324": "openrouter",
+    "deepseek-chat-v3-0324": "openrouter",
+    "deepseek/deepseek-chat-v3.1": "openrouter",
+    "deepseek-ai/deepseek-chat-v3.1": "openrouter",
+    "deepseek-chat-v3.1": "openrouter",
     # Note: Cerebras DOES support Llama models natively (3.1 and 3.3 series)
     # No override needed - let natural provider detection route to Cerebras
 }
@@ -450,6 +458,13 @@ def get_model_id_mapping(provider: str) -> dict[str, str]:
             "deepseek/deepseek-chat": "deepseek/deepseek-chat",
             "deepseek-ai/deepseek-chat": "deepseek/deepseek-chat",
             "deepseek-chat": "deepseek/deepseek-chat",
+            # DeepSeek Chat V3 variants - non-standard names that should map to deepseek-chat
+            "deepseek/deepseek-chat-v3-0324": "deepseek/deepseek-chat",
+            "deepseek-ai/deepseek-chat-v3-0324": "deepseek/deepseek-chat",
+            "deepseek-chat-v3-0324": "deepseek/deepseek-chat",
+            "deepseek/deepseek-chat-v3.1": "deepseek/deepseek-chat",
+            "deepseek-ai/deepseek-chat-v3.1": "deepseek/deepseek-chat",
+            "deepseek-chat-v3.1": "deepseek/deepseek-chat",
             # Cerebras models explicitly routed through OpenRouter
             # (for users who request provider="openrouter" explicitly or failover scenarios)
             "cerebras/llama-3.3-70b": "meta-llama/llama-3.3-70b-instruct",

--- a/src/services/request_prioritization.py
+++ b/src/services/request_prioritization.py
@@ -46,7 +46,7 @@ LOW_LATENCY_MODELS: set[str] = {
     "google/gemini-2.0-flash-exp:free",
     "mistralai/ministral-3b-2512",  # 421ms
     # Fireworks fast models
-    "fireworks/accounts/fireworks/models/deepseek-v3-0324",  # 326ms
+    "fireworks/accounts/fireworks/models/deepseek-v3p1",  # 326ms (was v3-0324, corrected to actual model ID)
 }
 
 # Provider latency tiers based on production data (lower = faster)
@@ -446,7 +446,7 @@ def suggest_low_latency_alternative(model_id: str) -> str | None:
         "gpt-3.5": "groq/llama-3.1-8b-instant",
         "openai": "groq/llama-3.3-70b-versatile",
         # For reasoning models (slower by nature)
-        "deepseek-r1": "fireworks/accounts/fireworks/models/deepseek-v3-0324",
+        "deepseek-r1": "fireworks/accounts/fireworks/models/deepseek-r1-0528",
         "o1": "groq/llama-3.3-70b-versatile",
         "o3": "groq/llama-3.3-70b-versatile",
         # For general chat


### PR DESCRIPTION
## Summary
- Fix invalid Fireworks model ID `deepseek-v3-0324` → `deepseek-v3p1` in request_prioritization.py
- Fix incorrect deepseek-r1 fallback mapping to use correct `deepseek-r1-0528` model
- Add missing DeepSeek Chat V3 variant mappings to route non-standard model names to OpenRouter

## Problem
Users requesting `deepseek/deepseek-chat-v3-0324` or `deepseek/deepseek-chat-v3.1` were getting 404 errors because:
1. These models have no explicit Fireworks mapping
2. They were incorrectly being routed to Fireworks which doesn't have these models

## Solution
- Added provider overrides to route these variants to OpenRouter
- Added OpenRouter mappings to transform these to `deepseek/deepseek-chat`
- Fixed hardcoded references to non-existent `deepseek-v3-0324` model ID

## Test plan
- [ ] Verify requests for `deepseek/deepseek-chat-v3-0324` now route to OpenRouter
- [ ] Verify requests for `deepseek/deepseek-chat-v3.1` now route to OpenRouter
- [ ] Verify low-latency model list uses correct Fireworks model ID
- [ ] Verify deepseek-r1 fallback uses correct model

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures correct routing and faster fallbacks for DeepSeek models across providers.
> 
> - Add provider overrides and OpenRouter mappings for non-standard DeepSeek Chat V3 IDs (`deepseek-chat-v3-0324`, `deepseek-chat-v3.1`) to map to `deepseek/deepseek-chat`
> - Correct Fireworks low-latency model ID from `deepseek-v3-0324` to `deepseek-v3p1` in `request_prioritization.py`
> - Update low-latency alternative mapping for `deepseek-r1` to `fireworks/accounts/fireworks/models/deepseek-r1-0528`
> - Extend `MODEL_PROVIDER_OVERRIDES` and OpenRouter mapping tables in `model_transformations.py` to route DeepSeek variants to OpenRouter and canonical models
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ade464b0b0f2ea81e0007d67a548bc9ab06163f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Corrects invalid DeepSeek model ID references in request prioritization, fixing Fireworks model ID from `deepseek-v3-0324` to `deepseek-v3p1` and updating fallback mapping for `deepseek-r1` to use correct `deepseek-r1-0528`
- Adds provider overrides and OpenRouter mappings for DeepSeek Chat V3 variants (`deepseek-chat-v3-0324`, `deepseek-chat-v3.1`) to route non-standard model names to OpenRouter instead of failing with 404 errors
- Implements mapping transformations to convert DeepSeek Chat V3 variants to the canonical `deepseek/deepseek-chat` model ID on OpenRouter

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| `src/services/request_prioritization.py` | Fixed invalid Fireworks model ID references that would cause 404 errors in low-latency routing |
| `src/services/model_transformations.py` | Added provider overrides and OpenRouter mappings for DeepSeek Chat V3 variants to prevent routing failures |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk as it fixes critical model routing issues that were causing 404 errors
- Score reflects straightforward model ID corrections and addition of proper routing mappings with no complex logic changes or breaking changes
- Pay attention to both files as they work together to fix the DeepSeek model routing pipeline

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant "Chat API" as API
    participant "Model Transformations" as Transform
    participant "Provider Overrides" as Override
    participant "OpenRouter Mapping" as Mapping
    participant "Request Prioritization" as Priority
    participant OpenRouter

    User->>API: "Request deepseek/deepseek-chat-v3-0324"
    API->>Transform: "transform_model_id(deepseek/deepseek-chat-v3-0324)"
    Transform->>Override: "Check MODEL_PROVIDER_OVERRIDES"
    Override-->>Transform: "deepseek/deepseek-chat-v3-0324 -> openrouter"
    Transform->>Mapping: "Get OpenRouter mapping"
    Mapping-->>Transform: "deepseek/deepseek-chat-v3-0324 -> deepseek/deepseek-chat"
    Transform-->>API: "deepseek/deepseek-chat (provider: openrouter)"
    API->>Priority: "Check low-latency alternatives"
    Priority-->>API: "Use corrected deepseek-v3p1 for low-latency"
    API->>OpenRouter: "POST /chat/completions (deepseek/deepseek-chat)"
    OpenRouter-->>API: "Chat completion response"
    API-->>User: "Response from DeepSeek Chat V3"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->