### PR TITLE
fix(backend): add DeepSeek Chat V3 variant model mappings

### DIFF
--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -36,6 +36,17 @@ MODEL_PROVIDER_OVERRIDES = {
     "deepseek/deepseek-chat": "openrouter",
     "deepseek-ai/deepseek-chat": "openrouter",
     "deepseek-chat": "openrouter",
+    # DeepSeek Chat V3 variants - these are user-requested aliases that should route to OpenRouter
+    # since "deepseek-chat" is the canonical OpenRouter model name for DeepSeek's latest chat model
+    "deepseek/deepseek-chat-v3": "openrouter",
+    "deepseek/deepseek-chat-v3.1": "openrouter",
+    "deepseek/deepseek-chat-v3-0324": "openrouter",
+    "deepseek-ai/deepseek-chat-v3": "openrouter",
+    "deepseek-ai/deepseek-chat-v3.1": "openrouter",
+    "deepseek-ai/deepseek-chat-v3-0324": "openrouter",
+    "deepseek-chat-v3": "openrouter",
+    "deepseek-chat-v3.1": "openrouter",
+    "deepseek-chat-v3-0324": "openrouter",
     # Note: Cerebras DOES support Llama models natively (3.1 and 3.3 series)
     # No override needed - let natural provider detection route to Cerebras
 }
@@ -450,6 +461,16 @@ def get_model_id_mapping(provider: str) -> dict[str, str]:
             "deepseek/deepseek-chat": "deepseek/deepseek-chat",
             "deepseek-ai/deepseek-chat": "deepseek/deepseek-chat",
             "deepseek-chat": "deepseek/deepseek-chat",
+            # DeepSeek Chat V3 variants - map to the canonical deepseek/deepseek-chat on OpenRouter
+            "deepseek/deepseek-chat-v3": "deepseek/deepseek-chat",
+            "deepseek/deepseek-chat-v3.1": "deepseek/deepseek-chat",
+            "deepseek/deepseek-chat-v3-0324": "deepseek/deepseek-chat",
+            "deepseek-ai/deepseek-chat-v3": "deepseek/deepseek-chat",
+            "deepseek-ai/deepseek-chat-v3.1": "deepseek/deepseek-chat",
+            "deepseek-ai/deepseek-chat-v3-0324": "deepseek/deepseek-chat",
+            "deepseek-chat-v3": "deepseek/deepseek-chat",
+            "deepseek-chat-v3.1": "deepseek/deepseek-chat",
+            "deepseek-chat-v3-0324": "deepseek/deepseek-chat",
             # Cerebras models explicitly routed through OpenRouter
             # (for users who request provider="openrouter" explicitly or failover scenarios)
             "cerebras/llama-3.3-70b": "meta-llama/llama-3.3-70b-instruct",


### PR DESCRIPTION
## Summary
- Add provider overrides for DeepSeek Chat V3 model variants to route to OpenRouter
- Add OpenRouter mappings to transform V3 variants to canonical `deepseek/deepseek-chat`
- Fixes 404 errors for models: `deepseek-chat-v3.1`, `deepseek-chat-v3-0324`, and related variants

## Problem
Railway logs showed 404 errors when users requested DeepSeek Chat V3 variants like:
- `deepseek/deepseek-chat-v3.1`
- `deepseek/deepseek-chat-v3-0324`

These models were being routed to Fireworks via emergency fallback, but Fireworks doesn't recognize these model identifiers.

## Solution
Added proper provider overrides and model mappings so these variants are:
1. Routed to OpenRouter (which hosts DeepSeek models)
2. Transformed to `deepseek/deepseek-chat` (the canonical OpenRouter model name)

## Test plan
- [x] Verified MODEL_PROVIDER_OVERRIDES correctly maps new variants to "openrouter"
- [x] Verified transform_model_id correctly transforms to "deepseek/deepseek-chat"
- [ ] CI tests should pass

## Related
- Railway logs showed multiple 404 errors from Fireworks for these model IDs
- Also observed: OpenRouter 402 (insufficient credits) - separate billing issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Routes DeepSeek Chat V3 variant aliases to OpenRouter and normalizes them to the canonical chat model.
> 
> - Extend `MODEL_PROVIDER_OVERRIDES` with `deepseek-chat-v3*` aliases → `openrouter`
> - Update OpenRouter mappings in `get_model_id_mapping` to transform `deepseek[-ai]/deepseek-chat-v3*` and `deepseek-chat-v3*` → `deepseek/deepseek-chat`
> - Prevents 404s for requests like `deepseek-chat-v3.1` and `deepseek-chat-v3-0324`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0cf67a1ccc0d1b4ed466f581c789af09d24a01b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds provider overrides and mappings for DeepSeek Chat V3 model variants to prevent 404 errors by routing through OpenRouter instead of Fireworks fallback
- Extends `MODEL_PROVIDER_OVERRIDES` with 9 new DeepSeek Chat V3 variants that explicitly route to OpenRouter
- Includes OpenRouter mappings to transform variant names like `deepseek-chat-v3.1` to the canonical `deepseek/deepseek-chat` model name

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/services/model_transformations.py | Added provider overrides and OpenRouter model ID mappings for DeepSeek Chat V3 variants to fix 404 routing errors |

<h3>Confidence score: 4/5</h3>


- This PR is safe to merge with minimal risk as it follows established patterns for model aliasing and provider routing
- Score reflects well-structured changes that address a clear production issue, but deducted one point due to the addition of multiple variant mappings without corresponding tests
- Pay close attention to `src/services/model_transformations.py` to ensure all variant patterns are correctly mapped and no edge cases are missed

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API as "FastAPI Router"
    participant Transformer as "Model Transformer"
    participant Overrides as "Provider Overrides"
    participant Mappings as "Model Mappings"

    User->>API: "Request model: deepseek-chat-v3.1"
    API->>Transformer: "transform_model_id(deepseek-chat-v3.1, openrouter)"
    Transformer->>Overrides: "Check MODEL_PROVIDER_OVERRIDES"
    Overrides-->>Transformer: "deepseek-chat-v3.1 → openrouter"
    Transformer->>Mappings: "get_model_id_mapping(openrouter)"
    Mappings-->>Transformer: "deepseek-chat-v3.1 → deepseek/deepseek-chat"
    Transformer-->>API: "Return transformed model ID"
    API-->>User: "Route request to OpenRouter with deepseek/deepseek-chat"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->