### PR TITLE
fix(backend): add google-vertex/ prefix to canonical_slug to prevent deduplication

### DIFF
--- a/src/services/google_vertex_client.py
+++ b/src/services/google_vertex_client.py
@@ -1187,10 +1187,15 @@ def fetch_models_from_google_vertex():
             input_modalities = model.modalities if model.modalities else ["text"]
             output_modalities = ["text"]  # Google models output text
 
+            # Use google-vertex/ prefix for slug and canonical_slug to avoid
+            # deduplication conflicts with other gateways (e.g., onerouter) that
+            # have models with the same base name. The id stays unchanged since
+            # it's used for actual API calls to Google Vertex AI.
+            prefixed_slug = f"google-vertex/{model.id}"
             normalized = {
                 "id": model.id,
-                "slug": model.id,
-                "canonical_slug": model.id,
+                "slug": prefixed_slug,
+                "canonical_slug": prefixed_slug,
                 "hugging_face_id": None,
                 "name": model.name,
                 "created": None,

--- a/tests/services/test_google_vertex_client.py
+++ b/tests/services/test_google_vertex_client.py
@@ -517,6 +517,13 @@ class TestFetchModelsFromGoogleVertex:
         # Check source_gateway is set correctly
         assert model["source_gateway"] == "google-vertex"
 
+        # Check that slug and canonical_slug have google-vertex/ prefix
+        # This ensures Google Vertex models don't get deduplicated with other gateways
+        assert model["slug"].startswith("google-vertex/"), f"Expected slug to start with 'google-vertex/', got: {model['slug']}"
+        assert model["canonical_slug"].startswith("google-vertex/"), f"Expected canonical_slug to start with 'google-vertex/', got: {model['canonical_slug']}"
+        assert model["slug"] == f"google-vertex/{model['id']}"
+        assert model["canonical_slug"] == f"google-vertex/{model['id']}"
+
     def test_fetch_models_updates_cache(self):
         """Test that fetch_models_from_google_vertex updates the cache"""
         from src.cache import _google_vertex_models_cache


### PR DESCRIPTION
## Summary
- Fix for Google Vertex models not appearing when using `gateway=all`
- Only 3 of 8 Google Vertex models were loading due to canonical_slug deduplication conflict with onerouter
- Root cause: `merge_models_by_slug` uses `canonical_slug` as deduplication key, and both Google Vertex and onerouter had models with the same `canonical_slug` (e.g., "gemini-2.5-flash")
- Since onerouter is processed before google_models in the merge order, Google Vertex models were being skipped

## Test plan
- [x] Verified that the fix correctly prefixes `slug` and `canonical_slug` with `google-vertex/`
- [x] Added test assertion to verify the prefix format
- [ ] Deploy to staging and verify all 8 Google Vertex models appear when filtering by `google-vertex` gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures Google Vertex models are uniquely identified across gateways to prevent deduplication collisions.
> 
> - In `fetch_models_from_google_vertex`, set `slug` and `canonical_slug` to `google-vertex/{id}` while keeping `id` unchanged for API calls
> - Update tests in `tests/services/test_google_vertex_client.py` to assert the new prefixed `slug`/`canonical_slug` format and maintain cache update verification
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5654514774a2880d365422a9d44b132630c0714c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Fixes Google Vertex model deduplication issue where only 3 of 8 models appeared when using `gateway=all` due to canonical_slug conflicts with onerouter models
- Adds "google-vertex/" prefix to `slug` and `canonical_slug` fields while preserving `id` field for API calls, ensuring unique model identifiers across providers
- Updates test assertions to verify the new prefixed format and prevent regression of the deduplication bug

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/services/google_vertex_client.py | Modified model normalization to prefix slug and canonical_slug with "google-vertex/" to prevent deduplication conflicts |
| tests/services/test_google_vertex_client.py | Added test assertions to verify the google-vertex/ prefix format and ensure deduplication fix works correctly |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk as it addresses a specific model discovery bug with a well-targeted fix
- Score reflects clear problem identification, proper solution implementation, and comprehensive test coverage to prevent regression
- No files require special attention as the changes are straightforward and well-tested

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API
    participant GoogleVertexClient
    participant GoogleModelsConfig
    participant Cache

    User->>API: "GET /models?gateway=all"
    API->>GoogleVertexClient: "fetch_models_from_google_vertex()"
    GoogleVertexClient->>GoogleModelsConfig: "get_google_models()"
    GoogleModelsConfig-->>GoogleVertexClient: "return multi_provider_models"
    
    loop For each model
        GoogleVertexClient->>GoogleVertexClient: "prefix slug and canonical_slug with 'google-vertex/'"
        GoogleVertexClient->>GoogleVertexClient: "normalize model format"
    end
    
    GoogleVertexClient->>Cache: "update _google_vertex_models_cache"
    GoogleVertexClient-->>API: "return normalized_models"
    API-->>User: "return models list with google-vertex/ prefixed models"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->