### PR TITLE
fix(failover): restore 402 status code and c10x model routing lost in merge

### DIFF
--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 MODEL_PROVIDER_OVERRIDES = {
     "katanemo/arch-router-1.5b": "huggingface",
     "zai-org/glm-4.6-fp8": "near",
+    # Featherless-only models - not available on OpenRouter
+    "c10x/longwriter-qwen2.5-7b-instruct": "featherless",
     # DeepSeek models NOT available on Fireworks - route to OpenRouter instead
     # Fireworks ONLY has: deepseek-v3p1 (V3/V3.1) and deepseek-r1-0528 (R1)
     # All other DeepSeek models must go to OpenRouter

--- a/src/services/provider_failover.py
+++ b/src/services/provider_failover.py
@@ -40,7 +40,8 @@ FALLBACK_PROVIDER_PRIORITY: tuple[str, ...] = (
     "openrouter",
 )
 FALLBACK_ELIGIBLE_PROVIDERS = set(FALLBACK_PROVIDER_PRIORITY)
-FAILOVER_STATUS_CODES = {401, 403, 404, 502, 503, 504}
+# Include 402 (Payment Required) to allow failover when provider credits are exhausted
+FAILOVER_STATUS_CODES = {401, 402, 403, 404, 502, 503, 504}
 _OPENROUTER_SUFFIX_LOCKS = {"exacto", "free", "extended"}
 _OPENROUTER_PREFIX_LOCKS = ("openrouter/", "openai/", "anthropic/")
 

--- a/tests/services/test_provider_failover.py
+++ b/tests/services/test_provider_failover.py
@@ -258,6 +258,7 @@ class TestShouldFailover:
     def test_failover_status_codes_constant(self):
         """Test FAILOVER_STATUS_CODES contains expected codes"""
         assert 401 in FAILOVER_STATUS_CODES
+        assert 402 in FAILOVER_STATUS_CODES  # Payment Required - failover when provider credits exhausted
         assert 403 in FAILOVER_STATUS_CODES
         assert 404 in FAILOVER_STATUS_CODES
         assert 502 in FAILOVER_STATUS_CODES
@@ -268,6 +269,11 @@ class TestShouldFailover:
         assert 400 not in FAILOVER_STATUS_CODES
         assert 429 not in FAILOVER_STATUS_CODES  # 429 should be returned to client
         assert 500 not in FAILOVER_STATUS_CODES
+
+    def test_should_failover_402(self):
+        """Test 402 Payment Required triggers failover (e.g., provider credits exhausted)"""
+        exc = HTTPException(status_code=402, detail="Insufficient credits")
+        assert should_failover(exc) is True
 
 
 # ============================================================


### PR DESCRIPTION
## Summary
- Restores changes from commit 8a61a41 that were lost when PR #708 (Google Vertex fix) was merged from an older base
- Add 402 (Payment Required) to FAILOVER_STATUS_CODES to enable automatic failover when provider credits are exhausted
- Add MODEL_PROVIDER_OVERRIDES for c10x/longwriter-qwen2.5-7b-instruct to route directly to Featherless

## Test plan
- [ ] Verify 402 errors from providers now trigger failover to next provider
- [ ] Verify c10x/longwriter-qwen2.5-7b-instruct routes directly to Featherless
- [ ] Run existing provider failover tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Failover:** Add `402` to `FAILOVER_STATUS_CODES` in `provider_failover.py` so Payment Required errors trigger provider failover; extend tests to cover 402 handling and constants.
> - **Routing:** Add `MODEL_PROVIDER_OVERRIDES` for `c10x/longwriter-qwen2.5-7b-instruct` → `featherless` in `model_transformations.py` to ensure direct Featherless routing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf7919d2111180f6a6a3917c5b2a93ebb75b3a70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Restores critical failover functionality by adding 402 (Payment Required) status code to `FAILOVER_STATUS_CODES` to enable automatic provider failover when credits are exhausted
- Adds provider routing override for `c10x/longwriter-qwen2.5-7b-instruct` model to route directly to Featherless instead of OpenRouter
- Includes comprehensive test coverage to verify 402 failover behavior and the status code constant inclusion

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| `src/services/provider_failover.py` | Added 402 to FAILOVER_STATUS_CODES to trigger failover when provider credits exhausted |
| `src/services/model_transformations.py` | Added MODEL_PROVIDER_OVERRIDES entry to route specific c10x model directly to Featherless |
| `tests/services/test_provider_failover.py` | Added tests to verify 402 status code inclusion and failover behavior |

<h3>Confidence score: 5/5</h3>


- This PR is extremely safe to merge with minimal risk as it only restores previously lost functionality with proper test coverage
- Score reflects simple, well-tested changes that follow existing patterns and improve system reliability without introducing new complexity
- No files require special attention; all changes are straightforward restoration of merge-conflict lost functionality

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Gateway as "API Gateway"
    participant ProviderFailover as "Provider Failover"
    participant ModelTransform as "Model Transform"
    participant Provider1 as "Initial Provider"
    participant Featherless as "Featherless Provider"

    User->>Gateway: "POST /chat/completions with c10x/longwriter-qwen2.5-7b-instruct"
    Gateway->>ModelTransform: "Check MODEL_PROVIDER_OVERRIDES"
    ModelTransform->>Gateway: "Route to featherless (override found)"
    Gateway->>ProviderFailover: "Build failover chain starting with featherless"
    ProviderFailover->>Gateway: "Return [featherless, cerebras, huggingface, ...]"
    Gateway->>Provider1: "Try another provider request (insufficient credits)"
    Provider1->>Gateway: "HTTP 402 Payment Required"
    Gateway->>ProviderFailover: "Check should_failover(402)"
    ProviderFailover->>Gateway: "True (402 in FAILOVER_STATUS_CODES)"
    Gateway->>Featherless: "Failover to featherless provider"
    Featherless->>Gateway: "Success response"
    Gateway->>User: "Return successful completion"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->