### PR TITLE
fix(rate-limits): handle missing rate_limit_alerts table and rate_limit_config column

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -225,7 +225,9 @@ class Config:
     GOOGLE_VERTEX_ENDPOINT_ID = os.environ.get("GOOGLE_VERTEX_ENDPOINT_ID", "6072619212881264640")
     GOOGLE_APPLICATION_CREDENTIALS = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
     GOOGLE_VERTEX_TRANSPORT = os.environ.get("GOOGLE_VERTEX_TRANSPORT", "rest").lower()
-    GOOGLE_VERTEX_TIMEOUT = float(os.environ.get("GOOGLE_VERTEX_TIMEOUT", "60"))
+    # Timeout for Google Vertex API calls. Default increased to 120s to accommodate
+    # larger models like gemini-2.5-pro which may take longer to process complex requests.
+    GOOGLE_VERTEX_TIMEOUT = float(os.environ.get("GOOGLE_VERTEX_TIMEOUT", "120"))
 
     # OpenRouter Analytics Cookie (for transaction analytics API)
     OPENROUTER_COOKIE = os.environ.get("OPENROUTER_COOKIE")

--- a/src/db/api_keys.py
+++ b/src/db/api_keys.py
@@ -16,6 +16,9 @@ logger = logging.getLogger(__name__)
 SCHEMA_CACHE_ERROR_CODE = "PGRST204"
 ENCRYPTED_COLUMNS = {"encrypted_key", "key_version", "key_hash", "last4"}
 
+# Track if we've already logged the encryption warning to reduce log noise
+_encryption_warning_logged = False
+
 
 # near the top of the module
 def _pct(used: int, limit: int | None) -> float | None:
@@ -138,6 +141,7 @@ def create_api_key(
     is_primary: bool = False,
 ) -> tuple[str, int]:
     """Create a new API key for a user"""
+    global _encryption_warning_logged
     try:
         client = get_supabase_client()
 
@@ -218,11 +222,13 @@ def create_api_key(
                 )
                 logger.error(error_msg)
                 raise ValueError(error_msg) from hash_error
-            # Encryption keys are optional - log warning and continue
-            logger.warning(
-                "Encryption unavailable; proceeding without encrypted fields: %s",
-                sanitize_for_logging(str(hash_error)),
-            )
+            # Encryption keys are optional - log warning once and continue
+            if not _encryption_warning_logged:
+                logger.warning(
+                    "Encryption unavailable; proceeding without encrypted fields: %s",
+                    sanitize_for_logging(str(hash_error)),
+                )
+                _encryption_warning_logged = True
             encrypted_token, key_version, api_key_hash, api_key_last4 = (
                 None,
                 None,
@@ -230,10 +236,13 @@ def create_api_key(
                 (api_key[-4:] if api_key else None),
             )
         except Exception as enc_e:
-            logger.warning(
-                "Encryption unavailable or failed; proceeding without encrypted fields: %s",
-                sanitize_for_logging(str(enc_e)),
-            )
+            # Log encryption failures once to reduce noise
+            if not _encryption_warning_logged:
+                logger.warning(
+                    "Encryption unavailable or failed; proceeding without encrypted fields: %s",
+                    sanitize_for_logging(str(enc_e)),
+                )
+                _encryption_warning_logged = True
             encrypted_token, key_version, api_key_hash, api_key_last4 = (
                 None,
                 None,

--- a/supabase/migrations/20251228000000_add_rate_limit_config_column_and_alerts_table.sql
+++ b/supabase/migrations/20251228000000_add_rate_limit_config_column_and_alerts_table.sql
@@ -1,0 +1,75 @@
+-- Add rate_limit_config column to api_keys_new table
+-- and create rate_limit_alerts table for monitoring
+
+-- ============================================
+-- ADD rate_limit_config COLUMN TO api_keys_new
+-- ============================================
+
+-- Add the rate_limit_config column if it doesn't exist
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+        AND table_name = 'api_keys_new'
+        AND column_name = 'rate_limit_config'
+    ) THEN
+        ALTER TABLE "public"."api_keys_new"
+        ADD COLUMN "rate_limit_config" jsonb DEFAULT NULL;
+
+        RAISE NOTICE 'Added rate_limit_config column to api_keys_new table';
+    ELSE
+        RAISE NOTICE 'rate_limit_config column already exists in api_keys_new table';
+    END IF;
+END $$;
+
+-- Create index for faster lookups on rate_limit_config
+CREATE INDEX IF NOT EXISTS "api_keys_new_rate_limit_config_idx"
+ON "public"."api_keys_new" USING gin ("rate_limit_config")
+WHERE "rate_limit_config" IS NOT NULL;
+
+-- ============================================
+-- CREATE rate_limit_alerts TABLE
+-- ============================================
+
+-- Create sequence first (must exist before table creation)
+CREATE SEQUENCE IF NOT EXISTS "public"."rate_limit_alerts_id_seq";
+
+-- Create rate_limit_alerts table
+-- Stores rate limit alerts for monitoring and alerting
+CREATE TABLE IF NOT EXISTS "public"."rate_limit_alerts" (
+    "id" bigint NOT NULL DEFAULT nextval('rate_limit_alerts_id_seq'::regclass),
+    "api_key" text NOT NULL,
+    "alert_type" text NOT NULL,
+    "details" jsonb DEFAULT '{}'::jsonb,
+    "resolved" boolean DEFAULT false,
+    "resolved_at" timestamp with time zone DEFAULT NULL,
+    "created_at" timestamp with time zone DEFAULT (now() AT TIME ZONE 'UTC'::text),
+    CONSTRAINT "rate_limit_alerts_pkey" PRIMARY KEY ("id")
+);
+
+-- Create indexes for performance
+CREATE INDEX IF NOT EXISTS "rate_limit_alerts_api_key_idx" ON "public"."rate_limit_alerts" USING btree ("api_key");
+CREATE INDEX IF NOT EXISTS "rate_limit_alerts_alert_type_idx" ON "public"."rate_limit_alerts" USING btree ("alert_type");
+CREATE INDEX IF NOT EXISTS "rate_limit_alerts_resolved_idx" ON "public"."rate_limit_alerts" USING btree ("resolved");
+CREATE INDEX IF NOT EXISTS "rate_limit_alerts_created_at_idx" ON "public"."rate_limit_alerts" USING btree ("created_at");
+
+-- Set sequence ownership
+ALTER SEQUENCE "public"."rate_limit_alerts_id_seq" OWNED BY "public"."rate_limit_alerts"."id";
+
+-- Grant permissions
+GRANT SELECT, INSERT, UPDATE, DELETE ON "public"."rate_limit_alerts" TO "authenticated";
+GRANT ALL ON "public"."rate_limit_alerts" TO "service_role";
+
+-- Add RLS policies for security
+ALTER TABLE "public"."rate_limit_alerts" ENABLE ROW LEVEL SECURITY;
+
+-- Drop existing policies if they exist (for idempotency)
+DROP POLICY IF EXISTS "Service role can manage rate limit alerts" ON "public"."rate_limit_alerts";
+
+CREATE POLICY "Service role can manage rate limit alerts" ON "public"."rate_limit_alerts"
+    FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);


### PR DESCRIPTION
## Summary
- Adds graceful fallback for missing `rate_limit_alerts` table
- Adds graceful fallback for missing `rate_limit_config` column
- Prevents crashes when database schema elements are absent

## Context
This fix is needed by gatewayz-monorepo PR #230 which updates the backend submodule pointer.

The monorepo PR is currently failing CI because this commit (`2a1e0e06`) is not yet on the backend main branch.

## Test plan
- [x] Verify the changes handle missing tables gracefully
- [x] Build and run tests

---
*🤖 Automated by Terry (Terragon Labs)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves resilience of rate-limiting features and aligns DB schema.
> 
> - **Graceful fallbacks**: `src/db/rate_limits.py` and `src/routes/rate_limits.py` now handle absent `rate_limit_config` column and `rate_limit_alerts` table by querying alternatives (e.g., `rate_limit_configs`) or returning safe defaults
> - **Admin listing robustness**: `/admin/rate-limits/users` tolerates missing `rate_limit_config` and populates configs from `rate_limit_configs` when available
> - **DB migration**: adds `supabase/migrations/20251228000000_add_rate_limit_config_column_and_alerts_table.sql` to create `rate_limit_config` (jsonb) on `api_keys_new` and new `rate_limit_alerts` table with indexes/RLS
> - **Noise reduction**: `src/db/api_keys.py` logs encryption-unavailable warnings only once
> - **Config tweak**: increases `GOOGLE_VERTEX_TIMEOUT` default from 60s to 120s in `src/config/config.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a1e0e062e6645050299e371086ce6deff5a522b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds graceful fallback handling for missing `rate_limit_alerts` table and `rate_limit_config` column in the database schema to prevent application crashes during schema migrations
- Updates Google Vertex AI timeout from 60s to 120s to accommodate larger models like gemini-2.5-pro
- Includes a complete database migration to add the missing schema elements (`rate_limit_config` JSONB column and `rate_limit_alerts` table)

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| `src/db/rate_limits.py` | Added graceful fallbacks for missing schema elements; handles absent `rate_limit_config` column and `rate_limit_alerts` table |
| `src/routes/rate_limits.py` | Modified admin rate limits endpoint to handle missing `rate_limit_config` column with fallback to `rate_limit_configs` table |
| `supabase/migrations/20251228000000_add_rate_limit_config_column_and_alerts_table.sql` | New migration file that adds the missing `rate_limit_config` column and `rate_limit_alerts` table with proper indexing |

<h3>Confidence score: 4/5</h3>


- This PR is relatively safe to merge with low risk of breaking existing functionality
- Score reflects comprehensive error handling and graceful fallbacks that improve system resilience, though the database migration requires careful attention
- Pay close attention to the migration file and verify it runs successfully in all environments before deployment

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant RateLimitRouter as "Rate Limit Router"
    participant RateLimitService as "Rate Limit Service"
    participant SupabaseClient as "Supabase Client"
    participant ApiKeysTable as "api_keys_new Table"
    participant RateLimitConfigs as "rate_limit_configs Table"
    participant RateLimitUsage as "rate_limit_usage Table"

    User->>RateLimitRouter: "POST /api/request (with API key)"
    RateLimitRouter->>RateLimitService: "check_rate_limit(api_key, tokens_used)"
    
    RateLimitService->>RateLimitService: "get_user_rate_limits(api_key)"
    RateLimitService->>SupabaseClient: "Get client instance"
    
    alt Try new system first
        RateLimitService->>ApiKeysTable: "SELECT * FROM api_keys_new WHERE api_key = ?"
        ApiKeysTable-->>RateLimitService: "Key record with ID"
        RateLimitService->>RateLimitConfigs: "SELECT * FROM rate_limit_configs WHERE api_key_id = ?"
        
        alt Table exists and has config
            RateLimitConfigs-->>RateLimitService: "Rate limit configuration"
        else Table missing or no config
            RateLimitConfigs-->>RateLimitService: "Exception or empty result"
            RateLimitService->>RateLimitService: "Fallback to old system"
        end
    end
    
    RateLimitService->>RateLimitUsage: "SELECT * FROM rate_limit_usage WHERE api_key = ?"
    
    alt Usage table exists
        RateLimitUsage-->>RateLimitService: "Current usage records for windows"
        RateLimitService->>RateLimitService: "Calculate current usage vs limits"
        
        alt Within limits
            RateLimitService-->>RateLimitRouter: "{'allowed': True, 'reason': 'Within rate limits'}"
        else Exceeded limits
            RateLimitService-->>RateLimitRouter: "{'allowed': False, 'reason': 'Rate limit exceeded'}"
        end
    else Table missing
        RateLimitUsage-->>RateLimitService: "Table not accessible exception"
        RateLimitService-->>RateLimitRouter: "{'allowed': True, 'reason': 'Rate limit check unavailable'}"
    end
    
    RateLimitRouter-->>User: "Rate limit check result"
    
    alt Request allowed
        RateLimitRouter->>RateLimitService: "update_rate_limit_usage(api_key, tokens_used)"
        RateLimitService->>RateLimitUsage: "Update or insert usage records for minute/hour/day windows"
        RateLimitUsage-->>RateLimitService: "Usage updated"
        RateLimitService-->>RateLimitRouter: "Usage tracking complete"
        RateLimitRouter-->>User: "Process API request"
    end
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->