### PR TITLE
fix(pricing): add aihubmix and alibaba-cloud to GATEWAY_PROVIDERS

### DIFF
--- a/src/services/pricing_lookup.py
+++ b/src/services/pricing_lookup.py
@@ -12,8 +12,10 @@ logger = logging.getLogger(__name__)
 
 # Gateway providers that route to underlying providers (OpenAI, Anthropic, etc.)
 # These need cross-reference pricing from OpenRouter if no manual pricing exists
-# Note: AiHubMix is NOT included here because their API exposes pricing directly
+# Models without valid pricing will be filtered out to avoid appearing as "free"
 GATEWAY_PROVIDERS = {
+    "aihubmix",
+    "alibaba-cloud",
     "anannas",
     "helicone",
     "vercel-ai-gateway",


### PR DESCRIPTION
## Summary

- Add `aihubmix` and `alibaba-cloud` to `GATEWAY_PROVIDERS` set in `pricing_lookup.py`
- Models from these gateway providers that cannot find valid pricing will now be filtered out instead of appearing with zero pricing (showing as "free" in the UI)
- This significantly reduces the number of models incorrectly marked as free (from ~859 to a much lower count)

## Problem

Gateway providers (aihubmix, alibaba-cloud, anannas, helicone, vercel-ai-gateway) route to underlying providers (OpenAI, Anthropic, etc.). When these providers' APIs don't return pricing, the models were being displayed with `"prompt": "0", "completion": "0"`, making them appear as "free" in the frontend when they're actually not free.

## Solution

By adding `aihubmix` and `alibaba-cloud` to `GATEWAY_PROVIDERS`, the `enrich_model_with_pricing()` function will now:
1. Try to find manual pricing from `manual_pricing.json`
2. Try to cross-reference pricing from OpenRouter
3. Filter out the model (return `None`) if no pricing is found

This prevents these models from incorrectly appearing as free.

## Test plan
- [x] Updated existing tests in `test_pricing_lookup.py` to reflect the changes
- [x] Verified `TestGatewayProviders` now includes assertions for `aihubmix` and `alibaba-cloud`
- [x] Updated test comments to accurately reflect the behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds two providers to `GATEWAY_PROVIDERS` so gateway models without real pricing are filtered (or cross-referenced via OpenRouter) instead of showing zero-cost.
> 
> - Update `GATEWAY_PROVIDERS` in `pricing_lookup.py` to include `aihubmix` and `alibaba-cloud`; note that models without valid pricing are filtered to avoid "free" display
> - `enrich_model_with_pricing` behavior now applies to these providers: prefer manual pricing, then OpenRouter cross-reference, filter when unavailable (except during catalog build)
> - Tests updated in `test_pricing_lookup.py`: assertions for new providers in the set, gateway enrichment cases switched to `aihubmix`/`alibaba-cloud`, and comments aligned with new behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b382b86e9053fbfb9f3b6f42c76f375f07ce4d65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds `aihubmix` and `alibaba-cloud` to the `GATEWAY_PROVIDERS` set in `src/services/pricing_lookup.py` to prevent models from these providers appearing as "free" when they lack pricing data
- Updates the pricing enrichment logic for these gateway providers to try manual pricing, then OpenRouter cross-reference, and filter out models without valid pricing rather than showing zero cost
- Updates test assertions and test cases in `tests/services/test_pricing_lookup.py` to include the new gateway providers and reflect the updated filtering behavior

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/services/pricing_lookup.py | Added `aihubmix` and `alibaba-cloud` to `GATEWAY_PROVIDERS` set to enable proper pricing filtering for gateway models |
| tests/services/test_pricing_lookup.py | Updated test assertions and cases to include new gateway providers and reflect updated pricing behavior |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Score reflects simple, well-tested changes with clear business logic improvements and comprehensive test coverage
- No files require special attention as both changes are straightforward additions to existing patterns

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Frontend
    participant API
    participant PricingLookup
    participant ManualPricingFile
    participant ModelsService

    User->>Frontend: "Request models list"
    Frontend->>API: "GET /models"
    API->>ModelsService: "get_cached_models(gateway)"
    ModelsService->>API: "return raw models"
    
    loop For each model
        API->>PricingLookup: "enrich_model_with_pricing(model_data, gateway)"
        PricingLookup->>PricingLookup: "check if gateway is in GATEWAY_PROVIDERS"
        alt Gateway provider (aihubmix, alibaba-cloud, etc)
            PricingLookup->>ManualPricingFile: "get_model_pricing(gateway, model_id)"
            ManualPricingFile-->>PricingLookup: "manual pricing or None"
            alt Manual pricing not found
                PricingLookup->>ModelsService: "_get_cross_reference_pricing(model_id)"
                ModelsService-->>PricingLookup: "OpenRouter pricing or None"
                alt No pricing found
                    PricingLookup-->>API: "None (filter out model)"
                else Pricing found
                    PricingLookup-->>API: "model with cross-reference pricing"
                end
            else Manual pricing found
                PricingLookup-->>API: "model with manual pricing"
            end
        else Non-gateway provider
            PricingLookup->>ManualPricingFile: "get_model_pricing(gateway, model_id)"
            PricingLookup-->>API: "model with pricing or original model"
        end
    end
    
    API->>API: "filter out None models"
    API-->>Frontend: "enriched models list"
    Frontend-->>User: "display models with correct pricing"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->