### PR TITLE
fix: resolve Braintrust logging TypeError and reduce deprecation log noise

### DIFF
--- a/src/middleware/deprecation.py
+++ b/src/middleware/deprecation.py
@@ -78,8 +78,9 @@ class DeprecationMiddleware(BaseHTTPMiddleware):
                 f"Sunset: {deprecation_info['sunset_date']}"
             )
 
-            # Log deprecation usage (can be used for tracking)
-            logger.info(
+            # Log deprecation usage at debug level to reduce log noise
+            # The deprecation headers on responses provide sufficient notification to clients
+            logger.debug(
                 f"Deprecated endpoint used: {path} by {request.client.host if request.client else 'unknown'}"
             )
 

--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -3352,9 +3352,16 @@ async def unified_responses(
                 else:
                     input_messages.append({"role": inp_msg.role, "content": str(inp_msg.content)})
 
+            # Safely extract output content for Braintrust logging
+            bt_output = ""
+            if response.get("output") and len(response["output"]) > 0:
+                first_output = response["output"][0]
+                if isinstance(first_output, dict):
+                    bt_output = first_output.get("content", "")
+
             span.log(
                 input=input_messages,
-                output=response["output"][0].get("content", "") if response["output"] else "",
+                output=bt_output,
                 metrics={
                     "prompt_tokens": prompt_tokens,
                     "completion_tokens": completion_tokens,


### PR DESCRIPTION
## Summary

- Fix `'NoneType' object is not subscriptable` error in Braintrust logging by adding proper null checks before accessing `response["output"][0]`
- Change deprecated endpoint logging from INFO to DEBUG level to reduce log noise (RFC 8594 deprecation headers are still sent to clients)

## Changes

### 1. Braintrust Logging Fix (`src/routes/chat.py:3355-3360`)

**Problem**: The code was accessing `response["output"][0].get("content", "")` without checking if `response["output"]` is empty or if the first element is a dict.

**Fix**: Added proper null checks:
```python
bt_output = ""
if response.get("output") and len(response["output"]) > 0:
    first_output = response["output"][0]
    if isinstance(first_output, dict):
        bt_output = first_output.get("content", "")
```

### 2. Deprecation Log Noise (`src/middleware/deprecation.py:81-85`)

**Problem**: Deprecated endpoint usage was logged at INFO level, causing hundreds of log entries per minute in Railway logs.

**Fix**: Changed log level from `logger.info()` to `logger.debug()`. Clients still receive RFC 8594 compliant deprecation headers on responses.

## Test plan

- [ ] Verify Braintrust logging no longer throws TypeError when response output is empty
- [ ] Verify deprecation warnings no longer appear in Railway logs at INFO level
- [ ] Verify deprecation headers still appear on responses (Deprecation, Sunset, Link headers)
- [ ] Run existing unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents errors in Braintrust logging and reduces deprecation log noise.
> 
> - In `src/routes/chat.py` (Responses API), safely extract `bt_output` for `span.log` by checking `response.get("output")` and validating the first element is a `dict` before reading `content`.
> - In `src/middleware/deprecation.py`, change deprecation usage logging from `logger.info` to `logger.debug`; RFC 8594 deprecation headers remain unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8ec12775dd0124125728c42f60dc41a82c493d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Fix runtime TypeError in Braintrust logging by adding null checks before accessing `response["output"][0]` to prevent crashes when providers return empty response arrays
- Reduce Railway log noise by changing deprecation endpoint logging from INFO to DEBUG level while maintaining RFC 8594 compliance for client deprecation headers

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/routes/chat.py | Fixed 'NoneType' object is not subscriptable error in Braintrust logging by adding defensive null checks |
| src/middleware/deprecation.py | Changed deprecation logging from INFO to DEBUG level to reduce production log noise |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk of introducing new issues
- Score reflects simple, defensive changes that address specific operational problems without altering core functionality
- Pay close attention to the Braintrust logging fix as it prevents runtime exceptions in production

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant ChatAPI as "Chat API"
    participant Provider as "AI Provider"
    participant Braintrust as "Braintrust Logging"

    Client->>ChatAPI: "POST /v1/chat/completions"
    ChatAPI->>Provider: "Make request"
    Provider->>ChatAPI: "Return response"
    
    Note over ChatAPI: Extract response data safely
    ChatAPI->>ChatAPI: "Check response.get('output')"
    ChatAPI->>ChatAPI: "Validate len(response['output']) > 0"
    ChatAPI->>ChatAPI: "Check isinstance(first_output, dict)"
    ChatAPI->>ChatAPI: "Extract bt_output = first_output.get('content', '')"
    
    ChatAPI->>Braintrust: "span.log(output=bt_output)"
    Braintrust->>ChatAPI: "Log success"
    
    ChatAPI->>Client: "Return response"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->