### PR TITLE
fix: filter out models with zero/missing pricing to prevent appearing as free

### DIFF
--- a/src/services/pricing_lookup.py
+++ b/src/services/pricing_lookup.py
@@ -17,7 +17,9 @@ GATEWAY_PROVIDERS = {
     "aihubmix",
     "alibaba-cloud",
     "anannas",
+    "clarifai",
     "helicone",
+    "onerouter",
     "vercel-ai-gateway",
 }
 
@@ -246,10 +248,19 @@ def enrich_model_with_pricing(model_data: dict[str, Any], gateway: str) -> dict[
         if is_gateway_provider:
             cross_ref_pricing = _get_cross_reference_pricing(model_id)
             if cross_ref_pricing:
-                model_data["pricing"] = cross_ref_pricing
-                model_data["pricing_source"] = "cross-reference"
-                logger.debug(f"Enriched {model_id} with cross-reference pricing from OpenRouter")
-                return model_data
+                # Verify cross-reference pricing has non-zero values
+                # Models with zero pricing from OpenRouter should still be filtered out
+                has_valid_pricing = any(
+                    is_non_zero(v) for k, v in cross_ref_pricing.items()
+                    if k in ("prompt", "completion")
+                )
+                if has_valid_pricing:
+                    model_data["pricing"] = cross_ref_pricing
+                    model_data["pricing_source"] = "cross-reference"
+                    logger.debug(f"Enriched {model_id} with cross-reference pricing from OpenRouter")
+                    return model_data
+                else:
+                    logger.debug(f"Cross-reference pricing for {model_id} is zero, filtering out")
 
             # During catalog build, return the model with zero pricing instead of filtering
             # This prevents models from disappearing during initial build. They'll get


### PR DESCRIPTION
## Summary

- Add `clarifai` and `onerouter` to `GATEWAY_PROVIDERS` for consistent filtering
- **OneRouter**: Use `manual_pricing.json` fallback when `display_models` API lacks pricing, filter out models with zero pricing
- **Clarifai**: Apply `enrich_model_with_pricing` and filter zero-priced models  
- **pricing_lookup**: Validate cross-reference pricing has non-zero prompt/completion values before accepting

## Problem

Models from gateway providers (OneRouter, Clarifai, Helicone, Anannas, etc.) that don't have valid pricing data were appearing as "free" in the catalog, which could cause credit drain issues for users.

## Solution

1. Extended `GATEWAY_PROVIDERS` to include `clarifai` and `onerouter`
2. Added validation to ensure cross-reference pricing from OpenRouter has non-zero prompt/completion values
3. OneRouter client now falls back to `manual_pricing.json` when API pricing is unavailable
4. Clarifai client now properly uses `enrich_model_with_pricing` with zero-price filtering
5. All gateway provider models without valid pricing are now filtered out instead of appearing as free

## Test plan

- [x] Added unit tests for zero pricing filtering in `test_pricing_lookup.py`
- [x] Added tests for new gateway providers (clarifai, onerouter) in GATEWAY_PROVIDERS
- [ ] Verify models catalog no longer shows free models from gateway providers
- [ ] Manual verification of OneRouter and Clarifai model listings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents gateway models from appearing "free" by enforcing pricing validation and adding fallbacks.
> 
> - **Pricing lookup**: Add `clarifai` and `onerouter` to `GATEWAY_PROVIDERS`; accept cross-reference pricing only if `prompt`/`completion` are non-zero.
> - **OneRouter**: Enrich from `display_models`; fallback to `manual_pricing.json` when missing; filter models with zero/missing pricing; add `pricing_source` and detailed counts in logs.
> - **Clarifai**: Use `enrich_model_with_pricing` during model transform; filter models with missing/zero pricing and log filtered count.
> - **Tests**: New unit tests for zero-pricing filtering and gateway provider coverage, including Clarifai/OneRouter entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54d5df732cfed51cb00a59d1c06e4662da701638. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Prevents gateway provider models with zero/missing pricing from appearing as "free" in the catalog by implementing comprehensive pricing validation and fallback mechanisms
- Adds `clarifai` and `onerouter` to `GATEWAY_PROVIDERS` constant and enhances cross-reference pricing validation to require non-zero prompt/completion values
- Implements provider-specific filtering in OneRouter and Clarifai clients with manual pricing fallbacks and detailed logging of filtered models

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/services/pricing_lookup.py | Added clarifai/onerouter to GATEWAY_PROVIDERS; validates cross-reference pricing has non-zero prompt/completion values |
| src/services/onerouter_client.py | Implements pricing enrichment with manual pricing fallback and filters models with zero/missing pricing |
| src/services/clarifai_client.py | Uses `enrich_model_with_pricing` during model transformation and filters models with missing/zero pricing |
| tests/services/test_pricing_lookup.py | Added comprehensive test coverage for new zero pricing filtering logic and gateway provider validation |

<h3>Confidence score: 4/5</h3>


- This PR addresses a critical business logic issue that could lead to unexpected credit charges for users
- Score reflects well-implemented pricing validation with proper fallback mechanisms and comprehensive test coverage
- Pay close attention to `src/services/pricing_lookup.py` and the provider client files to ensure the zero pricing validation logic is robust

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ModelsAPI as "Models API"
    participant ClarifaiClient as "Clarifai Client"
    participant OneRouterClient as "OneRouter Client"
    participant PricingLookup as "Pricing Lookup"
    participant ManualPricing as "manual_pricing.json"
    participant OpenRouterAPI as "OpenRouter API"

    User->>ModelsAPI: "GET /models"
    ModelsAPI->>ModelsAPI: "Build catalog from all providers"
    
    par Clarifai Models
        ModelsAPI->>ClarifaiClient: "fetch_models_from_clarifai()"
        ClarifaiClient->>ClarifaiClient: "Fetch models from API"
        loop For each model
            ClarifaiClient->>PricingLookup: "enrich_model_with_pricing(model, 'clarifai')"
            PricingLookup->>ManualPricing: "get_model_pricing('clarifai', model_id)"
            alt Manual pricing found
                ManualPricing-->>PricingLookup: "Return pricing data"
                PricingLookup-->>ClarifaiClient: "Return enriched model"
            else No manual pricing (clarifai is gateway provider)
                PricingLookup->>OpenRouterAPI: "Cross-reference pricing lookup"
                alt Cross-reference pricing has non-zero values
                    OpenRouterAPI-->>PricingLookup: "Return valid pricing"
                    PricingLookup-->>ClarifaiClient: "Return enriched model"
                else Cross-reference pricing is zero/missing
                    PricingLookup-->>ClarifaiClient: "Return null (filter out)"
                end
            end
            alt Model has valid pricing
                ClarifaiClient->>ClarifaiClient: "Add to models list"
            else Model has zero/missing pricing
                ClarifaiClient->>ClarifaiClient: "Filter out model"
            end
        end
        ClarifaiClient-->>ModelsAPI: "Return filtered models with pricing"
    and OneRouter Models
        ModelsAPI->>OneRouterClient: "fetch_models_from_onerouter()"
        OneRouterClient->>OneRouterClient: "Fetch from /v1/models API"
        OneRouterClient->>OneRouterClient: "Fetch pricing from display_models API"
        loop For each model
            alt Pricing found in display_models API
                OneRouterClient->>OneRouterClient: "Use API pricing"
            else No API pricing
                OneRouterClient->>ManualPricing: "Fallback to manual_pricing.json"
                alt Manual pricing found
                    ManualPricing-->>OneRouterClient: "Return pricing data"
                else No pricing available
                    OneRouterClient->>OneRouterClient: "Filter out model"
                end
            end
            alt Pricing is non-zero
                OneRouterClient->>OneRouterClient: "Add to models list"
            else Pricing is zero
                OneRouterClient->>OneRouterClient: "Filter out model"
            end
        end
        OneRouterClient-->>ModelsAPI: "Return filtered models with pricing"
    end
    
    ModelsAPI->>ModelsAPI: "Combine all provider models"
    ModelsAPI-->>User: "Return catalog with only priced models"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->