### PR TITLE
fix(pricing): add deepinfra and featherless to GATEWAY_PROVIDERS

### DIFF
--- a/src/services/models.py
+++ b/src/services/models.py
@@ -1078,7 +1078,11 @@ def fetch_models_from_featherless():
                 # Filter models that have a valid id (normalize functions may return models without id)
                 combined = {model["id"]: model for model in normalized_models if model.get("id")}
                 for export_model in export_models:
-                    # Run export models through pricing enrichment to filter those without valid pricing
+                    # Run export models through pricing enrichment to filter those without valid pricing.
+                    # Note: During catalog build (_is_building_catalog=True), models are kept even without
+                    # pricing to bootstrap the catalog. During regular operation, only models with valid
+                    # pricing (from manual_pricing.json or cross-reference) are kept. This intentionally
+                    # filters out export models without pricing to prevent them appearing as "free".
                     enriched = enrich_model_with_pricing(export_model, "featherless")
                     if enriched and enriched.get("id"):
                         combined[enriched["id"]] = enriched


### PR DESCRIPTION
## Summary
- Add `deepinfra` and `featherless` to `GATEWAY_PROVIDERS` set for zero-pricing filtering
- Update `manual_pricing.json` metadata with pricing URLs for additional providers
- Add comprehensive tests for new gateway provider behavior

## Changes
1. **GATEWAY_PROVIDERS** now includes 9 providers:
   - aihubmix, alibaba-cloud, anannas, clarifai, **deepinfra**, **featherless**, helicone, onerouter, vercel-ai-gateway

2. **Documented pricing URLs** for providers:
   - Fireworks AI: https://fireworks.ai/pricing
   - Groq: https://groq.com/pricing (API: https://api.groq.com/openai/v1/models)
   - Together AI: https://www.together.ai/pricing
   - Akash Network: https://akashml.com
   - Cloudflare Workers AI: https://developers.cloudflare.com/workers-ai/platform/pricing/

3. **New tests** verify:
   - `deepinfra` and `featherless` are in GATEWAY_PROVIDERS
   - Both providers filter out models without valid pricing
   - Both providers accept models with manual pricing

## Test plan
- [x] All 44 non-integration tests pass
- [x] Tests verify deepinfra/featherless filtering behavior
- [x] Tests verify manual pricing acceptance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines Featherless API fallback merge for accuracy and safety.
> 
> - Filters `normalized_models` to only include entries with a valid `id` before merging
> - Enriches export models via `enrich_model_with_pricing(…, "featherless")` and only merges if enrichment returns a model with valid `id`
> - Prevents unpriced export entries from appearing as "free" in the catalog
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 413a433eae1255807dad35bee408b90ddec7bc42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds `deepinfra` and `featherless` to `GATEWAY_PROVIDERS` set to ensure proper pricing validation and prevent models from displaying as incorrectly "free"
- Updates pricing metadata documentation with additional provider pricing source URLs including Fireworks AI, Groq, Together AI, Akash Network, and Cloudflare Workers AI
- Expands test coverage to verify the new gateway providers filter models without valid pricing and accept models with manual pricing

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| `src/services/pricing_lookup.py` | Adds `deepinfra` and `featherless` to GATEWAY_PROVIDERS set for proper pricing validation |
| `tests/services/test_pricing_lookup.py` | Adds comprehensive tests for new gateway providers and updates existing tests to use `openrouter` |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Score reflects simple, well-tested changes that follow existing patterns and improve data accuracy
- No files require special attention

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant "Pricing Lookup" as PL
    participant "Manual Pricing" as MP
    participant "Models Service" as MS
    participant "OpenRouter Cache" as OR

    User->>PL: "enrich_model_with_pricing(model, gateway)"
    PL->>PL: "Check if model has valid pricing"
    alt Has non-zero pricing
        PL->>User: "Return model unchanged"
    else Zero/no pricing
        PL->>MP: "get_model_pricing(gateway, model_id)"
        alt Manual pricing found
            MP->>PL: "Return manual pricing"
            PL->>User: "Return enriched model"
        else No manual pricing
            alt Gateway provider
                PL->>MS: "get_cached_models(openrouter)"
                MS->>OR: "Fetch cached models"
                OR->>MS: "Return cached models"
                MS->>PL: "Return OpenRouter models"
                PL->>PL: "Match model ID with OpenRouter"
                alt Cross-reference found
                    PL->>User: "Return enriched model"
                else No cross-reference
                    PL->>User: "Return null (filter out)"
                end
            else Non-gateway provider
                PL->>User: "Return model unchanged"
            end
        end
    end
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->