### PR TITLE
fix: add null safety checks to Braintrust logging

### DIFF
--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -2250,10 +2250,10 @@ async def chat_completions(
                 m.model_dump() if hasattr(m, "model_dump") else m for m in req.messages
             ]
             # Safely extract output content for Braintrust logging
-            bt_choices = processed.get("choices") or [{}]
-            bt_first_choice = bt_choices[0] if bt_choices else {}
-            bt_message = bt_first_choice.get("message") or {}
-            bt_output = bt_message.get("content", "")
+            bt_choices = processed.get("choices") or []
+            bt_first_choice = bt_choices[0] if bt_choices else None
+            bt_message = bt_first_choice.get("message") if isinstance(bt_first_choice, dict) else None
+            bt_output = bt_message.get("content", "") if isinstance(bt_message, dict) else ""
             span.log(
                 input=messages_for_log,
                 output=bt_output,
@@ -3354,8 +3354,9 @@ async def unified_responses(
 
             # Safely extract output content for Braintrust logging
             bt_output = ""
-            if response.get("output") and len(response["output"]) > 0:
-                first_output = response["output"][0]
+            output_list = response.get("output")
+            if isinstance(output_list, list) and len(output_list) > 0:
+                first_output = output_list[0]
                 if isinstance(first_output, dict):
                     bt_output = first_output.get("content", "")
 


### PR DESCRIPTION
## Summary
- Fixes "'NoneType' object is not subscriptable" error in Braintrust logging
- Adds `isinstance()` checks before accessing dictionary properties
- Prevents logging failures when response data contains None elements

## Changes
- In `/v1/chat/completions` (line 2252-2256): Added isinstance() checks before calling .get() on `bt_first_choice` and `bt_message` which could be None
- In `/v1/responses` (line 3355-3361): Added isinstance() check to verify `output_list` is a list before calling len() on it

## Test plan
- [x] Code compiles without errors
- [ ] Deploy to staging and verify Braintrust logging errors are resolved
- [ ] Check Railway logs for any remaining "'NoneType' object is not subscriptable" errors

## Related
- Error observed in Railway logs during 8-hour review period
- Error report: `docs/ERROR_REPORT_2025-12-31_PM.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens Braintrust logging to prevent crashes when responses contain `None` or unexpected types.
> 
> - In `chat_completions`: extract `bt_output` with null-safe checks (`choices` may be empty/non-dict), avoiding `[{}]` default and guarding `.get()` calls
> - In `unified_responses`: verify `response['output']` is a list before indexing and only read `content` from dict items
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc80af9eee95baf1b06ddc04d45827c23792cd8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds null safety checks to Braintrust logging in `src/routes/chat.py` to prevent runtime crashes when response data contains None values
- Implements defensive programming with `isinstance()` checks before accessing dictionary methods on potentially None variables
- Fixes "'NoneType' object is not subscriptable" errors observed in Railway production logs during chat completion and unified response processing

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/routes/chat.py | Enhanced Braintrust logging with null safety checks in chat completions (lines 2253-2256) and unified responses (lines 3357-3361) |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk as it implements defensive programming patterns without changing core functionality
- Score reflects simple, well-targeted null safety improvements that follow established patterns in the codebase for handling provider response variations
- Pay attention to the Braintrust logging sections to ensure the null checks are comprehensive and don't introduce edge cases

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant "FastAPI Router" as Router
    participant "Chat Handler" as Handler
    participant "Provider Client" as Provider
    participant "Braintrust Logger" as Braintrust
    participant Database as DB

    User->>Router: "POST /v1/chat/completions"
    Router->>Handler: "chat_completions(req, api_key)"
    
    Handler->>DB: "get_user(api_key)"
    DB-->>Handler: "user data"
    
    Handler->>DB: "validate_trial_access(api_key)"
    DB-->>Handler: "trial status"
    
    Handler->>Provider: "make_request(messages, model)"
    Provider-->>Handler: "response with choices"
    
    Note over Handler: Extract response data with null checks
    Handler->>Handler: "choices = processed.get('choices') or []"
    Handler->>Handler: "bt_first_choice = choices[0] if choices else None"
    Handler->>Handler: "bt_message = bt_first_choice.get('message') if isinstance(bt_first_choice, dict) else None"
    Handler->>Handler: "bt_output = bt_message.get('content', '') if isinstance(bt_message, dict) else ''"
    
    Handler->>Braintrust: "span.log(input, output, metrics)"
    Braintrust-->>Handler: "logged successfully"
    
    Handler->>DB: "save_chat_message(session_id, content)"
    DB-->>Handler: "message saved"
    
    Handler-->>User: "JSON response with choices"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->