### PR TITLE
fix: handle None and list content types in Braintrust logging

### DIFF
--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -2284,12 +2284,18 @@ async def chat_completions(
             elif isinstance(bt_content, str):
                 bt_output = bt_content
             elif isinstance(bt_content, list):
-                # Extract text from multimodal content
-                bt_output = " ".join(
-                    item.get("text", "") if isinstance(item, dict) else str(item)
-                    for item in bt_content
-                    if item is not None
-                )
+                # Extract text from multimodal content, filtering empty strings
+                texts = []
+                for item in bt_content:
+                    if item is None:
+                        continue
+                    if isinstance(item, dict):
+                        text = item.get("text")
+                        if text is not None:
+                            texts.append(str(text))
+                    else:
+                        texts.append(str(item))
+                bt_output = " ".join(t for t in texts if t)
             else:
                 bt_output = str(bt_content)
             span.log(
@@ -3326,13 +3332,15 @@ async def unified_responses(
                         # Extract text content from multimodal content if needed
                         user_content = last_user.get("content", "")
                         if isinstance(user_content, list):
-                            # Extract text from multimodal content
+                            # Extract text from multimodal content, filtering empty strings
                             text_parts = []
                             for item in user_content:
                                 if isinstance(item, dict) and item.get("type") == "text":
-                                    text_parts.append(item.get("text", ""))
+                                    text = item.get("text")
+                                    if text is not None:
+                                        text_parts.append(str(text))
                             user_content = (
-                                " ".join(text_parts) if text_parts else "[multimodal content]"
+                                " ".join(t for t in text_parts if t) if text_parts else "[multimodal content]"
                             )
 
                         await _to_thread(
@@ -3428,12 +3436,18 @@ async def unified_responses(
                     elif isinstance(bt_content, str):
                         bt_output = bt_content
                     elif isinstance(bt_content, list):
-                        # Extract text from multimodal content
-                        bt_output = " ".join(
-                            item.get("text", "") if isinstance(item, dict) else str(item)
-                            for item in bt_content
-                            if item is not None
-                        )
+                        # Extract text from multimodal content, filtering empty strings
+                        texts = []
+                        for item in bt_content:
+                            if item is None:
+                                continue
+                            if isinstance(item, dict):
+                                text = item.get("text")
+                                if text is not None:
+                                    texts.append(str(text))
+                            else:
+                                texts.append(str(item))
+                        bt_output = " ".join(t for t in texts if t)
                     else:
                         bt_output = str(bt_content)
 


### PR DESCRIPTION
## Summary
- Fixed recurring "'NoneType' object is not subscriptable" error in Braintrust logging
- Added comprehensive type checking to handle content values that are None, strings, or lists (multimodal)
- Applied fix to both `/v1/chat/completions` and `/v1/responses` endpoints

## Root Cause
The previous fix added `isinstance()` checks but missed a subtle issue:
- `bt_message.get("content", "")` returns the default `""` only if the key is **missing**
- If the key exists but has value `None`, it returns `None`
- Multimodal content can also be a `list` which requires special handling

## Test Plan
- [ ] Verify no more "'NoneType' object is not subscriptable" errors in Railway logs
- [ ] Verify Braintrust telemetry data is being captured for all request types
- [ ] Test with multimodal content to ensure text extraction works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens Braintrust telemetry to safely handle `None`, string, and list (multimodal) `content`, avoiding crashes and improving logged output text.
> 
> - Adds defensive extraction/normalization of assistant `content` for `/v1/chat/completions` and `/v1/responses` (filters empty strings, joins multimodal text)
> - Improves user message text extraction for history saves by filtering `None` and empty strings in multimodal arrays
> - Leaves API behavior unchanged; scoped to logging/telemetry and history text extraction
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96c35ca3248c4a2808a4f70b137974bad2b3d947. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Fixes production error in Braintrust telemetry logging where "'NoneType' object is not subscriptable" exceptions occurred when processing message content
- Adds robust type checking to handle message content that can be None, strings, or lists (multimodal) with proper text extraction and fallbacks
- Applies the fix to both `/v1/chat/completions` and `/v1/responses` endpoints to ensure consistent telemetry capture across all content types

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| `src/routes/chat.py` | Added comprehensive type checking for Braintrust telemetry content handling, replacing simple `.get("content", "")` with robust logic that handles None values, strings, and multimodal list content |

<h3>Confidence score: 4/5</h3>


- This PR addresses a well-defined production bug with a targeted fix that improves error handling without breaking existing functionality
- Score reflects the straightforward nature of the fix and thorough type checking implementation covering multiple content scenarios
- Pay close attention to the type checking logic to ensure it properly handles all edge cases mentioned in the multimodal content scenarios

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ChatAPI as "chat_completions"
    participant Braintrust as "Braintrust Span"
    participant Provider as "AI Provider"

    User->>ChatAPI: "POST /v1/chat/completions"
    ChatAPI->>Braintrust: "start_span(name, type='llm')"
    ChatAPI->>Provider: "Make request to provider"
    Provider->>ChatAPI: "Return AI response"
    ChatAPI->>ChatAPI: "Extract response content safely"
    Note over ChatAPI: "Handle None, string, or list content types"
    ChatAPI->>Braintrust: "span.log(input, output, metrics, metadata)"
    ChatAPI->>Braintrust: "span.end()"
    ChatAPI->>User: "Return response"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->