### PR TITLE
fix: Add correct max tier product ID to subscription_products table

### DIFF
--- a/supabase/migrations/20260104000000_fix_max_tier_product_id.sql
+++ b/supabase/migrations/20260104000000_fix_max_tier_product_id.sql
@@ -1,0 +1,92 @@
+-- Migration: Fix max tier product ID in subscription_products table
+--
+-- Issue: The frontend uses product ID 'prod_TMHUXL8p0onwwO' for max tier,
+-- but the database has 'prod_TKOqRE2L6qXu7s'. This causes tier resolution
+-- to fail when processing Stripe webhooks.
+--
+-- Fix: Add the correct product ID 'prod_TMHUXL8p0onwwO' to subscription_products
+-- and update any users who subscribed with this product ID to max tier.
+
+BEGIN;
+
+-- Step 1: Insert the correct max tier product ID if it doesn't exist
+INSERT INTO subscription_products (product_id, tier, display_name, credits_per_month, description, is_active)
+VALUES ('prod_TMHUXL8p0onwwO', 'max', 'MAX', 150.00, 'Maximum tier with $150 monthly credits', TRUE)
+ON CONFLICT (product_id) DO UPDATE SET
+    tier = 'max',
+    display_name = 'MAX',
+    credits_per_month = 150.00,
+    is_active = TRUE;
+
+-- Step 2: Log current state before fix
+DO $$
+DECLARE
+    affected_count INTEGER;
+BEGIN
+    -- Count users with mismatched tier (have max product ID but not max tier)
+    SELECT COUNT(*) INTO affected_count
+    FROM users
+    WHERE stripe_product_id = 'prod_TMHUXL8p0onwwO'
+      AND (tier IS NULL OR tier != 'max');
+
+    RAISE NOTICE 'Users with max product ID but incorrect tier: %', affected_count;
+END $$;
+
+-- Step 3: Fix users who subscribed with the max product ID but have wrong tier
+UPDATE users
+SET
+    tier = 'max',
+    subscription_status = 'active',
+    updated_at = NOW()
+WHERE stripe_product_id = 'prod_TMHUXL8p0onwwO'
+  AND (tier IS NULL OR tier != 'max');
+
+-- Step 4: Also clear trial status for these users' API keys
+UPDATE api_keys_new
+SET
+    is_trial = FALSE,
+    trial_converted = TRUE,
+    subscription_status = 'active',
+    subscription_plan = 'max'
+WHERE user_id IN (
+    SELECT id FROM users WHERE stripe_product_id = 'prod_TMHUXL8p0onwwO'
+)
+AND (is_trial = TRUE OR subscription_status != 'active');
+
+-- Step 5: Log the fix result
+DO $$
+DECLARE
+    fixed_users INTEGER;
+    fixed_keys INTEGER;
+BEGIN
+    -- Count fixed users
+    SELECT COUNT(*) INTO fixed_users
+    FROM users
+    WHERE stripe_product_id = 'prod_TMHUXL8p0onwwO'
+      AND tier = 'max';
+
+    RAISE NOTICE 'Users now correctly set to max tier: %', fixed_users;
+
+    -- Count fixed API keys
+    SELECT COUNT(*) INTO fixed_keys
+    FROM api_keys_new ak
+    JOIN users u ON ak.user_id = u.id
+    WHERE u.stripe_product_id = 'prod_TMHUXL8p0onwwO'
+      AND ak.subscription_plan = 'max';
+
+    RAISE NOTICE 'API keys now correctly set to max plan: %', fixed_keys;
+END $$;
+
+-- Verify both product IDs exist for max tier (old and new)
+DO $$
+DECLARE
+    product_count INTEGER;
+BEGIN
+    SELECT COUNT(*) INTO product_count
+    FROM subscription_products
+    WHERE tier = 'max';
+
+    RAISE NOTICE 'Total max tier products in subscription_products: %', product_count;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Fixes user vaughn.dimarco@gmail.com showing as "free trial" despite paying for MAX tier
- Adds the correct product ID `prod_TKOraBpWMxMAIu` to the `subscription_products` table
- Updates any existing users with this product ID to have `tier='max'`
- Clears trial status for their API keys

## Root Cause
The frontend sends product ID `prod_TKOraBpWMxMAIu` for MAX tier subscriptions, but the database `subscription_products` table only had `prod_TKOqRE2L6qXu7s`.

When Stripe webhook fires with the frontend product ID, tier resolution failed and defaulted to 'basic' or 'pro', causing users to show incorrect trial status.

## Test Plan
- [ ] Run migration on staging/production database
- [ ] Verify user `vaughn.dimarco@gmail.com` now shows as MAX tier
- [ ] Verify subscription_products table has both product IDs for max tier
- [ ] Test new MAX subscription flow to ensure tier is correctly assigned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures MAX tier consistency across subscription data and webhooks.
> 
> - Inserts/updates `subscription_products` with `product_id='prod_TKOraBpWMxMAIu'` as `tier='max'` (active, $150 credits)
> - Updates `users` with this product ID to `tier='max'`, `subscription_status='active'`, and `updated_at=NOW()`
> - Updates `api_keys_new` for those users to clear trial, set `subscription_status='active'`, `subscription_plan='max'`, and mark `trial_converted=TRUE`
> - Adds `RAISE NOTICE` logs to report affected/fixed counts and verifies both MAX-tier product IDs exist
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1e5edc6b897f0fc2d56d17e42fb8438432bb703. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds missing product ID `prod_TKOraBpWMxMAIu` to `subscription_products` table to fix MAX tier subscription identification issue
- Updates existing users with mismatched product IDs to correct `tier='max'` status and clears trial flags from their API keys
- Addresses data inconsistency where frontend used different product ID than what existed in database, causing tier resolution failures

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| supabase/migrations/20260103000000_fix_max_tier_product_id.sql | New migration that inserts missing MAX tier product ID mapping and updates affected users and API keys to correct subscription status |

<h3>Confidence score: 4/5</h3>


- This PR safely resolves a specific data inconsistency issue with proper transaction boundaries and idempotent operations
- Migration includes comprehensive logging and handles edge cases with ON CONFLICT clauses for safe execution
- Pay close attention to the migration execution and verify the affected user count matches expectations before production deployment

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Frontend
    participant "Stripe Webhook"
    participant "Subscription Service"
    participant "subscription_products table"
    participant "users table"
    participant "api_keys_new table"

    Frontend->>Stripe: "Create subscription with prod_TKOraBpWMxMAIu"
    Stripe->>Frontend: "Subscription created"
    Stripe->>"Stripe Webhook": "Subscription event fired"
    "Stripe Webhook"->>Frontend: "POST webhook with prod_TKOraBpWMxMAIu"
    Frontend->>"Subscription Service": "Process subscription webhook"
    "Subscription Service"->>"subscription_products table": "SELECT tier WHERE product_id = prod_TKOraBpWMxMAIu"
    "subscription_products table"->>"Subscription Service": "No matching product found"
    "Subscription Service"->>"users table": "UPDATE user with tier = basic/pro (fallback)"
    "Subscription Service"->>"api_keys_new table": "UPDATE with incorrect subscription_plan"
    "users table"->>Frontend: "User shows as 'free trial' status"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->