### PR TITLE
feat(rate-limiting): add severe rate limiting for temporary & blocked accounts

### DIFF
--- a/src/services/rate_limiting.py
+++ b/src/services/rate_limiting.py
@@ -695,9 +695,8 @@ class RateLimitManager:
                 )
                 return SEVERE_RATE_LIMIT_CONFIG
 
-            # Check for flagged/suspicious accounts (future: could check a database flag)
-            # if user.get("is_flagged") or user.get("is_suspicious"):
-            #     return SEVERE_RATE_LIMIT_CONFIG
+            # Future enhancement: Apply SEVERE limits to accounts marked as flagged
+            # or suspicious in the database (e.g., user.is_flagged or user.is_suspicious)
 
             return None
 


### PR DESCRIPTION
## Summary
- Implements severe rate limiting for accounts using temporary/disposable email domains
- Implements even more restrictive rate limiting for blocked email domains (e.g., rccg-clf.org)
- Protects against trial abuse and bulk account creation attacks

## Rate Limit Configurations

### SEVERE_RATE_LIMIT_CONFIG (for temporary email domains)
| Limit | Value | Default |
|-------|-------|---------|
| Requests/minute | 5 | 250 |
| Requests/hour | 20 | 1,000 |
| Requests/day | 50 | 10,000 |
| Tokens/minute | 500 | 10,000 |
| Burst limit | 3 | 100 |
| Concurrency | 1 | 50 |

### BLOCKED_ACCOUNT_CONFIG (for blocked domains like rccg-clf.org)
| Limit | Value | Default |
|-------|-------|---------|
| Requests/minute | 1 | 250 |
| Requests/hour | 5 | 1,000 |
| Requests/day | 10 | 10,000 |
| Tokens/minute | 100 | 10,000 |
| Burst limit | 1 | 100 |
| Concurrency | 1 | 50 |

## Changes
- `src/services/rate_limiting.py`:
  - Added `SEVERE_RATE_LIMIT_CONFIG` and `BLOCKED_ACCOUNT_CONFIG`
  - Added `_get_severe_rate_limit_config()` method to detect suspicious accounts
  - Integrated check into `check_rate_limit()` flow (before cache check)
  
- `tests/services/test_rate_limiting.py`:
  - Added 8 new tests for severe rate limiting functionality
  - Tests cover: config values, temporary emails, blocked domains, normal users, edge cases

## Security Context
This addresses the bulk account creation abuse observed from @rccg-clf.org domain (10+ accounts in ~5 minutes). Combined with the domain blocking added in PR #761, this provides layered protection:
1. **Prevention**: Blocked domains can't register
2. **Mitigation**: Existing accounts from blocked domains are heavily rate limited
3. **Protection**: Temporary email domains (700+ known domains) are rate limited

## Test plan
- [x] Syntax validation passed
- [x] Unit tests added for all scenarios
- [ ] CI tests pass
- [ ] Deploy and verify blocked domain accounts hit rate limits
- [ ] Monitor logs for severe rate limiting events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h4>Greetile Summary</h4>

- Implements severe rate limiting for accounts using temporary/disposable email domains and blocked domains to prevent trial abuse and bulk account creation attacks
- Adds two new restrictive rate limit configurations: `SEVERE_RATE_LIMIT_CONFIG` (5 req/min for temporary emails) and `BLOCKED_ACCOUNT_CONFIG` (1 req/min for blocked domains like rccg-clf.org)
- Integrates email domain detection into the rate limiting flow with comprehensive test coverage for all scenarios including error handling and priority rules

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/services/rate_limiting.py | Added severe rate limiting configurations and `_get_severe_rate_limit_config()` method to detect suspicious email domains and apply restrictive limits |
| tests/services/test_rate_limiting.py | Added 8 comprehensive tests covering severe rate limiting functionality, configuration validation, and edge cases |

<h3>Confidence score: 4/5</h3>


- This PR is generally safe to merge but requires careful monitoring due to its security-critical nature
- Score reflects well-implemented defensive security measures with proper testing, but the impact on legitimate users with temporary emails needs monitoring
- Pay close attention to the rate limiting logic to ensure legitimate users aren't inadvertently blocked by overly aggressive restrictions

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API as "FastAPI Request"
    participant RateLimitManager
    participant UserLookup as "User Lookup Cache"
    participant SecurityValidators as "Security Validators"
    participant RateLimiter as "Sliding Window Rate Limiter"
    participant Response as "Rate Limit Response"

    User->>API: "POST /chat/completions with API key"
    API->>RateLimitManager: "check_rate_limit(api_key, tokens_used)"
    
    Note over RateLimitManager: Check for admin tier bypass first
    RateLimitManager->>UserLookup: "get_user(api_key)"
    UserLookup-->>RateLimitManager: "user data with email"
    
    Note over RateLimitManager: Admin check passed, check for severe rate limiting
    RateLimitManager->>RateLimitManager: "_get_severe_rate_limit_config(api_key)"
    RateLimitManager->>SecurityValidators: "is_blocked_email_domain(email)"
    SecurityValidators-->>RateLimitManager: "true (for rccg-clf.org)"
    
    Note over RateLimitManager: Apply BLOCKED_ACCOUNT_CONFIG (1 req/min)
    RateLimitManager->>RateLimiter: "check_rate_limit(api_key, BLOCKED_ACCOUNT_CONFIG, tokens_used)"
    
    Note over RateLimiter: Check concurrency (limit: 1), burst (limit: 1), sliding window
    RateLimiter->>RateLimiter: "_check_sliding_window(api_key, config, tokens_used)"
    
    alt Rate limit exceeded
        RateLimiter-->>RateLimitManager: "RateLimitResult(allowed=false, reason='Minute request limit exceeded')"
        RateLimitManager-->>API: "Rate limit exceeded for blocked domain"
        API-->>User: "HTTP 429 Too Many Requests"
    else Rate limit OK
        RateLimiter-->>RateLimitManager: "RateLimitResult(allowed=true)"
        RateLimitManager-->>API: "Request allowed"
        API-->>User: "HTTP 200 Chat completion response"
    end
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->