### PR TITLE
fix(provider_failover): allow failover on 402 Payment Required errors for provider-restricted models

### DIFF
--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -1909,6 +1909,26 @@ async def chat_completions(
                         )
                         continue
 
+                    # If this is a 402 (Payment Required) error and we've exhausted the chain,
+                    # rebuild the chain allowing payment failover to try alternative providers
+                    if http_exc.status_code == 402 and idx == len(provider_chain) - 1:
+                        extended_chain = build_provider_failover_chain(provider)
+                        extended_chain = enforce_model_failover_rules(
+                            original_model, extended_chain, allow_payment_failover=True
+                        )
+                        extended_chain = filter_by_circuit_breaker(original_model, extended_chain)
+                        # Find providers we haven't tried yet
+                        new_providers = [p for p in extended_chain if p not in provider_chain]
+                        if new_providers:
+                            logger.warning(
+                                "Provider '%s' returned 402 (Payment Required). "
+                                "Extending failover chain with: %s",
+                                attempt_provider,
+                                new_providers,
+                            )
+                            provider_chain.extend(new_providers)
+                            continue
+
                     raise http_exc
 
             raise last_http_exc or HTTPException(status_code=502, detail="Upstream error")
@@ -2177,6 +2197,26 @@ async def chat_completions(
                         next_provider,
                     )
                     continue
+
+                # If this is a 402 (Payment Required) error and we've exhausted the chain,
+                # rebuild the chain allowing payment failover to try alternative providers
+                if http_exc.status_code == 402 and idx == len(provider_chain) - 1:
+                    extended_chain = build_provider_failover_chain(provider)
+                    extended_chain = enforce_model_failover_rules(
+                        original_model, extended_chain, allow_payment_failover=True
+                    )
+                    extended_chain = filter_by_circuit_breaker(original_model, extended_chain)
+                    # Find providers we haven't tried yet
+                    new_providers = [p for p in extended_chain if p not in provider_chain]
+                    if new_providers:
+                        logger.warning(
+                            "Provider '%s' returned 402 (Payment Required). "
+                            "Extending failover chain with: %s",
+                            attempt_provider,
+                            new_providers,
+                        )
+                        provider_chain.extend(new_providers)
+                        continue
 
                 raise http_exc
 
@@ -3238,6 +3278,26 @@ async def unified_responses(
                     )
                     continue
 
+                # If this is a 402 (Payment Required) error and we've exhausted the chain,
+                # rebuild the chain allowing payment failover to try alternative providers
+                if http_exc.status_code == 402 and idx == len(provider_chain) - 1:
+                    extended_chain = build_provider_failover_chain(provider)
+                    extended_chain = enforce_model_failover_rules(
+                        original_model, extended_chain, allow_payment_failover=True
+                    )
+                    extended_chain = filter_by_circuit_breaker(original_model, extended_chain)
+                    # Find providers we haven't tried yet
+                    new_providers = [p for p in extended_chain if p not in provider_chain]
+                    if new_providers:
+                        logger.warning(
+                            "Provider '%s' returned 402 (Payment Required). "
+                            "Extending failover chain with: %s",
+                            attempt_provider,
+                            new_providers,
+                        )
+                        provider_chain.extend(new_providers)
+                        continue
+
                 raise http_exc
 
             raise last_http_exc or HTTPException(status_code=502, detail="Upstream error")
@@ -3371,6 +3431,26 @@ async def unified_responses(
                     next_provider,
                 )
                 continue
+
+            # If this is a 402 (Payment Required) error and we've exhausted the chain,
+            # rebuild the chain allowing payment failover to try alternative providers
+            if http_exc.status_code == 402 and idx == len(provider_chain) - 1:
+                extended_chain = build_provider_failover_chain(provider)
+                extended_chain = enforce_model_failover_rules(
+                    original_model, extended_chain, allow_payment_failover=True
+                )
+                extended_chain = filter_by_circuit_breaker(original_model, extended_chain)
+                # Find providers we haven't tried yet
+                new_providers = [p for p in extended_chain if p not in provider_chain]
+                if new_providers:
+                    logger.warning(
+                        "Provider '%s' returned 402 (Payment Required). "
+                        "Extending failover chain with: %s",
+                        attempt_provider,
+                        new_providers,
+                    )
+                    provider_chain.extend(new_providers)
+                    continue
 
             raise http_exc
 


### PR DESCRIPTION
## Summary
- Add `allow_payment_failover` parameter to `enforce_model_failover_rules()` to bypass provider lock restrictions when a 402 (Payment Required) error occurs
- Add 402 failover extension logic in `chat.py` (4 locations) and `messages.py` (1 location)
- Add unit tests for payment failover functionality

## Problem
When OpenRouter returns a 402 (Payment Required) error due to exhausted credits, models with `anthropic/`, `openai/`, or `openrouter/` prefixes were unable to failover to alternative providers because of provider lock restrictions in `enforce_model_failover_rules()`.

## Solution
When a provider returns 402 and the normal failover chain is exhausted:
1. System rebuilds provider chain with `allow_payment_failover=True`
2. This bypasses provider locks (e.g., `anthropic/` models locked to OpenRouter)
3. Adds untried providers to chain and continues failover

## Test plan
- [x] Unit tests for `allow_payment_failover` parameter added
- [ ] Manual testing with 402 error scenario
- [ ] Deploy to staging and verify failover behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds `allow_payment_failover` parameter to provider failover logic enabling models locked to specific providers (like `anthropic/`, `openai/` prefixes) to failover to alternative providers when receiving 402 Payment Required errors
- Implements 402 failover logic in `src/routes/chat.py` (4 locations) and `src/routes/messages.py` (1 location) that rebuilds provider chains with relaxed restrictions when credits are exhausted
- Adds comprehensive unit tests covering payment failover scenarios for different model types and provider lock configurations

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/services/provider_failover.py | Enhanced `enforce_model_failover_rules()` to accept `allow_payment_failover` parameter that bypasses provider restrictions when True |
| src/routes/chat.py | Added identical 402 failover handling in 4code paths (streaming/non-streaming for both chat completions and unified responses) |
| src/routes/messages.py | Added 402 failover logic to Anthropic Messages API endpoint matching chat.py implementation |
| tests/services/test_provider_failover.py | Added 4 new unit test methods covering payment failover scenarios and edge cases |

<h3>Confidence score: 4/5</h3>


- This PR implements a well-targeted solution for a specific edge case where payment failures prevent legitimate failover attempts
- The implementation follows existing failover patterns and maintains backward compatibility with new optional parameters  
- Pay close attention to the duplicated failover logic across 4 code paths in `chat.py` which could benefit from refactoring to reduce code duplication

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ChatAPI as Chat API
    participant ProviderFailover as Provider Failover
    participant Provider1 as Primary Provider
    participant Provider2 as Alternative Provider

    User->>ChatAPI: "POST /v1/chat/completions"
    ChatAPI->>ProviderFailover: "build_provider_failover_chain(provider)"
    ProviderFailover-->>ChatAPI: "provider_chain"
    
    ChatAPI->>ProviderFailover: "enforce_model_failover_rules(model, chain)"
    ProviderFailover-->>ChatAPI: "filtered_chain"
    
    loop For each provider in chain
        ChatAPI->>Provider1: "make_request(messages, model)"
        Provider1-->>ChatAPI: "HTTP 402 Payment Required"
        
        ChatAPI->>ProviderFailover: "map_provider_error(provider, model, exc)"
        ProviderFailover-->>ChatAPI: "HTTPException(402)"
        
        ChatAPI->>ProviderFailover: "should_failover(http_exc)"
        ProviderFailover-->>ChatAPI: "true"
    end
    
    Note over ChatAPI: Chain exhausted with 402 error
    
    ChatAPI->>ProviderFailover: "build_provider_failover_chain(provider)"
    ProviderFailover-->>ChatAPI: "extended_chain"
    
    ChatAPI->>ProviderFailover: "enforce_model_failover_rules(model, extended_chain, allow_payment_failover=True)"
    ProviderFailover-->>ChatAPI: "full_chain (bypasses provider lock)"
    
    ChatAPI->>Provider2: "make_request(messages, model)"
    Provider2-->>ChatAPI: "successful response"
    
    ChatAPI-->>User: "streaming response"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->