### PR TITLE
fix: add Braintrust flush and debug logging for prompt recording

### DIFF
--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -46,7 +46,7 @@ from src.utils.sentry_context import capture_payment_error, capture_provider_err
 request_id_var: ContextVar[str] = ContextVar("request_id", default="")
 # Make braintrust optional for test environments
 try:
-    from braintrust import current_span, start_span, traced
+    from braintrust import current_span, start_span, traced, flush as braintrust_flush
 
     BRAINTRUST_AVAILABLE = True
 except ImportError:
@@ -71,6 +71,9 @@ except ImportError:
 
     def current_span():
         return MockSpan()
+
+    def braintrust_flush():
+        pass
 
 
 
@@ -2413,6 +2416,7 @@ async def chat_completions(
 
         # === 7) Log to Braintrust ===
         try:
+            logger.info(f"[Braintrust] Starting log for request_id={request_id}, model={model}, BRAINTRUST_AVAILABLE={BRAINTRUST_AVAILABLE}")
             # Safely convert messages to dicts, filtering out None values and sanitizing content
             messages_for_log = []
             for m in req.messages:
@@ -2474,6 +2478,7 @@ async def chat_completions(
             bt_user_id = user["id"] if user else "anonymous"
             bt_environment = user.get("environment_tag", "live") if user else "live"
             bt_is_trial = trial.get("is_trial", False) if trial else False
+            logger.info(f"[Braintrust] Logging span: user_id={bt_user_id}, model={model}, tokens={total_tokens}")
             span.log(
                 input=messages_for_log,
                 output=bt_output,
@@ -2494,8 +2499,11 @@ async def chat_completions(
                 },
             )
             span.end()
+            # Flush to ensure data is sent to Braintrust
+            braintrust_flush()
+            logger.info(f"[Braintrust] Successfully logged and flushed span for request_id={request_id}")
         except Exception as e:
-            logger.warning(f"Failed to log to Braintrust: {e}")
+            logger.warning(f"[Braintrust] Failed to log to Braintrust: {e}", exc_info=True)
 
         # Capture health metrics (passive monitoring) - run as background task
         background_tasks.add_task(
@@ -3629,6 +3637,7 @@ async def unified_responses(
 
         # === 7) Log to Braintrust ===
         try:
+            logger.info(f"[Braintrust] Starting log for request_id={request_id}, model={model}, endpoint=/v1/responses, BRAINTRUST_AVAILABLE={BRAINTRUST_AVAILABLE}")
             # Convert input messages to loggable format, safely handling None values
             input_messages = []
             for inp_msg in req.input:
@@ -3687,6 +3696,7 @@ async def unified_responses(
             bt_user_id = user["id"] if user else "anonymous"
             bt_environment = user.get("environment_tag", "live") if user else "live"
             bt_is_trial = trial.get("is_trial", False) if trial else False
+            logger.info(f"[Braintrust] Logging span: user_id={bt_user_id}, model={model}, tokens={total_tokens}")
             span.log(
                 input=input_messages,
                 output=bt_output,
@@ -3708,8 +3718,11 @@ async def unified_responses(
                 },
             )
             span.end()
+            # Flush to ensure data is sent to Braintrust
+            braintrust_flush()
+            logger.info(f"[Braintrust] Successfully logged and flushed span for request_id={request_id}")
         except Exception as e:
-            logger.warning(f"Failed to log to Braintrust: {e}")
+            logger.warning(f"[Braintrust] Failed to log to Braintrust: {e}", exc_info=True)
 
         # Save chat completion request metadata to database - run as background task
         background_tasks.add_task(


### PR DESCRIPTION
## Summary
- Import braintrust `flush` function to ensure data is sent to server before request completes
- Add debug logging before/after Braintrust `span.log()` calls to diagnose missing prompts
- Add `braintrust_flush()` call after `span.end()` in both `/v1/chat/completions` and `/v1/responses` endpoints
- Enhanced error logging with `exc_info=True` for full stack traces

## Problem
User prompts were not appearing in the Braintrust dashboard despite configuration being correct. The issue was likely that spans were not being flushed before the request completed.

## Test plan
- [ ] Deploy to staging/production
- [ ] Check Railway logs for `[Braintrust]` debug messages
- [ ] Verify prompts appear in Braintrust dashboard
- [ ] If errors occur, stack traces will now be logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds Braintrust flush functionality and debug logging to ensure user prompts are properly recorded in the Braintrust dashboard
- Imports `flush` function from braintrust with no-op fallback and calls `braintrust_flush()` after span operations in chat endpoints
- Enhances error logging with stack traces and adds comprehensive debug messages to diagnose Braintrust integration issues

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/routes/chat.py | Added Braintrust flush calls and debug logging to fix missing prompts in dashboard |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Score reflects a straightforward observability fix with proper error handling and backward compatibility
- No files require special attention

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ChatEndpoint as "/v1/chat/completions"
    participant Braintrust
    participant AuthValidation as "Auth & Validation"
    participant Provider as "AI Provider"
    participant Database
    participant Metrics as "Metrics & Monitoring"

    User->>ChatEndpoint: "POST /v1/chat/completions"
    ChatEndpoint->>ChatEndpoint: "Generate request_id"
    ChatEndpoint->>Braintrust: "start_span()"
    
    ChatEndpoint->>AuthValidation: "validate_api_key()"
    AuthValidation-->>ChatEndpoint: "user_data"
    
    ChatEndpoint->>AuthValidation: "validate_trial_access()"
    AuthValidation-->>ChatEndpoint: "trial_status"
    
    ChatEndpoint->>AuthValidation: "enforce_plan_limits()"
    AuthValidation-->>ChatEndpoint: "plan_check"
    
    ChatEndpoint->>Provider: "make_provider_request()"
    Provider-->>ChatEndpoint: "ai_response"
    
    ChatEndpoint->>Database: "deduct_credits()"
    ChatEndpoint->>Database: "log_activity()"
    ChatEndpoint->>Database: "save_chat_message()"
    
    ChatEndpoint->>Metrics: "record_inference_metrics()"
    ChatEndpoint->>Metrics: "capture_model_health()"
    
    ChatEndpoint->>Braintrust: "span.log(input, output, metrics)"
    ChatEndpoint->>Braintrust: "span.end()"
    ChatEndpoint->>Braintrust: "braintrust_flush()"
    
    ChatEndpoint-->>User: "chat_response"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))

<!-- /greptile_comment -->