### PR TITLE
[24hr] Reduce log spam for missing AiHubMix IDs

### DIFF
--- a/src/services/models.py
+++ b/src/services/models.py
@@ -3334,7 +3334,8 @@ def normalize_aihubmix_model_with_pricing(model: dict) -> dict | None:
     # Support both 'id' and 'model_id' field names for API compatibility
     model_id = model.get("id") or model.get("model_id")
     if not model_id:
-        logger.warning("AiHubMix model missing 'id': %s", sanitize_for_logging(str(model)))
+        # Use debug level to avoid excessive logging during catalog refresh
+        logger.debug("AiHubMix model missing both 'id' and 'model_id' fields: %s", sanitize_for_logging(str(model)))
         return None
 
     try:
@@ -3425,7 +3426,8 @@ def normalize_aihubmix_model(model) -> dict | None:
         context_length = getattr(model, "context_length", 4096)
 
     if not model_id:
-        logger.warning("AiHubMix model missing 'id': %s", sanitize_for_logging(str(model)))
+        # Use debug level to avoid excessive logging during catalog refresh
+        logger.debug("AiHubMix model missing both 'id' and 'model_id' fields: %s", sanitize_for_logging(str(model)))
         return None
 
     try:


### PR DESCRIPTION
## Summary
- Avoids excessive logging when AiHubMix models lack 'id' or 'model_id' by downgrading to DEBUG during catalog refresh
- Preserves existing behavior for valid models and pricing normalization

## Changes

### Backend
- **src/services/models.py**
  - In `normalize_aihubmix_model_with_pricing` and `normalize_aihubmix_model`, when both 'id' and 'model_id' are missing, log at DEBUG level instead of WARNING to reduce log noise during catalog refresh
  - Retain the existing early return of `None` for missing IDs

### Tests
- **tests/services/test_aihubmix_normalization.py**
  - Added `test_missing_id_logs_debug_not_warning` to verify that missing IDs emit a DEBUG log and do not log WARNINGs
  - Added `test_model_id_field_works_without_warnings` to ensure models containing `model_id` are processed without warnings and normalize correctly

## Test plan
- Run: pytest -k aihubmix_normalization
- Verify that:
  - Missing IDs produce DEBUG logs, not WARNINGs
  - Models with `model_id` normalize successfully and produce no warnings

## Rollback plan
- If needed, revert to WARNING level for missing IDs to reintroduce previous logging behavior, but no functional changes are impacted

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/86976e99-d145-481c-a9a6-c28ee262e9c4

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Changes AiHubMix model normalization logging from WARNING to DEBUG level when models are missing both `id` and `model_id` fields to reduce excessive log spam during catalog refresh operations
- Adds comprehensive tests to verify the logging behavior change and ensure models with `model_id` fields process correctly without generating warnings
- Maintains existing functionality for model filtering while preventing log pollution that could potentially hit Railway's 500 logs/second rate limit

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| `src/services/models.py` | Updated two normalization functions to use DEBUG instead of WARNING logging for missing AiHubMix model IDs |
| `tests/services/test_aihubmix_normalization.py` | Added tests to verify DEBUG logging behavior and ensure valid models with `model_id` process without warnings |

<h3>Confidence score: 5/5</h3>


- This PR is extremely safe to merge with minimal risk as it only changes logging levels without affecting business logic
- Score reflects that this is a defensive optimization with no functional changes to model processing or API behavior 
- No files require special attention as the changes are straightforward logging improvements with appropriate test coverage

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API as "API Gateway"
    participant ModelsService as "Models Service"
    participant AiHubMixNormalizer as "AiHubMix Normalizer"
    participant Cache as "Models Cache"
    participant Logger as "Logger"

    User->>API: "GET /models"
    API->>ModelsService: "get_cached_models('aihubmix')"
    ModelsService->>Cache: "check cache freshness"
    Cache-->>ModelsService: "cache expired"
    ModelsService->>ModelsService: "fetch_models_from_aihubmix()"
    ModelsService->>ModelsService: "fetch from API"
    loop "For each model in response"
        ModelsService->>AiHubMixNormalizer: "normalize_aihubmix_model_with_pricing(model)"
        alt "Model has 'id' or 'model_id'"
            AiHubMixNormalizer->>AiHubMixNormalizer: "extract model_id"
            AiHubMixNormalizer->>AiHubMixNormalizer: "convert pricing per 1K to per 1M tokens"
            AiHubMixNormalizer-->>ModelsService: "return normalized model"
        else "Model missing both 'id' and 'model_id'"
            AiHubMixNormalizer->>Logger: "log at DEBUG level"
            AiHubMixNormalizer-->>ModelsService: "return None"
        end
    end
    ModelsService->>Cache: "update cache with normalized models"
    ModelsService-->>API: "return filtered models list"
    API-->>User: "return models response"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->