### PR TITLE
feat(chat): add share chat API endpoints for link sharing

### DIFF
--- a/src/db/shared_chats.py
+++ b/src/db/shared_chats.py
@@ -1,0 +1,365 @@
+"""Database functions for shared chat links."""
+
+import logging
+import secrets
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+from httpx import ConnectError, ReadTimeout, RemoteProtocolError
+
+from src.config.supabase_config import get_supabase_client
+from src.utils.retry import with_retry
+
+logger = logging.getLogger(__name__)
+
+
+def _execute_with_connection_retry(
+    operation,
+    operation_name: str,
+    max_retries: int = 3,
+    initial_delay: float = 0.1,
+):
+    """
+    Execute a Supabase operation with retry logic for transient connection errors.
+    """
+    last_exception = None
+    delay = initial_delay
+
+    for attempt in range(max_retries + 1):
+        try:
+            return operation()
+        except (RemoteProtocolError, ConnectError, ReadTimeout) as e:
+            last_exception = e
+            error_type = type(e).__name__
+
+            if attempt < max_retries:
+                logger.warning(
+                    f"{operation_name} failed with {error_type}: {e}. "
+                    f"Retrying in {delay:.2f}s (attempt {attempt + 1}/{max_retries})"
+                )
+                time.sleep(delay)
+                delay *= 2  # Exponential backoff
+            else:
+                logger.error(
+                    f"{operation_name} failed after {max_retries} retries with {error_type}: {e}"
+                )
+        except Exception as e:
+            logger.error(f"{operation_name} failed with non-retryable error: {e}")
+            raise
+
+    if last_exception:
+        raise last_exception
+    raise RuntimeError(f"{operation_name} failed without exception details")
+
+
+def generate_share_token() -> str:
+    """Generate a cryptographically secure share token."""
+    return secrets.token_urlsafe(32)
+
+
+@with_retry(
+    max_attempts=3,
+    initial_delay=0.1,
+    max_delay=2.0,
+    exceptions=(Exception,),
+)
+def create_shared_chat(
+    session_id: int,
+    user_id: int,
+    expires_at: datetime | None = None,
+) -> dict[str, Any]:
+    """
+    Create a shared chat link for a session.
+
+    Args:
+        session_id: The chat session ID to share
+        user_id: The user creating the share link
+        expires_at: Optional expiration date
+
+    Returns:
+        The created shared_chat record
+    """
+    try:
+        client = get_supabase_client()
+        share_token = generate_share_token()
+
+        share_data = {
+            "session_id": session_id,
+            "share_token": share_token,
+            "created_by_user_id": user_id,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "expires_at": expires_at.isoformat() if expires_at else None,
+            "view_count": 0,
+            "is_active": True,
+        }
+
+        def insert_share():
+            return client.table("shared_chats").insert(share_data).execute()
+
+        result = _execute_with_connection_retry(
+            insert_share, f"create_shared_chat(session={session_id}, user={user_id})"
+        )
+
+        if not result.data:
+            raise ValueError("Failed to create shared chat link")
+
+        share = result.data[0]
+        logger.info(
+            f"Created shared chat link {share['id']} for session {session_id} by user {user_id}"
+        )
+        return share
+
+    except Exception as e:
+        logger.error(f"Failed to create shared chat link: {e}")
+        raise RuntimeError(f"Failed to create shared chat link: {e}") from e
+
+
+def get_shared_chat_by_token(token: str) -> dict[str, Any] | None:
+    """
+    Get a shared chat by its token (public endpoint).
+
+    Returns the shared chat with session data and messages if found and valid.
+    """
+    try:
+        client = get_supabase_client()
+
+        # Get the share record
+        def query_share():
+            return (
+                client.table("shared_chats")
+                .select("*")
+                .eq("share_token", token)
+                .eq("is_active", True)
+                .execute()
+            )
+
+        share_result = _execute_with_connection_retry(
+            query_share, f"get_shared_chat_by_token(token={token[:8]}...)"
+        )
+
+        if not share_result.data:
+            logger.warning(f"Shared chat not found for token {token[:8]}...")
+            return None
+
+        share = share_result.data[0]
+
+        # Check if expired
+        if share.get("expires_at"):
+            expires_at = datetime.fromisoformat(share["expires_at"].replace("Z", "+00:00"))
+            if expires_at < datetime.now(timezone.utc):
+                logger.warning(f"Shared chat {share['id']} has expired")
+                return None
+
+        # Get the session data
+        def query_session():
+            return (
+                client.table("chat_sessions")
+                .select("*")
+                .eq("id", share["session_id"])
+                .eq("is_active", True)
+                .execute()
+            )
+
+        session_result = _execute_with_connection_retry(
+            query_session, f"get_session_for_share(session={share['session_id']})"
+        )
+
+        if not session_result.data:
+            logger.warning(f"Session {share['session_id']} not found for shared chat")
+            return None
+
+        session = session_result.data[0]
+
+        # Get the messages
+        def query_messages():
+            return (
+                client.table("chat_messages")
+                .select("*")
+                .eq("session_id", share["session_id"])
+                .order("created_at", desc=False)
+                .execute()
+            )
+
+        messages_result = _execute_with_connection_retry(
+            query_messages, f"get_messages_for_share(session={share['session_id']})"
+        )
+
+        messages = messages_result.data or []
+
+        # Update view count
+        try:
+            def update_view_count():
+                return (
+                    client.table("shared_chats")
+                    .update({
+                        "view_count": share["view_count"] + 1,
+                        "last_viewed_at": datetime.now(timezone.utc).isoformat(),
+                    })
+                    .eq("id", share["id"])
+                    .execute()
+                )
+
+            _execute_with_connection_retry(
+                update_view_count, f"update_view_count(share={share['id']})"
+            )
+        except Exception as e:
+            # Don't fail the request if view count update fails
+            logger.warning(f"Failed to update view count for share {share['id']}: {e}")
+
+        logger.info(
+            f"Retrieved shared chat {share['id']} for session {share['session_id']} "
+            f"with {len(messages)} messages"
+        )
+
+        return {
+            "session_id": session["id"],
+            "title": session["title"],
+            "model": session["model"],
+            "created_at": session["created_at"],
+            "messages": messages,
+        }
+
+    except Exception as e:
+        logger.error(f"Failed to get shared chat by token: {e}")
+        raise RuntimeError(f"Failed to get shared chat by token: {e}") from e
+
+
+def get_user_shared_chats(
+    user_id: int, limit: int = 50, offset: int = 0
+) -> list[dict[str, Any]]:
+    """Get all share links created by a user."""
+    try:
+        client = get_supabase_client()
+
+        def query_shares():
+            return (
+                client.table("shared_chats")
+                .select("*")
+                .eq("created_by_user_id", user_id)
+                .eq("is_active", True)
+                .order("created_at", desc=True)
+                .range(offset, offset + limit - 1)
+                .execute()
+            )
+
+        result = _execute_with_connection_retry(
+            query_shares, f"get_user_shared_chats(user={user_id})"
+        )
+
+        shares = result.data or []
+        logger.info(f"Retrieved {len(shares)} shared chats for user {user_id}")
+        return shares
+
+    except Exception as e:
+        logger.error(f"Failed to get user shared chats: {e}")
+        raise RuntimeError(f"Failed to get user shared chats: {e}") from e
+
+
+@with_retry(
+    max_attempts=3,
+    initial_delay=0.1,
+    max_delay=2.0,
+    exceptions=(Exception,),
+)
+def delete_shared_chat(token: str, user_id: int) -> bool:
+    """
+    Delete (soft delete) a shared chat by token.
+
+    Only the user who created the share can delete it.
+    """
+    try:
+        client = get_supabase_client()
+
+        def soft_delete_share():
+            return (
+                client.table("shared_chats")
+                .update({
+                    "is_active": False,
+                })
+                .eq("share_token", token)
+                .eq("created_by_user_id", user_id)
+                .execute()
+            )
+
+        result = _execute_with_connection_retry(
+            soft_delete_share, f"delete_shared_chat(token={token[:8]}..., user={user_id})"
+        )
+
+        if not result.data:
+            logger.warning(f"Shared chat not found or not owned by user {user_id}")
+            return False
+
+        logger.info(f"Deleted shared chat with token {token[:8]}... by user {user_id}")
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to delete shared chat: {e}")
+        raise RuntimeError(f"Failed to delete shared chat: {e}") from e
+
+
+def verify_session_ownership(session_id: int, user_id: int) -> bool:
+    """Verify that a session belongs to a user."""
+    try:
+        client = get_supabase_client()
+
+        def query_session():
+            return (
+                client.table("chat_sessions")
+                .select("id")
+                .eq("id", session_id)
+                .eq("user_id", user_id)
+                .eq("is_active", True)
+                .execute()
+            )
+
+        result = _execute_with_connection_retry(
+            query_session, f"verify_session_ownership(session={session_id}, user={user_id})"
+        )
+
+        return bool(result.data)
+
+    except Exception as e:
+        logger.error(f"Failed to verify session ownership: {e}")
+        return False
+
+
+def check_share_rate_limit(user_id: int, max_shares_per_hour: int = 10) -> bool:
+    """
+    Check if user has exceeded the share rate limit.
+
+    Returns True if user can create more shares, False if rate limited.
+    """
+    try:
+        client = get_supabase_client()
+        one_hour_ago = datetime.now(timezone.utc).replace(
+            minute=0, second=0, microsecond=0
+        ).isoformat()
+
+        def count_recent_shares():
+            return (
+                client.table("shared_chats")
+                .select("id")
+                .eq("created_by_user_id", user_id)
+                .gte("created_at", one_hour_ago)
+                .execute()
+            )
+
+        result = _execute_with_connection_retry(
+            count_recent_shares, f"check_share_rate_limit(user={user_id})"
+        )
+
+        count = len(result.data) if result.data else 0
+        within_limit = count < max_shares_per_hour
+
+        if not within_limit:
+            logger.warning(
+                f"User {user_id} rate limited for shares: {count}/{max_shares_per_hour} in last hour"
+            )
+
+        return within_limit
+
+    except Exception as e:
+        logger.error(f"Failed to check share rate limit: {e}")
+        # On error, allow the share (fail open)
+        return True

--- a/src/main.py
+++ b/src/main.py
@@ -415,6 +415,7 @@ def create_app() -> FastAPI:
         ("rate_limits", "Rate Limiting"),
         ("payments", "Stripe Payments"),
         ("chat_history", "Chat History"),
+        ("share", "Chat Share Links"),  # Shareable chat links
         ("ranking", "Model Ranking"),
         ("activity", "Activity Tracking"),
         ("coupons", "Coupon Management"),

--- a/src/routes/share.py
+++ b/src/routes/share.py
@@ -1,0 +1,233 @@
+"""
+Share Chat API endpoints.
+
+Provides endpoints for creating and managing shareable chat links.
+"""
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from src.db.shared_chats import (
+    check_share_rate_limit,
+    create_shared_chat,
+    delete_shared_chat,
+    get_shared_chat_by_token,
+    get_user_shared_chats,
+    verify_session_ownership,
+)
+from src.schemas.share import (
+    CreateShareLinkRequest,
+    CreateShareLinkResponse,
+    SharedChatPublicView,
+    ShareLinksListResponse,
+)
+from src.security.deps import get_api_key, get_api_key_optional
+from src.services.user_lookup_cache import get_user
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/v1/chat/share", tags=["chat-share"])
+
+
+@router.post("", response_model=CreateShareLinkResponse)
+async def create_share_link(
+    request: CreateShareLinkRequest,
+    api_key: str = Depends(get_api_key),
+):
+    """
+    Create a shareable link for a chat session.
+
+    The link can be shared publicly and allows anyone with the link
+    to view the entire conversation.
+
+    Rate limited to 10 shares per hour per user.
+    """
+    try:
+        # Get authenticated user
+        user = get_user(api_key)
+        if not user:
+            raise HTTPException(status_code=401, detail="Invalid API key")
+
+        user_id = user["id"]
+
+        # Check rate limit
+        if not check_share_rate_limit(user_id):
+            raise HTTPException(
+                status_code=429,
+                detail="Rate limit exceeded. Maximum 10 shares per hour.",
+            )
+
+        # Verify user owns the session
+        if not verify_session_ownership(request.session_id, user_id):
+            raise HTTPException(
+                status_code=404,
+                detail="Chat session not found or access denied",
+            )
+
+        # Parse expires_at if provided
+        expires_at = None
+        if request.expires_at:
+            try:
+                expires_at = datetime.fromisoformat(request.expires_at.replace("Z", "+00:00"))
+            except ValueError:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Invalid expires_at format. Use ISO 8601 format.",
+                )
+
+        # Create the share link
+        share = create_shared_chat(
+            session_id=request.session_id,
+            user_id=user_id,
+            expires_at=expires_at,
+        )
+
+        logger.info(f"Created share link {share['id']} for session {request.session_id} by user {user_id}")
+
+        return CreateShareLinkResponse(
+            success=True,
+            id=share["id"],
+            session_id=share["session_id"],
+            share_token=share["share_token"],
+            created_by_user_id=share["created_by_user_id"],
+            created_at=share["created_at"],
+            expires_at=share.get("expires_at"),
+            view_count=share["view_count"],
+            last_viewed_at=share.get("last_viewed_at"),
+            is_active=share["is_active"],
+            message="Share link created successfully",
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to create share link: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to create share link: {str(e)}",
+        ) from e
+
+
+@router.get("", response_model=ShareLinksListResponse)
+async def get_my_share_links(
+    api_key: str = Depends(get_api_key),
+    limit: int = Query(50, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+):
+    """
+    Get all share links created by the authenticated user.
+    """
+    try:
+        # Get authenticated user
+        user = get_user(api_key)
+        if not user:
+            raise HTTPException(status_code=401, detail="Invalid API key")
+
+        shares = get_user_shared_chats(
+            user_id=user["id"],
+            limit=limit,
+            offset=offset,
+        )
+
+        logger.info(f"Retrieved {len(shares)} share links for user {user['id']}")
+
+        return ShareLinksListResponse(
+            success=True,
+            data=shares,
+            count=len(shares),
+            message=f"Retrieved {len(shares)} share links",
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to get share links: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to get share links: {str(e)}",
+        ) from e
+
+
+@router.get("/{token}", response_model=SharedChatPublicView)
+async def get_shared_chat(
+    token: str,
+):
+    """
+    Get a shared chat by its token (public endpoint).
+
+    This endpoint does not require authentication and returns the
+    chat conversation including all messages.
+    """
+    try:
+        shared_chat = get_shared_chat_by_token(token)
+
+        if not shared_chat:
+            raise HTTPException(
+                status_code=404,
+                detail="Shared chat not found or has expired",
+            )
+
+        logger.info(f"Retrieved shared chat for token {token[:8]}...")
+
+        return SharedChatPublicView(
+            success=True,
+            session_id=shared_chat["session_id"],
+            title=shared_chat["title"],
+            model=shared_chat["model"],
+            created_at=shared_chat["created_at"],
+            messages=shared_chat["messages"],
+            message="Shared chat retrieved successfully",
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to get shared chat: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to get shared chat: {str(e)}",
+        ) from e
+
+
+@router.delete("/{token}")
+async def delete_share_link(
+    token: str,
+    api_key: str = Depends(get_api_key),
+):
+    """
+    Delete a share link by its token.
+
+    Only the user who created the share link can delete it.
+    """
+    try:
+        # Get authenticated user
+        user = get_user(api_key)
+        if not user:
+            raise HTTPException(status_code=401, detail="Invalid API key")
+
+        success = delete_shared_chat(token, user["id"])
+
+        if not success:
+            raise HTTPException(
+                status_code=404,
+                detail="Share link not found or access denied",
+            )
+
+        logger.info(f"Deleted share link {token[:8]}... by user {user['id']}")
+
+        return {
+            "success": True,
+            "message": "Share link deleted successfully",
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to delete share link: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to delete share link: {str(e)}",
+        ) from e

--- a/src/schemas/share.py
+++ b/src/schemas/share.py
@@ -1,0 +1,71 @@
+"""Schema definitions for share chat functionality."""
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class SharedChatMessage(BaseModel):
+    """A message in a shared chat."""
+    id: int
+    session_id: int
+    role: str  # 'user' or 'assistant'
+    content: str
+    model: str | None = None
+    tokens: int | None = 0
+    created_at: str | None = None
+
+
+class CreateShareLinkRequest(BaseModel):
+    """Request to create a share link."""
+    session_id: int
+    expires_at: str | None = None  # ISO 8601 datetime string
+
+
+class CreateShareLinkResponse(BaseModel):
+    """Response from creating a share link."""
+    success: bool
+    id: int | None = None
+    session_id: int | None = None
+    share_token: str | None = None
+    created_by_user_id: int | None = None
+    created_at: str | None = None
+    expires_at: str | None = None
+    view_count: int | None = None
+    last_viewed_at: str | None = None
+    is_active: bool | None = None
+    message: str | None = None
+
+
+class ShareLinkData(BaseModel):
+    """Data for a single share link."""
+    id: int
+    session_id: int
+    share_token: str
+    created_by_user_id: int
+    created_at: str | None = None
+    expires_at: str | None = None
+    view_count: int = 0
+    last_viewed_at: str | None = None
+    is_active: bool = True
+
+
+class ShareLinksListResponse(BaseModel):
+    """Response for listing share links."""
+    success: bool
+    data: list[dict[str, Any]]
+    count: int
+    message: str | None = None
+
+
+class SharedChatPublicView(BaseModel):
+    """Public view of a shared chat."""
+    success: bool
+    session_id: int | None = None
+    title: str | None = None
+    model: str | None = None
+    created_at: str | None = None
+    messages: list[dict[str, Any]] | None = None
+    message: str | None = None
+    error: str | None = None

--- a/supabase/migrations/20260107000000_add_shared_chats_table.sql
+++ b/supabase/migrations/20260107000000_add_shared_chats_table.sql
@@ -1,0 +1,80 @@
+-- Migration: Add shared_chats table for chat link sharing functionality
+-- This table stores shared chat links with unique tokens for public access
+
+-- Create the shared_chats table
+CREATE TABLE IF NOT EXISTS "public"."shared_chats" (
+    "id" SERIAL PRIMARY KEY,
+    "session_id" INTEGER NOT NULL,
+    "share_token" VARCHAR(64) NOT NULL UNIQUE,
+    "created_by_user_id" INTEGER NOT NULL,
+    "created_at" TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    "expires_at" TIMESTAMP WITH TIME ZONE DEFAULT NULL,
+    "view_count" INTEGER DEFAULT 0,
+    "last_viewed_at" TIMESTAMP WITH TIME ZONE DEFAULT NULL,
+    "is_active" BOOLEAN DEFAULT TRUE,
+    CONSTRAINT "fk_shared_chats_session_id" FOREIGN KEY ("session_id")
+        REFERENCES "public"."chat_sessions"("id") ON DELETE CASCADE,
+    CONSTRAINT "fk_shared_chats_user_id" FOREIGN KEY ("created_by_user_id")
+        REFERENCES "public"."users"("id") ON DELETE CASCADE
+);
+
+-- Add comments for documentation
+COMMENT ON TABLE "public"."shared_chats" IS 'Stores shareable links for chat sessions';
+COMMENT ON COLUMN "public"."shared_chats"."share_token" IS 'Unique token used in share URLs';
+COMMENT ON COLUMN "public"."shared_chats"."expires_at" IS 'Optional expiration date for the share link';
+COMMENT ON COLUMN "public"."shared_chats"."view_count" IS 'Number of times this shared link has been viewed';
+COMMENT ON COLUMN "public"."shared_chats"."is_active" IS 'Soft delete flag - FALSE means share link is disabled';
+
+-- Create indexes for efficient lookups
+CREATE INDEX IF NOT EXISTS "idx_shared_chats_share_token" ON "public"."shared_chats" ("share_token");
+CREATE INDEX IF NOT EXISTS "idx_shared_chats_session_id" ON "public"."shared_chats" ("session_id");
+CREATE INDEX IF NOT EXISTS "idx_shared_chats_user_id" ON "public"."shared_chats" ("created_by_user_id");
+CREATE INDEX IF NOT EXISTS "idx_shared_chats_is_active" ON "public"."shared_chats" ("is_active") WHERE "is_active" = TRUE;
+
+-- Enable Row Level Security
+ALTER TABLE "public"."shared_chats" ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies
+
+-- Policy: Users can view their own share links
+CREATE POLICY "Users can view own share links"
+    ON "public"."shared_chats"
+    FOR SELECT
+    TO authenticated
+    USING (created_by_user_id = (current_setting('request.jwt.claims', true)::json->>'sub')::integer);
+
+-- Policy: Users can create share links for their own sessions
+CREATE POLICY "Users can create share links"
+    ON "public"."shared_chats"
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (
+        created_by_user_id = (current_setting('request.jwt.claims', true)::json->>'sub')::integer
+        AND EXISTS (
+            SELECT 1 FROM "public"."chat_sessions"
+            WHERE id = session_id
+            AND user_id = created_by_user_id
+        )
+    );
+
+-- Policy: Users can update/delete their own share links
+CREATE POLICY "Users can manage own share links"
+    ON "public"."shared_chats"
+    FOR UPDATE
+    TO authenticated
+    USING (created_by_user_id = (current_setting('request.jwt.claims', true)::json->>'sub')::integer);
+
+CREATE POLICY "Users can delete own share links"
+    ON "public"."shared_chats"
+    FOR DELETE
+    TO authenticated
+    USING (created_by_user_id = (current_setting('request.jwt.claims', true)::json->>'sub')::integer);
+
+-- Grant permissions
+GRANT ALL ON TABLE "public"."shared_chats" TO "anon";
+GRANT ALL ON TABLE "public"."shared_chats" TO "authenticated";
+GRANT ALL ON TABLE "public"."shared_chats" TO "service_role";
+
+GRANT ALL ON SEQUENCE "public"."shared_chats_id_seq" TO "anon";
+GRANT ALL ON SEQUENCE "public"."shared_chats_id_seq" TO "authenticated";
+GRANT ALL ON SEQUENCE "public"."shared_chats_id_seq" TO "service_role";

--- a/tests/db/test_shared_chats.py
+++ b/tests/db/test_shared_chats.py
@@ -1,0 +1,382 @@
+"""
+Tests for the shared_chats database functions.
+
+Tests cover:
+- create_shared_chat
+- get_shared_chat_by_token
+- get_user_shared_chats
+- delete_shared_chat
+- verify_session_ownership
+- check_share_rate_limit
+- generate_share_token
+"""
+
+import importlib
+import pytest
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch, MagicMock
+
+# Import the module
+MODULE_PATH = "src.db.shared_chats"
+
+try:
+    db_module = importlib.import_module(MODULE_PATH)
+except ModuleNotFoundError as e:
+    pytest.skip(f"Missing optional dependency: {e}", allow_module_level=True)
+
+
+# =========================
+# Tests: generate_share_token
+# =========================
+
+
+def test_generate_share_token_is_unique():
+    """Test that generate_share_token produces unique tokens"""
+    token1 = db_module.generate_share_token()
+    token2 = db_module.generate_share_token()
+
+    assert token1 != token2
+    assert len(token1) > 20  # Should be reasonably long
+    assert len(token2) > 20
+
+
+def test_generate_share_token_is_url_safe():
+    """Test that generated tokens are URL-safe"""
+    token = db_module.generate_share_token()
+
+    # URL-safe characters: alphanumeric, dash, underscore
+    for char in token:
+        assert char.isalnum() or char in '-_'
+
+
+# =========================
+# Tests: create_shared_chat
+# =========================
+
+
+@patch("src.db.shared_chats.get_supabase_client")
+def test_create_shared_chat_success(mock_get_client):
+    """Test successfully creating a shared chat"""
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    expected_share = {
+        "id": 1,
+        "session_id": 100,
+        "share_token": "test_token_123",
+        "created_by_user_id": 1,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "expires_at": None,
+        "view_count": 0,
+        "is_active": True,
+    }
+
+    mock_result = MagicMock()
+    mock_result.data = [expected_share]
+    mock_client.table.return_value.insert.return_value.execute.return_value = mock_result
+
+    result = db_module.create_shared_chat(session_id=100, user_id=1)
+
+    assert result["session_id"] == 100
+    assert result["created_by_user_id"] == 1
+    assert result["is_active"] is True
+
+
+@patch("src.db.shared_chats.get_supabase_client")
+def test_create_shared_chat_with_expiry(mock_get_client):
+    """Test creating shared chat with expiration date"""
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    expires_at = datetime.now(timezone.utc) + timedelta(days=7)
+    expected_share = {
+        "id": 1,
+        "session_id": 100,
+        "share_token": "test_token_123",
+        "created_by_user_id": 1,
+        "expires_at": expires_at.isoformat(),
+        "view_count": 0,
+        "is_active": True,
+    }
+
+    mock_result = MagicMock()
+    mock_result.data = [expected_share]
+    mock_client.table.return_value.insert.return_value.execute.return_value = mock_result
+
+    result = db_module.create_shared_chat(
+        session_id=100, user_id=1, expires_at=expires_at
+    )
+
+    assert result["expires_at"] == expires_at.isoformat()
+
+
+# =========================
+# Tests: get_shared_chat_by_token
+# =========================
+
+
+@patch("src.db.shared_chats.get_supabase_client")
+def test_get_shared_chat_by_token_success(mock_get_client):
+    """Test getting shared chat by token"""
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    mock_share = {
+        "id": 1,
+        "session_id": 100,
+        "share_token": "test_token",
+        "created_by_user_id": 1,
+        "expires_at": None,
+        "view_count": 5,
+        "is_active": True,
+    }
+
+    mock_session = {
+        "id": 100,
+        "user_id": 1,
+        "title": "Test Session",
+        "model": "openai/gpt-4o",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "is_active": True,
+    }
+
+    mock_messages = [
+        {"id": 1, "session_id": 100, "role": "user", "content": "Hello"},
+        {"id": 2, "session_id": 100, "role": "assistant", "content": "Hi!"},
+    ]
+
+    # Mock the chain of calls
+    share_result = MagicMock()
+    share_result.data = [mock_share]
+
+    session_result = MagicMock()
+    session_result.data = [mock_session]
+
+    messages_result = MagicMock()
+    messages_result.data = mock_messages
+
+    update_result = MagicMock()
+    update_result.data = [{"view_count": 6}]
+
+    # Set up the mock to return different results based on table name
+    def table_side_effect(table_name):
+        mock_table = MagicMock()
+        if table_name == "shared_chats":
+            mock_table.select.return_value.eq.return_value.eq.return_value.execute.return_value = share_result
+            mock_table.update.return_value.eq.return_value.execute.return_value = update_result
+        elif table_name == "chat_sessions":
+            mock_table.select.return_value.eq.return_value.eq.return_value.execute.return_value = session_result
+        elif table_name == "chat_messages":
+            mock_table.select.return_value.eq.return_value.order.return_value.execute.return_value = messages_result
+        return mock_table
+
+    mock_client.table.side_effect = table_side_effect
+
+    result = db_module.get_shared_chat_by_token("test_token")
+
+    assert result is not None
+    assert result["session_id"] == 100
+    assert result["title"] == "Test Session"
+    assert len(result["messages"]) == 2
+
+
+@patch("src.db.shared_chats.get_supabase_client")
+def test_get_shared_chat_by_token_not_found(mock_get_client):
+    """Test getting non-existent shared chat"""
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    mock_result = MagicMock()
+    mock_result.data = []
+    mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.execute.return_value = mock_result
+
+    result = db_module.get_shared_chat_by_token("invalid_token")
+
+    assert result is None
+
+
+@patch("src.db.shared_chats.get_supabase_client")
+def test_get_shared_chat_by_token_expired(mock_get_client):
+    """Test getting expired shared chat returns None"""
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    # Expired share
+    mock_share = {
+        "id": 1,
+        "session_id": 100,
+        "share_token": "test_token",
+        "expires_at": (datetime.now(timezone.utc) - timedelta(days=1)).isoformat(),
+        "is_active": True,
+    }
+
+    mock_result = MagicMock()
+    mock_result.data = [mock_share]
+    mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.execute.return_value = mock_result
+
+    result = db_module.get_shared_chat_by_token("test_token")
+
+    assert result is None
+
+
+# =========================
+# Tests: get_user_shared_chats
+# =========================
+
+
+@patch("src.db.shared_chats.get_supabase_client")
+def test_get_user_shared_chats_success(mock_get_client):
+    """Test getting user's shared chats"""
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    mock_shares = [
+        {"id": 1, "session_id": 100, "share_token": "token1"},
+        {"id": 2, "session_id": 101, "share_token": "token2"},
+    ]
+
+    mock_result = MagicMock()
+    mock_result.data = mock_shares
+    mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.range.return_value.execute.return_value = mock_result
+
+    result = db_module.get_user_shared_chats(user_id=1)
+
+    assert len(result) == 2
+
+
+@patch("src.db.shared_chats.get_supabase_client")
+def test_get_user_shared_chats_empty(mock_get_client):
+    """Test getting shared chats when user has none"""
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    mock_result = MagicMock()
+    mock_result.data = []
+    mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.order.return_value.range.return_value.execute.return_value = mock_result
+
+    result = db_module.get_user_shared_chats(user_id=1)
+
+    assert result == []
+
+
+# =========================
+# Tests: delete_shared_chat
+# =========================
+
+
+@patch("src.db.shared_chats.get_supabase_client")
+def test_delete_shared_chat_success(mock_get_client):
+    """Test deleting a shared chat"""
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    mock_result = MagicMock()
+    mock_result.data = [{"id": 1, "is_active": False}]
+    mock_client.table.return_value.update.return_value.eq.return_value.eq.return_value.execute.return_value = mock_result
+
+    result = db_module.delete_shared_chat(token="test_token", user_id=1)
+
+    assert result is True
+
+
+@patch("src.db.shared_chats.get_supabase_client")
+def test_delete_shared_chat_not_found(mock_get_client):
+    """Test deleting non-existent shared chat"""
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    mock_result = MagicMock()
+    mock_result.data = []
+    mock_client.table.return_value.update.return_value.eq.return_value.eq.return_value.execute.return_value = mock_result
+
+    result = db_module.delete_shared_chat(token="invalid_token", user_id=1)
+
+    assert result is False
+
+
+# =========================
+# Tests: verify_session_ownership
+# =========================
+
+
+@patch("src.db.shared_chats.get_supabase_client")
+def test_verify_session_ownership_true(mock_get_client):
+    """Test verifying session ownership returns True for owner"""
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    mock_result = MagicMock()
+    mock_result.data = [{"id": 100}]
+    mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.eq.return_value.execute.return_value = mock_result
+
+    result = db_module.verify_session_ownership(session_id=100, user_id=1)
+
+    assert result is True
+
+
+@patch("src.db.shared_chats.get_supabase_client")
+def test_verify_session_ownership_false(mock_get_client):
+    """Test verifying session ownership returns False for non-owner"""
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    mock_result = MagicMock()
+    mock_result.data = []
+    mock_client.table.return_value.select.return_value.eq.return_value.eq.return_value.eq.return_value.execute.return_value = mock_result
+
+    result = db_module.verify_session_ownership(session_id=100, user_id=999)
+
+    assert result is False
+
+
+# =========================
+# Tests: check_share_rate_limit
+# =========================
+
+
+@patch("src.db.shared_chats.get_supabase_client")
+def test_check_share_rate_limit_within_limit(mock_get_client):
+    """Test rate limit check when within limit"""
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    # User has created 5 shares in the last hour (limit is 10)
+    mock_result = MagicMock()
+    mock_result.data = [{"id": i} for i in range(5)]
+    mock_client.table.return_value.select.return_value.eq.return_value.gte.return_value.execute.return_value = mock_result
+
+    result = db_module.check_share_rate_limit(user_id=1)
+
+    assert result is True
+
+
+@patch("src.db.shared_chats.get_supabase_client")
+def test_check_share_rate_limit_exceeded(mock_get_client):
+    """Test rate limit check when limit exceeded"""
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    # User has created 10 shares in the last hour (at limit)
+    mock_result = MagicMock()
+    mock_result.data = [{"id": i} for i in range(10)]
+    mock_client.table.return_value.select.return_value.eq.return_value.gte.return_value.execute.return_value = mock_result
+
+    result = db_module.check_share_rate_limit(user_id=1)
+
+    assert result is False
+
+
+@patch("src.db.shared_chats.get_supabase_client")
+def test_check_share_rate_limit_custom_limit(mock_get_client):
+    """Test rate limit check with custom limit"""
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    # User has created 3 shares, custom limit is 5
+    mock_result = MagicMock()
+    mock_result.data = [{"id": i} for i in range(3)]
+    mock_client.table.return_value.select.return_value.eq.return_value.gte.return_value.execute.return_value = mock_result
+
+    result = db_module.check_share_rate_limit(user_id=1, max_shares_per_hour=5)
+
+    assert result is True

--- a/tests/routes/test_share.py
+++ b/tests/routes/test_share.py
@@ -1,0 +1,413 @@
+"""
+Tests for the chat share API endpoints.
+
+Tests cover:
+- POST /v1/chat/share - Create share link
+- GET /v1/chat/share - Get user's share links
+- GET /v1/chat/share/{token} - Get shared chat by token (public)
+- DELETE /v1/chat/share/{token} - Delete share link
+"""
+
+import importlib
+import pytest
+from datetime import datetime, timezone
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+# Import the share module
+MODULE_PATH = "src.routes.share"
+
+try:
+    api = importlib.import_module(MODULE_PATH)
+except ModuleNotFoundError as e:
+    pytest.skip(f"Missing optional dependency: {e}", allow_module_level=True)
+
+
+@pytest.fixture(scope="function")
+def client():
+    from src.security.deps import get_api_key
+
+    app = FastAPI()
+    app.include_router(api.router)
+
+    # Override the get_api_key dependency to bypass authentication
+    async def mock_get_api_key() -> str:
+        return "test_api_key"
+
+    app.dependency_overrides[get_api_key] = mock_get_api_key
+    return TestClient(app)
+
+
+@pytest.fixture
+def auth_headers():
+    """Provide authorization headers for test requests"""
+    return {"Authorization": "Bearer test_api_key"}
+
+
+@pytest.fixture
+def mock_user():
+    """Return a mock user object"""
+    return {"id": 1, "email": "test@example.com", "credits": 100.0}
+
+
+@pytest.fixture
+def mock_share():
+    """Return a mock shared chat object"""
+    return {
+        "id": 1,
+        "session_id": 100,
+        "share_token": "abc123def456",
+        "created_by_user_id": 1,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "expires_at": None,
+        "view_count": 0,
+        "last_viewed_at": None,
+        "is_active": True,
+    }
+
+
+@pytest.fixture
+def mock_shared_chat_data():
+    """Return mock shared chat view data"""
+    return {
+        "session_id": 100,
+        "title": "Test Chat Session",
+        "model": "openai/gpt-4o",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "messages": [
+            {
+                "id": 1,
+                "session_id": 100,
+                "role": "user",
+                "content": "Hello!",
+                "model": None,
+                "tokens": 5,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+            },
+            {
+                "id": 2,
+                "session_id": 100,
+                "role": "assistant",
+                "content": "Hi there! How can I help you?",
+                "model": "openai/gpt-4o",
+                "tokens": 15,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+            },
+        ],
+    }
+
+
+# =========================
+# Tests: Create Share Link
+# =========================
+
+
+@patch("src.routes.share.create_shared_chat")
+@patch("src.routes.share.verify_session_ownership")
+@patch("src.routes.share.check_share_rate_limit")
+@patch("src.routes.share.get_user")
+def test_create_share_link_success(
+    mock_get_user,
+    mock_rate_limit,
+    mock_verify_ownership,
+    mock_create_share,
+    client,
+    auth_headers,
+    mock_user,
+    mock_share,
+):
+    """Test successfully creating a share link"""
+    mock_get_user.return_value = mock_user
+    mock_rate_limit.return_value = True
+    mock_verify_ownership.return_value = True
+    mock_create_share.return_value = mock_share
+
+    response = client.post(
+        "/v1/chat/share",
+        json={"session_id": 100},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["session_id"] == 100
+    assert data["share_token"] == "abc123def456"
+    assert data["is_active"] is True
+
+
+@patch("src.routes.share.get_user")
+def test_create_share_link_unauthenticated(mock_get_user, client, auth_headers):
+    """Test creating share link without authentication"""
+    mock_get_user.return_value = None
+
+    response = client.post(
+        "/v1/chat/share",
+        json={"session_id": 100},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 401
+    assert "Invalid API key" in response.json()["detail"]
+
+
+@patch("src.routes.share.check_share_rate_limit")
+@patch("src.routes.share.get_user")
+def test_create_share_link_rate_limited(
+    mock_get_user, mock_rate_limit, client, auth_headers, mock_user
+):
+    """Test creating share link when rate limited"""
+    mock_get_user.return_value = mock_user
+    mock_rate_limit.return_value = False
+
+    response = client.post(
+        "/v1/chat/share",
+        json={"session_id": 100},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 429
+    assert "Rate limit exceeded" in response.json()["detail"]
+
+
+@patch("src.routes.share.verify_session_ownership")
+@patch("src.routes.share.check_share_rate_limit")
+@patch("src.routes.share.get_user")
+def test_create_share_link_session_not_found(
+    mock_get_user,
+    mock_rate_limit,
+    mock_verify_ownership,
+    client,
+    auth_headers,
+    mock_user,
+):
+    """Test creating share link for non-existent session"""
+    mock_get_user.return_value = mock_user
+    mock_rate_limit.return_value = True
+    mock_verify_ownership.return_value = False
+
+    response = client.post(
+        "/v1/chat/share",
+        json={"session_id": 999},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+@patch("src.routes.share.create_shared_chat")
+@patch("src.routes.share.verify_session_ownership")
+@patch("src.routes.share.check_share_rate_limit")
+@patch("src.routes.share.get_user")
+def test_create_share_link_with_expiry(
+    mock_get_user,
+    mock_rate_limit,
+    mock_verify_ownership,
+    mock_create_share,
+    client,
+    auth_headers,
+    mock_user,
+    mock_share,
+):
+    """Test creating share link with expiration date"""
+    mock_get_user.return_value = mock_user
+    mock_rate_limit.return_value = True
+    mock_verify_ownership.return_value = True
+    mock_share["expires_at"] = "2026-12-31T23:59:59+00:00"
+    mock_create_share.return_value = mock_share
+
+    response = client.post(
+        "/v1/chat/share",
+        json={"session_id": 100, "expires_at": "2026-12-31T23:59:59+00:00"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["expires_at"] == "2026-12-31T23:59:59+00:00"
+
+
+# =========================
+# Tests: Get User's Share Links
+# =========================
+
+
+@patch("src.routes.share.get_user_shared_chats")
+@patch("src.routes.share.get_user")
+def test_get_my_share_links_success(
+    mock_get_user, mock_get_shares, client, auth_headers, mock_user, mock_share
+):
+    """Test getting user's share links"""
+    mock_get_user.return_value = mock_user
+    mock_get_shares.return_value = [mock_share]
+
+    response = client.get("/v1/chat/share", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["count"] == 1
+    assert len(data["data"]) == 1
+
+
+@patch("src.routes.share.get_user_shared_chats")
+@patch("src.routes.share.get_user")
+def test_get_my_share_links_empty(
+    mock_get_user, mock_get_shares, client, auth_headers, mock_user
+):
+    """Test getting share links when none exist"""
+    mock_get_user.return_value = mock_user
+    mock_get_shares.return_value = []
+
+    response = client.get("/v1/chat/share", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["count"] == 0
+    assert len(data["data"]) == 0
+
+
+@patch("src.routes.share.get_user")
+def test_get_my_share_links_unauthenticated(mock_get_user, client, auth_headers):
+    """Test getting share links without authentication"""
+    mock_get_user.return_value = None
+
+    response = client.get("/v1/chat/share", headers=auth_headers)
+
+    assert response.status_code == 401
+
+
+# =========================
+# Tests: Get Shared Chat (Public)
+# =========================
+
+
+@patch("src.routes.share.get_shared_chat_by_token")
+def test_get_shared_chat_success(
+    mock_get_shared, client, mock_shared_chat_data
+):
+    """Test getting shared chat by token (public endpoint)"""
+    mock_get_shared.return_value = mock_shared_chat_data
+
+    response = client.get("/v1/chat/share/abc123def456")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["session_id"] == 100
+    assert data["title"] == "Test Chat Session"
+    assert len(data["messages"]) == 2
+
+
+@patch("src.routes.share.get_shared_chat_by_token")
+def test_get_shared_chat_not_found(mock_get_shared, client):
+    """Test getting non-existent shared chat"""
+    mock_get_shared.return_value = None
+
+    response = client.get("/v1/chat/share/invalid_token")
+
+    assert response.status_code == 404
+    assert "not found or has expired" in response.json()["detail"].lower()
+
+
+@patch("src.routes.share.get_shared_chat_by_token")
+def test_get_shared_chat_expired(mock_get_shared, client):
+    """Test getting expired shared chat"""
+    mock_get_shared.return_value = None  # Expired chats return None
+
+    response = client.get("/v1/chat/share/expired_token")
+
+    assert response.status_code == 404
+
+
+# =========================
+# Tests: Delete Share Link
+# =========================
+
+
+@patch("src.routes.share.delete_shared_chat")
+@patch("src.routes.share.get_user")
+def test_delete_share_link_success(
+    mock_get_user, mock_delete_share, client, auth_headers, mock_user
+):
+    """Test deleting a share link"""
+    mock_get_user.return_value = mock_user
+    mock_delete_share.return_value = True
+
+    response = client.delete("/v1/chat/share/abc123def456", headers=auth_headers)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert "deleted" in data["message"].lower()
+
+
+@patch("src.routes.share.delete_shared_chat")
+@patch("src.routes.share.get_user")
+def test_delete_share_link_not_found(
+    mock_get_user, mock_delete_share, client, auth_headers, mock_user
+):
+    """Test deleting non-existent share link"""
+    mock_get_user.return_value = mock_user
+    mock_delete_share.return_value = False
+
+    response = client.delete("/v1/chat/share/invalid_token", headers=auth_headers)
+
+    assert response.status_code == 404
+
+
+@patch("src.routes.share.get_user")
+def test_delete_share_link_unauthenticated(mock_get_user, client, auth_headers):
+    """Test deleting share link without authentication"""
+    mock_get_user.return_value = None
+
+    response = client.delete("/v1/chat/share/abc123def456", headers=auth_headers)
+
+    assert response.status_code == 401
+
+
+# =========================
+# Tests: Edge Cases
+# =========================
+
+
+def test_create_share_link_missing_session_id(client, auth_headers):
+    """Test creating share link without session_id"""
+    response = client.post(
+        "/v1/chat/share",
+        json={},
+        headers=auth_headers,
+    )
+
+    # Pydantic returns 422 for validation errors
+    assert response.status_code == 422
+
+
+@patch("src.routes.share.verify_session_ownership")
+@patch("src.routes.share.check_share_rate_limit")
+@patch("src.routes.share.get_user")
+def test_create_share_link_invalid_expiry_format(
+    mock_get_user,
+    mock_rate_limit,
+    mock_verify_ownership,
+    client,
+    auth_headers,
+    mock_user,
+):
+    """Test creating share link with invalid expiry format"""
+    mock_get_user.return_value = mock_user
+    mock_rate_limit.return_value = True
+    mock_verify_ownership.return_value = True
+
+    response = client.post(
+        "/v1/chat/share",
+        json={"session_id": 100, "expires_at": "invalid-date"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 400
+    assert "Invalid expires_at format" in response.json()["detail"]


### PR DESCRIPTION
## Summary

This PR adds backend API endpoints to support chat link sharing functionality, fixing the issue where link sharing for `/chat` doesn't work.

### Changes:
- **POST /v1/chat/share** - Create shareable link for a chat session
- **GET /v1/chat/share** - Get user's share links
- **GET /v1/chat/share/{token}** - Get shared chat by token (public, no auth required)
- **DELETE /v1/chat/share/{token}** - Delete share link

### Features:
- Unique, cryptographically secure share tokens using `secrets.token_urlsafe(32)`
- Rate limiting (10 shares/hour per user)
- Optional expiration dates for share links
- View count tracking
- Session ownership verification before sharing

### Files Added:
- `src/db/shared_chats.py` - Database functions for share operations
- `src/routes/share.py` - FastAPI route handlers
- `src/schemas/share.py` - Pydantic schema definitions
- `supabase/migrations/20260107000000_add_shared_chats_table.sql` - Database migration with RLS policies
- `tests/routes/test_share.py` - Route tests
- `tests/db/test_shared_chats.py` - Database function tests

### Files Modified:
- `src/main.py` - Registered share routes

## Test plan
- [x] Unit tests for database functions
- [x] Unit tests for API routes
- [ ] Integration test with frontend (pending frontend API call verification)
- [ ] Manual test of share link creation and viewing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds comprehensive chat link sharing API with 4 new endpoints (`POST`/`GET` for creating/listing shares, public `GET /{token}` access, and `DELETE /{token}`) to enable users to share chat sessions via secure links
- Implements secure token-based sharing system with cryptographically secure tokens (`secrets.token_urlsafe(32)`), rate limiting (10 shares/hour), optional expiration dates, and view count tracking
- Includes database migration for new `shared_chats` table with proper RLS policies, comprehensive test coverage for both database functions and API routes, and follows established codebase patterns

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| `src/routes/share.py` | New file implementing 4 REST endpoints for chat sharing with authentication, rate limiting, and error handling; contains async/sync function mixing issue |
| `supabase/migrations/20260107000000_add_shared_chats_table.sql` | New migration creating shared_chats table with proper foreign key constraints, comprehensive indexing, and RLS policies for secure access control |
| `src/db/shared_chats.py` | New database operations module for share functionality with secure token generation, ownership verification, and rate limiting logic |

<h3>Confidence score: 3/5</h3>


- This PR requires careful review due to several technical concerns and potential production issues
- Score lowered due to async/sync function mixing in routes (using synchronous `get_user()` in async endpoints), potential performance issues from non-cached user lookups, and some inconsistencies in schema design with nullable fields and string datetime handling
- Pay close attention to `src/routes/share.py` for the async/sync mixing issues and `src/schemas/share.py` for data consistency concerns

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API
    participant Auth as Security/Auth
    participant ShareDB as SharedChats DB
    participant SessionDB as Sessions DB
    participant MessagesDB as Messages DB
    
    Note over User,MessagesDB: Create Share Link Flow
    
    User->>API: POST /v1/chat/share {"session_id": 100}
    API->>Auth: "get_api_key()"
    Auth->>API: "validated_api_key"
    API->>Auth: "get_user(api_key)"
    Auth->>API: "user_data"
    API->>ShareDB: "check_share_rate_limit(user_id)"
    ShareDB->>API: "within_limit: true"
    API->>SessionDB: "verify_session_ownership(session_id, user_id)"
    SessionDB->>API: "ownership_verified: true"
    API->>ShareDB: "create_shared_chat(session_id, user_id)"
    ShareDB->>ShareDB: "generate_share_token()"
    ShareDB->>API: "share_link_data"
    API->>User: "CreateShareLinkResponse {share_token, success}"
    
    Note over User,MessagesDB: Public View Flow (No Auth)
    
    User->>API: GET /v1/chat/share/{token}
    API->>ShareDB: "get_shared_chat_by_token(token)"
    ShareDB->>SessionDB: "get session data"
    SessionDB->>ShareDB: "session_data"
    ShareDB->>MessagesDB: "get messages for session"
    MessagesDB->>ShareDB: "messages_data"
    ShareDB->>ShareDB: "increment view_count"
    ShareDB->>API: "shared_chat_with_messages"
    API->>User: "SharedChatPublicView {session, messages, success}"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->