### PR TITLE
fix(schemas): add 'developer' message role to ALLOWED_CHAT_ROLES

### DIFF
--- a/src/schemas/proxy.py
+++ b/src/schemas/proxy.py
@@ -3,7 +3,7 @@ from typing import Annotated, Any, Literal, Union
 
 from pydantic import BaseModel, Discriminator, Field, field_validator, model_validator
 
-ALLOWED_CHAT_ROLES = {"system", "user", "assistant", "tool", "function"}
+ALLOWED_CHAT_ROLES = {"system", "user", "assistant", "tool", "function", "developer"}
 
 
 class Message(BaseModel):
@@ -54,8 +54,8 @@ class Message(BaseModel):
                 return len(c) == 0
             return False
 
-        # User and system messages must have non-empty content
-        if role in ("user", "system") and is_empty_content(content):
+        # User, system, and developer messages must have non-empty content
+        if role in ("user", "system", "developer") and is_empty_content(content):
             raise ValueError(f"'{role}' messages must have non-empty content.")
 
         # Tool/function responses must have non-empty content

--- a/src/schemas/proxy.py
+++ b/src/schemas/proxy.py
@@ -35,7 +35,7 @@ class Message(BaseModel):
     def validate_content_for_role(self) -> "Message":
         """Validate that content is provided for roles that require it.
 
-        - user and system roles require non-empty content
+        - user, system, and developer roles require non-empty content
         - assistant role allows null content when tool_calls is present
         - tool and function roles require non-empty content (the tool response)
         """

--- a/tests/schemas/test_proxy.py
+++ b/tests/schemas/test_proxy.py
@@ -57,7 +57,7 @@ class TestMessageSchema:
 
     def test_valid_roles(self):
         """Test all valid message roles"""
-        valid_roles = ["system", "user", "assistant", "tool", "function"]
+        valid_roles = ["system", "user", "assistant", "tool", "function", "developer"]
         for role in valid_roles:
             msg = Message(role=role, content="test")
             assert msg.role == role
@@ -78,6 +78,18 @@ class TestMessageSchema:
         with pytest.raises(ValidationError) as exc_info:
             Message(role="system", content=None)
         assert "'system' messages must have non-empty content" in str(exc_info.value)
+
+    def test_developer_message_requires_content(self):
+        """Test that developer messages must have content"""
+        with pytest.raises(ValidationError) as exc_info:
+            Message(role="developer", content=None)
+        assert "'developer' messages must have non-empty content" in str(exc_info.value)
+
+    def test_developer_message_basic(self):
+        """Test basic developer message creation (OpenAI developer role)"""
+        msg = Message(role="developer", content="You are a helpful assistant.")
+        assert msg.role == "developer"
+        assert msg.content == "You are a helpful assistant."
 
     def test_tool_message_requires_content(self):
         """Test that tool messages must have content (the response)"""
@@ -628,6 +640,16 @@ class TestMessageContentValidation:
         """Test that system messages reject empty string content"""
         with pytest.raises(ValidationError, match="must have non-empty content"):
             Message(role="system", content="")
+
+    def test_developer_message_rejects_empty_string(self):
+        """Test that developer messages reject empty string content"""
+        with pytest.raises(ValidationError, match="must have non-empty content"):
+            Message(role="developer", content="")
+
+    def test_developer_message_rejects_whitespace_only(self):
+        """Test that developer messages reject whitespace-only content"""
+        with pytest.raises(ValidationError, match="must have non-empty content"):
+            Message(role="developer", content="   \n\t  ")
 
     def test_tool_message_rejects_empty_string(self):
         """Test that tool messages reject empty string content"""


### PR DESCRIPTION
## Summary
- Adds `developer` to `ALLOWED_CHAT_ROLES` set in proxy schema
- Updates content validation to require non-empty content for developer messages (same as system/user)
- Adds comprehensive tests for developer role messages

## Problem
The OpenAI API supports a `developer` message role (used as an alternative to `system` for certain models), but our schema validation rejected it with:
```
Invalid message role 'developer'. Supported roles are: assistant, function, system, tool, user.
```

This caused errors when using models like `allenai/olmo-3.1-32b-instruct` that send developer role messages.

## Test plan
- [x] Verified developer role is now accepted
- [x] Verified developer messages require non-empty content
- [x] Verified developer messages reject empty strings and whitespace
- [x] Verified all existing roles still work correctly
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

## Overview
This PR adds support for the OpenAI `developer` message role to the schema validation, along with comprehensive tests. However, **this PR includes unintended commits** from a separate xAI reasoning feature that should have been merged independently.

## What Changed

### Primary Change: Developer Role Support (Intended)
- **Problem Solved**: The OpenAI API supports a `developer` message role (alternative to `system` for certain models), but the gateway was rejecting it with a validation error
- **Implementation**: Added `"developer"` to `ALLOWED_CHAT_ROLES` set and updated content validation to require non-empty content (same rules as `user` and `system` roles)
- **Test Coverage**: Comprehensive tests cover role acceptance, content requirements, empty string rejection, and whitespace-only rejection

### Secondary Changes: xAI Reasoning Support (Unintended)
This PR also includes changes from commit `6d10ddf6` that add xAI Grok reasoning model support:
- Extended timeout (600s read) for xAI reasoning models in `connection_pool.py`
- Reasoning details extraction (`reasoning_details` array handling) in `stream_normalizer.py`
- Reasoning model detection and parameter injection in `xai_client.py`
- Comprehensive tests for all xAI reasoning functionality

## Code Quality
The developer role implementation is correct and follows OpenAI's specification. The xAI reasoning feature is well-implemented with good test coverage. Both features work independently without conflicts.

## Issue Found
- **Style**: Docstring in `validate_content_for_role` method not updated to mention developer role requirement (line 38)

### Confidence Score: 4/5

- This PR is safe to merge but includes unintended commits from a separate feature branch
- Score of 4 reflects solid implementation quality with comprehensive tests, but docked one point due to PR scope issue (includes xAI reasoning feature commits that weren't mentioned in the PR description) and one minor documentation gap. The code itself is correct and well-tested.
- src/schemas/proxy.py needs docstring update. Consider rebasing to include only the developer role changes, or update the PR description to reflect the xAI reasoning feature inclusion.

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/schemas/proxy.py | 4/5 | Adds 'developer' role to ALLOWED_CHAT_ROLES and validation logic. Docstring not updated to reflect developer role requirement. |
| tests/schemas/test_proxy.py | 5/5 | Comprehensive test coverage for developer role including validation, empty content checks, and whitespace rejection. |
| src/services/connection_pool.py | 5/5 | Adds XAI_REASONING_TIMEOUT (600s read timeout) for xAI Grok reasoning models. Part of separate feature merged in this PR. |
| src/services/xai_client.py | 5/5 | Adds reasoning model detection and parameter injection for xAI models. Handles enable_reasoning override. Part of separate feature. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API as Chat API Endpoint
    participant Schema as ProxyRequest Schema
    participant Message as Message Validator
    participant Provider as Provider Client

    Client->>API: POST /v1/chat/completions
    Note over Client,API: messages: [{role: "developer", content: "..."}]
    
    API->>Schema: Validate ProxyRequest
    Schema->>Message: Validate each Message
    
    alt role validation
        Message->>Message: Check role in ALLOWED_CHAT_ROLES
        Note over Message: {"system", "user", "assistant",<br/>"tool", "function", "developer"}
    end
    
    alt content validation for developer role
        Message->>Message: is_empty_content(content)?
        alt content is None or empty
            Message-->>API: ValidationError: 'developer' messages<br/>must have non-empty content
        else content is valid
            Message->>Schema: Message valid
        end
    end
    
    Schema->>API: Request valid
    API->>Provider: Forward request with developer message
    Provider-->>API: Response
    API-->>Client: Chat completion response
```

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/schemas/proxy.py | 4/5 | Adds 'developer' role to ALLOWED_CHAT_ROLES and validation logic. Docstring not updated to reflect developer role requirement. |
| tests/schemas/test_proxy.py | 5/5 | Comprehensive test coverage for developer role including validation, empty content checks, and whitespace rejection. |
| src/services/connection_pool.py | 5/5 | Adds XAI_REASONING_TIMEOUT (600s read timeout) for xAI Grok reasoning models. Part of separate feature merged in this PR. |
| src/services/xai_client.py | 5/5 | Adds reasoning model detection and parameter injection for xAI models. Handles enable_reasoning override. Part of separate feature. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API as Chat API Endpoint
    participant Schema as ProxyRequest Schema
    participant Message as Message Validator
    participant Provider as Provider Client

    Client->>API: POST /v1/chat/completions
    Note over Client,API: messages: [{role: "developer", content: "..."}]
    
    API->>Schema: Validate ProxyRequest
    Schema->>Message: Validate each Message
    
    alt role validation
        Message->>Message: Check role in ALLOWED_CHAT_ROLES
        Note over Message: {"system", "user", "assistant",<br/>"tool", "function", "developer"}
    end
    
    alt content validation for developer role
        Message->>Message: is_empty_content(content)?
        alt content is None or empty
            Message-->>API: ValidationError: 'developer' messages<br/>must have non-empty content
        else content is valid
            Message->>Schema: Message valid
        end
    end
    
    Schema->>API: Request valid
    API->>Provider: Forward request with developer message
    Provider-->>API: Response
    API-->>Client: Chat completion response
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->