### PR TITLE
Integrate Simplismart pricing: catalog, aliases, and tests

### DIFF
--- a/src/data/manual_pricing.json
+++ b/src/data/manual_pricing.json
@@ -801,6 +801,132 @@
       "request": "0",
       "image": "0",
       "context_length": 32768
+    },
+    "meta-llama/Llama-4-Maverick-17B-Instruct": {
+      "prompt": "0.74",
+      "completion": "0.74",
+      "request": "0",
+      "image": "0",
+      "context_length": 131072
+    },
+    "deepseek-ai/DeepSeek-R1-Distill-Llama-70B": {
+      "prompt": "0.74",
+      "completion": "0.74",
+      "request": "0",
+      "image": "0",
+      "context_length": 65536
+    },
+    "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B": {
+      "prompt": "1.08",
+      "completion": "1.08",
+      "request": "0",
+      "image": "0",
+      "context_length": 65536
+    },
+    "google/gemma-3-27b-it": {
+      "prompt": "0.30",
+      "completion": "0.30",
+      "request": "0",
+      "image": "0",
+      "context_length": 8192
+    },
+    "Qwen/Qwen2.5-14B-Instruct": {
+      "prompt": "0.30",
+      "completion": "0.30",
+      "request": "0",
+      "image": "0",
+      "context_length": 32768
+    },
+    "Qwen/Qwen2.5-32B-Instruct": {
+      "prompt": "1.08",
+      "completion": "1.08",
+      "request": "0",
+      "image": "0",
+      "context_length": 32768
+    },
+    "mistralai/Mixtral-8x7B-Instruct-v0.1-FP8": {
+      "prompt": "0.30",
+      "completion": "0.30",
+      "request": "0",
+      "image": "0",
+      "context_length": 32768
+    },
+    "mistralai/Devstral-Small-2505": {
+      "prompt": "0.30",
+      "completion": "0.30",
+      "request": "0",
+      "image": "0",
+      "context_length": 32768
+    },
+    "simplismart/flux-1.1-pro": {
+      "prompt": "0",
+      "completion": "0",
+      "request": "0.05",
+      "image": "0.05",
+      "pricing_model": "per_image"
+    },
+    "simplismart/flux-dev": {
+      "prompt": "0",
+      "completion": "0",
+      "request": "0.03",
+      "image": "0.03",
+      "pricing_model": "per_image"
+    },
+    "simplismart/flux-kontext": {
+      "prompt": "0",
+      "completion": "0",
+      "request": "0.04",
+      "image": "0.04",
+      "pricing_model": "per_image"
+    },
+    "simplismart/flux-1.1-pro-redux": {
+      "prompt": "0",
+      "completion": "0",
+      "request": "0.05",
+      "image": "0.05",
+      "pricing_model": "per_image"
+    },
+    "simplismart/flux-pro-canny": {
+      "prompt": "0",
+      "completion": "0",
+      "request": "0.05",
+      "image": "0.05",
+      "pricing_model": "per_image"
+    },
+    "simplismart/flux-pro-depth": {
+      "prompt": "0",
+      "completion": "0",
+      "request": "0.05",
+      "image": "0.05",
+      "pricing_model": "per_image"
+    },
+    "simplismart/sdxl": {
+      "prompt": "0",
+      "completion": "0",
+      "request": "0.28",
+      "image": "0.28",
+      "pricing_model": "per_image"
+    },
+    "simplismart/whisper-large-v2": {
+      "prompt": "0",
+      "completion": "0",
+      "request": "0.0028",
+      "image": "0",
+      "pricing_model": "per_minute"
+    },
+    "simplismart/whisper-large-v3": {
+      "prompt": "0",
+      "completion": "0",
+      "request": "0.0030",
+      "image": "0",
+      "pricing_model": "per_minute"
+    },
+    "simplismart/whisper-v3-turbo": {
+      "prompt": "0",
+      "completion": "0",
+      "request": "0.0018",
+      "image": "0",
+      "pricing_model": "per_minute"
     }
   },
   "onerouter": {
@@ -1072,10 +1198,10 @@
     }
   },
   "_metadata": {
-    "last_updated": "2026-01-04",
+    "last_updated": "2026-01-11",
     "note": "Manual pricing data for providers that don't expose pricing via API. Near AI and Alibaba Cloud pricing are now fetched dynamically from API but kept here as fallback.",
     "sources": [
-      "https://simplismart.ai/pricing (Simplismart - MLOps platform with LLM inference)",
+      "https://simplismart.ai/pricing (Simplismart - MLOps platform with LLM inference, image generation, and speech-to-text)",
       "https://openai.com/api/pricing (OpenAI - official API pricing)",
       "https://www.anthropic.com/pricing (Anthropic - Claude models pricing)",
       "https://deepinfra.com/pricing",

--- a/src/services/simplismart_client.py
+++ b/src/services/simplismart_client.py
@@ -1,35 +1,49 @@
 """
 Simplismart AI provider client module.
 
-Simplismart provides OpenAI-compatible API endpoints for various LLM models
-including Llama, Gemma, Qwen, DeepSeek, Phi-3, Mixtral, and more.
+Simplismart provides OpenAI-compatible API endpoints for various LLM models,
+image generation (Flux, SDXL), and speech-to-text (Whisper).
 
 API Documentation: https://docs.simplismart.ai/overview
 Base URL: https://api.simplismart.live
 Pricing: https://simplismart.ai/pricing
 
-Supported models:
-- meta-llama/Meta-Llama-3.1-8B-Instruct ($0.13/1M tokens)
-- meta-llama/Meta-Llama-3.1-70B-Instruct ($0.74/1M tokens)
-- meta-llama/Meta-Llama-3.1-405B-Instruct ($3.00/1M tokens)
-- meta-llama/Llama-3.3-70B-Instruct ($0.74/1M tokens)
+Supported LLM models (per 1M tokens):
+- meta-llama/Meta-Llama-3.1-8B-Instruct ($0.13)
+- meta-llama/Meta-Llama-3.1-70B-Instruct ($0.74)
+- meta-llama/Meta-Llama-3.1-405B-Instruct ($3.00)
+- meta-llama/Llama-3.3-70B-Instruct ($0.74)
 - meta-llama/Llama-4-Maverick-17B-Instruct (preview)
-- deepseek-ai/DeepSeek-R1 ($3.90/1M tokens)
-- deepseek-ai/DeepSeek-V3 ($0.90/1M tokens)
-- deepseek-ai/DeepSeek-R1-Distill-Llama-70B
-- deepseek-ai/DeepSeek-R1-Distill-Qwen-32B
-- google/gemma-3-1b-it ($0.06/1M tokens)
-- google/gemma-3-4b-it ($0.10/1M tokens)
-- google/gemma-3-27b-it
-- microsoft/Phi-3-medium-128k-instruct ($0.08/1M tokens)
-- microsoft/Phi-3-mini-4k-instruct ($0.08/1M tokens)
-- Qwen/Qwen2.5-7B-Instruct ($0.30/1M tokens)
-- Qwen/Qwen2.5-14B-Instruct
-- Qwen/Qwen2.5-32B-Instruct
-- Qwen/Qwen2.5-72B-Instruct ($1.08/1M tokens)
-- Qwen/Qwen3-4B ($0.10/1M tokens)
-- mistralai/Mixtral-8x7B-Instruct-v0.1-FP8
-- mistralai/Devstral-Small-2505
+- deepseek-ai/DeepSeek-R1 ($3.90)
+- deepseek-ai/DeepSeek-V3 ($0.90)
+- deepseek-ai/DeepSeek-R1-Distill-Llama-70B ($0.74)
+- deepseek-ai/DeepSeek-R1-Distill-Qwen-32B ($1.08)
+- google/gemma-3-1b-it ($0.06)
+- google/gemma-3-4b-it ($0.10)
+- google/gemma-3-27b-it ($0.30)
+- microsoft/Phi-3-medium-128k-instruct ($0.08)
+- microsoft/Phi-3-mini-4k-instruct ($0.08)
+- Qwen/Qwen2.5-7B-Instruct ($0.30)
+- Qwen/Qwen2.5-14B-Instruct ($0.30)
+- Qwen/Qwen2.5-32B-Instruct ($1.08)
+- Qwen/Qwen2.5-72B-Instruct ($1.08)
+- Qwen/Qwen3-4B ($0.10)
+- mistralai/Mixtral-8x7B-Instruct-v0.1-FP8 ($0.30)
+- mistralai/Devstral-Small-2505 ($0.30)
+
+Supported Diffusion models (per 1024x1024 image):
+- simplismart/flux-1.1-pro ($0.05)
+- simplismart/flux-dev ($0.03)
+- simplismart/flux-kontext ($0.04)
+- simplismart/flux-1.1-pro-redux ($0.05)
+- simplismart/flux-pro-canny ($0.05)
+- simplismart/flux-pro-depth ($0.05)
+- simplismart/sdxl ($0.28)
+
+Supported Speech-to-Text models (per audio minute):
+- simplismart/whisper-large-v2 ($0.0028)
+- simplismart/whisper-large-v3 ($0.0030)
+- simplismart/whisper-v3-turbo ($0.0018)
 """
 
 import logging
@@ -182,6 +196,134 @@ SIMPLISMART_MODELS = {
         "description": "Mistral's Devstral Small coding assistant model",
         "pricing": {"prompt": "0.30", "completion": "0.30", "request": "0", "image": "0"},
     },
+    # =====================
+    # Diffusion/Image Models
+    # =====================
+    # Pricing is per 1024x1024 image from https://simplismart.ai/pricing
+    "simplismart/flux-1.1-pro": {
+        "name": "Flux 1.1 Pro",
+        "type": "text-to-image",
+        "description": "High-quality Flux 1.1 Pro image generation model",
+        "pricing": {
+            "prompt": "0",
+            "completion": "0",
+            "request": "0.05",
+            "image": "0.05",
+            "pricing_model": "per_image",
+        },
+    },
+    "simplismart/flux-dev": {
+        "name": "Flux Dev",
+        "type": "text-to-image",
+        "description": "Flux Dev image generation model for development",
+        "pricing": {
+            "prompt": "0",
+            "completion": "0",
+            "request": "0.03",
+            "image": "0.03",
+            "pricing_model": "per_image",
+        },
+    },
+    "simplismart/flux-kontext": {
+        "name": "Flux Kontext",
+        "type": "text-to-image",
+        "description": "Flux Kontext context-aware image generation",
+        "pricing": {
+            "prompt": "0",
+            "completion": "0",
+            "request": "0.04",
+            "image": "0.04",
+            "pricing_model": "per_image",
+        },
+    },
+    "simplismart/flux-1.1-pro-redux": {
+        "name": "Flux 1.1 Pro Redux",
+        "type": "image-to-image",
+        "description": "Flux 1.1 Pro Redux for image variations and remixing",
+        "pricing": {
+            "prompt": "0",
+            "completion": "0",
+            "request": "0.05",
+            "image": "0.05",
+            "pricing_model": "per_image",
+        },
+    },
+    "simplismart/flux-pro-canny": {
+        "name": "Flux Pro Canny",
+        "type": "image-to-image",
+        "description": "Flux Pro with Canny edge detection control",
+        "pricing": {
+            "prompt": "0",
+            "completion": "0",
+            "request": "0.05",
+            "image": "0.05",
+            "pricing_model": "per_image",
+        },
+    },
+    "simplismart/flux-pro-depth": {
+        "name": "Flux Pro Depth",
+        "type": "image-to-image",
+        "description": "Flux Pro with depth map control",
+        "pricing": {
+            "prompt": "0",
+            "completion": "0",
+            "request": "0.05",
+            "image": "0.05",
+            "pricing_model": "per_image",
+        },
+    },
+    "simplismart/sdxl": {
+        "name": "Stable Diffusion XL",
+        "type": "text-to-image",
+        "description": "Stable Diffusion XL image generation model",
+        "pricing": {
+            "prompt": "0",
+            "completion": "0",
+            "request": "0.28",
+            "image": "0.28",
+            "pricing_model": "per_image",
+        },
+    },
+    # =====================
+    # Speech-to-Text Models
+    # =====================
+    # Pricing is per audio minute from https://simplismart.ai/pricing
+    "simplismart/whisper-large-v2": {
+        "name": "Whisper Large v2",
+        "type": "speech-to-text",
+        "description": "OpenAI Whisper Large v2 for speech transcription",
+        "pricing": {
+            "prompt": "0",
+            "completion": "0",
+            "request": "0.0028",
+            "image": "0",
+            "pricing_model": "per_minute",
+        },
+    },
+    "simplismart/whisper-large-v3": {
+        "name": "Whisper Large v3",
+        "type": "speech-to-text",
+        "description": "OpenAI Whisper Large v3 for speech transcription",
+        "pricing": {
+            "prompt": "0",
+            "completion": "0",
+            "request": "0.0030",
+            "image": "0",
+            "pricing_model": "per_minute",
+        },
+    },
+    "simplismart/whisper-v3-turbo": {
+        "name": "Whisper v3 Turbo",
+        "type": "speech-to-text",
+        "description": "Fast OpenAI Whisper v3 Turbo for speech transcription",
+        "pricing": {
+            "prompt": "0",
+            "completion": "0",
+            "request": "0.0018",
+            "image": "0",
+            "pricing_model": "per_minute",
+        },
+    },
 }
 
 # Model ID aliases for user convenience
@@ -233,6 +375,26 @@ SIMPLISMART_MODEL_ALIASES = {
     "mixtral-8x7b-instruct": "mistralai/Mixtral-8x7B-Instruct-v0.1-FP8",
     # Devstral aliases
     "devstral-small": "mistralai/Devstral-Small-2505",
+    # Flux image model aliases
+    "flux-1.1-pro": "simplismart/flux-1.1-pro",
+    "flux-pro": "simplismart/flux-1.1-pro",
+    "flux-dev": "simplismart/flux-dev",
+    "flux-kontext": "simplismart/flux-kontext",
+    "flux-1.1-pro-redux": "simplismart/flux-1.1-pro-redux",
+    "flux-pro-redux": "simplismart/flux-1.1-pro-redux",
+    "flux-pro-canny": "simplismart/flux-pro-canny",
+    "flux-canny": "simplismart/flux-pro-canny",
+    "flux-pro-depth": "simplismart/flux-pro-depth",
+    "flux-depth": "simplismart/flux-pro-depth",
+    "sdxl": "simplismart/sdxl",
+    "stable-diffusion-xl": "simplismart/sdxl",
+    # Whisper speech-to-text aliases
+    "whisper-large-v2": "simplismart/whisper-large-v2",
+    "whisper-v2": "simplismart/whisper-large-v2",
+    "whisper-large-v3": "simplismart/whisper-large-v3",
+    "whisper-v3": "simplismart/whisper-large-v3",
+    "whisper-v3-turbo": "simplismart/whisper-v3-turbo",
+    "whisper-turbo": "simplismart/whisper-v3-turbo",
 }
 
 
@@ -368,6 +530,8 @@ def fetch_models_from_simplismart():
 
     Returns a list of model info dictionaries in catalog format.
     Includes pricing data from https://simplismart.ai/pricing
+
+    Supports LLM, text-to-image, image-to-image, and speech-to-text models.
     """
     try:
         models = []
@@ -376,10 +540,15 @@ def fetch_models_from_simplismart():
                 "id": model_id,
                 "name": model_info["name"],
                 "description": model_info.get("description", ""),
-                "context_length": model_info.get("context_length", 8192),
                 "provider": "simplismart",
                 "provider_name": "Simplismart",
             }
+            # Include model type if available (text-to-image, speech-to-text, etc.)
+            if "type" in model_info:
+                model_data["type"] = model_info["type"]
+            # Include context_length for LLM models
+            if "context_length" in model_info:
+                model_data["context_length"] = model_info["context_length"]
             # Include pricing if available
             if "pricing" in model_info:
                 model_data["pricing"] = model_info["pricing"]


### PR DESCRIPTION
## Summary
- Adds comprehensive Simplismart pricing and model catalog support, including LLMs, diffusion/image, and speech-to-text models with appropriate pricing models (per_token, per_image, per_minute).
- Introduces model type handling and context_length awareness in catalog fetch and tests for new model types.
- Adds alias resolution for Simplismart Flux, SDXL, and Whisper models to improve UX.

## Changes

### Data
- Updated src/data/manual_pricing.json with new Simplismart entries:
  - LLMs and Mixtral-related models (context_length where applicable)
  - Diffusion/image models: flux-1.1-pro, flux-dev, flux-kontext, flux-1.1-pro-redux, flux-pro-canny, flux-pro-depth, sdxl
  - Speech-to-Text models: whisper-large-v2, whisper-large-v3, whisper-v3-turbo
  - Pricing models now include per_image for image models, per_minute for Whisper models, with explicit pricing values.
- Updated last_updated metadata to 2026-01-11 and expanded sources note to include image generation pricing context.

### Core code
- Enhanced src/services/simplismart_client.py:
  - Expanded SIMPLISMART_MODELS to cover new LLMs, diffusion, and STT models with pricing and type metadata.
  - Added model_type distinctions (text-to-image, image-to-image, speech-to-text) and per-model pricing blocks.
  - Included aliases for convenient model resolution and improved documentation inline.
- Updated fetch_models_from_simplismart() to:
  - Emit model_type when present.
  - Emit context_length for LLM models when available.
  - Preserve pricing structure for all models present in SIMPLISMART_MODELS.

- Added SIMPLISMART_MODEL_ALIASES to surface-friendly aliases for Flux, sdxl, and Whisper models (e.g., flux-1.1-pro -> simplismart/flux-1.1-pro, stable-diffusion-xl -> simplismart/sdxl).

### Tests
- Expanded tests/services/test_simplismart_client.py with new suites:
  - TestSimplismartImageModels: validates Flux and SDXL model catalog presence, types, and per_image pricing, plus alias resolution for image models.
  - TestSimplismartSpeechModels: validates Whisper model catalog presence, types, per_minute pricing, and alias resolution.
  - TestSimplismartIsModelWithNewTypes: ensures new model types (text-to-image, image-to-image, speech-to-text) are recognized by is_simplismart_model.
- Updated existing tests to account for new type-based context_length requirements (context_length is only required for LLM models).
- Added assertions to verify that new aliases resolve to correct canonical model identifiers.

## Test plan
- [x] Run unit tests for catalog loading, pricing validation, and alias resolution.
- [x] Validate that new image and speech models appear in the catalog and have correct pricing models (per_image, per_minute).
- [x] Ensure context_length is required only for LLM-type models in tests.
- [x] Validate is_simplismart_model recognizes new model types.

## Notes
- This update lays groundwork for dynamic pricing usage by defaulting to manualPricing.json fallbacks for Simplismart models when dynamic pricing is unavailable via API. The catalog now reflects available model types and pricing schemas to support accurate cost estimation.
- No breaking changes anticipated for existing consumers; new fields are optional and only emitted when present in model data.



🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f9e11e43-f22d-4172-b378-db7613e145a3

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR extends Simplismart provider support beyond LLM models to include image generation (Flux, SDXL) and speech-to-text (Whisper) models. The changes add 17 new models across three categories with appropriate pricing structures:

- **LLM models**: Added 9 new models including Llama 4 Maverick, DeepSeek distilled models, Gemma 3-27b, Qwen 2.5-14B/32B, Mixtral FP8, and Devstral
- **Image models**: Added 7 Flux variants and SDXL with `per_image` pricing model
- **Speech models**: Added 3 Whisper variants with `per_minute` pricing model

The implementation correctly handles model type distinctions by:
- Adding optional `type` field to differentiate text-to-image, image-to-image, and speech-to-text models
- Making `context_length` conditional (only for LLM models, not image/speech models)
- Including `pricing_model` field in pricing structure to indicate per_image or per_minute pricing
- Creating user-friendly aliases for all new models

All changes maintain backward compatibility with existing LLM-only functionality and include comprehensive test coverage.

### Confidence Score: 5/5

- Safe to merge - well-structured additions with proper type handling and comprehensive tests
- The changes are additive and maintain backward compatibility. The code correctly conditionalizes context_length based on model type, includes proper pricing structures, and has extensive test coverage validating all new functionality. No breaking changes or bugs detected.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/data/manual_pricing.json | 5/5 | Added 17 new Simplismart model entries with correct pricing structures including per_image and per_minute pricing models |
| src/services/simplismart_client.py | 5/5 | Extended model catalog with image/speech models, added type field handling, and created aliases for new models |
| tests/services/test_simplismart_client.py | 5/5 | Added comprehensive test suites for image and speech models covering catalog, pricing, types, and alias resolution |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API
    participant SimplismartClient
    participant ModelCatalog
    participant PricingLookup
    
    User->>API: Request model catalog
    API->>SimplismartClient: fetch_models_from_simplismart()
    SimplismartClient->>ModelCatalog: Iterate SIMPLISMART_MODELS
    
    alt LLM Model
        ModelCatalog->>SimplismartClient: Include context_length
        ModelCatalog->>SimplismartClient: Use per_token pricing
    else Image Model (Flux/SDXL)
        ModelCatalog->>SimplismartClient: Add type: text-to-image/image-to-image
        ModelCatalog->>SimplismartClient: Use per_image pricing_model
    else Speech Model (Whisper)
        ModelCatalog->>SimplismartClient: Add type: speech-to-text
        ModelCatalog->>SimplismartClient: Use per_minute pricing_model
    end
    
    SimplismartClient->>API: Return models with type/pricing
    API->>User: Model catalog response
    
    User->>API: Request with alias (e.g., "flux-pro")
    API->>SimplismartClient: resolve_simplismart_model("flux-pro")
    SimplismartClient->>SimplismartClient: Check SIMPLISMART_MODEL_ALIASES
    SimplismartClient->>API: Return "simplismart/flux-1.1-pro"
    API->>SimplismartClient: make_simplismart_request_openai()
    SimplismartClient->>User: Execute request with resolved model
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->