### PR TITLE
feat: Add gateway uptime endpoint and fix health data logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Each provider has a dedicated client module:
 - ✅ **Braintrust** - ML evaluation & tracing
 - ✅ **OpenAI** - Direct ChatGPT API calls
 
-### API Endpoints (83+ endpoints)
+### API Endpoints (86+ endpoints)
 
 **Chat & Inference:**
 - `POST /chat/completions` - OpenAI-compatible chat
@@ -185,6 +185,11 @@ Each provider has a dedicated client module:
 - `GET /api/monitoring/chat-requests/models` - Model statistics
 - `GET /api/monitoring/chat-requests` - Full request logs
 - `GET /api/monitoring/anomalies` - Anomaly detection
+
+**Health & Uptime Timeline:**
+- `GET /health/providers/uptime` - Provider uptime timeline with time-bucketed samples
+- `GET /health/models/uptime` - Model uptime timeline with incident tracking
+- `GET /health/gateways/uptime` - Gateway uptime timeline and provider health
 
 **Prometheus Metrics:**
 - `GET /metrics` - Prometheus format metrics

--- a/src/schemas/health_timeline.py
+++ b/src/schemas/health_timeline.py
@@ -81,3 +81,25 @@ class ModelUptimeResponse(BaseModel):
     """Response for GET /health/models/uptime"""
     success: bool = True
     models: list[ModelUptimeData]
+
+
+# ===========================
+# Gateway Uptime Schemas
+# ===========================
+
+class GatewayUptimeData(BaseModel):
+    """Uptime data for a single gateway"""
+    gateway: str = Field(..., description="Gateway name (e.g., openrouter, fireworks)")
+    uptime_percentage: float = Field(..., description="Uptime percentage over the period")
+    period_label: str = Field(..., description="Human-readable period label")
+    last_checked: datetime = Field(..., description="Timestamp of last health check")
+    total_providers: int = Field(..., description="Total number of providers on this gateway")
+    healthy_providers: int = Field(..., description="Number of healthy providers")
+    samples: list[UptimeSample] = Field(..., description="Array of uptime samples per time bucket")
+    incident_summary: IncidentSummary = Field(..., description="Summary of incidents over the period")
+
+
+class GatewayUptimeResponse(BaseModel):
+    """Response for GET /health/gateways/uptime"""
+    success: bool = True
+    gateways: list[GatewayUptimeData]


### PR DESCRIPTION
- Added GET /health/gateways/uptime endpoint for gateway uptime timelines
- Created GatewayUptimeData and GatewayUptimeResponse schemas
- Updated README with new endpoints documentation (86+ endpoints)
- Backend already correctly handles operational/degraded/downtime statuses
- Health check data is calculated from real database records
- Frontend will show realistic data once API keys are configured

Implementation Details:
- Gateway endpoint groups health data by gateway
- Calculates uptime from actual success/failure rates
- Provides time-bucketed samples with incident metadata
- Tracks provider health per gateway
- Cached for 5 minutes to reduce database load

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR adds a new gateway uptime monitoring endpoint (`GET /health/gateways/uptime`) that provides time-bucketed uptime timelines for each gateway, tracking provider health and incident history.

## Changes Made

**New Endpoint Implementation:**
- Adds `get_gateways_uptime()` endpoint in `src/routes/health_timeline.py` (lines 501-676)
- Follows the same proven architecture as existing provider and model uptime endpoints
- Groups health data by gateway (vs. by provider or model)
- Calculates uptime percentage from actual database success/failure rates
- Provides time-bucketed samples with operational/degraded/downtime status
- Tracks provider health per gateway (counts providers with ≥50% success rate)
- Includes incident detection (downtime, error surges, latency spikes)
- Protected by admin authentication via `require_admin` dependency
- Cached for 5 minutes to reduce database load

**Schema Definitions:**
- Added `GatewayUptimeData` schema with fields: gateway, uptime_percentage, total_providers, healthy_providers, samples, incident_summary
- Added `GatewayUptimeResponse` wrapper schema
- Reuses existing `UptimeSample` and `IncidentSummary` schemas for consistency

**Documentation:**
- Updated README from "83+ endpoints" to "86+ endpoints"
- Added new "Health & Uptime Timeline" section documenting all 3 uptime endpoints
- Descriptions accurately reflect functionality

## Code Quality

The implementation demonstrates excellent code quality:

1. **Consistency**: Follows the exact same pattern as `get_providers_uptime` and `get_models_uptime` endpoints
2. **Edge Case Handling**: Properly handles empty buckets, no data scenarios, and NULL gateway values
3. **Type Safety**: Uses Pydantic models and Literal types for validation
4. **Security**: Requires admin authentication, uses parameterized queries
5. **Performance**: Implements 5-minute caching, leverages database indexes
6. **Maintainability**: Clear variable names, comprehensive docstring, consistent code style

## Technical Implementation

The endpoint queries `model_health_history` table and:
- Groups records by gateway
- Creates time buckets based on period (24h/72h/7d) and bucket size (5m/1h)
- Calculates success rates and determines status thresholds:
  - Operational: ≥95% success rate
  - Degraded: 50-95% success rate
  - Downtime: <50% success rate
- Counts healthy providers (those with ≥50% success rate)
- Detects incidents based on error rates and latency
- Returns sorted results (worst uptime first for alerting)

No issues found during review.

### Confidence Score: 5/5

- This PR is safe to merge with no concerns
- Score reflects excellent code quality with no bugs, security issues, or logic errors found. The implementation follows established patterns exactly, includes proper edge case handling, authentication, caching, and comprehensive testing during review revealed no issues. The code is production-ready.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| README.md | 5/5 | Documentation update correctly reflects new gateway uptime endpoint, endpoint count increased from 83 to 86 |
| src/routes/health_timeline.py | 5/5 | New gateway uptime endpoint follows established patterns, properly handles edge cases, includes admin auth and caching |
| src/schemas/health_timeline.py | 5/5 | New schemas properly defined with appropriate field types and descriptions for gateway uptime data |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant FastAPI
    participant Auth as require_admin
    participant Cache
    participant Supabase
    participant Endpoint as get_gateways_uptime
    
    Client->>FastAPI: GET /health/gateways/uptime?period=72h&bucket=1h
    FastAPI->>Auth: Verify admin credentials
    Auth-->>FastAPI: Admin user validated
    
    FastAPI->>Endpoint: Execute endpoint handler
    Endpoint->>Cache: Check cache for key
    
    alt Cache Hit
        Cache-->>Endpoint: Return cached response
        Endpoint-->>Client: GatewayUptimeResponse (cached)
    else Cache Miss
        Endpoint->>Supabase: Query model_health_history table
        Note over Endpoint,Supabase: SELECT provider, gateway, checked_at, status, response_time_ms<br/>WHERE checked_at >= start_time AND checked_at <= current_time
        Supabase-->>Endpoint: Return history records
        
        Endpoint->>Endpoint: Group records by gateway
        Endpoint->>Endpoint: Create time buckets
        
        loop For each gateway
            Endpoint->>Endpoint: Calculate metrics per time bucket
            Endpoint->>Endpoint: Determine status (operational/degraded/downtime)
            Endpoint->>Endpoint: Detect incidents (latency spikes, error surges)
            Endpoint->>Endpoint: Calculate provider health (success rate >= 50%)
            Endpoint->>Endpoint: Aggregate uptime percentage
        end
        
        Endpoint->>Endpoint: Sort gateways by uptime (worst first)
        Endpoint->>Cache: Store response (5 min TTL)
        Endpoint-->>Client: GatewayUptimeResponse with timeline data
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->