### PR TITLE
Audit offline AI gateways: register new providers in catalog sync

### DIFF
--- a/src/services/model_catalog_sync.py
+++ b/src/services/model_catalog_sync.py
@@ -14,6 +14,8 @@ from src.db.providers_db import (
     get_provider_by_slug,
 )
 from src.services.cerebras_client import fetch_models_from_cerebras
+from src.services.clarifai_client import fetch_models_from_clarifai
+from src.services.cloudflare_workers_ai_client import fetch_models_from_cloudflare_workers_ai
 from src.services.google_vertex_client import fetch_models_from_google_vertex
 from src.services.huggingface_models import fetch_models_from_huggingface_api
 from src.services.models import (
@@ -21,6 +23,7 @@ from src.services.models import (
     fetch_models_from_aimo,
     fetch_models_from_alibaba,
     fetch_models_from_anannas,
+    fetch_models_from_anthropic,
     fetch_models_from_chutes,
     fetch_models_from_deepinfra,
     fetch_models_from_fal,
@@ -29,12 +32,16 @@ from src.services.models import (
     fetch_models_from_groq,
     fetch_models_from_helicone,
     fetch_models_from_near,
+    fetch_models_from_openai,
     fetch_models_from_openrouter,
     fetch_models_from_together,
     fetch_models_from_vercel_ai_gateway,
 )
+from src.services.modelz_client import fetch_models_from_modelz
 from src.services.nebius_client import fetch_models_from_nebius
 from src.services.novita_client import fetch_models_from_novita
+from src.services.onerouter_client import fetch_models_from_onerouter
+from src.services.simplismart_client import fetch_models_from_simplismart
 from src.services.xai_client import fetch_models_from_xai
 
 logger = logging.getLogger(__name__)
@@ -63,6 +70,14 @@ PROVIDER_FETCH_FUNCTIONS = {
     "xai": fetch_models_from_xai,
     "nebius": fetch_models_from_nebius,
     "novita": fetch_models_from_novita,
+    # Additional providers that were missing
+    "openai": fetch_models_from_openai,
+    "anthropic": fetch_models_from_anthropic,
+    "clarifai": fetch_models_from_clarifai,
+    "simplismart": fetch_models_from_simplismart,
+    "onerouter": fetch_models_from_onerouter,
+    "cloudflare-workers-ai": fetch_models_from_cloudflare_workers_ai,
+    "modelz": fetch_models_from_modelz,
 }
 
 
@@ -358,6 +373,82 @@ def ensure_provider_exists(provider_slug: str) -> dict[str, Any] | None:
                 "base_url": "https://api.x.ai/v1",
                 "api_key_env_var": "XAI_API_KEY",
                 "site_url": "https://x.ai",
+                "supports_streaming": True,
+            },
+            "openai": {
+                "name": "OpenAI",
+                "description": "OpenAI GPT models",
+                "base_url": "https://api.openai.com/v1",
+                "api_key_env_var": "OPENAI_API_KEY",
+                "site_url": "https://openai.com",
+                "supports_streaming": True,
+                "supports_function_calling": True,
+                "supports_vision": True,
+            },
+            "anthropic": {
+                "name": "Anthropic",
+                "description": "Anthropic Claude models",
+                "base_url": "https://api.anthropic.com/v1",
+                "api_key_env_var": "ANTHROPIC_API_KEY",
+                "site_url": "https://anthropic.com",
+                "supports_streaming": True,
+                "supports_function_calling": True,
+                "supports_vision": True,
+            },
+            "clarifai": {
+                "name": "Clarifai",
+                "description": "Clarifai AI platform",
+                "base_url": "https://api.clarifai.com",
+                "api_key_env_var": "CLARIFAI_API_KEY",
+                "site_url": "https://clarifai.com",
+                "supports_streaming": True,
+            },
+            "simplismart": {
+                "name": "SimpliSmart",
+                "description": "SimpliSmart AI inference",
+                "base_url": "https://api.simplismart.ai/v1",
+                "api_key_env_var": "SIMPLISMART_API_KEY",
+                "site_url": "https://simplismart.ai",
+                "supports_streaming": True,
+            },
+            "onerouter": {
+                "name": "OneRouter",
+                "description": "OneRouter multi-provider gateway",
+                "base_url": "https://api.onerouter.pro/v1",
+                "api_key_env_var": "ONEROUTER_API_KEY",
+                "site_url": "https://onerouter.pro",
+                "supports_streaming": True,
+            },
+            "cloudflare-workers-ai": {
+                "name": "Cloudflare Workers AI",
+                "description": "Cloudflare Workers AI inference",
+                "base_url": None,
+                "api_key_env_var": "CLOUDFLARE_API_TOKEN",
+                "site_url": "https://developers.cloudflare.com/workers-ai",
+                "supports_streaming": True,
+            },
+            "nebius": {
+                "name": "Nebius",
+                "description": "Nebius AI Studio",
+                "base_url": "https://api.studio.nebius.ai/v1",
+                "api_key_env_var": "NEBIUS_API_KEY",
+                "site_url": "https://studio.nebius.ai",
+                "supports_streaming": True,
+            },
+            "novita": {
+                "name": "Novita",
+                "description": "Novita AI inference",
+                "base_url": "https://api.novita.ai/v3/openai",
+                "api_key_env_var": "NOVITA_API_KEY",
+                "site_url": "https://novita.ai",
+                "supports_streaming": True,
+            },
+            "modelz": {
+                "name": "Modelz",
+                "description": "Modelz AI model deployment platform",
+                "base_url": "https://backend.alpacanetwork.ai",
+                "api_key_env_var": "MODELZ_API_KEY",
+                "site_url": "https://modelz.ai",
                 "supports_streaming": True,
             },
         }

--- a/tests/services/test_model_catalog_sync.py
+++ b/tests/services/test_model_catalog_sync.py
@@ -1,6 +1,7 @@
 """Tests for model catalog sync functionality."""
 
 from src.services.model_catalog_sync import (
+    PROVIDER_FETCH_FUNCTIONS,
     transform_normalized_model_to_db_schema,
     extract_modality,
     extract_pricing,
@@ -213,3 +214,85 @@ class TestExtractCapabilities:
         model = {"architecture": {"input_modalities": ["text"]}}
         caps = extract_capabilities(model)
         assert caps["supports_vision"] is False
+
+
+class TestProviderFetchFunctionsRegistry:
+    """Tests for PROVIDER_FETCH_FUNCTIONS registry completeness."""
+
+    def test_openai_registered(self):
+        """Test that OpenAI provider is registered."""
+        assert "openai" in PROVIDER_FETCH_FUNCTIONS
+        assert callable(PROVIDER_FETCH_FUNCTIONS["openai"])
+
+    def test_anthropic_registered(self):
+        """Test that Anthropic provider is registered."""
+        assert "anthropic" in PROVIDER_FETCH_FUNCTIONS
+        assert callable(PROVIDER_FETCH_FUNCTIONS["anthropic"])
+
+    def test_clarifai_registered(self):
+        """Test that Clarifai provider is registered."""
+        assert "clarifai" in PROVIDER_FETCH_FUNCTIONS
+        assert callable(PROVIDER_FETCH_FUNCTIONS["clarifai"])
+
+    def test_simplismart_registered(self):
+        """Test that SimpliSmart provider is registered."""
+        assert "simplismart" in PROVIDER_FETCH_FUNCTIONS
+        assert callable(PROVIDER_FETCH_FUNCTIONS["simplismart"])
+
+    def test_onerouter_registered(self):
+        """Test that OneRouter provider is registered."""
+        assert "onerouter" in PROVIDER_FETCH_FUNCTIONS
+        assert callable(PROVIDER_FETCH_FUNCTIONS["onerouter"])
+
+    def test_cloudflare_workers_ai_registered(self):
+        """Test that Cloudflare Workers AI provider is registered."""
+        assert "cloudflare-workers-ai" in PROVIDER_FETCH_FUNCTIONS
+        assert callable(PROVIDER_FETCH_FUNCTIONS["cloudflare-workers-ai"])
+
+    def test_modelz_registered(self):
+        """Test that Modelz provider is registered."""
+        assert "modelz" in PROVIDER_FETCH_FUNCTIONS
+        assert callable(PROVIDER_FETCH_FUNCTIONS["modelz"])
+
+    def test_all_core_providers_registered(self):
+        """Test that all core providers have fetch functions registered."""
+        expected_providers = [
+            "openrouter",
+            "deepinfra",
+            "featherless",
+            "chutes",
+            "groq",
+            "fireworks",
+            "together",
+            "aimo",
+            "near",
+            "fal",
+            "vercel-ai-gateway",
+            "aihubmix",
+            "helicone",
+            "anannas",
+            "alibaba",
+            "huggingface",
+            "cerebras",
+            "google-vertex",
+            "xai",
+            "nebius",
+            "novita",
+            "openai",
+            "anthropic",
+            "clarifai",
+            "simplismart",
+            "onerouter",
+            "cloudflare-workers-ai",
+            "modelz",
+        ]
+        for provider in expected_providers:
+            assert provider in PROVIDER_FETCH_FUNCTIONS, f"Provider '{provider}' not registered"
+            assert callable(PROVIDER_FETCH_FUNCTIONS[provider]), \
+                f"Provider '{provider}' fetch function is not callable"
+
+    def test_provider_count(self):
+        """Test that we have the expected number of providers registered."""
+        # 28 providers total after adding the missing ones
+        assert len(PROVIDER_FETCH_FUNCTIONS) >= 28, \
+            f"Expected at least 28 providers, got {len(PROVIDER_FETCH_FUNCTIONS)}"


### PR DESCRIPTION
## Summary
- Expands provider catalog sync to support additional offline gateways: OpenAI, Anthropic, Clarifai, SimpliSmart, OneRouter, Cloudflare Workers AI, and Modelz.

## Changes

### Backend
- src/services/model_catalog_sync.py
  - Extend PROVIDER_FETCH_FUNCTIONS with:
    - `openai`, `anthropic`, `clarifai`, `simplismart`, `onerouter`, `cloudflare-workers-ai`, `modelz`
  - Add provider metadata in `ensure_provider_exists` for the new providers with fields like name, description, base_url, api_key_env_var, site_url, supports_streaming, supports_function_calling, supports_vision.
- src/services/modelz_client.py
  - Add `fetch_models_from_modelz()` to fetch tokens from Modelz API, normalize to catalog schema, and cache results.
- tests/services/test_model_catalog_sync.py
  - Update tests to verify new provider registrations exist in `PROVIDER_FETCH_FUNCTIONS` and are callable.
  - Validate core expected providers presence and count.

## Why
- Ensures offline AI gateways are discoverable and usable by the catalog sync service, enabling model discovery and integration, including the Modelz platform.

## Test plan
- Run unit tests:
  - Ensure all new providers are registered and their fetch functions are callable.
  - Existing tests for catalog sync remain passing.
- Optional: Run integration-like checks for Modelz fetch (requires API access).

## Additional notes
- No changes to public API surfaces beyond adding new provider support; existing behavior unchanged for core providers.
- Consider adding environment-based API key injection tests in CI if needed.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/d88d1ebe-322b-4a9f-ae0a-46cb8e4998f5

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds support for 7 new AI providers to the model catalog synchronization system: OpenAI, Anthropic, Clarifai, SimpliSmart, OneRouter, Cloudflare Workers AI, and Modelz
- Implements a new synchronous fetch function `fetch_models_from_modelz()` in `src/services/modelz_client.py` to enable model discovery from the Modelz platform
- Expands test coverage to validate that all new providers are properly registered and their fetch functions are callable

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/services/model_catalog_sync.py | Added 7 new providers to PROVIDER_FETCH_FUNCTIONS registry and comprehensive provider metadata for database registration |
| src/services/modelz_client.py | Added new synchronous `fetch_models_from_modelz()` function that duplicates async logic for catalog sync compatibility |
| tests/services/test_model_catalog_sync.py | Enhanced test coverage to validate new provider registrations and updated provider count expectations to 28 total |

<h3>Context used:</h3>

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
