### PR TITLE
feat: add /health/models/data and /health/providers/data endpoints

### DIFF
--- a/src/services/model_health_monitor.py
+++ b/src/services/model_health_monitor.py
@@ -852,17 +852,54 @@ class ModelHealthMonitor:
                     gateway_health[gateway_name]["status"] = "degraded"
 
             # Add all gateways from GATEWAY_CONFIG that aren't tracked
+            # Check cache and API key status to determine appropriate status
             try:
                 from src.services.gateway_health_service import GATEWAY_CONFIG
-                for gateway_name in GATEWAY_CONFIG.keys():
+                for gateway_name, gateway_config in GATEWAY_CONFIG.items():
                     if gateway_name not in gateway_health:
+                        # Check if API key is configured (static_catalog is valid for some gateways)
+                        api_key = gateway_config.get("api_key")
+                        url = gateway_config.get("url")
+                        # Gateway is considered configured if it has an API key OR doesn't need one (url is None)
+                        has_api_key = api_key is not None and api_key != ""
+                        needs_api_key = url is not None  # Gateways with url=None use static catalogs
+
+                        # Check if cache has models
+                        cache = gateway_config.get("cache", {})
+                        cache_data = cache.get("data") if cache else None
+                        has_cached_models = cache_data is not None and len(cache_data) > 0 if cache_data else False
+                        model_count = len(cache_data) if has_cached_models else 0
+
+                        # Determine status and error based on configuration state
+                        if needs_api_key and not has_api_key:
+                            status = "unconfigured"
+                            error_msg = f"API key not configured. Set {gateway_config.get('api_key_env', 'API_KEY')} environment variable."
+                            is_healthy = False
+                        elif has_cached_models:
+                            # Has models in cache - gateway is available
+                            status = "healthy"
+                            error_msg = None
+                            is_healthy = True
+                        elif not needs_api_key:
+                            # Static catalog gateway without cached models yet
+                            status = "pending"
+                            error_msg = "Static catalog not yet loaded. Models will appear on first request."
+                            is_healthy = False
+                        else:
+                            # Has API key but no models in cache - needs sync
+                            status = "pending"
+                            error_msg = "Models not yet synced. They will appear when first accessed."
+                            is_healthy = False
+
                         gateway_health[gateway_name] = {
-                            "healthy": False,
-                            "status": "unconfigured",
+                            "healthy": is_healthy,
+                            "status": status,
                             "latency_ms": None,
-                            "available": False,
+                            "available": is_healthy,
                             "last_check": datetime.now(timezone.utc).isoformat(),
-                            "error": "No models synced for this gateway. Run model sync to populate."
+                            "error": error_msg,
+                            "total_models": model_count,
+                            "configured": has_api_key or not needs_api_key,
                         }
             except Exception as e:
                 logger.warning(f"Failed to add unconfigured gateways: {e}")


### PR DESCRIPTION
- Add /health/models/data endpoint to fetch ALL models from catalog (9000+)
  - Supports pagination with limit/offset parameters
  - Supports filtering by gateway and provider
  - Returns gateway counts and metadata

- Add /health/providers/data endpoint to fetch ALL providers (30+)
  - Returns complete gateway registry data
  - Shows model counts, API key status, and configuration
  - Supports priority filtering (fast/slow)

- Fix gateway 'unconfigured' status logic:
  - Check if gateway needs API key (url-based detection)
  - Gateways with url=None use static catalogs and don't need API keys
  - Show 'pending' status instead of 'unconfigured' for valid gateways
  - Remove misleading 'No models synced' error for configured gateways

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds comprehensive catalog data access endpoints (`/health/models/data` and `/health/providers/data`) to fetch complete model and provider datasets with pagination and filtering capabilities
- Implements intelligent gateway status detection logic that differentiates between gateways requiring API keys versus static catalog gateways that don't need configuration
- Fixes misleading "unconfigured" status messages by properly checking API key requirements and cache status for accurate gateway health reporting

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| `src/routes/health.py` | New file - added two major endpoints for catalog data access: `/health/models/data` (9000+ models with pagination) and `/health/providers/data` (30+ providers with configuration metadata) |
| `src/services/intelligent_health_monitor.py` | Updated gateway status determination logic to properly distinguish between API-key-required gateways vs static catalog gateways, eliminating false "unconfigured" errors |

<h3>Confidence score: 4/5</h3>


- This PR adds valuable data access endpoints that expand beyond health monitoring into full catalog functionality
- Score reflects the significant scope expansion from health monitoring to general data access, which may blur API boundaries and could impact performance when fetching 9000+ models
- Pay close attention to the new endpoints in `health.py` as they handle large datasets and the gateway status logic in `intelligent_health_monitor.py` for potential configuration edge cases

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant FastAPI as "FastAPI Health Endpoint"
    participant HealthCache as "Simple Health Cache"
    participant ModelsService as "Models Service"
    participant CatalogRegistry as "Catalog Registry"
    participant GatewayConfig as "Gateway Config"
    participant Supabase

    User->>FastAPI: "GET /health/models/data?gateway=x&provider=y&limit=100&offset=0"
    FastAPI->>ModelsService: "get_all_models_parallel()"
    ModelsService->>CatalogRegistry: "get all gateway models"
    CatalogRegistry-->>ModelsService: "all models from all gateways"
    ModelsService-->>FastAPI: "all_models list (~9000+)"
    FastAPI->>FastAPI: "filter by gateway and provider"
    FastAPI->>FastAPI: "apply pagination (offset, limit)"
    FastAPI->>FastAPI: "calculate gateway_counts"
    FastAPI-->>User: "paginated models with metadata"

    User->>FastAPI: "GET /health/providers/data?priority=fast"
    FastAPI->>CatalogRegistry: "get GATEWAY_REGISTRY"
    FastAPI->>GatewayConfig: "get GATEWAY_CONFIG"
    loop For each gateway
        FastAPI->>GatewayConfig: "check api_key and cache data"
        FastAPI->>FastAPI: "determine status (configured/unconfigured/pending)"
    end
    FastAPI->>FastAPI: "filter by priority and sort"
    FastAPI-->>User: "providers with configuration status"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->