### PR TITLE
feat(fal): fetch models from FAL REST API instead of static catalog

### DIFF
--- a/src/services/models.py
+++ b/src/services/models.py
@@ -2289,23 +2289,26 @@ def normalize_fal_model(fal_model: dict) -> dict | None:
     - 839+ models across text-to-image, text-to-video, image-to-video, etc.
     - Models include FLUX, Stable Diffusion, Veo, Sora, and many more
     - Supports image, video, audio, and 3D generation
+
+    Handles both static catalog format (uses "id") and API format (uses "endpoint_id")
     """
-    model_id = fal_model.get("id")
+    # API returns "endpoint_id", static catalog uses "id"
+    model_id = fal_model.get("endpoint_id") or fal_model.get("id")
     if not model_id:
-        logger.warning("Fal.ai model missing 'id' field: %s", sanitize_for_logging(str(fal_model)))
+        logger.warning("Fal.ai model missing 'id'/'endpoint_id' field: %s", sanitize_for_logging(str(fal_model)))
         return None
 
     # Extract provider from model ID (e.g., "fal-ai/flux-pro" -> "fal-ai")
     provider_slug = model_id.split("/")[0] if "/" in model_id else "fal-ai"
 
-    # Use name or derive from ID
-    display_name = fal_model.get("name") or model_id.split("/")[-1]
+    # Use title (API) or name (catalog) or derive from ID
+    display_name = fal_model.get("title") or fal_model.get("name") or model_id.split("/")[-1]
 
     # Get description
     description = fal_model.get("description", f"Fal.ai {display_name} model")
 
-    # Determine modality based on type
-    model_type = fal_model.get("type", "text-to-image")
+    # Determine modality based on type or category (API uses "category")
+    model_type = fal_model.get("type") or fal_model.get("category", "text-to-image")
     modality_map = {
         "text-to-image": MODALITY_TEXT_TO_IMAGE,
         "text-to-video": "text->video",


### PR DESCRIPTION
## Summary
- Add `fetch_fal_models_from_api()` function to dynamically fetch all FAL models via the `/v1/models` endpoint
- Uses pagination to retrieve all available models (839+ models)
- Falls back to static catalog if API call fails or FAL_API_KEY is not configured
- Update `normalize_fal_model()` to handle both API response format (`endpoint_id`, `title`, `category`) and static catalog format (`id`, `name`, `type`)

## Problem
The FAL models were being loaded from a static JSON catalog (`fal_catalog.json`) that only contained ~69 manually curated models, while FAL has 839+ models available.

## Solution
Fetch models dynamically from the FAL REST API:
```
GET https://api.fal.ai/v1/models
Authorization: Key <FAL_API_KEY>
```

## Test plan
- [ ] Verify FAL models are fetched from API when FAL_API_KEY is configured
- [ ] Verify fallback to static catalog when API fails
- [ ] Check that model count increases from ~69 to 800+
- [ ] Confirm model normalization works for both API and catalog formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds dynamic FAL model fetching from the FAL REST API instead of using a static catalog, increasing available models from ~69 to 839+
- Implements pagination logic in `fetch_fal_models_from_api()` function with safety limits and error handling
- Updates `normalize_fal_model()` to handle both API response format (`endpoint_id`, `title`, `category`) and static catalog format (`id`, `name`, `type`) with fallback logic

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/services/fal_image_client.py | Added `fetch_fal_models_from_api()` function with pagination and fallback to static catalog |
| src/services/models.py | Updated `normalize_fal_model()` to handle dual format compatibility for API and catalog responses |

<h3>Confidence score: 4/5</h3>


- This PR is generally safe to merge but requires careful testing of the new API integration
- Score reflects potential risks around pagination logic, error handling, and dual format support that need validation
- Pay close attention to the pagination implementation and ensure proper testing of both API and fallback scenarios

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant FAL as "fal_image_client"
    participant API as "api.fal.ai"
    participant Cache as "_fal_api_models_cache"
    participant Catalog as "static fal_catalog.json"

    Note over Client, Catalog: FAL Models Fetch Flow (Primary Path)

    Client->>FAL: get_fal_models()
    FAL->>FAL: fetch_fal_models_from_api()
    
    alt Cache Hit
        FAL->>Cache: Check _fal_api_models_cache
        Cache->>FAL: Return cached models
    else Cache Miss
        FAL->>API: Check Config.FAL_API_KEY
        
        alt API Key Available
            loop Paginated Fetch
                FAL->>API: GET /v1/models?page={page}&per_page=100
                API->>FAL: Return page of models
                FAL->>FAL: all_models.extend(models)
                
                alt More Pages
                    FAL->>FAL: page += 1
                else Last Page
                    Note over FAL: Break pagination loop
                end
            end
            
            FAL->>Cache: _fal_api_models_cache = all_models
            FAL->>FAL: return all_models
        else No API Key
            FAL->>FAL: load_fal_models_catalog()
            FAL->>Catalog: Load fal_catalog.json
            Catalog->>FAL: Return static models
            FAL->>FAL: return static models
        end
    end
    
    FAL->>Client: Return models list
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->