### PR TITLE
fix(fal): address review comments for FAL API integration

### DIFF
--- a/src/services/fal_image_client.py
+++ b/src/services/fal_image_client.py
@@ -167,21 +167,31 @@ def get_fal_models_by_type(model_type: str) -> list[dict[str, Any]]:
     Returns:
         List of models matching the specified type
     """
-    all_models = load_fal_models_catalog()
-    return [model for model in all_models if model.get("type") == model_type]
+    all_models = get_fal_models()
+    # API uses "category", static catalog uses "type"
+    return [
+        model for model in all_models
+        if model.get("type") == model_type or model.get("category") == model_type
+    ]
 
 
 def validate_fal_model(model_id: str) -> bool:
-    """Check if a model ID is valid in the Fal.ai catalog
+    """Check if a model ID is valid in the Fal.ai models list
+
+    Checks both API-fetched models and static catalog.
 
     Args:
         model_id: Model identifier to validate
 
     Returns:
-        True if model exists in catalog, False otherwise
+        True if model exists, False otherwise
     """
-    all_models = load_fal_models_catalog()
-    return any(model.get("id") == model_id for model in all_models)
+    all_models = get_fal_models()
+    # API uses "endpoint_id", static catalog uses "id"
+    return any(
+        model.get("id") == model_id or model.get("endpoint_id") == model_id
+        for model in all_models
+    )
 
 
 def _parse_image_size(size: str) -> tuple[int, int]:


### PR DESCRIPTION
## Summary
Addresses review comments from PR #826 (Greptile review):

1. **`get_fal_models_by_type()`** - Now uses `get_fal_models()` instead of `load_fal_models_catalog()` to include API-fetched models, and checks both `type` and `category` fields for compatibility with both static catalog and API formats.

2. **`validate_fal_model()`** - Now uses `get_fal_models()` instead of `load_fal_models_catalog()` and checks both `id` and `endpoint_id` fields to validate models from both sources.

## Related PR
- #826 - feat(fal): fetch models from FAL REST API instead of static catalog

## Test plan
- [ ] Verify `get_fal_models_by_type()` returns API models when filtered by type/category
- [ ] Verify `validate_fal_model()` validates models from both API and static catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Addresses review comments from PR #826 by updating FAL model validation functions to use unified model retrieval (`get_fal_models()`) instead of static catalog
- Implements dual format compatibility to handle both API response fields (`category`, `endpoint_id`) and static catalog fields (`type`, `id`)
- Ensures consistency between dynamic FAL model fetching and model validation/filtering operations

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/services/fal_image_client.py | Updated `get_fal_models_by_type()` and `validate_fal_model()` functions to use unified model retrieval with dual format compatibility |

<h3>Confidence score: 4/5</h3>


- This PR is safe to merge with minimal risk as it addresses identified inconsistencies and improves integration
- Score reflects solid implementation of review feedback with proper backwards compatibility and error handling
- Pay close attention to the dual format field checking logic to ensure it correctly handles both API and catalog data sources

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant get_fal_models_by_type
    participant get_fal_models
    participant fetch_fal_models_from_api
    participant FAL_API
    participant load_fal_models_catalog
    participant FileSystem
    participant make_fal_image_request

    User->>get_fal_models_by_type: "get_fal_models_by_type(model_type)"
    get_fal_models_by_type->>get_fal_models: "get_fal_models()"
    get_fal_models->>fetch_fal_models_from_api: "fetch_fal_models_from_api()"
    fetch_fal_models_from_api->>FAL_API: "GET /v1/models (paginated)"
    FAL_API-->>fetch_fal_models_from_api: "models data"
    fetch_fal_models_from_api-->>get_fal_models: "api_models"
    alt API models available
        get_fal_models-->>get_fal_models_by_type: "api_models"
    else API failed
        get_fal_models->>load_fal_models_catalog: "load_fal_models_catalog()"
        load_fal_models_catalog->>FileSystem: "read fal_catalog.json"
        FileSystem-->>load_fal_models_catalog: "catalog data"
        load_fal_models_catalog-->>get_fal_models: "catalog_models"
        get_fal_models-->>get_fal_models_by_type: "catalog_models"
    end
    get_fal_models_by_type-->>User: "filtered models (by type/category)"

    User->>make_fal_image_request: "make_fal_image_request(prompt, model, size, n)"
    make_fal_image_request->>FAL_API: "POST /{model} with payload"
    FAL_API-->>make_fal_image_request: "generation response"
    make_fal_image_request-->>User: "OpenAI-compatible response"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))

<!-- /greptile_comment -->