### PR TITLE
fix(audio): prefix unused api_key parameter with underscore

### DIFF
--- a/src/routes/audio.py
+++ b/src/routes/audio.py
@@ -66,7 +66,7 @@ async def create_transcription(
         le=1.0,
         description="Sampling temperature (0-1). Lower values are more deterministic."
     ),
-    api_key: Optional[str] = Depends(get_optional_api_key),
+    _api_key: Optional[str] = Depends(get_optional_api_key),  # noqa: ARG001 - Used for auth side effects
 ):
     """
     Transcribe audio using OpenAI Whisper or compatible services.
@@ -222,7 +222,7 @@ async def create_transcription_base64(
     prompt: Optional[str] = Form(default=None),
     response_format: str = Form(default="json"),
     temperature: float = Form(default=0.0, ge=0.0, le=1.0),
-    api_key: Optional[str] = Depends(get_optional_api_key),
+    _api_key: Optional[str] = Depends(get_optional_api_key),  # noqa: ARG001 - Used for auth side effects
 ):
     """
     Transcribe base64-encoded audio.


### PR DESCRIPTION
## Summary
- Renamed `api_key` parameter to `_api_key` in audio transcription endpoints
- Added `noqa: ARG001` comment to suppress linter warnings
- The dependency is used for authentication side effects but the variable value itself is not used

## Context
This addresses a Greptile code review comment about unused variables in `audio.py`. The `get_optional_api_key` dependency is intentionally included to trigger authentication validation, but the returned value isn't needed in the endpoint logic.

## Test plan
- [ ] Verify audio transcription endpoints still work correctly
- [ ] Confirm linter no longer flags unused parameter warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Fixes linter warning by renaming unused `api_key` parameter to `_api_key` in two audio transcription endpoints
- Adds `noqa: ARG001` comments to suppress linter warnings for intentionally unused dependency parameters
- The dependency is kept for authentication side effects but the returned value isn't used in endpoint logic

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/routes/audio.py | Renamed unused `api_key` parameter to `_api_key` with linter suppression comments |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Score reflects simple linting fix with proper Python conventions for unused variables
- No files require special attention as this is a straightforward code quality improvement

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant AudioRouter as "Audio Router"
    participant SecurityDeps as "Security Dependencies"
    participant OpenAIClient as "OpenAI Client"
    participant WhisperAPI as "Whisper API"

    User->>AudioRouter: "POST /audio/transcriptions with audio file"
    AudioRouter->>SecurityDeps: "get_optional_api_key()"
    SecurityDeps-->>AudioRouter: "API key validation"
    AudioRouter->>AudioRouter: "Validate audio format and size"
    AudioRouter->>AudioRouter: "Create temporary file"
    AudioRouter->>OpenAIClient: "get_openai_pooled_client()"
    OpenAIClient-->>AudioRouter: "OpenAI client instance"
    AudioRouter->>WhisperAPI: "audio.transcriptions.create()"
    WhisperAPI-->>AudioRouter: "Transcription response"
    AudioRouter->>AudioRouter: "Format response based on response_format"
    AudioRouter-->>User: "JSON response with transcribed text"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->