### PR TITLE
feat(morpheus): complete Morpheus API integration as model provider

### DIFF
--- a/src/cache.py
+++ b/src/cache.py
@@ -221,6 +221,13 @@ _simplismart_models_cache = {
     "stale_ttl": 7200,
 }
 
+_morpheus_models_cache = {
+    "data": None,
+    "timestamp": None,
+    "ttl": 3600,  # 1 hour TTL for Morpheus AI Gateway catalog
+    "stale_ttl": 7200,
+}
+
 # BACKWARD COMPATIBILITY: Alias for old cache name
 # Some deployed modules may still reference the old name
 _hug_models_cache = _huggingface_models_cache
@@ -262,6 +269,7 @@ def get_models_cache(gateway: str):
         "openai": _openai_models_cache,
         "anthropic": _anthropic_models_cache,
         "simplismart": _simplismart_models_cache,
+        "morpheus": _morpheus_models_cache,
         "modelz": _modelz_cache,
     }
     return cache_map.get(gateway.lower())
@@ -303,6 +311,7 @@ def clear_models_cache(gateway: str):
         "openai": _openai_models_cache,
         "anthropic": _anthropic_models_cache,
         "simplismart": _simplismart_models_cache,
+        "morpheus": _morpheus_models_cache,
         "modelz": _modelz_cache,
     }
     cache = cache_map.get(gateway.lower())

--- a/src/routes/catalog.py
+++ b/src/routes/catalog.py
@@ -40,13 +40,13 @@ DESC_GATEWAY_AUTO_DETECT = (
     "Gateway to use: 'openrouter', 'onerouter', 'featherless', 'deepinfra', 'chutes', "
     "'groq', 'fireworks', 'together', 'cerebras', 'nebius', 'xai', 'novita', "
     "'huggingface' (or 'hug'), 'aimo', 'near', 'fal', 'helicone', 'anannas', 'aihubmix', "
-    "'vercel-ai-gateway', 'google-vertex', 'simplismart', or auto-detect if not specified"
+    "'vercel-ai-gateway', 'google-vertex', 'simplismart', 'morpheus', or auto-detect if not specified"
 )
 DESC_GATEWAY_WITH_ALL = (
     "Gateway to use: 'openrouter', 'onerouter', 'featherless', 'deepinfra', 'chutes', "
     "'groq', 'fireworks', 'together', 'cerebras', 'nebius', 'xai', 'novita', "
     "'huggingface' (or 'hug'), 'aimo', 'near', 'fal', 'helicone', 'anannas', 'aihubmix', "
-    "'vercel-ai-gateway', 'google-vertex', 'simplismart', or 'all'"
+    "'vercel-ai-gateway', 'google-vertex', 'simplismart', 'morpheus', or 'all'"
 )
 ERROR_MODELS_DATA_UNAVAILABLE = "Models data unavailable"
 ERROR_PROVIDER_DATA_UNAVAILABLE = "Provider data unavailable"
@@ -238,6 +238,12 @@ GATEWAY_REGISTRY = {
         "color": "bg-orange-500",
         "priority": "slow",
         "site_url": "https://developers.cloudflare.com/workers-ai",
+    },
+    "morpheus": {
+        "name": "Morpheus",
+        "color": "bg-cyan-600",
+        "priority": "slow",
+        "site_url": "https://mor.org",
     },
 }
 

--- a/src/services/models.py
+++ b/src/services/models.py
@@ -31,6 +31,7 @@ from src.cache import (
     _huggingface_cache,
     _huggingface_models_cache,
     _models_cache,
+    _morpheus_models_cache,
     _multi_provider_catalog_cache,
     _near_models_cache,
     _nebius_models_cache,
@@ -59,6 +60,7 @@ from src.services.multi_provider_registry import (
     CanonicalModelProvider,
     get_registry,
 )
+from src.services.morpheus_client import fetch_models_from_morpheus
 from src.services.nebius_client import fetch_models_from_nebius
 from src.services.novita_client import fetch_models_from_novita
 from src.services.onerouter_client import fetch_models_from_onerouter
@@ -562,6 +564,7 @@ def get_all_models_sequential():
     openai_models = get_cached_models("openai") or []
     anthropic_models = get_cached_models("anthropic") or []
     simplismart_models = get_cached_models("simplismart") or []
+    morpheus_models = get_cached_models("morpheus") or []
     return (
         openrouter_models
         + featherless_models
@@ -589,6 +592,7 @@ def get_all_models_sequential():
         + openai_models
         + anthropic_models
         + simplismart_models
+        + morpheus_models
     )
 
 
@@ -896,6 +900,14 @@ def get_cached_models(gateway: str = "openrouter"):
                 return cached
             result = fetch_models_from_simplismart()
             _register_canonical_records("simplismart", result)
+            return result if result is not None else []
+
+        if gateway == "morpheus":
+            cached = _get_fresh_or_stale_cached_models(_morpheus_models_cache, "morpheus")
+            if cached is not None:
+                return cached
+            result = fetch_models_from_morpheus()
+            _register_canonical_records("morpheus", result)
             return result if result is not None else []
 
         if gateway == "all":


### PR DESCRIPTION
## Summary
- Add `_morpheus_models_cache` to cache.py with 1-hour TTL and stale-while-revalidate
- Add Morpheus to `GATEWAY_REGISTRY` in catalog.py for frontend auto-discovery
- Add Morpheus to `get_cached_models()` and `get_all_models_sequential()` in models.py
- Import `fetch_models_from_morpheus` in models.py
- Add comprehensive integration tests for cache, gateway registry, and connection pool

## Morpheus API Details
- **32 models available**: LLMs (llama, qwen, mistral, glm, hermes), TTS (kokoro), STT (whisper), embeddings (bge-m3)
- **Base URL**: `https://api.mor.org/api/v1`
- **OpenAI-compatible** API format
- **Free access** (billing infrastructure launching soon)

## Test Plan
- [x] Syntax validation passes for all modified files
- [x] Morpheus cache integration tests
- [x] Gateway registry tests
- [x] Connection pool tests
- [ ] Full test suite (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds Morpheus as a new AI model provider to the Gatewayz platform with 32 available models (LLMs, TTS, STT, embeddings) using OpenAI-compatible API format
- Integrates Morpheus into caching system (`src/cache.py`), gateway registry for frontend auto-discovery (`src/routes/catalog.py`), and model fetching pipeline (`src/services/models.py`)
- Includes comprehensive integration tests covering cache functionality, gateway registry validation, and connection pool testing

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| `src/services/models.py` | Imports missing `fetch_models_from_morpheus` function and integrates Morpheus into model fetching pipeline; critical import error will cause runtime failures |
| `tests/services/test_morpheus_client.py` | New comprehensive integration tests for Morpheus provider covering cache, gateway registry, and connection pool functionality |
| `src/routes/catalog.py` | Adds Morpheus to GATEWAY_REGISTRY for frontend auto-discovery with proper configuration (color, priority, site URL) |

<h3>Confidence score: 0/5</h3>


- This PR will definitely cause import errors and runtime failures when deployed due to missing `fetch_models_from_morpheus` implementation
- The PR imports and references a function `fetch_models_from_morpheus` from `src/services/morpheus_client` that doesn't exist in the codebase changes, causing immediate import failures
- While the integration pattern follows established conventions and the caching/registry changes are solid, the critical missing implementation makes this PR unsafe to merge

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API as "Catalog API"
    participant Cache as "Cache Service"
    participant Morpheus as "Morpheus API"
    participant Pricing as "Pricing Service"

    User->>API: "GET /v1/models?gateway=morpheus"
    API->>Cache: "get_cached_models('morpheus')"
    
    alt Fresh cache available
        Cache-->>API: "return cached models"
    else Cache expired/missing
        Cache->>Morpheus: "GET https://api.mor.org/api/v1/models"
        Morpheus-->>Cache: "models data"
        Cache->>Pricing: "enrich_model_with_pricing()"
        Pricing-->>Cache: "models with pricing"
        Cache->>Cache: "update _morpheus_models_cache"
        Cache-->>API: "return normalized models"
    end
    
    API-->>User: "models response"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->