### PR TITLE
Railway/new endpoints

### DIFF
--- a/prometheus.yml
+++ b/prometheus.yml
@@ -12,12 +12,11 @@ global:
 alerting:
   alertmanagers:
     - static_configs:
-        - targets: []
+        - targets: ['localhost:9093']  # Alertmanager endpoint
 
 # Rule files
 rule_files:
-  # - "alert_rules.yml"
-  # - "recording_rules.yml"
+  - "/etc/prometheus/alert.rules.yml"
 
 # Scrape configurations
 scrape_configs:

--- a/prometheus/test/.env.example
+++ b/prometheus/test/.env.example
@@ -1,0 +1,10 @@
+# SMTP Configuration for Alertmanager Email Notifications
+# Copy this file to .env and fill in your actual credentials
+
+# Gmail SMTP credentials
+# Get App Password from: https://myaccount.google.com/apppasswords
+SMTP_USERNAME=manjeshprasad21@gmail.com
+SMTP_PASSWORD=your-16-character-app-password-here
+
+# Example App Password format (16 characters, no spaces in actual password):
+# SMTP_PASSWORD=abcdabcdabcdabcd

--- a/prometheus/test/Dockerfile.alertmanager
+++ b/prometheus/test/Dockerfile.alertmanager
@@ -1,0 +1,18 @@
+FROM prom/alertmanager:latest
+
+# Install gettext for envsubst command
+USER root
+RUN apk add --no-cache gettext
+
+# Copy the template configuration
+COPY alertmanager.yml.template /etc/alertmanager/alertmanager.yml.template
+
+# Copy entrypoint script
+COPY alertmanager-entrypoint.sh /alertmanager-entrypoint.sh
+RUN chmod +x /alertmanager-entrypoint.sh
+
+# Set back to alertmanager user
+USER nobody
+
+ENTRYPOINT ["/alertmanager-entrypoint.sh"]
+CMD ["--config.file=/etc/alertmanager/alertmanager.yml", "--storage.path=/alertmanager"]

--- a/prometheus/test/README.md
+++ b/prometheus/test/README.md
@@ -1,0 +1,325 @@
+# Prometheus/Alertmanager Test Environment
+
+## 🎯 Purpose
+
+This test environment fixes **3 critical issues** identified in the original Prometheus/Alertmanager setup:
+
+### Issues Fixed
+
+1. **❌ SMTP Environment Variables Not Substituted**
+   - **Problem**: `alertmanager.yml` uses `${SMTP_USERNAME}` and `${SMTP_PASSWORD}` syntax, but the official `prom/alertmanager` image doesn't perform environment variable substitution
+   - **Solution**: Custom Dockerfile with `envsubst` and entrypoint script that processes template before starting Alertmanager
+
+2. **❌ Missing Alerting Configuration in Prometheus**
+   - **Problem**: `prom.yml` was missing the `alerting` section, so Prometheus couldn't send alerts to Alertmanager
+   - **Solution**: Added complete `alerting` section to `prometheus-test.yml` with proper endpoint configuration
+
+3. **❌ Alert Rules Fail During Zero Traffic (NaN Division)**
+   - **Problem**: When calculating `success_rate = successful_requests / total_requests`, during zero traffic both are 0, resulting in `NaN`. Alerts comparing `NaN < 20` always evaluate to false, so alerts don't fire during total outages
+   - **Solution**: Added additional conditions to detect zero traffic and fire alerts appropriately
+
+---
+
+## 📁 Files
+
+| File | Purpose |
+|------|---------|
+| `prometheus-test.yml` | **FIXED** Prometheus config with `alerting` section |
+| `alert.rules.test.yml` | **FIXED** Alert rules that handle zero traffic/NaN |
+| `alertmanager.yml.template` | Alertmanager config template (for env var substitution) |
+| `Dockerfile.alertmanager` | Custom Alertmanager image with `envsubst` |
+| `alertmanager-entrypoint.sh` | **FIXED** Entrypoint that substitutes env vars |
+| `docker-compose.test.yml` | Test environment on different ports |
+| `.env.example` | Example environment variables |
+| `README.md` | This file |
+
+---
+
+## 🚀 Quick Start
+
+### 1. Create `.env` file
+
+```bash
+cd prometheus/test
+cp .env.example .env
+
+# Edit .env with your Gmail credentials
+SMTP_USERNAME=manjeshprasad21@gmail.com
+SMTP_PASSWORD=your-16-char-app-password
+```
+
+### 2. Start Test Environment
+
+```bash
+# Build and start services
+docker-compose -f docker-compose.test.yml up -d --build
+
+# Check logs
+docker-compose -f docker-compose.test.yml logs -f
+```
+
+### 3. Access Services
+
+| Service | URL | Purpose |
+|---------|-----|---------|
+| **Prometheus Test** | http://localhost:9091 | View metrics & alerts |
+| **Alertmanager Test** | http://localhost:9094 | View alert status |
+| **Backend API** | http://localhost:8000/metrics | Metrics endpoint |
+
+---
+
+## 🔍 Testing the Fixes
+
+### Test 1: Verify SMTP Env Var Substitution
+
+```bash
+# Check if environment variables were substituted correctly
+docker-compose -f docker-compose.test.yml exec alertmanager-test cat /etc/alertmanager/alertmanager.yml | grep smtp_auth_username
+
+# Should show: smtp_auth_username: 'manjeshprasad21@gmail.com'
+# NOT: smtp_auth_username: '${SMTP_USERNAME}'
+```
+
+### Test 2: Verify Prometheus Can Send to Alertmanager
+
+```bash
+# Check Prometheus can reach Alertmanager
+curl http://localhost:9091/api/v1/alertmanagers | jq
+
+# Should show alertmanager endpoint as "up"
+```
+
+### Test 3: Verify Alerts Handle Zero Traffic
+
+```bash
+# Query current traffic
+curl 'http://localhost:9091/api/v1/query?query=sum(rate(model_inference_requests_total[10m]))'
+
+# If result is 0, check if NoTrafficDetected alert fires
+curl 'http://localhost:9091/api/v1/alerts' | jq '.data.alerts[] | select(.labels.alertname=="NoTrafficDetected")'
+```
+
+---
+
+## 🧪 Test Scenarios
+
+### Scenario 1: Normal Operation (Success Rate 80%)
+
+**Expected**: No alerts fire
+
+```bash
+# Generate some successful requests
+for i in {1..100}; do curl http://localhost:8000/metrics; done
+
+# Wait 5-10 minutes
+# Check Prometheus alerts
+open http://localhost:9091/alerts
+```
+
+### Scenario 2: High Error Rate (Success Rate 15%)
+
+**Expected**: `LowModelHealthScore` alert fires after 5 minutes
+
+```bash
+# Simulate errors (if you have a test endpoint)
+# Or manually check existing metrics
+
+# Wait 5+ minutes
+# Check Alertmanager for firing alerts
+open http://localhost:9094/#/alerts
+```
+
+### Scenario 3: Zero Traffic (Total Outage)
+
+**Expected**: `NoTrafficDetected` alert fires after 10 minutes
+
+```bash
+# Stop making requests to backend
+# Wait 10+ minutes
+
+# Check alert status
+curl 'http://localhost:9091/api/v1/alerts' | jq '.data.alerts[] | select(.labels.alertname=="NoTrafficDetected")'
+```
+
+### Scenario 4: Email Alert Delivery
+
+**Expected**: Email sent to manjeshprasad21@gmail.com
+
+```bash
+# Force an alert by editing threshold
+# Edit alert.rules.test.yml: Change `< 20` to `< 99`
+
+# Reload Prometheus config
+curl -X POST http://localhost:9091/-/reload
+
+# Wait 5-10 minutes
+# Check email inbox
+```
+
+---
+
+## 📊 How the Fixes Work
+
+### Fix 1: Environment Variable Substitution
+
+**Before** (Original):
+```yaml
+# alertmanager.yml
+smtp_auth_username: '${SMTP_USERNAME}'  # ❌ Not substituted
+```
+
+**After** (Fixed):
+```bash
+# alertmanager-entrypoint.sh
+envsubst < /etc/alertmanager/alertmanager.yml.template > /etc/alertmanager/alertmanager.yml
+# Now: smtp_auth_username: 'manjeshprasad21@gmail.com'  ✅
+```
+
+### Fix 2: Prometheus Alerting Configuration
+
+**Before** (Missing):
+```yaml
+# prometheus.yml
+# alerting:  # ❌ Missing section
+```
+
+**After** (Fixed):
+```yaml
+# prometheus-test.yml
+alerting:  # ✅ Added
+  alertmanagers:
+    - static_configs:
+        - targets: ['localhost:9093']
+```
+
+### Fix 3: Zero Traffic / NaN Handling
+
+**Before** (Broken):
+```yaml
+# Alert only checks ratio
+expr: |
+  (
+    sum(rate(model_inference_requests_total{status="success"}[10m]))
+    /
+    sum(rate(model_inference_requests_total[10m]))
+  ) * 100 < 20  
+# ❌ When both are 0, this is NaN, alert doesn't fire
+```
+
+**After** (Fixed):
+```yaml
+# Alert checks ratio OR zero traffic
+expr: |
+  (
+    # Check success rate
+    (sum(rate(...{status="success"}...)) / sum(rate(...))) * 100 < 20
+  )
+  or
+  (
+    # Fire if zero traffic (outage)
+    sum(rate(model_inference_requests_total[10m])) == 0  # ✅
+  )
+```
+
+---
+
+## 🛠️ Troubleshooting
+
+### Issue: Alertmanager shows SMTP auth failed
+
+```bash
+# Check if env vars were substituted
+docker-compose -f docker-compose.test.yml logs alertmanager-test | grep SMTP
+
+# Verify .env file exists and has correct values
+cat .env
+
+# Rebuild container
+docker-compose -f docker-compose.test.yml up -d --build alertmanager-test
+```
+
+### Issue: Prometheus can't reach Alertmanager
+
+```bash
+# Check if alertmanager is running
+docker-compose -f docker-compose.test.yml ps alertmanager-test
+
+# Check network connectivity
+docker-compose -f docker-compose.test.yml exec prometheus-test wget -qO- http://alertmanager-test:9093/-/healthy
+
+# Check Prometheus config
+curl 'http://localhost:9091/api/v1/status/config' | jq '.data.yaml' | grep -A5 alerting
+```
+
+### Issue: Alerts not firing during zero traffic
+
+```bash
+# Verify alert rules are loaded
+curl 'http://localhost:9091/api/v1/rules' | jq '.data.groups[] | select(.name=="model_health_alerts_test")'
+
+# Check if NoTrafficDetected rule exists
+curl 'http://localhost:9091/api/v1/rules' | jq '.data.groups[].rules[] | select(.name=="NoTrafficDetected")'
+
+# Manually evaluate expression
+curl 'http://localhost:9091/api/v1/query?query=sum(rate(model_inference_requests_total[15m]))==0'
+```
+
+---
+
+## 📖 URLs Without Conflicts
+
+All services run on different ports to avoid conflicts:
+
+| Service | Original Port | Test Port | URL |
+|---------|---------------|-----------|-----|
+| Prometheus | 9090 | **9091** | http://localhost:9091 |
+| Alertmanager | 9093 | **9094** | http://localhost:9094 |
+| Backend API | 8000 | 8000 | http://localhost:8000 |
+
+---
+
+## 🎯 Next Steps
+
+### After Testing Successfully
+
+1. **Apply fixes to production**:
+   - Copy fixed files to `railway-grafana-stack/prometheus/`
+   - Update `docker-compose.yml` to use custom Alertmanager image
+   - Deploy to Railway
+
+2. **Set production env vars**:
+   ```
+   SMTP_USERNAME = manjeshprasad21@gmail.com
+   SMTP_PASSWORD = your-app-password
+   ```
+
+3. **Monitor alerts**:
+   - Check Prometheus: http://your-prometheus.railway.app/alerts
+   - Check Alertmanager: http://your-alertmanager.railway.app
+
+---
+
+## 📝 Summary of Changes
+
+### Configuration Files
+
+| Original | Fixed | Changes |
+|----------|-------|---------|
+| `prom.yml` | `prometheus-test.yml` | ✅ Added `alerting` section |
+| `alert.rules.yml` | `alert.rules.test.yml` | ✅ Handle zero traffic/NaN |
+| `alertmanager.yml` | `alertmanager.yml.template` | ✅ Use as template |
+| N/A | `alertmanager-entrypoint.sh` | ✅ New: env var substitution |
+| N/A | `Dockerfile.alertmanager` | ✅ New: custom image with envsubst |
+
+### Test Environment
+
+- ✅ Runs on ports 9091 (Prometheus) and 9094 (Alertmanager)
+- ✅ No conflicts with existing services
+- ✅ Isolated Docker network
+- ✅ Separate data volumes
+
+---
+
+**Status**: Ready for testing  
+**Email**: manjeshprasad21@gmail.com  
+**Test Ports**: 9091 (Prometheus), 9094 (Alertmanager)

--- a/prometheus/test/alert.rules.test.yml
+++ b/prometheus/test/alert.rules.test.yml
@@ -1,0 +1,186 @@
+groups:
+  - name: model_health_alerts_test
+    interval: 1m
+    rules:
+      # FIXED: Model Health Score Alert - Handles NaN/zero division
+      # This alert now fires during total outages by checking if traffic exists
+      - alert: LowModelHealthScore
+        expr: |
+          (
+            # Calculate success rate
+            (
+              sum(rate(model_inference_requests_total{status="success"}[10m]))
+              /
+              sum(rate(model_inference_requests_total[10m]))
+            ) * 100 < 20
+          )
+          or
+          (
+            # Fire if there's ZERO traffic (total outage scenario)
+            sum(rate(model_inference_requests_total[10m])) == 0
+          )
+        for: 5m
+        labels:
+          severity: critical
+          component: model
+          email: "manjeshprasad21@gmail.com"
+        annotations:
+          summary: "Overall model health score critically low or service down"
+          description: >
+            {% raw %}Overall model health score is {{ $value | humanize }}%, below critical threshold of 20%,
+            OR the service is experiencing a total outage with zero requests.
+            This indicates major service degradation or complete failure.
+            Immediate investigation required.{% endraw %}
+          dashboard: "http://localhost:3000/d/model-performance-v1/model-performance-analytics"
+      
+      # FIXED: Individual Provider Health Score - Handles NaN/zero division
+      - alert: LowProviderHealthScore
+        expr: |
+          (
+            # Calculate per-provider success rate
+            (
+              sum(rate(model_inference_requests_total{status="success"}[10m])) by (provider)
+              /
+              sum(rate(model_inference_requests_total[10m])) by (provider)
+            ) * 100 < 20
+          )
+          or
+          (
+            # Fire if provider has zero traffic but was recently active
+            (
+              sum(rate(model_inference_requests_total[10m])) by (provider) == 0
+            )
+            and
+            (
+              sum(rate(model_inference_requests_total[1h] offset 1h)) by (provider) > 0
+            )
+          )
+        for: 5m
+        labels:
+          severity: critical
+          component: provider
+          email: "manjeshprasad21@gmail.com"
+        annotations:
+          summary: "Provider {% raw %}{{ $labels.provider }}{% endraw %} health score critically low or down"
+          description: >
+            {% raw %}Provider {{ $labels.provider }} health score is {{ $value | humanize }}%, 
+            below critical threshold of 20%, OR this provider has gone completely silent.
+            This provider is experiencing major issues or has failed.{% endraw %}
+          dashboard: "http://localhost:3000/d/gateway-comparison-v1/gateway-comparison"
+      
+      # No Traffic Alert - Fires when there's been no traffic for extended period
+      - alert: NoTrafficDetected
+        expr: |
+          sum(rate(model_inference_requests_total[15m])) == 0
+          and
+          sum(rate(model_inference_requests_total[1h] offset 1h)) > 0
+        for: 10m
+        labels:
+          severity: critical
+          component: system
+          email: "manjeshprasad21@gmail.com"
+        annotations:
+          summary: "No API traffic detected for 15 minutes"
+          description: >
+            The GatewayZ API has received zero requests in the last 15 minutes,
+            but was receiving traffic in the previous hour.
+            This indicates a complete service outage or network issue.
+            Check backend health, network connectivity, and DNS.
+          dashboard: "http://localhost:3000/d/model-performance-v1/model-performance-analytics"
+
+  - name: performance_alerts_test
+    interval: 30s
+    rules:
+      # API Error Rate - FIXED: Handles zero traffic
+      - alert: HighAPIErrorRate
+        expr: |
+          (
+            sum(rate(fastapi_requests_total{status_code=~'4..|5..'}[5m]))
+            /
+            sum(rate(fastapi_requests_total[5m]))
+          ) > 0.1
+          and
+          sum(rate(fastapi_requests_total[5m])) > 0
+        for: 3m
+        labels:
+          severity: critical
+          component: api
+        annotations:
+          summary: "High API error rate detected"
+          description: "API error rate is {% raw %}{{ $value | humanizePercentage }}{% endraw %}, exceeding critical threshold of 10%. Immediate investigation required."
+
+      # API Latency
+      - alert: CriticalAPILatency
+        expr: |
+          histogram_quantile(0.95, sum(rate(fastapi_requests_duration_seconds_bucket[5m])) by (le)) > 3.0
+        for: 2m
+        labels:
+          severity: critical
+          component: api
+        annotations:
+          summary: "Critical API latency detected"
+          description: "API latency (p95) is {% raw %}{{ $value }}{% endraw %}s, exceeding critical threshold of 3.0s. Immediate investigation required."
+
+      # Model Inference Latency - FIXED: Handles no traffic
+      - alert: HighModelInferenceLatency
+        expr: |
+          histogram_quantile(0.95, sum(rate(model_inference_duration_seconds_bucket[5m])) by (le, model)) > 5.0
+          and
+          sum(rate(model_inference_requests_total[5m])) by (model) > 0
+        for: 5m
+        labels:
+          severity: warning
+          component: model
+        annotations:
+          summary: "High model inference latency for {% raw %}{{ $labels.model }}{% endraw %}"
+          description: "Model {% raw %}{{ $labels.model }}{% endraw %} inference latency (p95) is {% raw %}{{ $value }}{% endraw %}s, exceeding threshold of 5.0s."
+
+      # Model Inference Error Spike - FIXED: Handles zero traffic
+      - alert: ModelInferenceErrorSpike
+        expr: |
+          (
+            sum(rate(model_inference_requests_total{status="error"}[5m]))
+            /
+            sum(rate(model_inference_requests_total[5m]))
+          ) > 0.15
+          and
+          sum(rate(model_inference_requests_total[5m])) > 0
+        for: 3m
+        labels:
+          severity: critical
+          component: model
+        annotations:
+          summary: "High model inference error rate"
+          description: "Model inference error rate is {% raw %}{{ $value | humanizePercentage }}{% endraw %}, exceeding critical threshold of 15%."
+
+      # Provider Response Time - FIXED: Handles no traffic
+      - alert: SlowProviderResponse
+        expr: |
+          histogram_quantile(0.95, sum(rate(model_inference_duration_seconds_bucket{provider!=""}[5m])) by (le, provider)) > 4.0
+          and
+          sum(rate(model_inference_requests_total{provider!=""}[5m])) by (provider) > 0
+        for: 5m
+        labels:
+          severity: warning
+          component: provider
+        annotations:
+          summary: "Slow response from provider {% raw %}{{ $labels.provider }}{% endraw %}"
+          description: "Provider {% raw %}{{ $labels.provider }}{% endraw %} response latency (p95) is {% raw %}{{ $value }}{% endraw %}s, exceeding threshold of 4.0s."
+
+      # Provider Error Spike - FIXED: Handles zero traffic
+      - alert: ProviderErrorSpike
+        expr: |
+          (
+            sum(rate(model_inference_requests_total{status="error", provider!=""}[5m])) by (provider)
+            /
+            sum(rate(model_inference_requests_total{provider!=""}[5m])) by (provider)
+          ) > 0.2
+          and
+          sum(rate(model_inference_requests_total{provider!=""}[5m])) by (provider) > 0
+        for: 3m
+        labels:
+          severity: critical
+          component: provider
+        annotations:
+          summary: "High error rate for provider {% raw %}{{ $labels.provider }}{% endraw %}"
+          description: "Provider {% raw %}{{ $labels.provider }}{% endraw %} error rate is {% raw %}{{ $value | humanizePercentage }}{% endraw %}, exceeding critical threshold of 20%."

--- a/prometheus/test/alertmanager-entrypoint.sh
+++ b/prometheus/test/alertmanager-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Alertmanager entrypoint script with environment variable substitution
+# Fixes: SMTP credentials not being substituted from environment variables
+
+set -e
+
+# Check if SMTP credentials are provided
+if [ -z "$SMTP_USERNAME" ] || [ -z "$SMTP_PASSWORD" ]; then
+    echo "WARNING: SMTP_USERNAME or SMTP_PASSWORD not set. Email alerts will fail."
+    echo "Please set these environment variables for email notifications to work."
+fi
+
+# Substitute environment variables in alertmanager config
+envsubst < /etc/alertmanager/alertmanager.yml.template > /etc/alertmanager/alertmanager.yml
+
+echo "✅ Alertmanager configuration processed with environment variables"
+echo "   SMTP_USERNAME: ${SMTP_USERNAME:-not set}"
+echo "   SMTP_PASSWORD: ${SMTP_PASSWORD:+***set***}"
+
+# Start Alertmanager with provided arguments
+exec /bin/alertmanager "$@"

--- a/prometheus/test/alertmanager.yml.template
+++ b/prometheus/test/alertmanager.yml.template
@@ -1,0 +1,239 @@
+# Alertmanager Configuration for GatewayZ
+# Sends email notifications for critical alerts
+
+global:
+  # SMTP configuration for email alerts
+  # Using Gmail SMTP (requires App Password if 2FA is enabled)
+  smtp_smarthost: 'smtp.gmail.com:587'
+  smtp_from: 'alerts@gatewayz.ai'
+  smtp_auth_username: '${SMTP_USERNAME}'  # Set in Railway environment
+  smtp_auth_password: '${SMTP_PASSWORD}'  # Set in Railway environment (use App Password for Gmail)
+  smtp_require_tls: true
+  
+  # Notification rate limiting
+  resolve_timeout: 5m
+
+# Route configuration - defines how alerts are routed to receivers
+route:
+  # Default receiver for all alerts
+  receiver: 'email-default'
+  
+  # Group alerts by these labels to reduce notification spam
+  group_by: ['alertname', 'severity', 'component']
+  
+  # Wait before sending notification (allows grouping)
+  group_wait: 30s
+  
+  # Wait before sending notification about new alerts in group
+  group_interval: 5m
+  
+  # Re-send notifications if alert is still firing
+  repeat_interval: 4h
+  
+  # Child routes for specific alert types
+  routes:
+    # Critical alerts - send immediately
+    - match:
+        severity: critical
+      receiver: 'email-critical'
+      group_wait: 10s
+      repeat_interval: 30m
+      continue: true  # Also send to default receiver
+    
+    # Model health alerts - high priority
+    - match:
+        component: model
+      receiver: 'email-model-health'
+      group_wait: 1m
+      repeat_interval: 1h
+    
+    # Provider health alerts
+    - match:
+        component: provider
+      receiver: 'email-provider-health'
+      group_wait: 2m
+      repeat_interval: 2h
+
+# Receivers - define where notifications are sent
+receivers:
+  # Default receiver for all alerts
+  - name: 'email-default'
+    email_configs:
+      - to: 'manjeshprasad21@gmail.com'
+        send_resolved: true
+        headers:
+          Subject: '[GatewayZ] {{ .GroupLabels.alertname }} - {{ .GroupLabels.severity | toUpper }}'
+        html: |
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <style>
+              body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
+              .header { background: #f4f4f4; padding: 20px; border-bottom: 3px solid #007bff; }
+              .alert { margin: 20px 0; padding: 15px; border-left: 4px solid #ffc107; background: #fff3cd; }
+              .alert.critical { border-color: #dc3545; background: #f8d7da; }
+              .alert.warning { border-color: #ffc107; background: #fff3cd; }
+              .details { margin: 10px 0; padding: 10px; background: #f8f9fa; border-radius: 4px; }
+              .footer { margin-top: 20px; padding-top: 20px; border-top: 1px solid #ddd; font-size: 12px; color: #666; }
+              a { color: #007bff; text-decoration: none; }
+              a:hover { text-decoration: underline; }
+            </style>
+          </head>
+          <body>
+            <div class="header">
+              <h1>🚨 GatewayZ Alert</h1>
+              <p><strong>Status:</strong> {{ .Status | toUpper }}</p>
+              <p><strong>Time:</strong> {{ .StartsAt.Format "2006-01-02 15:04:05 MST" }}</p>
+            </div>
+            
+            {{ range .Alerts }}
+            <div class="alert {{ .Labels.severity }}">
+              <h2>{{ .Labels.alertname }}</h2>
+              <p><strong>Summary:</strong> {{ .Annotations.summary }}</p>
+              <p><strong>Description:</strong> {{ .Annotations.description }}</p>
+              
+              <div class="details">
+                <p><strong>Severity:</strong> {{ .Labels.severity }}</p>
+                <p><strong>Component:</strong> {{ .Labels.component }}</p>
+                {{ if .Annotations.dashboard }}
+                <p><strong>Dashboard:</strong> <a href="{{ .Annotations.dashboard }}">View Dashboard</a></p>
+                {{ end }}
+                <p><strong>Started:</strong> {{ .StartsAt.Format "2006-01-02 15:04:05 MST" }}</p>
+                {{ if .EndsAt }}
+                <p><strong>Ended:</strong> {{ .EndsAt.Format "2006-01-02 15:04:05 MST" }}</p>
+                {{ end }}
+              </div>
+            </div>
+            {{ end }}
+            
+            <div class="footer">
+              <p>This is an automated alert from GatewayZ Monitoring System.</p>
+              <p>For more details, visit <a href="http://localhost:3000">Grafana Dashboard</a></p>
+            </div>
+          </body>
+          </html>
+  
+  # Critical alerts - urgent attention needed
+  - name: 'email-critical'
+    email_configs:
+      - to: 'manjeshprasad21@gmail.com'
+        send_resolved: true
+        headers:
+          Subject: '🚨 [CRITICAL] GatewayZ Alert: {{ .GroupLabels.alertname }}'
+          Priority: 'urgent'
+          X-Priority: '1'
+        html: |
+          <!DOCTYPE html>
+          <html>
+          <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+            <div style="background: #dc3545; color: white; padding: 20px; border-radius: 4px;">
+              <h1>🚨 CRITICAL ALERT</h1>
+              <p style="font-size: 18px; margin: 0;"><strong>{{ .GroupLabels.alertname }}</strong></p>
+            </div>
+            
+            {{ range .Alerts }}
+            <div style="margin: 20px 0; padding: 15px; border-left: 4px solid #dc3545; background: #f8d7da;">
+              <h2>{{ .Annotations.summary }}</h2>
+              <p>{{ .Annotations.description }}</p>
+              
+              {{ if .Annotations.dashboard }}
+              <p><a href="{{ .Annotations.dashboard }}" style="color: #007bff;">View Dashboard →</a></p>
+              {{ end }}
+              
+              <p style="margin-top: 15px; font-size: 12px; color: #666;">
+                Started: {{ .StartsAt.Format "2006-01-02 15:04:05 MST" }}
+              </p>
+            </div>
+            {{ end }}
+            
+            <p style="margin-top: 20px; padding-top: 20px; border-top: 1px solid #ddd; font-size: 12px; color: #666;">
+              Immediate action required. Visit <a href="http://localhost:3000">Grafana Dashboard</a> for details.
+            </p>
+          </body>
+          </html>
+  
+  # Model health alerts - health score issues
+  - name: 'email-model-health'
+    email_configs:
+      - to: 'manjeshprasad21@gmail.com'
+        send_resolved: true
+        headers:
+          Subject: '⚠️ [MODEL HEALTH] GatewayZ Alert: {{ .GroupLabels.alertname }}'
+        html: |
+          <!DOCTYPE html>
+          <html>
+          <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+            <div style="background: #ffc107; color: #333; padding: 20px; border-radius: 4px;">
+              <h1>⚠️ Model Health Alert</h1>
+              <p style="font-size: 18px; margin: 0;"><strong>{{ .GroupLabels.alertname }}</strong></p>
+            </div>
+            
+            {{ range .Alerts }}
+            <div style="margin: 20px 0; padding: 15px; border-left: 4px solid #ffc107; background: #fff3cd;">
+              <h2>{{ .Annotations.summary }}</h2>
+              <p>{{ .Annotations.description }}</p>
+              
+              {{ if .Annotations.dashboard }}
+              <p><a href="{{ .Annotations.dashboard }}" style="color: #007bff;">View Model Performance Dashboard →</a></p>
+              {{ end }}
+              
+              <p style="margin-top: 15px; font-size: 12px; color: #666;">
+                Started: {{ .StartsAt.Format "2006-01-02 15:04:05 MST" }}
+              </p>
+            </div>
+            {{ end }}
+          </body>
+          </html>
+  
+  # Provider health alerts
+  - name: 'email-provider-health'
+    email_configs:
+      - to: 'manjeshprasad21@gmail.com'
+        send_resolved: true
+        headers:
+          Subject: '⚠️ [PROVIDER HEALTH] GatewayZ: {{ .GroupLabels.alertname }}'
+        html: |
+          <!DOCTYPE html>
+          <html>
+          <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+            <div style="background: #17a2b8; color: white; padding: 20px; border-radius: 4px;">
+              <h1>⚠️ Provider Health Alert</h1>
+              <p style="font-size: 18px; margin: 0;"><strong>{{ .GroupLabels.alertname }}</strong></p>
+            </div>
+            
+            {{ range .Alerts }}
+            <div style="margin: 20px 0; padding: 15px; border-left: 4px solid #17a2b8; background: #d1ecf1;">
+              <h2>{{ .Annotations.summary }}</h2>
+              <p>{{ .Annotations.description }}</p>
+              
+              {{ if .Labels.provider }}
+              <p><strong>Provider:</strong> {{ .Labels.provider }}</p>
+              {{ end }}
+              
+              {{ if .Annotations.dashboard }}
+              <p><a href="{{ .Annotations.dashboard }}" style="color: #007bff;">View Provider Dashboard →</a></p>
+              {{ end }}
+              
+              <p style="margin-top: 15px; font-size: 12px; color: #666;">
+                Started: {{ .StartsAt.Format "2006-01-02 15:04:05 MST" }}
+              </p>
+            </div>
+            {{ end }}
+          </body>
+          </html>
+
+# Inhibition rules - suppress alerts based on other alerts
+inhibit_rules:
+  # If a critical alert is firing, suppress warning alerts for the same component
+  - source_match:
+      severity: 'critical'
+    target_match:
+      severity: 'warning'
+    equal: ['component', 'alertname']
+  
+  # If overall health is low, suppress individual provider health alerts
+  - source_match:
+      alertname: 'LowModelHealthScore'
+    target_match:
+      alertname: 'LowProviderHealthScore'
+    equal: []

--- a/prometheus/test/docker-compose.test.yml
+++ b/prometheus/test/docker-compose.test.yml
@@ -1,0 +1,50 @@
+version: '3.8'
+
+services:
+  prometheus-test:
+    image: prom/prometheus:latest
+    container_name: prometheus-test
+    ports:
+      - "9091:9090"  # Different port to avoid conflicts
+    volumes:
+      - ./prometheus-test.yml:/etc/prometheus/prometheus.yml:ro
+      - ./alert.rules.test.yml:/etc/prometheus/alert.rules.test.yml:ro
+      - prometheus_test_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
+      - '--web.enable-lifecycle'
+    restart: unless-stopped
+    networks:
+      - monitoring-test
+
+  alertmanager-test:
+    build:
+      context: .
+      dockerfile: Dockerfile.alertmanager
+    container_name: alertmanager-test
+    ports:
+      - "9094:9093"  # Different port to avoid conflicts
+    volumes:
+      - alertmanager_test_data:/alertmanager
+    environment:
+      - SMTP_USERNAME=${SMTP_USERNAME}
+      - SMTP_PASSWORD=${SMTP_PASSWORD}
+    restart: unless-stopped
+    networks:
+      - monitoring-test
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9093/-/healthy"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+
+networks:
+  monitoring-test:
+    driver: bridge
+
+volumes:
+  prometheus_test_data:
+  alertmanager_test_data:

--- a/prometheus/test/docker-compose.test.yml
+++ b/prometheus/test/docker-compose.test.yml
@@ -41,6 +41,30 @@ services:
       timeout: 5s
       retries: 5
 
+  grafana-test:
+    image: grafana/grafana:latest
+    container_name: grafana-test
+    ports:
+      - "3001:3000"  # Different port to avoid conflicts
+    volumes:
+      - grafana_test_data:/var/lib/grafana
+      - ./grafana-dashboard-test.json:/etc/grafana/provisioning/dashboards/prometheus-test.json:ro
+      - ./grafana-datasource.yml:/etc/grafana/provisioning/datasources/prometheus.yml:ro
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    restart: unless-stopped
+    networks:
+      - monitoring-test
+    depends_on:
+      - prometheus-test
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+
 networks:
   monitoring-test:
     driver: bridge
@@ -48,3 +72,4 @@ networks:
 volumes:
   prometheus_test_data:
   alertmanager_test_data:
+  grafana_test_data:

--- a/prometheus/test/grafana-dashboard-test.json
+++ b/prometheus/test/grafana-dashboard-test.json
@@ -1,0 +1,681 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 20
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "green",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "(\n  sum(rate(model_inference_requests_total{status=\"success\"}[10m]))\n  /\n  sum(rate(model_inference_requests_total[10m]))\n) * 100",
+          "refId": "A",
+          "legendFormat": "Health Score"
+        }
+      ],
+      "title": "Overall Model Health Score",
+      "type": "gauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 18,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "(\n  sum(rate(model_inference_requests_total{status=\"success\"}[10m]))\n  /\n  sum(rate(model_inference_requests_total[10m]))\n) * 100",
+          "refId": "A",
+          "legendFormat": "Health Score"
+        }
+      ],
+      "title": "Model Health Score Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "No Alerts"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "count(ALERTS{alertstate=\"firing\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Firing Alerts",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum(rate(model_inference_requests_total[5m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Rate (req/s)",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.15
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum(rate(model_inference_requests_total{status=\"error\"}[5m])) / sum(rate(model_inference_requests_total[5m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "count(up{job=\"gatewayz-api-test\"} == 1)",
+          "refId": "A"
+        }
+      ],
+      "title": "Backend Status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 7,
+      "options": {
+        "showHeader": true
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "ALERTS{alertstate=\"firing\"}",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Active Alerts",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "alertstate": true,
+              "instance": true,
+              "job": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "alertname": "Alert Name",
+              "severity": "Severity",
+              "component": "Component",
+              "Value": "Status"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Health Score %",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 20
+              },
+              {
+                "color": "green",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "(\n  sum(rate(model_inference_requests_total{status=\"success\"}[10m])) by (provider)\n  /\n  sum(rate(model_inference_requests_total[10m])) by (provider)\n) * 100",
+          "refId": "A",
+          "legendFormat": "{{provider}}"
+        }
+      ],
+      "title": "Provider Health Scores",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Requests/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Success"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(model_inference_requests_total{status=\"success\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "Success"
+        },
+        {
+          "expr": "sum(rate(model_inference_requests_total{status=\"error\"}[5m]))",
+          "refId": "B",
+          "legendFormat": "Error"
+        }
+      ],
+      "title": "Request Status (Success vs Error)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "prometheus",
+    "alerting",
+    "test"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Prometheus Alerting Test Dashboard",
+  "uid": "prometheus-test-v1",
+  "version": 0
+}

--- a/prometheus/test/grafana-datasource.yml
+++ b/prometheus/test/grafana-datasource.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus-test:9090
+    isDefault: true
+    editable: true
+    jsonData:
+      timeInterval: "5s"
+      queryTimeout: "60s"

--- a/prometheus/test/prometheus-test.yml
+++ b/prometheus/test/prometheus-test.yml
@@ -1,0 +1,48 @@
+# Prometheus Test Configuration for GatewayZ
+# This configuration fixes the missing alerting section issue
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    cluster: 'gatewayz-test'
+    environment: 'test'
+
+# Alerting configuration - FIXED: Added alertmanager endpoint
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - 'localhost:9093'  # Alertmanager endpoint
+      timeout: 10s
+      api_version: v2
+
+# Rule files - Load alert rules
+rule_files:
+  - "/etc/prometheus/alert.rules.test.yml"
+
+# Scrape configurations
+scrape_configs:
+  # Backend API metrics
+  - job_name: 'gatewayz-api-test'
+    metrics_path: '/metrics'
+    scrape_interval: 15s
+    scrape_timeout: 10s
+    static_configs:
+      - targets:
+            - 'localhost:8000'  # Backend API
+        labels:
+          service: 'gatewayz-backend'
+          environment: 'test'
+
+  # Prometheus self-monitoring
+  - job_name: 'prometheus'
+    static_configs:
+      - targets:
+            - 'localhost:9090'
+
+  # Alertmanager monitoring
+  - job_name: 'alertmanager'
+    static_configs:
+      - targets:
+            - 'localhost:9093'

--- a/src/routes/prometheus_data.py
+++ b/src/routes/prometheus_data.py
@@ -1,0 +1,1353 @@
+"""
+Prometheus Data Endpoints for Grafana Stack Integration.
+
+This module provides REST API endpoints specifically designed for the Railway Grafana stack
+(Prometheus, Grafana, Loki, Tempo) to consume telemetry data.
+
+All endpoints are under the /prometheus/data/* path to avoid conflicts with existing routes.
+
+CACHING STRATEGY:
+- All expensive endpoints use Redis caching with configurable TTL
+- Each response includes `cached_at` and `cache_ttl_seconds` for transparency
+- Cache keys are prefixed with "prometheus:data:" for easy management
+- Cache can be invalidated via /prometheus/data/cache/invalidate
+
+Endpoints:
+- GET /prometheus/data/health-scores         → Provider health scores (TTL: 30s)
+- GET /prometheus/data/circuit-breakers      → Circuit breaker states (TTL: 15s)
+- GET /prometheus/data/anomalies             → Active anomalies/alerts (TTL: 30s)
+- GET /prometheus/data/cost-analysis         → Cost breakdown (TTL: 5min)
+- GET /prometheus/data/error-rates           → Error rates by model (TTL: 1min)
+- GET /prometheus/data/chat-requests/summary → Request summary (TTL: 30s)
+- GET /prometheus/data/stats/realtime        → Real-time stats (TTL: 15s)
+- GET /prometheus/data/provider-health       → Provider health scorecard (TTL: 30s)
+- GET /prometheus/data/instrumentation/*     → Instrumentation status (no cache)
+- GET /prometheus/data/model-performance     → Model metrics (TTL: 1min)
+- GET /prometheus/data/trending-models       → Trending models (TTL: 2min)
+- DELETE /prometheus/data/cache/invalidate   → Invalidate all caches
+"""
+
+import json
+import logging
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from src.security.deps import get_optional_api_key
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/prometheus/data", tags=["prometheus-data"])
+
+# Cache configuration
+CACHE_PREFIX = "prometheus:data:"
+CACHE_TTL = {
+    "health_scores": 30,        # 30 seconds - health scores change frequently
+    "circuit_breakers": 15,     # 15 seconds - circuit states can change rapidly
+    "anomalies": 30,            # 30 seconds - anomalies are time-sensitive
+    "cost_analysis": 300,       # 5 minutes - cost data is relatively stable
+    "error_rates": 60,          # 1 minute - error rates need quick updates
+    "chat_summary": 30,         # 30 seconds - overview should be fresh
+    "realtime_stats": 15,       # 15 seconds - "realtime" should be fresh
+    "provider_health": 30,      # 30 seconds - health scorecard
+    "model_performance": 60,    # 1 minute - model stats
+    "trending_models": 120,     # 2 minutes - trends don't change that fast
+}
+
+
+# ============================================================================
+# Response Models
+# ============================================================================
+
+class HealthScoreItem(BaseModel):
+    """Single provider health score."""
+    provider: str
+    health_score: float = Field(..., ge=0, le=100)
+    status: str  # healthy, degraded, unhealthy
+    availability: float = Field(..., ge=0, le=100)
+    error_rate: float = Field(..., ge=0, le=100)
+    avg_latency_ms: float
+    last_updated: str
+
+
+class CircuitBreakerItem(BaseModel):
+    """Circuit breaker state for grafana table."""
+    provider: str
+    model: str
+    status: str  # CLOSED, OPEN, HALF_OPEN
+    requests_last_5m: int
+    failures_last_5m: int
+    failure_rate: float
+    is_available: bool
+    last_failure_time: str | None
+
+
+class AnomalyItem(BaseModel):
+    """Detected anomaly for alerts panel."""
+    type: str  # high_error_rate, latency_spike, cost_spike, etc.
+    severity: str  # CRITICAL, WARNING, INFO
+    provider: str | None
+    model: str | None
+    description: str
+    current_value: float
+    threshold: float
+    detected_at: str
+
+
+class CostAnalysisItem(BaseModel):
+    """Cost analysis per model/provider."""
+    model: str
+    provider: str
+    cost: float
+    requests: int
+    cost_per_request: float
+    tokens_used: int
+    cost_per_1k_tokens: float
+
+
+class ErrorRateItem(BaseModel):
+    """Error rate by model."""
+    model: str
+    provider: str
+    total_requests: int
+    failed_requests: int
+    error_rate: float
+    error_types: dict[str, int]
+
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+def _classify_health_status(score: float) -> str:
+    """Classify health score into status."""
+    if score >= 80:
+        return "healthy"
+    elif score >= 50:
+        return "degraded"
+    else:
+        return "unhealthy"
+
+
+async def _get_redis_client():
+    """Get Redis client for caching."""
+    try:
+        from src.config.redis_config import get_redis_client
+        return await get_redis_client()
+    except Exception as e:
+        logger.warning(f"Failed to get Redis client for caching: {e}")
+        return None
+
+
+async def _get_cached_data(cache_key: str) -> dict | None:
+    """Get data from Redis cache."""
+    try:
+        redis = await _get_redis_client()
+        if not redis:
+            return None
+
+        full_key = f"{CACHE_PREFIX}{cache_key}"
+        cached = await redis.get(full_key)
+        if cached:
+            return json.loads(cached)
+        return None
+    except Exception as e:
+        logger.warning(f"Cache read error for {cache_key}: {e}")
+        return None
+
+
+async def _set_cached_data(cache_key: str, data: dict, ttl_seconds: int) -> bool:
+    """Set data in Redis cache with TTL."""
+    try:
+        redis = await _get_redis_client()
+        if not redis:
+            return False
+
+        full_key = f"{CACHE_PREFIX}{cache_key}"
+        # Add cache metadata to data
+        data["_cache_metadata"] = {
+            "cached_at": datetime.now(timezone.utc).isoformat(),
+            "cache_ttl_seconds": ttl_seconds,
+            "cache_key": cache_key
+        }
+        await redis.setex(full_key, ttl_seconds, json.dumps(data, default=str))
+        return True
+    except Exception as e:
+        logger.warning(f"Cache write error for {cache_key}: {e}")
+        return False
+
+
+async def _invalidate_cache(pattern: str = "*") -> int:
+    """Invalidate cache entries matching pattern."""
+    try:
+        redis = await _get_redis_client()
+        if not redis:
+            return 0
+
+        full_pattern = f"{CACHE_PREFIX}{pattern}"
+        keys = await redis.keys(full_pattern)
+        if keys:
+            await redis.delete(*keys)
+            return len(keys)
+        return 0
+    except Exception as e:
+        logger.warning(f"Cache invalidation error: {e}")
+        return 0
+
+
+def _add_cache_info(response: dict, cache_key: str, ttl: int, from_cache: bool) -> dict:
+    """Add cache information to response."""
+    response["_cache"] = {
+        "from_cache": from_cache,
+        "cache_key": cache_key,
+        "cache_ttl_seconds": ttl,
+        "timestamp": datetime.now(timezone.utc).isoformat()
+    }
+    return response
+
+
+# ============================================================================
+# Cache Management Endpoints
+# ============================================================================
+
+@router.delete("/cache/invalidate")
+async def invalidate_cache(
+    pattern: str = Query("*", description="Cache key pattern to invalidate (* for all)"),
+    api_key: str | None = Depends(get_optional_api_key)
+):
+    """
+    Invalidate prometheus data cache entries.
+
+    Use this to force fresh data on the next request.
+    Patterns: * (all), health_scores, circuit_breakers, anomalies, etc.
+    """
+    count = await _invalidate_cache(pattern)
+    return {
+        "success": True,
+        "invalidated_count": count,
+        "pattern": pattern,
+        "timestamp": datetime.now(timezone.utc).isoformat()
+    }
+
+
+@router.get("/cache/status")
+async def get_cache_status(api_key: str | None = Depends(get_optional_api_key)):
+    """
+    Get cache status and statistics.
+
+    Returns information about cached data and TTL settings.
+    """
+    try:
+        redis = await _get_redis_client()
+        if not redis:
+            return {
+                "status": "unavailable",
+                "message": "Redis not connected",
+                "timestamp": datetime.now(timezone.utc).isoformat()
+            }
+
+        # Get all prometheus data cache keys
+        keys = await redis.keys(f"{CACHE_PREFIX}*")
+        cache_entries = []
+
+        for key in keys:
+            ttl = await redis.ttl(key)
+            short_key = key.replace(CACHE_PREFIX, "") if isinstance(key, str) else key.decode().replace(CACHE_PREFIX, "")
+            cache_entries.append({
+                "key": short_key,
+                "ttl_remaining": ttl
+            })
+
+        return {
+            "status": "connected",
+            "cache_prefix": CACHE_PREFIX,
+            "ttl_settings": CACHE_TTL,
+            "cached_entries": cache_entries,
+            "entry_count": len(cache_entries),
+            "timestamp": datetime.now(timezone.utc).isoformat()
+        }
+    except Exception as e:
+        return {
+            "status": "error",
+            "error": str(e),
+            "timestamp": datetime.now(timezone.utc).isoformat()
+        }
+
+
+# ============================================================================
+# Health Score Endpoints
+# ============================================================================
+
+@router.get("/health-scores")
+async def get_health_scores(
+    skip_cache: bool = Query(False, description="Skip cache and fetch fresh data"),
+    api_key: str | None = Depends(get_optional_api_key)
+):
+    """
+    Get health scores for all providers.
+
+    Returns health metrics suitable for Grafana dashboard panels:
+    - Health score (0-100)
+    - Status (healthy/degraded/unhealthy)
+    - Availability percentage
+    - Error rate
+    - Average latency
+
+    Cache TTL: 30 seconds
+    """
+    cache_key = "health_scores"
+    ttl = CACHE_TTL[cache_key]
+
+    # Check cache first
+    if not skip_cache:
+        cached = await _get_cached_data(cache_key)
+        if cached:
+            return _add_cache_info(cached, cache_key, ttl, from_cache=True)
+
+    try:
+        from src.services.redis_metrics import get_redis_metrics
+
+        redis_metrics = get_redis_metrics()
+        health_scores = await redis_metrics.get_all_provider_health()
+
+        results = []
+        for provider, score in health_scores.items():
+            # Get additional metrics for each provider
+            hourly_stats = await redis_metrics.get_hourly_stats(provider, hours=1)
+
+            # Calculate aggregated stats
+            total_requests = sum(h.get("total_requests", 0) for h in hourly_stats.values())
+            total_errors = sum(h.get("error_count", 0) for h in hourly_stats.values())
+            total_latency = sum(h.get("total_latency", 0) for h in hourly_stats.values())
+
+            error_rate = (total_errors / total_requests * 100) if total_requests > 0 else 0.0
+            avg_latency = (total_latency / total_requests) if total_requests > 0 else 0.0
+            availability = 100.0 - error_rate
+
+            results.append({
+                "provider": provider,
+                "health_score": round(score, 2),
+                "status": _classify_health_status(score),
+                "availability": round(availability, 2),
+                "error_rate": round(error_rate, 2),
+                "avg_latency_ms": round(avg_latency, 2),
+                "requests_last_hour": total_requests,
+                "last_updated": datetime.now(timezone.utc).isoformat()
+            })
+
+        # Sort by health score (worst first for attention)
+        results.sort(key=lambda x: x["health_score"])
+
+        response = {
+            "data": results,
+            "count": len(results),
+            "timestamp": datetime.now(timezone.utc).isoformat()
+        }
+
+        # Cache the result
+        await _set_cached_data(cache_key, response, ttl)
+
+        return _add_cache_info(response, cache_key, ttl, from_cache=False)
+
+    except Exception as e:
+        logger.error(f"Failed to get health scores: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to get health scores: {str(e)}")
+
+
+# ============================================================================
+# Circuit Breaker Endpoints
+# ============================================================================
+
+@router.get("/circuit-breakers")
+async def get_circuit_breakers(
+    skip_cache: bool = Query(False, description="Skip cache and fetch fresh data"),
+    api_key: str | None = Depends(get_optional_api_key)
+):
+    """
+    Get circuit breaker states for all provider/model combinations.
+
+    Returns data formatted for Grafana table panels:
+    - Provider and model names
+    - Status (CLOSED/OPEN/HALF_OPEN)
+    - Request and failure counts
+    - Availability status
+
+    Cache TTL: 15 seconds (circuit states can change rapidly)
+    """
+    cache_key = "circuit_breakers"
+    ttl = CACHE_TTL[cache_key]
+
+    if not skip_cache:
+        cached = await _get_cached_data(cache_key)
+        if cached:
+            return _add_cache_info(cached, cache_key, ttl, from_cache=True)
+
+    try:
+        from src.services.model_availability import availability_service
+
+        circuit_states = []
+
+        for provider_key, circuit_data in availability_service.circuit_breakers.items():
+            parts = provider_key.split(":", 1)
+            if len(parts) != 2:
+                continue
+
+            provider, model = parts
+
+            # Calculate failure rate
+            total = circuit_data.success_count + circuit_data.failure_count
+            failure_rate = (circuit_data.failure_count / total * 100) if total > 0 else 0.0
+
+            last_failure = None
+            if circuit_data.last_failure_time:
+                last_failure = datetime.fromtimestamp(
+                    circuit_data.last_failure_time,
+                    tz=timezone.utc
+                ).isoformat()
+
+            circuit_states.append({
+                "provider": provider,
+                "model": model,
+                "status": circuit_data.state.name,
+                "requests_last_5m": total,
+                "failures_last_5m": circuit_data.failure_count,
+                "failure_rate": round(failure_rate, 2),
+                "is_available": availability_service.is_model_available(model, provider),
+                "last_failure_time": last_failure
+            })
+
+        # Sort by status priority (OPEN first)
+        status_priority = {"OPEN": 0, "HALF_OPEN": 1, "CLOSED": 2}
+        circuit_states.sort(key=lambda x: (status_priority.get(x["status"], 3), -x["failure_rate"]))
+
+        response = {
+            "data": circuit_states,
+            "count": len(circuit_states),
+            "open_count": sum(1 for c in circuit_states if c["status"] == "OPEN"),
+            "half_open_count": sum(1 for c in circuit_states if c["status"] == "HALF_OPEN"),
+            "closed_count": sum(1 for c in circuit_states if c["status"] == "CLOSED"),
+            "timestamp": datetime.now(timezone.utc).isoformat()
+        }
+
+        await _set_cached_data(cache_key, response, ttl)
+
+        return _add_cache_info(response, cache_key, ttl, from_cache=False)
+
+    except Exception as e:
+        logger.error(f"Failed to get circuit breakers: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to get circuit breakers: {str(e)}")
+
+
+# ============================================================================
+# Anomaly Detection Endpoints
+# ============================================================================
+
+@router.get("/anomalies")
+async def get_anomalies(
+    skip_cache: bool = Query(False, description="Skip cache and fetch fresh data"),
+    api_key: str | None = Depends(get_optional_api_key)
+):
+    """
+    Get detected anomalies and active alerts.
+
+    Returns anomalies formatted for Grafana alert panels:
+    - Type (high_error_rate, latency_spike, cost_spike)
+    - Severity (CRITICAL, WARNING, INFO)
+    - Description with context
+    - Current value vs threshold
+
+    Cache TTL: 30 seconds
+    """
+    cache_key = "anomalies"
+    ttl = CACHE_TTL[cache_key]
+
+    if not skip_cache:
+        cached = await _get_cached_data(cache_key)
+        if cached:
+            return _add_cache_info(cached, cache_key, ttl, from_cache=True)
+
+    try:
+        from src.services.analytics import get_analytics_service
+
+        analytics = get_analytics_service()
+        raw_anomalies = await analytics.detect_anomalies()
+
+        anomalies = []
+        for anomaly in raw_anomalies:
+            anomalies.append({
+                "type": anomaly.get("type", "unknown"),
+                "severity": anomaly.get("severity", "WARNING").upper(),
+                "provider": anomaly.get("provider"),
+                "model": anomaly.get("model"),
+                "description": anomaly.get("description", "Anomaly detected"),
+                "current_value": float(anomaly.get("current_value", 0)),
+                "threshold": float(anomaly.get("threshold", 0)),
+                "detected_at": anomaly.get("detected_at", datetime.now(timezone.utc).isoformat())
+            })
+
+        # Sort by severity
+        severity_priority = {"CRITICAL": 0, "WARNING": 1, "INFO": 2}
+        anomalies.sort(key=lambda x: severity_priority.get(x["severity"], 3))
+
+        response = {
+            "data": anomalies,
+            "count": len(anomalies),
+            "critical_count": sum(1 for a in anomalies if a["severity"] == "CRITICAL"),
+            "warning_count": sum(1 for a in anomalies if a["severity"] == "WARNING"),
+            "timestamp": datetime.now(timezone.utc).isoformat()
+        }
+
+        await _set_cached_data(cache_key, response, ttl)
+
+        return _add_cache_info(response, cache_key, ttl, from_cache=False)
+
+    except Exception as e:
+        logger.error(f"Failed to get anomalies: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to get anomalies: {str(e)}")
+
+
+# ============================================================================
+# Cost Analysis Endpoints
+# ============================================================================
+
+@router.get("/cost-analysis")
+async def get_cost_analysis(
+    days: int = Query(7, ge=1, le=90, description="Number of days to analyze"),
+    skip_cache: bool = Query(False, description="Skip cache and fetch fresh data"),
+    api_key: str | None = Depends(get_optional_api_key)
+):
+    """
+    Get cost breakdown by model and provider.
+
+    Returns cost metrics for Grafana cost dashboards:
+    - Total cost per model
+    - Request count
+    - Cost per request
+    - Token usage
+
+    Cache TTL: 5 minutes (cost data is relatively stable)
+    """
+    cache_key = f"cost_analysis:{days}d"
+    ttl = CACHE_TTL["cost_analysis"]
+
+    if not skip_cache:
+        cached = await _get_cached_data(cache_key)
+        if cached:
+            return _add_cache_info(cached, cache_key, ttl, from_cache=True)
+
+    try:
+        from src.services.analytics import get_analytics_service
+
+        analytics = get_analytics_service()
+        end_date = datetime.now(timezone.utc)
+        start_date = end_date - timedelta(days=days)
+
+        cost_data = await analytics.get_cost_by_provider(start_date, end_date)
+
+        results = []
+        total_cost = 0.0
+        total_requests = 0
+
+        for provider, provider_data in cost_data.get("providers", {}).items():
+            for model, model_data in provider_data.get("models", {}).items():
+                cost = model_data.get("cost", 0)
+                requests = model_data.get("requests", 0)
+                tokens = model_data.get("tokens", 0)
+
+                total_cost += cost
+                total_requests += requests
+
+                results.append({
+                    "model": model,
+                    "provider": provider,
+                    "cost": round(cost, 4),
+                    "requests": requests,
+                    "cost_per_request": round(cost / requests, 6) if requests > 0 else 0,
+                    "tokens_used": tokens,
+                    "cost_per_1k_tokens": round((cost / tokens * 1000), 6) if tokens > 0 else 0
+                })
+
+        # Sort by cost
+        results.sort(key=lambda x: x["cost"], reverse=True)
+
+        response = {
+            "data": results,
+            "count": len(results),
+            "period_days": days,
+            "total_cost": round(total_cost, 4),
+            "total_requests": total_requests,
+            "avg_cost_per_request": round(total_cost / total_requests, 6) if total_requests > 0 else 0,
+            "timestamp": datetime.now(timezone.utc).isoformat()
+        }
+
+        await _set_cached_data(cache_key, response, ttl)
+
+        return _add_cache_info(response, cache_key, ttl, from_cache=False)
+
+    except Exception as e:
+        logger.error(f"Failed to get cost analysis: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to get cost analysis: {str(e)}")
+
+
+# ============================================================================
+# Error Rate Endpoints
+# ============================================================================
+
+@router.get("/error-rates")
+async def get_error_rates(
+    hours: int = Query(24, ge=1, le=168, description="Number of hours to analyze"),
+    skip_cache: bool = Query(False, description="Skip cache and fetch fresh data"),
+    api_key: str | None = Depends(get_optional_api_key)
+):
+    """
+    Get error rates broken down by model.
+
+    Returns error metrics for Grafana error tracking panels.
+
+    Cache TTL: 1 minute
+    """
+    cache_key = f"error_rates:{hours}h"
+    ttl = CACHE_TTL["error_rates"]
+
+    if not skip_cache:
+        cached = await _get_cached_data(cache_key)
+        if cached:
+            return _add_cache_info(cached, cache_key, ttl, from_cache=True)
+
+    try:
+        from src.services.analytics import get_analytics_service
+
+        analytics = get_analytics_service()
+        error_data = await analytics.get_error_rate_by_model(hours=hours)
+
+        results = []
+        for model, model_data in error_data.get("models", {}).items():
+            provider = model_data.get("provider", "unknown")
+            total_requests = model_data.get("total_requests", 0)
+            failed_requests = model_data.get("failed_requests", 0)
+            error_rate = (failed_requests / total_requests * 100) if total_requests > 0 else 0
+
+            results.append({
+                "model": model,
+                "provider": provider,
+                "total_requests": total_requests,
+                "failed_requests": failed_requests,
+                "error_rate": round(error_rate, 2),
+                "error_types": model_data.get("error_types", {})
+            })
+
+        # Sort by error rate
+        results.sort(key=lambda x: x["error_rate"], reverse=True)
+
+        response = {
+            "data": results,
+            "count": len(results),
+            "period_hours": hours,
+            "overall_error_rate": round(
+                sum(r["failed_requests"] for r in results) /
+                max(sum(r["total_requests"] for r in results), 1) * 100, 2
+            ),
+            "timestamp": datetime.now(timezone.utc).isoformat()
+        }
+
+        await _set_cached_data(cache_key, response, ttl)
+
+        return _add_cache_info(response, cache_key, ttl, from_cache=False)
+
+    except Exception as e:
+        logger.error(f"Failed to get error rates: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to get error rates: {str(e)}")
+
+
+# ============================================================================
+# Chat Request Summary Endpoints
+# ============================================================================
+
+@router.get("/chat-requests/summary")
+async def get_chat_requests_summary(
+    hours: int = Query(24, ge=1, le=168, description="Number of hours to analyze"),
+    skip_cache: bool = Query(False, description="Skip cache and fetch fresh data"),
+    api_key: str | None = Depends(get_optional_api_key)
+):
+    """
+    Get summarized chat completion request metrics.
+
+    Cache TTL: 30 seconds
+    """
+    cache_key = f"chat_summary:{hours}h"
+    ttl = CACHE_TTL["chat_summary"]
+
+    if not skip_cache:
+        cached = await _get_cached_data(cache_key)
+        if cached:
+            return _add_cache_info(cached, cache_key, ttl, from_cache=True)
+
+    try:
+        from src.services.redis_metrics import get_redis_metrics
+
+        redis_metrics = get_redis_metrics()
+
+        total_requests = 0
+        total_success = 0
+        total_latency = 0
+        total_tokens = 0
+        model_requests: dict[str, int] = {}
+
+        health_scores = await redis_metrics.get_all_provider_health()
+
+        for provider in health_scores.keys():
+            hourly_stats = await redis_metrics.get_hourly_stats(provider, hours=hours)
+
+            for hour_data in hourly_stats.values():
+                requests = hour_data.get("total_requests", 0)
+                total_requests += requests
+                total_success += hour_data.get("success_count", requests)
+                total_latency += hour_data.get("total_latency", 0)
+                total_tokens += hour_data.get("total_tokens", 0)
+
+                for model, count in hour_data.get("model_requests", {}).items():
+                    model_requests[model] = model_requests.get(model, 0) + count
+
+        success_rate = (total_success / total_requests * 100) if total_requests > 0 else 100.0
+        avg_latency = (total_latency / total_requests) if total_requests > 0 else 0.0
+        requests_per_minute = total_requests / (hours * 60) if hours > 0 else 0.0
+        tokens_per_second = total_tokens / (hours * 3600) if hours > 0 else 0.0
+
+        top_models = sorted(model_requests.items(), key=lambda x: x[1], reverse=True)[:5]
+
+        response = {
+            "period_hours": hours,
+            "total_requests": total_requests,
+            "success_rate": round(success_rate, 2),
+            "avg_latency_ms": round(avg_latency, 2),
+            "total_tokens": total_tokens,
+            "tokens_per_second": round(tokens_per_second, 2),
+            "requests_per_minute": round(requests_per_minute, 2),
+            "top_models": [{"model": m, "requests": c} for m, c in top_models],
+            "avg_health_score": round(
+                sum(health_scores.values()) / len(health_scores) if health_scores else 0, 2
+            ),
+            "timestamp": datetime.now(timezone.utc).isoformat()
+        }
+
+        await _set_cached_data(cache_key, response, ttl)
+
+        return _add_cache_info(response, cache_key, ttl, from_cache=False)
+
+    except Exception as e:
+        logger.error(f"Failed to get chat requests summary: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to get summary: {str(e)}")
+
+
+# ============================================================================
+# Real-time Stats Endpoints
+# ============================================================================
+
+@router.get("/stats/realtime")
+async def get_realtime_stats(
+    hours: int = Query(1, ge=1, le=24, description="Number of hours to look back"),
+    skip_cache: bool = Query(False, description="Skip cache and fetch fresh data"),
+    api_key: str | None = Depends(get_optional_api_key)
+):
+    """
+    Get real-time statistics for live Grafana dashboards.
+
+    Cache TTL: 15 seconds (should be fairly fresh for "realtime")
+    """
+    cache_key = f"realtime_stats:{hours}h"
+    ttl = CACHE_TTL["realtime_stats"]
+
+    if not skip_cache:
+        cached = await _get_cached_data(cache_key)
+        if cached:
+            return _add_cache_info(cached, cache_key, ttl, from_cache=True)
+
+    try:
+        from src.services.redis_metrics import get_redis_metrics
+
+        redis_metrics = get_redis_metrics()
+        health_scores = await redis_metrics.get_all_provider_health()
+
+        total_requests = 0
+        total_cost = 0.0
+        total_errors = 0
+        provider_stats = {}
+
+        for provider, score in health_scores.items():
+            hourly_stats = await redis_metrics.get_hourly_stats(provider, hours=hours)
+
+            provider_requests = sum(h.get("total_requests", 0) for h in hourly_stats.values())
+            provider_cost = sum(h.get("total_cost", 0.0) for h in hourly_stats.values())
+            provider_errors = sum(h.get("error_count", 0) for h in hourly_stats.values())
+            provider_latency = sum(h.get("total_latency", 0) for h in hourly_stats.values())
+
+            total_requests += provider_requests
+            total_cost += provider_cost
+            total_errors += provider_errors
+
+            provider_stats[provider] = {
+                "health_score": round(score, 2),
+                "status": _classify_health_status(score),
+                "requests": provider_requests,
+                "cost": round(provider_cost, 4),
+                "error_rate": round(
+                    (provider_errors / provider_requests * 100) if provider_requests > 0 else 0, 2
+                ),
+                "avg_latency_ms": round(
+                    (provider_latency / provider_requests) if provider_requests > 0 else 0, 2
+                )
+            }
+
+        avg_health = sum(health_scores.values()) / len(health_scores) if health_scores else 0
+        error_rate = (total_errors / total_requests * 100) if total_requests > 0 else 0
+
+        response = {
+            "period_hours": hours,
+            "avg_health_score": round(avg_health, 2),
+            "total_requests": total_requests,
+            "total_cost": round(total_cost, 4),
+            "error_rate": round(error_rate, 2),
+            "requests_per_hour": round(total_requests / hours, 2) if hours > 0 else 0,
+            "providers": provider_stats,
+            "provider_count": len(provider_stats),
+            "timestamp": datetime.now(timezone.utc).isoformat()
+        }
+
+        await _set_cached_data(cache_key, response, ttl)
+
+        return _add_cache_info(response, cache_key, ttl, from_cache=False)
+
+    except Exception as e:
+        logger.error(f"Failed to get realtime stats: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to get realtime stats: {str(e)}")
+
+
+# ============================================================================
+# Provider Health Scorecard Endpoints
+# ============================================================================
+
+@router.get("/provider-health")
+async def get_provider_health_scorecard(
+    skip_cache: bool = Query(False, description="Skip cache and fetch fresh data"),
+    api_key: str | None = Depends(get_optional_api_key)
+):
+    """
+    Get detailed provider health scorecard.
+
+    Cache TTL: 30 seconds
+    """
+    cache_key = "provider_health"
+    ttl = CACHE_TTL[cache_key]
+
+    if not skip_cache:
+        cached = await _get_cached_data(cache_key)
+        if cached:
+            return _add_cache_info(cached, cache_key, ttl, from_cache=True)
+
+    try:
+        from src.services.redis_metrics import get_redis_metrics
+        from src.services.model_availability import availability_service
+
+        redis_metrics = get_redis_metrics()
+        health_scores = await redis_metrics.get_all_provider_health()
+
+        providers = []
+
+        for provider, score in health_scores.items():
+            current_stats = await redis_metrics.get_hourly_stats(provider, hours=1)
+            historical_stats = await redis_metrics.get_hourly_stats(provider, hours=24)
+
+            current_requests = sum(h.get("total_requests", 0) for h in current_stats.values())
+            current_errors = sum(h.get("error_count", 0) for h in current_stats.values())
+            current_latency = sum(h.get("total_latency", 0) for h in current_stats.values())
+            hist_requests = sum(h.get("total_requests", 0) for h in historical_stats.values())
+
+            active_models = sum(
+                1 for key in availability_service.circuit_breakers.keys()
+                if key.startswith(f"{provider}:")
+            )
+
+            error_rate = (current_errors / current_requests * 100) if current_requests > 0 else 0
+            avg_latency = (current_latency / current_requests) if current_requests > 0 else 0
+
+            avg_hourly = hist_requests / 24 if hist_requests > 0 else 0
+            trend = "stable"
+            if current_requests > avg_hourly * 1.2:
+                trend = "up"
+            elif current_requests < avg_hourly * 0.8:
+                trend = "down"
+
+            providers.append({
+                "provider": provider,
+                "health_score": round(score, 2),
+                "status": _classify_health_status(score),
+                "trend": trend,
+                "availability": round(100 - error_rate, 2),
+                "error_rate": round(error_rate, 2),
+                "avg_latency_ms": round(avg_latency, 2),
+                "requests_last_hour": current_requests,
+                "requests_last_24h": hist_requests,
+                "active_models": active_models,
+                "last_updated": datetime.now(timezone.utc).isoformat()
+            })
+
+        providers.sort(key=lambda x: x["health_score"], reverse=True)
+
+        response = {
+            "providers": providers,
+            "total_providers": len(providers),
+            "healthy_count": sum(1 for p in providers if p["status"] == "healthy"),
+            "degraded_count": sum(1 for p in providers if p["status"] == "degraded"),
+            "unhealthy_count": sum(1 for p in providers if p["status"] == "unhealthy"),
+            "timestamp": datetime.now(timezone.utc).isoformat()
+        }
+
+        await _set_cached_data(cache_key, response, ttl)
+
+        return _add_cache_info(response, cache_key, ttl, from_cache=False)
+
+    except Exception as e:
+        logger.error(f"Failed to get provider health scorecard: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to get scorecard: {str(e)}")
+
+
+# ============================================================================
+# Instrumentation Status Endpoints (NO CACHING - must be live)
+# ============================================================================
+
+@router.get("/instrumentation/health")
+async def get_instrumentation_health(api_key: str | None = Depends(get_optional_api_key)):
+    """
+    Get overall instrumentation and observability health.
+
+    Checks connectivity to Redis, Supabase, Prometheus, Loki, Tempo.
+
+    NO CACHING - this is a live health check.
+    """
+    try:
+        from src.config.supabase_config import get_supabase_client
+
+        health_status = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "status": "healthy",
+            "components": {}
+        }
+
+        # Check Redis
+        try:
+            redis = await _get_redis_client()
+            if redis:
+                await redis.ping()
+                health_status["components"]["redis"] = {"status": "healthy"}
+            else:
+                health_status["components"]["redis"] = {"status": "unavailable"}
+        except Exception as e:
+            health_status["components"]["redis"] = {"status": "unhealthy", "error": str(e)}
+            health_status["status"] = "degraded"
+
+        # Check Supabase
+        try:
+            client = get_supabase_client()
+            client.table("providers").select("id").limit(1).execute()
+            health_status["components"]["supabase"] = {"status": "healthy"}
+        except Exception as e:
+            health_status["components"]["supabase"] = {"status": "unhealthy", "error": str(e)}
+            health_status["status"] = "degraded"
+
+        # Check Prometheus metrics
+        try:
+            from prometheus_client import REGISTRY, generate_latest
+            metrics = generate_latest(REGISTRY)
+            health_status["components"]["prometheus"] = {
+                "status": "healthy",
+                "metrics_count": len(metrics.decode().split("\n"))
+            }
+        except Exception as e:
+            health_status["components"]["prometheus"] = {"status": "unhealthy", "error": str(e)}
+
+        # Check Loki
+        loki_url = os.environ.get("LOKI_URL")
+        if loki_url:
+            try:
+                import httpx
+                async with httpx.AsyncClient(timeout=5.0) as client:
+                    response = await client.get(f"{loki_url}/ready")
+                    health_status["components"]["loki"] = {
+                        "status": "healthy" if response.status_code == 200 else "degraded",
+                        "url": loki_url
+                    }
+            except Exception as e:
+                health_status["components"]["loki"] = {"status": "unhealthy", "error": str(e)}
+        else:
+            health_status["components"]["loki"] = {"status": "not_configured"}
+
+        # Check Tempo
+        tempo_url = os.environ.get("TEMPO_URL")
+        if tempo_url:
+            try:
+                import httpx
+                async with httpx.AsyncClient(timeout=5.0) as client:
+                    response = await client.get(f"{tempo_url}/ready")
+                    health_status["components"]["tempo"] = {
+                        "status": "healthy" if response.status_code == 200 else "degraded",
+                        "url": tempo_url
+                    }
+            except Exception as e:
+                health_status["components"]["tempo"] = {"status": "unhealthy", "error": str(e)}
+        else:
+            health_status["components"]["tempo"] = {"status": "not_configured"}
+
+        return health_status
+
+    except Exception as e:
+        logger.error(f"Failed to get instrumentation health: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Health check failed: {str(e)}")
+
+
+@router.get("/instrumentation/loki/status")
+async def get_loki_status(api_key: str | None = Depends(get_optional_api_key)):
+    """Get Loki logging service status (NO CACHING)."""
+    loki_url = os.environ.get("LOKI_URL", os.environ.get("LOKI_HOST"))
+
+    if not loki_url:
+        return {
+            "status": "not_configured",
+            "message": "LOKI_URL environment variable not set",
+            "timestamp": datetime.now(timezone.utc).isoformat()
+        }
+
+    try:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            ready_response = await client.get(f"{loki_url}/ready")
+            return {
+                "status": "healthy" if ready_response.status_code == 200 else "unhealthy",
+                "url": loki_url,
+                "ready": ready_response.status_code == 200,
+                "timestamp": datetime.now(timezone.utc).isoformat()
+            }
+
+    except Exception as e:
+        return {
+            "status": "error",
+            "error": str(e),
+            "timestamp": datetime.now(timezone.utc).isoformat()
+        }
+
+
+@router.get("/instrumentation/tempo/status")
+async def get_tempo_status(api_key: str | None = Depends(get_optional_api_key)):
+    """Get Tempo tracing service status (NO CACHING)."""
+    tempo_url = os.environ.get("TEMPO_URL", os.environ.get("TEMPO_HOST"))
+
+    if not tempo_url:
+        return {
+            "status": "not_configured",
+            "message": "TEMPO_URL environment variable not set",
+            "timestamp": datetime.now(timezone.utc).isoformat()
+        }
+
+    try:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            ready_response = await client.get(f"{tempo_url}/ready")
+            return {
+                "status": "healthy" if ready_response.status_code == 200 else "unhealthy",
+                "url": tempo_url,
+                "ready": ready_response.status_code == 200,
+                "timestamp": datetime.now(timezone.utc).isoformat()
+            }
+
+    except Exception as e:
+        return {
+            "status": "error",
+            "error": str(e),
+            "timestamp": datetime.now(timezone.utc).isoformat()
+        }
+
+
+@router.post("/instrumentation/test-log")
+async def test_log_ingestion(
+    message: str = Query("Test log message", description="Test message to log"),
+    level: str = Query("info", description="Log level (debug, info, warn, error)"),
+    api_key: str | None = Depends(get_optional_api_key)
+):
+    """Test log ingestion to Loki (NO CACHING)."""
+    trace_id = str(uuid.uuid4())
+
+    log_func = getattr(logger, level.lower(), logger.info)
+    log_func(f"[TEST LOG] {message}", extra={
+        "trace_id": trace_id,
+        "test": True,
+        "source": "prometheus_data_test"
+    })
+
+    return {
+        "success": True,
+        "message": f"Test log sent at level '{level}'",
+        "trace_id": trace_id,
+        "log_message": message,
+        "timestamp": datetime.now(timezone.utc).isoformat()
+    }
+
+
+@router.post("/instrumentation/test-trace")
+async def test_trace_ingestion(
+    operation: str = Query("test_operation", description="Operation name for the trace"),
+    api_key: str | None = Depends(get_optional_api_key)
+):
+    """Test trace ingestion to Tempo (NO CACHING)."""
+    trace_id = str(uuid.uuid4())
+    span_id = str(uuid.uuid4())[:16]
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.trace import SpanKind
+
+        tracer = trace.get_tracer(__name__)
+
+        with tracer.start_as_current_span(
+            operation,
+            kind=SpanKind.INTERNAL,
+            attributes={"test": True, "source": "prometheus_data_test"}
+        ) as span:
+            span.set_attribute("test.trace_id", trace_id)
+
+            return {
+                "success": True,
+                "message": "Test trace span created",
+                "trace_id": trace_id,
+                "span_id": span_id,
+                "operation": operation,
+                "method": "opentelemetry",
+                "timestamp": datetime.now(timezone.utc).isoformat()
+            }
+
+    except ImportError:
+        return {
+            "success": True,
+            "message": "Test trace simulated (OpenTelemetry not configured)",
+            "trace_id": trace_id,
+            "span_id": span_id,
+            "operation": operation,
+            "method": "simulated",
+            "timestamp": datetime.now(timezone.utc).isoformat()
+        }
+
+
+# ============================================================================
+# Model Performance Endpoints
+# ============================================================================
+
+@router.get("/model-performance")
+async def get_model_performance(
+    limit: int = Query(20, ge=1, le=100, description="Maximum number of models to return"),
+    skip_cache: bool = Query(False, description="Skip cache and fetch fresh data"),
+    api_key: str | None = Depends(get_optional_api_key)
+):
+    """
+    Get performance metrics for all models.
+
+    Cache TTL: 1 minute
+    """
+    cache_key = f"model_performance:{limit}"
+    ttl = CACHE_TTL["model_performance"]
+
+    if not skip_cache:
+        cached = await _get_cached_data(cache_key)
+        if cached:
+            return _add_cache_info(cached, cache_key, ttl, from_cache=True)
+
+    try:
+        from src.config.supabase_config import get_supabase_client
+
+        client = get_supabase_client()
+
+        # Get recent requests with pagination to avoid memory issues
+        result = client.table("chat_completion_requests").select(
+            """
+            model_id,
+            input_tokens,
+            output_tokens,
+            processing_time_ms,
+            status,
+            models!inner(
+                id,
+                model_id,
+                model_name,
+                providers!inner(name, slug)
+            )
+            """
+        ).order("created_at", desc=True).limit(10000).execute()
+
+        if not result.data:
+            response = {
+                "models": [],
+                "total_models": 0,
+                "timestamp": datetime.now(timezone.utc).isoformat()
+            }
+            await _set_cached_data(cache_key, response, ttl)
+            return _add_cache_info(response, cache_key, ttl, from_cache=False)
+
+        # Aggregate by model
+        model_stats: dict[str, dict[str, Any]] = {}
+
+        for record in result.data:
+            model_info = record.get("models", {})
+            model_id = model_info.get("model_id", "unknown")
+
+            if model_id not in model_stats:
+                model_stats[model_id] = {
+                    "model_id": model_id,
+                    "model_name": model_info.get("model_name", model_id),
+                    "provider": model_info.get("providers", {}).get("name", "unknown"),
+                    "provider_slug": model_info.get("providers", {}).get("slug", "unknown"),
+                    "total_requests": 0,
+                    "successful_requests": 0,
+                    "total_input_tokens": 0,
+                    "total_output_tokens": 0,
+                    "total_latency_ms": 0
+                }
+
+            stats = model_stats[model_id]
+            stats["total_requests"] += 1
+            if record.get("status") == "success":
+                stats["successful_requests"] += 1
+            stats["total_input_tokens"] += record.get("input_tokens", 0) or 0
+            stats["total_output_tokens"] += record.get("output_tokens", 0) or 0
+            stats["total_latency_ms"] += record.get("processing_time_ms", 0) or 0
+
+        # Calculate derived metrics
+        models = []
+        for model_id, stats in model_stats.items():
+            total = stats["total_requests"]
+            if total == 0:
+                continue
+
+            models.append({
+                "model_id": stats["model_id"],
+                "model_name": stats["model_name"],
+                "provider": stats["provider"],
+                "provider_slug": stats["provider_slug"],
+                "total_requests": total,
+                "success_rate": round(stats["successful_requests"] / total * 100, 2),
+                "avg_latency_ms": round(stats["total_latency_ms"] / total, 2),
+                "total_tokens": stats["total_input_tokens"] + stats["total_output_tokens"],
+                "avg_tokens_per_request": round(
+                    (stats["total_input_tokens"] + stats["total_output_tokens"]) / total, 2
+                )
+            })
+
+        models.sort(key=lambda x: x["total_requests"], reverse=True)
+
+        response = {
+            "models": models[:limit],
+            "total_models": len(models),
+            "timestamp": datetime.now(timezone.utc).isoformat()
+        }
+
+        await _set_cached_data(cache_key, response, ttl)
+
+        return _add_cache_info(response, cache_key, ttl, from_cache=False)
+
+    except Exception as e:
+        logger.error(f"Failed to get model performance: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to get performance: {str(e)}")
+
+
+@router.get("/trending-models")
+async def get_trending_models(
+    limit: int = Query(15, ge=1, le=50, description="Maximum number of models"),
+    time_range: str = Query("7d", description="Time range (1d, 7d, 30d)"),
+    skip_cache: bool = Query(False, description="Skip cache and fetch fresh data"),
+    api_key: str | None = Depends(get_optional_api_key)
+):
+    """
+    Get top trending models by request volume.
+
+    Cache TTL: 2 minutes
+    """
+    cache_key = f"trending_models:{time_range}:{limit}"
+    ttl = CACHE_TTL["trending_models"]
+
+    if not skip_cache:
+        cached = await _get_cached_data(cache_key)
+        if cached:
+            return _add_cache_info(cached, cache_key, ttl, from_cache=True)
+
+    try:
+        from src.config.supabase_config import get_supabase_client
+
+        days = {"1d": 1, "7d": 7, "30d": 30}.get(time_range, 7)
+        start_date = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+
+        client = get_supabase_client()
+
+        result = client.table("chat_completion_requests").select(
+            """
+            model_id,
+            models!inner(
+                model_id,
+                model_name,
+                providers!inner(name, slug)
+            )
+            """
+        ).gte("created_at", start_date).execute()
+
+        if not result.data:
+            response = {
+                "time_range": time_range,
+                "models": [],
+                "total_requests": 0,
+                "timestamp": datetime.now(timezone.utc).isoformat()
+            }
+            await _set_cached_data(cache_key, response, ttl)
+            return _add_cache_info(response, cache_key, ttl, from_cache=False)
+
+        # Count by model
+        model_counts: dict[str, dict[str, Any]] = {}
+        total_requests = 0
+
+        for record in result.data:
+            model_info = record.get("models", {})
+            model_id = model_info.get("model_id", "unknown")
+
+            if model_id not in model_counts:
+                model_counts[model_id] = {
+                    "model_id": model_id,
+                    "model_name": model_info.get("model_name", model_id),
+                    "provider": model_info.get("providers", {}).get("name", "unknown"),
+                    "provider_slug": model_info.get("providers", {}).get("slug", "unknown"),
+                    "requests": 0
+                }
+
+            model_counts[model_id]["requests"] += 1
+            total_requests += 1
+
+        models = []
+        for model_id, data in model_counts.items():
+            data["usage_share"] = round(data["requests"] / total_requests * 100, 2) if total_requests > 0 else 0
+            models.append(data)
+
+        models.sort(key=lambda x: x["requests"], reverse=True)
+
+        response = {
+            "time_range": time_range,
+            "models": models[:limit],
+            "total_requests": total_requests,
+            "timestamp": datetime.now(timezone.utc).isoformat()
+        }
+
+        await _set_cached_data(cache_key, response, ttl)
+
+        return _add_cache_info(response, cache_key, ttl, from_cache=False)
+
+    except Exception as e:
+        logger.error(f"Failed to get trending models: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to get trending models: {str(e)}")

--- a/src/routes/prometheus_grafana.py
+++ b/src/routes/prometheus_grafana.py
@@ -1,0 +1,253 @@
+"""
+Prometheus/Grafana SimpleJSON Datasource Endpoints
+
+This module provides endpoints compatible with Grafana's SimpleJSON datasource plugin.
+These endpoints act as a bridge between Grafana dashboards and the existing monitoring APIs.
+
+Endpoints:
+- GET /prometheus/datasource - Health check
+- POST /prometheus/datasource/search - Return available metrics
+- POST /prometheus/datasource/query - Query metrics data
+- POST /prometheus/datasource/annotations - Annotations (not implemented)
+- POST /prometheus/datasource/tag-keys - Tag keys (not implemented)
+- POST /prometheus/datasource/tag-values - Tag values (not implemented)
+
+Documentation:
+https://github.com/grafana/simple-json-datasource
+"""
+
+import logging
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from src.services.redis_metrics import get_redis_metrics
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/prometheus/datasource", tags=["prometheus-grafana"])
+
+
+# Request/Response Models
+class SearchRequest(BaseModel):
+    """Search request from Grafana"""
+
+    target: str | None = None
+
+
+class QueryTarget(BaseModel):
+    """Query target from Grafana"""
+
+    target: str
+    refId: str
+    type: str = "timeserie"
+
+
+class QueryRequest(BaseModel):
+    """Query request from Grafana"""
+
+    targets: list[QueryTarget]
+    range: dict[str, str] = Field(default_factory=dict)
+    interval: str | None = None
+    maxDataPoints: int | None = None
+
+
+class Datapoint(BaseModel):
+    """Single datapoint [value, timestamp_ms]"""
+
+    pass  # We'll return raw arrays
+
+
+class QueryResponse(BaseModel):
+    """Query response to Grafana"""
+
+    target: str
+    datapoints: list[list[float | int]]
+
+
+# Metric definitions - maps metric names to data extraction logic
+AVAILABLE_METRICS = [
+    "avg_health_score",
+    "total_requests",
+    "total_cost",
+    "error_rate",
+    "active_requests",
+    "avg_latency_ms",
+]
+
+
+@router.get("")
+async def health_check():
+    """
+    Health check endpoint for Grafana SimpleJSON datasource.
+
+    Returns 200 OK if the datasource is available.
+    """
+    return {"status": "ok", "message": "Prometheus/Grafana datasource proxy is operational"}
+
+
+@router.post("/search")
+async def search(request: SearchRequest):
+    """
+    Return list of available metrics for Grafana metric selection.
+
+    This endpoint is called when users open a panel to select metrics.
+    """
+    logger.info(f"Search request: {request.target if request else 'all'}")
+
+    # Return all available metrics
+    return AVAILABLE_METRICS
+
+
+@router.post("/query")
+async def query(request: QueryRequest):
+    """
+    Query metrics data for Grafana panels.
+
+    This is the main endpoint that fetches actual metric values.
+
+    Args:
+        request: Query request containing targets and time range
+
+    Returns:
+        List of QueryResponse objects with metric data
+    """
+    try:
+        logger.info(f"Query request: {len(request.targets)} targets")
+
+        results = []
+        current_timestamp = int(datetime.now().timestamp() * 1000)
+
+        redis_metrics = get_redis_metrics()
+
+        for target in request.targets:
+            metric_name = target.target
+
+            logger.info(f"Fetching metric: {metric_name}")
+
+            try:
+                # Fetch metric based on name
+                value = await _fetch_metric_value(metric_name, redis_metrics)
+
+                # Create datapoint [value, timestamp_ms]
+                datapoint = [value, current_timestamp]
+
+                results.append({"target": metric_name, "datapoints": [datapoint]})
+
+                logger.info(f"Metric {metric_name} = {value}")
+
+            except Exception as e:
+                logger.error(f"Error fetching {metric_name}: {e}", exc_info=True)
+                # Return 0 on error
+                results.append({"target": metric_name, "datapoints": [[0.0, current_timestamp]]})
+
+        return results
+
+    except Exception as e:
+        logger.error(f"Query error: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Query failed: {str(e)}")
+
+
+@router.post("/annotations")
+async def annotations(request: Request):
+    """
+    Return annotations for Grafana.
+
+    Not implemented - returns empty list.
+    """
+    return []
+
+
+@router.post("/tag-keys")
+async def tag_keys(request: Request):
+    """
+    Return available tag keys.
+
+    Not implemented - returns empty list.
+    """
+    return []
+
+
+@router.post("/tag-values")
+async def tag_values(request: Request):
+    """
+    Return available tag values.
+
+    Not implemented - returns empty list.
+    """
+    return []
+
+
+# Helper Functions
+async def _fetch_metric_value(metric_name: str, redis_metrics) -> float:
+    """
+    Fetch a specific metric value from the monitoring system.
+
+    Args:
+        metric_name: Name of the metric to fetch
+        redis_metrics: Redis metrics service instance
+
+    Returns:
+        Metric value as float
+
+    Raises:
+        ValueError: If metric name is unknown
+    """
+    if metric_name == "avg_health_score":
+        # Get average health score across all providers
+        health_scores = await redis_metrics.get_all_provider_health()
+        if health_scores:
+            avg_score = sum(health_scores.values()) / len(health_scores)
+            return float(avg_score)
+        return 100.0
+
+    elif metric_name == "total_requests":
+        # Get total requests across all providers (last hour)
+        total = 0
+        health_scores = await redis_metrics.get_all_provider_health()
+        for provider in health_scores.keys():
+            hourly_stats = await redis_metrics.get_hourly_stats(provider, hours=1)
+            for hour_data in hourly_stats.values():
+                total += hour_data.get("total_requests", 0)
+        return float(total)
+
+    elif metric_name == "total_cost":
+        # Get total cost across all providers (last hour)
+        total = 0.0
+        health_scores = await redis_metrics.get_all_provider_health()
+        for provider in health_scores.keys():
+            hourly_stats = await redis_metrics.get_hourly_stats(provider, hours=1)
+            for hour_data in hourly_stats.values():
+                total += hour_data.get("total_cost", 0.0)
+        return float(total)
+
+    elif metric_name == "error_rate":
+        # Calculate error rate (last hour)
+        total_requests = 0
+        failed_requests = 0
+        health_scores = await redis_metrics.get_all_provider_health()
+        for provider in health_scores.keys():
+            hourly_stats = await redis_metrics.get_hourly_stats(provider, hours=1)
+            for hour_data in hourly_stats.values():
+                total_requests += hour_data.get("total_requests", 0)
+                failed_requests += hour_data.get("failed_requests", 0)
+
+        if total_requests > 0:
+            error_rate = (failed_requests / total_requests) * 100
+            return float(error_rate)
+        return 0.0
+
+    elif metric_name == "active_requests":
+        # This would require tracking in-flight requests
+        # For now, return 0
+        return 0.0
+
+    elif metric_name == "avg_latency_ms":
+        # This would require calculating average latency from all providers
+        # For now, return 0
+        return 0.0
+
+    else:
+        raise ValueError(f"Unknown metric: {metric_name}")


### PR DESCRIPTION
Endpoint | Purpose | Cache TTL
GET /prometheus/data/health-scores | Provider health scores | 30s
GET /prometheus/data/circuit-breakers | Circuit breaker states | 15s
GET /prometheus/data/anomalies | Active anomalies / alerts | 30s
GET /prometheus/data/cost-analysis?days=7 | Cost breakdown | 5 min
GET /prometheus/data/error-rates?hours=24 | Error rates by model | 1 min
GET /prometheus/data/chat-requests/summary | Request summary | 30s
GET /prometheus/data/stats/realtime | Real-time stats | 15s
GET /prometheus/data/provider-health | Provider scorecard | 30s
GET /prometheus/data/model-performance | Model metrics | 1 min
GET /prometheus/data/trending-models | Top models | 2 min
GET /prometheus/data/instrumentation/health | System health check | No cache
GET /prometheus/data/instrumentation/loki/status | Loki status | No cache
GET /prometheus/data/instrumentation/tempo/status | Tempo status | No cache
POST /prometheus/data/instrumentation/test-log | Test log ingestion | No cache
POST /prometheus/data/instrumentation/test-trace | Test trace ingestion | No cache
GET /prometheus/data/cache/status | View cache status | —
DELETE /prometheus/data/cache/invalidate | Invalidate cache | —

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds comprehensive Prometheus/Grafana monitoring integration with 17 new data endpoints providing health scores, circuit breaker states, error rates, cost analysis, and performance metrics with Redis caching
- Implements a complete test environment for Prometheus/Alertmanager including Docker configurations, alert rules, Grafana dashboards, and SMTP notification setup
- Integrates Grafana SimpleJSON datasource proxy to bridge existing Redis-based metrics with Grafana visualization capabilities

**PR Description Notes:**
- The PR description provides a well-organized table of the new endpoints with their purposes and cache TTL settings

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/routes/prometheus_data.py | New comprehensive monitoring API with 1478 lines providing 17 endpoints for health scores, circuit breakers, metrics, and cache management with Redis caching |
| prometheus/test/README.md | Added extensive test environment documentation with hardcoded credentials that need security review |
| prometheus/test/docker-compose.test.yml | New test environment configuration for Prometheus/AlertManager/Grafana stack with proper health checks and isolation |
| prometheus.yml | Enabled Alertmanager configuration with hardcoded localhost:9093 endpoint that may not work in containerized Railway environments |

<h3>Confidence score: 3/5</h3>


- This PR requires careful review due to security concerns with hardcoded credentials and potential deployment issues with localhost configurations
- Score lowered due to hardcoded email addresses in documentation, untested stub endpoints returning zeros, localhost configuration that may break in containerized deployments, and lack of graceful Redis error handling
- Pay close attention to `prometheus/test/README.md` for security issues and `prometheus.yml` for deployment compatibility

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Router as "prometheus_data.py Router"
    participant Cache as "Redis Cache"
    participant Metrics as "Redis Metrics Service"
    participant Availability as "Availability Service"
    participant Supabase as "Supabase DB"

    User->>Router: "GET /prometheus/data/health-scores"
    Router->>Cache: "Check cached data for health_scores"
    
    alt Cache Miss
        Cache-->>Router: "No cached data"
        Router->>Metrics: "get_all_provider_health()"
        Metrics-->>Router: "Health scores by provider"
        Router->>Metrics: "get_hourly_stats(provider, hours=1)"
        Metrics-->>Router: "Hourly statistics"
        Router->>Router: "Calculate aggregated metrics"
        Router->>Cache: "Store result with 30s TTL"
        Cache-->>Router: "Data cached"
    else Cache Hit
        Cache-->>Router: "Return cached data"
    end
    
    Router-->>User: "Health scores with cache metadata"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->