### PR TITLE
feat(statsig): add session tracking for DAU/WAU/MAU metrics

### DIFF
--- a/src/routes/analytics.py
+++ b/src/routes/analytics.py
@@ -29,6 +29,18 @@ class AnalyticsEvent(BaseModel):
     metadata: dict[str, Any] | None = Field(None, description="Optional event metadata")
 
 
+class SessionStartEvent(BaseModel):
+    """Session start event model for DAU/WAU/MAU tracking"""
+
+    platform: str = Field(
+        default="web",
+        description="Platform identifier (web, ios, android, desktop)",
+    )
+    metadata: dict[str, Any] | None = Field(
+        None, description="Optional session metadata (version, referrer, etc.)"
+    )
+
+
 @router.post("/events")
 async def log_event(
     event: AnalyticsEvent, current_user: dict | None = Depends(get_current_user)
@@ -117,4 +129,57 @@ async def log_batch_events(
         logger.error(f"Failed to log batch analytics events: {e}")
         raise HTTPException(
             status_code=500, detail=f"Failed to log batch analytics events: {str(e)}"
+        ) from e
+
+
+@router.post("/session/start")
+async def log_session_start(
+    session: SessionStartEvent, current_user: dict | None = Depends(get_current_user)
+):
+    """
+    Log a session start event for DAU/WAU/MAU tracking.
+
+    This endpoint should be called when:
+    - User opens the app/website
+    - User logs in
+    - User returns after being idle
+
+    The session_start event is used by Statsig to compute Product Growth metrics
+    including Daily Active Users (DAU), Weekly Active Users (WAU),
+    Monthly Active Users (MAU), stickiness, and retention rates.
+
+    Args:
+        session: Session start event with platform and optional metadata
+        current_user: Authenticated user (from auth middleware)
+
+    Returns:
+        Success message
+    """
+    try:
+        # Determine user ID
+        user_id = "anonymous"
+        if current_user:
+            user_id = str(current_user.get("user_id", "anonymous"))
+
+        # Log session start to Statsig (for DAU/WAU/MAU)
+        statsig_service.log_session_start(
+            user_id=user_id,
+            platform=session.platform,
+            metadata=session.metadata,
+        )
+
+        # Log session start to PostHog
+        posthog_service.capture(
+            distinct_id=user_id,
+            event="session_start",
+            properties={"platform": session.platform, **(session.metadata or {})},
+        )
+
+        logger.debug(f"Session start logged for user {user_id} on {session.platform}")
+        return {"success": True, "message": "Session start logged successfully"}
+
+    except Exception as e:
+        logger.error(f"Failed to log session start: {e}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to log session start: {str(e)}"
         ) from e

--- a/src/services/statsig_service.py
+++ b/src/services/statsig_service.py
@@ -180,6 +180,72 @@ class StatsigService:
             logger.error(f"   Traceback:\n{traceback.format_exc()}")
             return False
 
+    def log_session_start(
+        self,
+        user_id: str,
+        platform: str = "web",
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        """
+        Log a session start event for DAU/WAU/MAU tracking.
+
+        This event is used by Statsig to compute Product Growth metrics
+        (Daily/Weekly/Monthly Active Users, stickiness, retention).
+
+        Args:
+            user_id: User identifier (required)
+            platform: Platform identifier (web, ios, android, desktop)
+            metadata: Optional additional session metadata
+
+        Returns:
+            True if logged successfully, False otherwise
+
+        Example:
+            statsig_service.log_session_start(
+                user_id="user123",
+                platform="web",
+                metadata={"version": "2.0.0", "referrer": "google"}
+            )
+        """
+        event_metadata = {"platform": platform}
+        if metadata:
+            event_metadata.update(metadata)
+
+        return self.log_event(
+            user_id=user_id,
+            event_name="session_start",
+            metadata=event_metadata,
+        )
+
+    def log_session_end(
+        self,
+        user_id: str,
+        session_duration_seconds: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        """
+        Log a session end event.
+
+        Args:
+            user_id: User identifier (required)
+            session_duration_seconds: Optional session duration in seconds
+            metadata: Optional additional session metadata
+
+        Returns:
+            True if logged successfully, False otherwise
+        """
+        event_metadata = {}
+        if session_duration_seconds is not None:
+            event_metadata["duration_seconds"] = str(session_duration_seconds)
+        if metadata:
+            event_metadata.update(metadata)
+
+        return self.log_event(
+            user_id=user_id,
+            event_name="session_end",
+            metadata=event_metadata if event_metadata else None,
+        )
+
     def get_feature_flag(self, flag_name: str, user_id: str, default_value: bool = False) -> bool:
         """
         Get a feature flag value for a user.


### PR DESCRIPTION
## Summary

Add session tracking events to properly populate Statsig's Product Growth metrics (DAU, WAU, MAU, stickiness, retention rates).

Currently, the Statsig dashboard shows "Recently Seen Users" correctly (394 yesterday, 2.74K past week) but the Product Growth metrics (DAU/WAU/MAU charts) are showing flat lines because they require `session_start` events to compute properly.

## Changes

| File | Change |
|------|--------|
| `src/services/statsig_service.py` | Add `log_session_start()` and `log_session_end()` methods |
| `src/routes/analytics.py` | Add `POST /v1/analytics/session/start` endpoint |
| `tests/services/test_statsig_service.py` | Add tests for session tracking |

## New API Endpoint

```
POST /v1/analytics/session/start
Content-Type: application/json

{
  "platform": "web",  // or "ios", "android", "desktop"
  "metadata": {       // optional
    "version": "2.0.0",
    "referrer": "google"
  }
}
```

## Frontend Integration Required

The frontend should call this endpoint when:
- User opens the app/website
- User logs in
- User returns after being idle (e.g., after 30 minutes)

Example:
```typescript
// On app mount or login
await fetch('/v1/analytics/session/start', {
  method: 'POST',
  headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
  body: JSON.stringify({ platform: 'web' })
});
```

## Test plan

- [ ] Deploy to staging
- [ ] Call the new endpoint manually and verify events appear in Statsig
- [ ] Check Statsig Product Growth metrics after 24-48 hours of data collection
- [ ] Verify DAU/WAU/MAU charts start showing real user counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds session tracking functionality to enable DAU/WAU/MAU metrics in Statsig dashboard by implementing `log_session_start()` and `log_session_end()` methods in `StatsigService`
- Creates new `POST /v1/analytics/session/start` endpoint that accepts platform and metadata parameters, logging session events to both Statsig and PostHog services
- Includes comprehensive test coverage for the new session tracking methods, verifying both fallback behavior and proper event logging with metadata

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| `src/services/statsig_service.py` | Adds session tracking methods with proper error handling and metadata support; minor type conversion issue with duration parameter |
| `src/routes/analytics.py` | New session tracking endpoint with Pydantic validation, authentication integration, and dual service logging |

<h3>Confidence score: 4/5</h3>


- This PR is safe to merge with minimal risk as it follows established patterns and includes comprehensive testing
- Score reflects a minor data type conversion issue where `session_duration_seconds` is unnecessarily converted to string, and dependency on frontend integration for full effectiveness  
- Pay close attention to `src/services/statsig_service.py` for the string conversion of duration parameter which may cause analytics issues

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Frontend
    participant Analytics_API
    participant Statsig_Service
    participant PostHog_Service
    participant Statsig_Dashboard

    User->>Frontend: "Opens app/logs in"
    Frontend->>Analytics_API: "POST /v1/analytics/session/start"
    Analytics_API->>Statsig_Service: "log_session_start(user_id, platform, metadata)"
    Analytics_API->>PostHog_Service: "capture(user_id, session_start, properties)"
    Statsig_Service->>Statsig_Dashboard: "Log session_start event"
    PostHog_Service->>PostHog_Service: "Log session_start event"
    Analytics_API->>Frontend: "Return success response"
    Frontend->>User: "App ready"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->