### PR TITLE
fix(chat): import traced decorator from braintrust SDK

### DIFF
--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -59,6 +59,8 @@ try:
         is_available as check_braintrust_available,
         NoopSpan,
     )
+    # Import traced decorator from braintrust SDK for route decoration
+    from braintrust import traced
 
     # Wrapper to maintain backward compatibility with existing code
     def start_span(name=None, span_type=None, **kwargs):


### PR DESCRIPTION
## Summary
- Fixes missing `traced` decorator import causing 404 on `/v1/chat/completions`
- The recent braintrust refactoring (commit ae147bbf) forgot to import `traced` when braintrust is available
- This caused a NameError preventing the chat route from registering

## Root Cause
When `BRAINTRUST_AVAILABLE = True`, the code defined `start_span` wrapper but forgot to import `traced` from the braintrust SDK. The `traced` decorator is used at line 1470: `@traced(name="chat_completions", type="llm")`, causing a `NameError: name 'traced' is not defined`.

## Test plan
- [ ] Deploy to staging and verify `/v1/chat/completions` returns 200
- [ ] Test chat functionality with cerebras/qwen-3-32b model
- [ ] Verify other providers work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Fixes critical missing `traced` decorator import in chat route that was causing 404 errors on `/v1/chat/completions` endpoint
- Adds proper fallback decorator for when Braintrust SDK is unavailable to ensure chat functionality works in all deployment scenarios

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/routes/chat.py | Fixed missing `traced` decorator import from Braintrust SDK and added no-op fallback decorator |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk as it only adds missing imports and fallback handling
- Score reflects a straightforward bug fix that restores critical chat endpoint functionality without introducing new complexity or breaking changes
- Pay close attention to verify the import structure correctly handles both Braintrust available/unavailable scenarios

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ChatRouter as Chat Router
    participant AuthService as Auth Service
    participant TrialService as Trial Service
    participant ProviderChain as Provider Chain
    participant UpstreamProvider as Upstream Provider
    participant CreditService as Credit Service
    participant MetricsService as Metrics Service
    participant ChatHistory as Chat History

    User->>ChatRouter: "POST /v1/chat/completions"
    ChatRouter->>AuthService: "get_user(api_key)"
    AuthService-->>ChatRouter: "user"
    ChatRouter->>TrialService: "validate_trial_access(api_key)"
    TrialService-->>ChatRouter: "trial"
    ChatRouter->>ProviderChain: "build_provider_failover_chain(provider)"
    ProviderChain-->>ChatRouter: "provider_chain"
    ChatRouter->>UpstreamProvider: "make_provider_request(messages, model, options)"
    UpstreamProvider-->>ChatRouter: "response"
    ChatRouter->>CreditService: "handle_credits_and_usage(api_key, user, tokens, cost)"
    CreditService-->>ChatRouter: "cost"
    ChatRouter->>MetricsService: "record_inference_metrics(provider, model, tokens, cost)"
    ChatRouter->>ChatHistory: "save_chat_message(session_id, content)"
    ChatRouter-->>User: "completion_response"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->