### PR TITLE
fix(models): add Claude Code native model ID aliases for OpenRouter compatibility

### DIFF
--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -126,6 +126,21 @@ MODEL_ID_ALIASES = {
     # Claude 4 series - Sonnet variants
     "claude-sonnet-4": "anthropic/claude-sonnet-4",
     "sonnet-4": "anthropic/claude-sonnet-4",
+    # Claude 4.5 series - Sonnet variants (Anthropic native dated format used by Claude Code)
+    "claude-sonnet-4-20250514": "anthropic/claude-sonnet-4.5",
+    "claude-sonnet-4.5-20250514": "anthropic/claude-sonnet-4.5",
+    "claude-4-5-sonnet-20250514": "anthropic/claude-sonnet-4.5",
+    "claude-4.5-sonnet-20250514": "anthropic/claude-sonnet-4.5",
+    "sonnet-4.5": "anthropic/claude-sonnet-4.5",
+    "claude-sonnet-4.5": "anthropic/claude-sonnet-4.5",
+    # Claude 4.5 series - Opus variants (Anthropic native dated format used by Claude Code)
+    "claude-opus-4-20250514": "anthropic/claude-opus-4.5",
+    "claude-opus-4.5-20250514": "anthropic/claude-opus-4.5",
+    "claude-4-5-opus-20250514": "anthropic/claude-opus-4.5",
+    "claude-4.5-opus-20250514": "anthropic/claude-opus-4.5",
+    # Claude 3.5 series (Anthropic native dated formats)
+    "claude-3-5-sonnet-20241022": "anthropic/claude-3.5-sonnet",
+    "claude-3-5-haiku-20241022": "anthropic/claude-3.5-haiku",
     # Claude 4 series - Haiku variants
     "claude-haiku-4.5": "anthropic/claude-haiku-4.5",
     "haiku-4.5": "anthropic/claude-haiku-4.5",
@@ -502,6 +517,18 @@ def get_model_id_mapping(provider: str) -> dict[str, str]:
             "claude-sonnet-4-5-20250929": CLAUDE_SONNET_4_5,
             "claude-opus-4.5": "anthropic/claude-opus-4.5",
             "claude-haiku-4.5": "anthropic/claude-haiku-4.5",
+            # Claude Code native format (Anthropic API dated model IDs)
+            "claude-sonnet-4-20250514": CLAUDE_SONNET_4_5,
+            "claude-sonnet-4.5-20250514": CLAUDE_SONNET_4_5,
+            "claude-4-5-sonnet-20250514": CLAUDE_SONNET_4_5,
+            "claude-4.5-sonnet-20250514": CLAUDE_SONNET_4_5,
+            "claude-opus-4-20250514": "anthropic/claude-opus-4.5",
+            "claude-opus-4.5-20250514": "anthropic/claude-opus-4.5",
+            "claude-4-5-opus-20250514": "anthropic/claude-opus-4.5",
+            "claude-4.5-opus-20250514": "anthropic/claude-opus-4.5",
+            # Claude 3.5 series (Anthropic native dated formats)
+            "claude-3-5-sonnet-20241022": "anthropic/claude-3.5-sonnet",
+            "claude-3-5-haiku-20241022": "anthropic/claude-3.5-haiku",
             # Google Gemini models on OpenRouter
             "google/gemini-3-flash-preview": "google/gemini-3-flash-preview",
             "google/gemini-3-pro-preview": "google/gemini-3-pro-preview",


### PR DESCRIPTION
## Summary
- Add model ID aliases for Anthropic-native dated format model IDs that Claude Code uses
- Maps `claude-sonnet-4-20250514` → `anthropic/claude-sonnet-4.5` (and similar)
- Fixes the error: "anthropic/claude-sonnet-4.5-20250514 is not a valid model ID" when using Claude Code Router (ccr) with GatewayZ

## Changes
Added aliases in `MODEL_ID_ALIASES` and OpenRouter provider mapping:
- `claude-sonnet-4-20250514` → `anthropic/claude-sonnet-4.5`
- `claude-opus-4-20250514` → `anthropic/claude-opus-4.5`
- `claude-3-5-sonnet-20241022` → `anthropic/claude-3.5-sonnet`
- `claude-3-5-haiku-20241022` → `anthropic/claude-3.5-haiku`
- Plus variant spellings

## Test plan
- [x] Verified aliases work with `apply_model_alias()` function
- [x] Verified `transform_model_id()` correctly maps to OpenRouter format
- [ ] Manual test with Claude Code Router

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds Claude Code router compatibility by mapping Anthropic's native dated model ID format to GatewayZ's internal format
- Implements model ID aliases for Claude 4.5 and 3.5 models (e.g., `claude-sonnet-4-20250514` → `anthropic/claude-sonnet-4.5`)
- Extends existing model transformation system in `src/services/model_transformations.py` to support Claude Code Router integration

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/services/model_transformations.py | Added 15 new model ID aliases for Claude models to support Anthropic native dated format compatibility |

<h3>Confidence score: 5/5</h3>


- This PR is extremely safe to merge with minimal risk
- Score reflects simple alias additions following existing well-established patterns in the codebase without any complex logic changes
- No files require special attention as this is a straightforward compatibility enhancement

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ModelTransformations
    participant Registry as "Multi-Provider Registry"
    participant ProviderSelector
    participant ModelAliases as "MODEL_ID_ALIASES"
    participant ProviderMappings as "Provider Mappings"

    User->>ModelTransformations: "transform_model_id('claude-sonnet-4-20250514', 'openrouter')"
    ModelTransformations->>ModelAliases: "apply_model_alias('claude-sonnet-4-20250514')"
    ModelAliases-->>ModelTransformations: "anthropic/claude-sonnet-4.5"
    
    ModelTransformations->>Registry: "get_registry().has_model('anthropic/claude-sonnet-4.5')"
    Registry-->>ModelTransformations: "false"
    
    ModelTransformations->>ProviderMappings: "get_model_id_mapping('openrouter')"
    ProviderMappings-->>ModelTransformations: "mapping dict"
    
    ModelTransformations->>ProviderMappings: "Check mapping['claude-sonnet-4-20250514']"
    ProviderMappings-->>ModelTransformations: "anthropic/claude-sonnet-4.5"
    
    ModelTransformations-->>User: "anthropic/claude-sonnet-4.5"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->