### PR TITLE
fix(router): rename 'auto' prefix to 'router' to avoid OpenRouter conflict

### DIFF
--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -532,7 +532,8 @@ PROVIDER_TIMEOUTS = {
 }
 
 # Auto-routing constants
-AUTO_ROUTE_MODEL_PREFIX = "auto"
+# Using "router" prefix to avoid confusion with OpenRouter's "openrouter/auto" model
+AUTO_ROUTE_MODEL_PREFIX = "router"
 AUTO_ROUTE_DEFAULT_MODEL = "openai/gpt-4o-mini"
 
 

--- a/src/services/prompt_router.py
+++ b/src/services/prompt_router.py
@@ -373,11 +373,14 @@ def route_request(
 
 
 def is_auto_route_request(model: str) -> bool:
-    """Check if a model string indicates auto-routing."""
+    """Check if a model string indicates auto-routing.
+
+    Uses 'router' prefix to avoid confusion with OpenRouter's 'openrouter/auto' model.
+    """
     if not model:
         return False
     model_lower = model.lower()
-    return model_lower.startswith("auto")
+    return model_lower.startswith("router")
 
 
 def parse_auto_route_options(model: str) -> tuple[str, RouterOptimization]:
@@ -385,13 +388,13 @@ def parse_auto_route_options(model: str) -> tuple[str, RouterOptimization]:
     Parse auto-route model string into tier and optimization.
 
     Examples:
-        "auto" -> ("small", BALANCED)
-        "auto:small" -> ("small", BALANCED)
-        "auto:medium" -> ("medium", BALANCED)
-        "auto:price" -> ("small", PRICE)
-        "auto:quality" -> ("medium", QUALITY)
+        "router" -> ("small", BALANCED)
+        "router:small" -> ("small", BALANCED)
+        "router:medium" -> ("medium", BALANCED)
+        "router:price" -> ("small", PRICE)
+        "router:quality" -> ("medium", QUALITY)
     """
-    if not model or not model.lower().startswith("auto"):
+    if not model or not model.lower().startswith("router"):
         return ("small", RouterOptimization.BALANCED)
 
     parts = model.lower().split(":")

--- a/tests/services/test_prompt_router.py
+++ b/tests/services/test_prompt_router.py
@@ -502,37 +502,40 @@ class TestAutoRouteHelpers:
 
     def test_is_auto_route_request(self):
         """Test detection of auto-route requests."""
-        assert is_auto_route_request("auto") is True
-        assert is_auto_route_request("AUTO") is True
-        assert is_auto_route_request("auto:small") is True
-        assert is_auto_route_request("auto:price") is True
+        # Router prefix should trigger auto-routing
+        assert is_auto_route_request("router") is True
+        assert is_auto_route_request("ROUTER") is True
+        assert is_auto_route_request("router:small") is True
+        assert is_auto_route_request("router:price") is True
+        # Other models should not trigger auto-routing
         assert is_auto_route_request("gpt-4o") is False
+        assert is_auto_route_request("openrouter/auto") is False  # OpenRouter's auto model
         assert is_auto_route_request("") is False
         assert is_auto_route_request(None) is False
 
     def test_parse_auto_route_options(self):
         """Test parsing of auto-route options."""
-        tier, opt = parse_auto_route_options("auto")
+        tier, opt = parse_auto_route_options("router")
         assert tier == "small"
         assert opt == RouterOptimization.BALANCED
 
-        tier, opt = parse_auto_route_options("auto:small")
+        tier, opt = parse_auto_route_options("router:small")
         assert tier == "small"
         assert opt == RouterOptimization.BALANCED
 
-        tier, opt = parse_auto_route_options("auto:medium")
+        tier, opt = parse_auto_route_options("router:medium")
         assert tier == "medium"
         assert opt == RouterOptimization.BALANCED
 
-        tier, opt = parse_auto_route_options("auto:price")
+        tier, opt = parse_auto_route_options("router:price")
         assert tier == "small"
         assert opt == RouterOptimization.PRICE
 
-        tier, opt = parse_auto_route_options("auto:quality")
+        tier, opt = parse_auto_route_options("router:quality")
         assert tier == "medium"
         assert opt == RouterOptimization.QUALITY
 
-        tier, opt = parse_auto_route_options("auto:fast")
+        tier, opt = parse_auto_route_options("router:fast")
         assert tier == "small"
         assert opt == RouterOptimization.FAST
 


### PR DESCRIPTION
## Summary
Rename the auto-routing model prefix from `auto` to `router` to prevent potential confusion with OpenRouter's `openrouter/auto` model.

## Problem
OpenRouter has their own auto-routing feature accessible via `openrouter/auto` model ID. While our current implementation (`auto`) wouldn't technically conflict (since `openrouter/auto` starts with "openrouter", not "auto"), using a more distinct prefix avoids user confusion and future conflicts.

## Solution
Changed the prefix from `auto` to `router`:

| Old Usage | New Usage |
|-----------|-----------|
| `auto` | `router` |
| `auto:small` | `router:small` |
| `auto:medium` | `router:medium` |
| `auto:large` | `router:large` |
| `auto:price` | `router:price` |
| `auto:quality` | `router:quality` |
| `auto:fast` | `router:fast` |

## Test plan
- [x] Updated tests to use new prefix
- [x] Added test case for `openrouter/auto` to ensure it doesn't trigger our router
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Renames internal auto-routing model prefix from `auto` to `router` to avoid confusion with OpenRouter's `openrouter/auto` model (e.g., `auto:small` becomes `router:small`)
- Updates routing logic and validation tests to use new prefix while ensuring OpenRouter's auto feature remains unaffected
- Changes are isolated to routing identification logic without affecting the underlying routing functionality

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/routes/chat.py | Updated `AUTO_ROUTE_MODEL_PREFIX` constant from "auto" to "router" |
| src/services/prompt_router.py | Updated auto-route detection and parsing functions to use "router" prefix |
| tests/services/test_prompt_router.py | Updated all test cases to use new prefix and added explicit test that `openrouter/auto` doesn't trigger internal router |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk as it's a straightforward naming change that improves API clarity
- Score reflects well-contained changes with comprehensive test coverage and clear intent to prevent user confusion
- All files have been updated consistently and tests verify the boundary case with OpenRouter's native auto feature

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ChatRoute as "Chat Route"
    participant PromptRouter as "Prompt Router"
    participant CapabilityGating as "Capability Gating"
    participant HealthSnapshots as "Health Snapshots"
    participant ClassifierRules as "Classifier Rules"
    participant ModelSelector as "Model Selector"
    participant ProviderRouting as "Provider Routing"
    participant Upstream as "Upstream Provider"

    User->>ChatRoute: "POST /v1/chat/completions"
    ChatRoute->>ChatRoute: "Check if model starts with 'router'"
    
    Note over ChatRoute: Auto-routing detected
    
    ChatRoute->>PromptRouter: "route_request(messages, tools, etc.)"
    PromptRouter->>CapabilityGating: "extract_capabilities(messages, tools, response_format)"
    CapabilityGating-->>PromptRouter: "RequiredCapabilities"
    
    PromptRouter->>HealthSnapshots: "get_healthy_models_sync(tier)"
    HealthSnapshots-->>PromptRouter: "healthy_models[]"
    
    PromptRouter->>CapabilityGating: "filter_by_capabilities(healthy_models, requirements)"
    CapabilityGating-->>PromptRouter: "capable_models[]"
    
    PromptRouter->>ClassifierRules: "classify_prompt(messages)"
    ClassifierRules-->>PromptRouter: "ClassificationResult"
    
    PromptRouter->>ModelSelector: "select_model(candidates, classification, optimization)"
    ModelSelector-->>PromptRouter: "selected_model, reason"
    
    PromptRouter-->>ChatRoute: "RouterDecision with selected_model"
    
    ChatRoute->>ChatRoute: "Update req.model with selected_model"
    ChatRoute->>ProviderRouting: "Make request with transformed model"
    ProviderRouting->>Upstream: "API call"
    Upstream-->>ProviderRouting: "Response"
    ProviderRouting-->>ChatRoute: "Processed response"
    ChatRoute-->>User: "Chat completion response"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->