### PR TITLE
fix(schema): add tiered credit fields to UserProfileResponse

### DIFF
--- a/src/schemas/users.py
+++ b/src/schemas/users.py
@@ -56,6 +56,11 @@ class UserProfileResponse(BaseModel):
     user_id: int
     api_key: str
     credits: int
+    # Tiered credit fields (in cents for frontend consistency)
+    subscription_allowance: int | None = None  # Monthly subscription allowance remaining
+    purchased_credits: int | None = None  # One-time purchased credits
+    total_credits: int | None = None  # Computed sum of both
+    allowance_reset_date: str | None = None  # When allowance was last reset
     username: str | None
     email: str | None
     auth_method: str | None

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -451,6 +451,10 @@ class TestUserProfileResponse:
             user_id=1,
             api_key="gw_live_key",
             credits=100,
+            subscription_allowance=1500,  # $15.00 in cents
+            purchased_credits=500,  # $5.00 in cents
+            total_credits=2000,  # $20.00 in cents
+            allowance_reset_date="2024-01-01T00:00:00Z",
             username="testuser",
             email="test@example.com",
             auth_method="email",
@@ -466,6 +470,73 @@ class TestUserProfileResponse:
         assert response.email == "test@example.com"
         assert response.is_active is True
         assert response.subscription_status == "active"
+        # Verify tiered credit fields
+        assert response.subscription_allowance == 1500
+        assert response.purchased_credits == 500
+        assert response.total_credits == 2000
+        assert response.allowance_reset_date == "2024-01-01T00:00:00Z"
+
+    def test_create_with_tiered_credits_for_pro_user(self):
+        """Test creating profile response with tiered credits for a PRO user"""
+        from src.schemas.users import UserProfileResponse
+
+        response = UserProfileResponse(
+            user_id=1,
+            api_key="gw_live_key",
+            credits=1500,  # Total credits in cents ($15.00)
+            subscription_allowance=1500,  # PRO tier monthly allowance in cents
+            purchased_credits=0,  # No purchased credits
+            total_credits=1500,
+            allowance_reset_date="2024-02-01T00:00:00Z",
+            username="prouser",
+            email="pro@example.com",
+            auth_method="email",
+            subscription_status="active",
+            tier="pro",
+            tier_display_name="Pro",
+            trial_expires_at=None,
+            is_active=True,
+            registration_date="2024-01-01",
+            created_at="2024-01-01T00:00:00Z",
+            updated_at="2024-01-15T12:00:00Z"
+        )
+
+        assert response.tier == "pro"
+        assert response.tier_display_name == "Pro"
+        assert response.subscription_allowance == 1500
+        assert response.purchased_credits == 0
+        assert response.total_credits == 1500
+
+    def test_create_with_tiered_credits_for_max_user(self):
+        """Test creating profile response with tiered credits for a MAX user"""
+        from src.schemas.users import UserProfileResponse
+
+        response = UserProfileResponse(
+            user_id=2,
+            api_key="gw_live_key",
+            credits=16000,  # Total credits in cents ($160.00)
+            subscription_allowance=15000,  # MAX tier monthly allowance in cents ($150.00)
+            purchased_credits=1000,  # $10.00 purchased credits
+            total_credits=16000,
+            allowance_reset_date="2024-02-01T00:00:00Z",
+            username="maxuser",
+            email="max@example.com",
+            auth_method="email",
+            subscription_status="active",
+            tier="max",
+            tier_display_name="MAX",
+            trial_expires_at=None,
+            is_active=True,
+            registration_date="2024-01-01",
+            created_at="2024-01-01T00:00:00Z",
+            updated_at="2024-01-15T12:00:00Z"
+        )
+
+        assert response.tier == "max"
+        assert response.tier_display_name == "MAX"
+        assert response.subscription_allowance == 15000
+        assert response.purchased_credits == 1000
+        assert response.total_credits == 16000
 
 
 class TestDeleteAccountRequest:


### PR DESCRIPTION
## Summary

- Add missing tiered credit fields to `UserProfileResponse` Pydantic schema
- Fields added: `subscription_allowance`, `purchased_credits`, `total_credits`, `allowance_reset_date`
- Add comprehensive tests for the new schema fields

## Problem

The `/user/profile` endpoint was not returning tiered credit fields (Monthly Allowance, Purchased Credits) to the frontend because they were missing from the Pydantic response model. This caused the Credits page to show empty values for PRO and MAX tier users.

## Solution

Added the missing fields to `UserProfileResponse` in `src/schemas/users.py` so FastAPI includes them in the API response.

## Test plan

- [x] Added schema tests for PRO and MAX tier users with tiered credits
- [x] Updated route tests to verify tiered credit fields in API response
- [x] Updated mock fixtures to include tiered credit fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added missing tiered credit fields (`subscription_allowance`, `purchased_credits`, `total_credits`, `allowance_reset_date`) to the `UserProfileResponse` Pydantic schema. These fields are returned by the database layer but were previously excluded from the API response, causing the frontend Credits page to show empty values for PRO and MAX tier users.

**Changes:**
- Added 4 optional integer/string fields to `UserProfileResponse` schema with descriptive comments
- Updated test fixtures in `test_users.py` to include tiered credit data (in cents) for PRO tier users
- Added new test case `test_get_profile_with_max_tier_tiered_credits` to verify MAX tier user responses
- Added comprehensive schema validation tests in `test_schemas.py` for both PRO and MAX tier scenarios
- All credit values are properly converted from dollars (database) to cents (frontend) for consistency with `TIER_CONFIG`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward schema additions with comprehensive test coverage. The fields were already being populated by the database layer (src/db/users.py) and simply needed to be exposed through the Pydantic response model. All new fields are optional (nullable), ensuring backward compatibility. Tests cover both PRO and MAX tier scenarios with proper validation.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/schemas/users.py | Added four optional tiered credit fields to UserProfileResponse schema with clear comments explaining their purpose |
| tests/test_schemas.py | Added comprehensive tests for tiered credit fields including PRO and MAX tier scenarios with proper validation |
| tests/routes/test_users.py | Updated mock fixtures and added test cases for PRO and MAX tier users to verify tiered credit fields in API responses |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Frontend Client
    participant API as GET /user/profile
    participant Route as routes/users.py
    participant DB as db/users.py
    participant Schema as UserProfileResponse
    participant Database as Supabase DB

    Client->>API: GET /user/profile
    API->>Route: get_user_profile_endpoint()
    Route->>DB: get_user(api_key)
    DB->>Database: SELECT user data
    Database-->>DB: User record with tier info
    DB-->>Route: User object
    Route->>DB: get_user_profile(api_key)
    DB->>Database: SELECT user profile fields
    Note over DB: Includes subscription_allowance,<br/>purchased_credits,<br/>allowance_reset_date
    Database-->>DB: User data (in dollars)
    Note over DB: Convert dollars to cents:<br/>subscription_allowance * 100<br/>purchased_credits * 100<br/>total_credits = sum * 100
    DB-->>Route: Profile dict with tiered fields (in cents)
    Route->>Schema: Validate with UserProfileResponse
    Note over Schema: Now includes 4 new fields:<br/>subscription_allowance (int | None)<br/>purchased_credits (int | None)<br/>total_credits (int | None)<br/>allowance_reset_date (str | None)
    Schema-->>Route: Validated response model
    Route-->>API: UserProfileResponse
    API-->>Client: JSON response with tiered credits
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->