### PR TITLE
fix(telemetry): remove duplicate /v1/traces path from OTLP endpoint

### DIFF
--- a/src/config/opentelemetry_config.py
+++ b/src/config/opentelemetry_config.py
@@ -188,9 +188,11 @@ class OpenTelemetryConfig:
             cls._tracer_provider = TracerProvider(resource=resource)
 
             # Create OTLP exporter with error handling for connection issues
+            # Note: OTLPSpanExporter automatically appends /v1/traces to the endpoint
+            # so we only provide the base URL (e.g., http://tempo:4318)
             try:
                 otlp_exporter = OTLPSpanExporter(
-                    endpoint=f"{tempo_endpoint}/v1/traces",
+                    endpoint=tempo_endpoint,
                     headers={},  # Add authentication headers if needed
                     timeout=10,  # 10 second timeout to prevent hanging (Railway cross-project)
                 )


### PR DESCRIPTION
## Summary
Fixes the 404 errors seen in Sentry for OTLP span export.

## Root Cause
The OpenTelemetry SDK's `OTLPSpanExporter` automatically appends `/v1/traces` to the endpoint URL internally. The code was also manually adding it, causing a double path issue:
- Input: `http://tempo:4318`
- After manual append: `http://tempo:4318/v1/traces`
- After SDK append: `http://tempo:4318/v1/traces/v1/traces` → **404**

## Fix
Remove the manual `/v1/traces` suffix, matching the correct implementation in `tempo_otlp.py`.

## Error Fixed
```
Failed to export span batch code: 404, reason: 404 page not found
```

## Test Plan
- [ ] Deploy to staging and verify no 404 errors in Tempo span export
- [ ] Verify traces appear in Grafana Tempo dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized telemetry endpoint configuration for improved observability infrastructure compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Removed the manual `/v1/traces` path suffix from the OTLP endpoint configuration. The `OTLPSpanExporter` SDK automatically appends this path, so the manual append was causing a duplicate path (`/v1/traces/v1/traces`) resulting in 404 errors.

- Changed line 195 from `endpoint=f"{tempo_endpoint}/v1/traces"` to `endpoint=tempo_endpoint`
- Added clear comment explaining the SDK behavior
- Matches the correct implementation already used in `tempo_otlp.py:128`

This fix resolves the 404 errors reported in Sentry for span exports to Grafana Tempo.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is a simple, well-documented correction that removes duplicate path handling. The change matches the already-working implementation in `tempo_otlp.py` and directly addresses the reported 404 errors. The fix is minimal (2 lines changed + comment), clearly explained, and follows SDK documentation.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/config/opentelemetry_config.py | Fixed duplicate `/v1/traces` path by removing manual append (SDK adds it automatically) |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as FastAPI Application
    participant Config as OpenTelemetryConfig
    participant SDK as OTLPSpanExporter SDK
    participant Tempo as Grafana Tempo

    Note over App,Tempo: Before Fix (404 Error)
    App->>Config: Initialize tracing
    Config->>Config: Manually append /v1/traces<br/>tempo_endpoint + "/v1/traces"
    Config->>SDK: OTLPSpanExporter(endpoint)
    SDK->>SDK: Automatically append /v1/traces
    SDK->>Tempo: POST /v1/traces/v1/traces
    Tempo-->>SDK: 404 Not Found
    
    Note over App,Tempo: After Fix (Working)
    App->>Config: Initialize tracing
    Config->>SDK: OTLPSpanExporter(tempo_endpoint)
    SDK->>SDK: Automatically append /v1/traces
    SDK->>Tempo: POST /v1/traces
    Tempo-->>SDK: 200 OK
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->