### PR TITLE
fix(auth): add tiered credit fields to auth response

### DIFF
--- a/src/schemas/auth.py
+++ b/src/schemas/auth.py
@@ -129,3 +129,8 @@ class PrivyAuthResponse(BaseModel):
     tier_display_name: str | None = None
     trial_expires_at: str | None = None
     subscription_end_date: int | None = None
+    # Tiered credit fields (in cents for frontend consistency)
+    subscription_allowance: int | None = None  # Monthly subscription allowance
+    purchased_credits: int | None = None  # One-time purchased credits
+    total_credits: int | None = None  # Sum of subscription_allowance + purchased_credits
+    allowance_reset_date: str | None = None  # When allowance was last reset


### PR DESCRIPTION
## Summary
- Add tiered credit fields to `PrivyAuthResponse` schema
- Calculate tiered credit breakdown for existing users with legacy fallback
- Include tiered credits for new users (trial credits → purchased_credits)
- Convert credits from dollars to cents for frontend consistency

## Problem
The frontend Credit Breakdown section was showing $0.00 because the auth endpoint wasn't returning:
- `subscription_allowance`
- `purchased_credits`
- `total_credits`
- `allowance_reset_date`

## Solution
The auth endpoint now returns these fields, using the same logic as `get_user_profile()`:
- For Pro/Max subscribers with legacy credits → `subscription_allowance`
- For basic users → `purchased_credits`
- All values converted to cents for frontend consistency

## Test plan
- [ ] Verify existing user login returns tiered credit fields
- [ ] Verify new user registration returns tiered credit fields
- [ ] Verify Credit Breakdown displays correct values in frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds tiered credit fields to the auth endpoint response to fix the frontend Credit Breakdown display showing $0.00.

**Changes:**
- Added four optional fields to `PrivyAuthResponse`: `subscription_allowance`, `purchased_credits`, `total_credits`, and `allowance_reset_date` (all in cents for frontend consistency)
- Implemented credit breakdown calculation in `_handle_existing_user()` using the same logic as `get_user_profile()`
- Added credit calculation for new user registration, where trial credits are mapped to `purchased_credits`
- Correctly handles legacy credits fallback: Pro/Max active subscribers get legacy credits as `subscription_allowance`, basic users get them as `purchased_credits`
- Converts all credit values from dollars (database format) to cents (frontend format) by multiplying by 100

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation correctly mirrors the existing `get_user_profile()` logic, properly handles edge cases (legacy credits fallback, None values), and maintains backward compatibility by adding optional fields. The dollar-to-cent conversion is mathematically sound, and the logic appropriately distinguishes between subscription allowances and purchased credits based on tier and subscription status.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/schemas/auth.py | Added four optional tiered credit fields to `PrivyAuthResponse` schema with clear documentation |
| src/routes/auth.py | Implemented tiered credit calculation logic for both existing and new users, matching `get_user_profile()` pattern |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Frontend
    participant AuthEndpoint as Auth Endpoint
    participant Database as Supabase DB
    participant Response as PrivyAuthResponse
    
    alt Existing User Login
        Frontend->>AuthEndpoint: POST /privy/auth (existing user)
        AuthEndpoint->>Database: Fetch user data
        Database-->>AuthEndpoint: User record with credits fields
        AuthEndpoint->>AuthEndpoint: Calculate tiered credits<br/>(subscription_allowance, purchased_credits)
        Note over AuthEndpoint: Convert dollars to cents (×100)
        Note over AuthEndpoint: Handle legacy credits fallback<br/>based on tier and subscription status
        AuthEndpoint->>Response: Build response with tiered fields
        Response-->>Frontend: Return auth response (cents)
    else New User Registration
        Frontend->>AuthEndpoint: POST /privy/auth (new user)
        AuthEndpoint->>Database: Create user with trial credits
        Database-->>AuthEndpoint: New user data
        AuthEndpoint->>AuthEndpoint: Set trial credits as purchased_credits
        Note over AuthEndpoint: subscription_allowance = 0<br/>purchased_credits = trial_credits × 100<br/>total_credits = purchased_credits
        AuthEndpoint->>Response: Build response with tiered fields
        Response-->>Frontend: Return auth response (cents)
    end
    
    Note over Frontend: Display Credit Breakdown<br/>with subscription_allowance,<br/>purchased_credits, total_credits
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->