### PR TITLE
feat(users): add settings column for auto top-up configuration

### DIFF
--- a/src/db/users.py
+++ b/src/db/users.py
@@ -1658,6 +1658,7 @@ def get_user_profile(api_key: str) -> dict[str, Any]:
             "subscription_end_date": user.get("subscription_end_date"),  # Unix timestamp
             "is_active": user.get("is_active"),
             "registration_date": user.get("registration_date"),
+            "settings": user.get("settings"),  # User settings including auto top-up configuration
         }
 
         logger.info(f"Profile built successfully for user {user.get('id')}")

--- a/src/schemas/users.py
+++ b/src/schemas/users.py
@@ -68,6 +68,7 @@ class UserProfileResponse(BaseModel):
     registration_date: str | None
     created_at: str | None
     updated_at: str | None
+    settings: dict[str, Any] | None = None  # User settings including auto top-up configuration
 
 
 class DeleteAccountRequest(BaseModel):

--- a/supabase/migrations/20260125000000_add_user_settings_column.sql
+++ b/supabase/migrations/20260125000000_add_user_settings_column.sql
@@ -1,0 +1,92 @@
+-- Migration: Add User Settings Column
+-- Description: Adds settings JSONB column to users table for storing user-specific
+--              configuration like auto top-up settings
+-- Date: 2026-01-25
+
+-- ============================================================================
+-- 1. Add settings column to users table for storing user settings
+-- ============================================================================
+
+-- Add settings JSONB column to users table if it doesn't exist
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+        AND table_name = 'users'
+        AND column_name = 'settings'
+    ) THEN
+        ALTER TABLE public.users
+        ADD COLUMN settings JSONB DEFAULT '{}'::jsonb;
+
+        COMMENT ON COLUMN public.users.settings IS
+            'User settings including auto top-up configuration. Example: {"auto_topup_enabled": true, "auto_topup_threshold": 500, "auto_topup_amount": 2500}';
+    END IF;
+END $$;
+
+-- Create GIN index for fast JSONB queries on settings
+CREATE INDEX IF NOT EXISTS idx_users_settings
+ON public.users USING GIN (settings);
+
+-- ============================================================================
+-- 2. Create function for getting user auto top-up settings
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.get_user_auto_topup_settings(p_user_id BIGINT)
+RETURNS TABLE (
+    auto_topup_enabled BOOLEAN,
+    auto_topup_threshold INTEGER,
+    auto_topup_amount INTEGER
+)
+LANGUAGE plpgsql
+STABLE
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        COALESCE((settings->>'auto_topup_enabled')::boolean, false) AS auto_topup_enabled,
+        COALESCE((settings->>'auto_topup_threshold')::integer, 0) AS auto_topup_threshold,
+        COALESCE((settings->>'auto_topup_amount')::integer, 0) AS auto_topup_amount
+    FROM public.users
+    WHERE id = p_user_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_user_auto_topup_settings IS
+    'Returns auto top-up settings for a user. Threshold and amount are in cents.';
+
+-- ============================================================================
+-- 3. Create function to get users eligible for auto top-up
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.get_users_needing_auto_topup()
+RETURNS TABLE (
+    user_id BIGINT,
+    email TEXT,
+    current_balance NUMERIC,
+    auto_topup_threshold INTEGER,
+    auto_topup_amount INTEGER,
+    stripe_customer_id TEXT
+)
+LANGUAGE plpgsql
+STABLE
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        u.id AS user_id,
+        u.email,
+        COALESCE(u.subscription_allowance, 0) + COALESCE(u.purchased_credits, 0) AS current_balance,
+        COALESCE((u.settings->>'auto_topup_threshold')::integer, 0) AS auto_topup_threshold,
+        COALESCE((u.settings->>'auto_topup_amount')::integer, 0) AS auto_topup_amount,
+        u.stripe_customer_id
+    FROM public.users u
+    WHERE (u.settings->>'auto_topup_enabled')::boolean = true
+        AND u.stripe_customer_id IS NOT NULL
+        AND (COALESCE(u.subscription_allowance, 0) + COALESCE(u.purchased_credits, 0)) * 100 <
+            COALESCE((u.settings->>'auto_topup_threshold')::integer, 0);
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_users_needing_auto_topup IS
+    'Returns users who have auto top-up enabled and whose balance is below their threshold. Used by the auto top-up cron job.';


### PR DESCRIPTION
## Summary
- Add `settings` JSONB column to users table via migration
- Add `settings` field to `UserProfileResponse` schema
- Include settings in `get_user_profile` response
- Add helper functions for auto top-up settings lookup

This enables the frontend auto top-up feature to persist user settings to the database.

## Changes
- **Migration**: `20260125000000_add_user_settings_column.sql`
  - Adds `settings` JSONB column with default `{}`
  - Creates GIN index for fast JSONB queries
  - Adds `get_user_auto_topup_settings()` function
  - Adds `get_users_needing_auto_topup()` function for future cron job

- **Schema**: Added `settings` field to `UserProfileResponse`
- **Database**: Added `settings` to profile response in `get_user_profile()`

## Test plan
- [x] Frontend tests pass (85 tests)
- [ ] Deploy migration to database
- [ ] Test auto top-up settings save/load via frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `settings` JSONB column to the users table to support auto top-up configuration persistence. The changes include database migration, schema updates, and API integration.

**What Changed:**
- Added `settings` JSONB column to `users` table with GIN index for performance
- Added `get_user_auto_topup_settings(user_id)` helper function to retrieve auto top-up settings
- Added `get_users_needing_auto_topup()` function for future cron job to identify users needing auto top-up
- Updated `UserProfileResponse` schema to include `settings` field
- Updated `get_user_profile()` to return the `settings` field to the frontend
- Existing `update_user_profile()` already supports updating `settings` (no changes needed)

**Critical Issue Found:**
The `get_users_needing_auto_topup()` function has a **critical balance comparison bug** on line 86 that will cause incorrect auto top-up triggers. The database stores credits in dollars (DECIMAL), but the query multiplies by 100 before comparing to the threshold in cents, creating a unit mismatch.

<h3>Confidence Score: 1/5</h3>

- DO NOT MERGE - Critical bug will cause incorrect auto top-up behavior
- The migration contains a critical logical error in the balance comparison (line 86) that will cause auto top-up to trigger at incorrect thresholds. Credits are stored in dollars in the database, but the query multiplies by 100 and compares against cents, creating a unit mismatch. This must be fixed before deployment.
- The migration file `supabase/migrations/20260125000000_add_user_settings_column.sql` requires immediate attention to fix the balance comparison logic in `get_users_needing_auto_topup()` function.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| supabase/migrations/20260125000000_add_user_settings_column.sql | adds `settings` JSONB column with helper functions, but contains critical balance comparison bug |
| src/schemas/users.py | added `settings` field to `UserProfileResponse` schema correctly |
| src/db/users.py | included `settings` in `get_user_profile` response with appropriate comment |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Frontend
    participant API as API (routes/users.py)
    participant DB as Database Layer (db/users.py)
    participant Supabase as PostgreSQL (users table)

    Note over Frontend,Supabase: Save Auto Top-Up Settings Flow
    Frontend->>API: PUT /user/profile<br/>{settings: {auto_topup_enabled: true, ...}}
    API->>DB: update_user_profile(api_key, {settings: {...}})
    DB->>Supabase: UPDATE users SET settings = {...}::jsonb
    Supabase-->>DB: Updated user row
    DB-->>API: Updated user data
    API-->>Frontend: UserProfileResponse with settings

    Note over Frontend,Supabase: Load User Profile with Settings Flow
    Frontend->>API: GET /user/profile
    API->>DB: get_user_profile(api_key)
    DB->>Supabase: SELECT * FROM users WHERE api_key = ?
    Supabase-->>DB: User row with settings JSONB
    DB-->>API: Profile dict including settings field
    API-->>Frontend: UserProfileResponse (settings in cents)

    Note over Supabase: Future Cron Job Flow
    Supabase->>Supabase: get_users_needing_auto_topup()
    Note right of Supabase: Returns users where:<br/>- auto_topup_enabled = true<br/>- balance < threshold<br/>- has stripe_customer_id
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->