### PR TITLE
fix(migration): correct balance comparison in get_users_needing_auto_topup

### DIFF
--- a/supabase/migrations/20260125100000_fix_auto_topup_balance_comparison.sql
+++ b/supabase/migrations/20260125100000_fix_auto_topup_balance_comparison.sql
@@ -1,0 +1,44 @@
+-- Migration: Fix Auto Top-Up Balance Comparison
+-- Description: Fixes the balance comparison in get_users_needing_auto_topup function.
+--              The previous version incorrectly multiplied the balance by 100, but
+--              since the database stores credits in dollars and thresholds in cents,
+--              we need to divide the threshold by 100 instead.
+-- Date: 2026-01-25
+
+-- ============================================================================
+-- Fix the get_users_needing_auto_topup function
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.get_users_needing_auto_topup()
+RETURNS TABLE (
+    user_id BIGINT,
+    email TEXT,
+    current_balance NUMERIC,
+    auto_topup_threshold INTEGER,
+    auto_topup_amount INTEGER,
+    stripe_customer_id TEXT
+)
+LANGUAGE plpgsql
+STABLE
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        u.id AS user_id,
+        u.email,
+        COALESCE(u.subscription_allowance, 0) + COALESCE(u.purchased_credits, 0) AS current_balance,
+        COALESCE((u.settings->>'auto_topup_threshold')::integer, 0) AS auto_topup_threshold,
+        COALESCE((u.settings->>'auto_topup_amount')::integer, 0) AS auto_topup_amount,
+        u.stripe_customer_id
+    FROM public.users u
+    WHERE (u.settings->>'auto_topup_enabled')::boolean = true
+        AND u.stripe_customer_id IS NOT NULL
+        -- Compare balance (in dollars) to threshold (in cents converted to dollars)
+        -- Example: balance $5.00 < threshold 1000 cents / 100 = $10.00 -> triggers top-up
+        AND (COALESCE(u.subscription_allowance, 0) + COALESCE(u.purchased_credits, 0)) <
+            COALESCE((u.settings->>'auto_topup_threshold')::integer, 0) / 100.0;
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_users_needing_auto_topup IS
+    'Returns users who have auto top-up enabled and whose balance (in dollars) is below their threshold (stored in cents, converted to dollars). Used by the auto top-up cron job.';


### PR DESCRIPTION
## Summary
Fixes a bug in the `get_users_needing_auto_topup()` function where the balance comparison was incorrect.

## Problem
The previous migration (#929) incorrectly multiplied the balance by 100 when comparing to the threshold:
```sql
AND (COALESCE(u.subscription_allowance, 0) + COALESCE(u.purchased_credits, 0)) * 100 <
    COALESCE((u.settings->>'auto_topup_threshold')::integer, 0);
```

Since:
- Database stores credits in **dollars** (e.g., `5.00` for $5)
- Thresholds are stored in **cents** (e.g., `1000` for $10)

The comparison was wrong: a $5 balance would become 500 and be compared against 1000, incorrectly triggering auto top-up.

## Fix
Divide the threshold by 100 to compare in the same units (dollars):
```sql
AND (COALESCE(u.subscription_allowance, 0) + COALESCE(u.purchased_credits, 0)) <
    COALESCE((u.settings->>'auto_topup_threshold')::integer, 0) / 100.0;
```

Now: $5.00 balance < $10.00 threshold → triggers auto top-up (correct)

## Addresses
Review comment from PR #929: https://github.com/Alpaca-Network/gatewayz-backend/pull/929#discussion_r2725908599

## Test plan
- [x] Migration file syntax validated
- [ ] Deploy migration and verify function behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed balance comparison logic in the auto top-up feature. Updated calculations to correctly evaluate current account balance against configured thresholds to determine when automatic top-ups are triggered for eligible users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes a critical bug in the `get_users_needing_auto_topup()` function where balance comparison was inverted. The previous migration (#929) incorrectly multiplied the user balance (stored in dollars) by 100 before comparing to the threshold (stored in cents), which would cause the comparison to work backwards. This fix correctly divides the threshold by 100 to compare both values in dollars.

**Key Changes:**
- Changed comparison from `(balance * 100) < threshold` to `balance < (threshold / 100.0)`
- Added clear inline comments explaining the unit conversion
- Updated function comment for clarity

**Impact:**
- Before: Balance of $5.00 would be compared as 500 < 1000 (cents), incorrectly triggering for users with balances below threshold in cents
- After: Balance of $5.00 correctly compared as $5.00 < $10.00, properly triggering auto top-up when balance is below threshold

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it fixes a critical logic bug with a simple mathematical correction
- The fix is straightforward and mathematically correct. It changes only the comparison logic in a single database function, with clear documentation explaining the units. The solution properly handles the unit conversion between dollars (balance) and cents (threshold). No edge cases are introduced by the division since it uses 100.0 (float) to ensure proper decimal handling.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| supabase/migrations/20260125100000_fix_auto_topup_balance_comparison.sql | Corrects balance comparison logic by dividing threshold by 100 instead of multiplying balance by 100 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant AutoTopUpCron as Auto Top-Up Cron Job
    participant DB as PostgreSQL Database
    participant Function as get_users_needing_auto_topup()
    participant Users as Users Table
    
    Note over AutoTopUpCron,Users: Auto Top-Up Threshold Check Flow
    
    AutoTopUpCron->>Function: Call get_users_needing_auto_topup()
    Function->>Users: Query users with auto_topup_enabled = true
    Users-->>Function: Return user records
    
    Note over Function: For each user:
    Note over Function: Balance = subscription_allowance + purchased_credits (in dollars)
    Note over Function: Threshold = settings->>'auto_topup_threshold' (in cents)
    
    alt Previous (Buggy) Logic
        Note over Function: (balance * 100) < threshold
        Note over Function: ($5.00 * 100 = 500) < 1000 ✓ WRONG!
        Note over Function: Should trigger but comparison is backwards
    end
    
    alt New (Fixed) Logic
        Note over Function: balance < (threshold / 100.0)
        Note over Function: $5.00 < (1000 / 100.0 = $10.00) ✓ CORRECT!
        Note over Function: Correctly triggers auto top-up
    end
    
    Function-->>AutoTopUpCron: Return users needing top-up
    AutoTopUpCron->>AutoTopUpCron: Process top-up for eligible users
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->