### PR TITLE
fix: resolve import errors breaking route loading

### DIFF
--- a/src/routes/nosana.py
+++ b/src/routes/nosana.py
@@ -16,7 +16,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
-from src.routes.auth import get_current_user
+from src.security.deps import get_current_user
 from src.services.nosana_client import (
     DEPLOYMENT_STATUSES,
     DEPLOYMENT_STRATEGIES,


### PR DESCRIPTION
## Summary

- Fix `nosana.py`: import `get_current_user` from `src.security.deps` instead of `src.routes.auth` where it doesn't exist
- Fix `pricing_analytics.py`: remove dependency on deleted `pricing_calculator.py` module (removed in d3f6c5b7). Now uses pricing from model_data or falls back to default rate.

## Errors Fixed

These fixes resolve the following startup errors that were breaking route loading:

```
[FAIL] Nosana GPU Computing (nosana) - Import failed
      Error: cannot import name 'get_current_user' from 'src.routes.auth'

[FAIL] Admin Pricing Analytics (admin_pricing_analytics) - Import failed
      Error: No module named 'pricing_calculator'
```

## Test Plan

- [ ] Verify backend starts without import errors
- [ ] Test Nosana routes are accessible
- [ ] Test Admin Pricing Analytics endpoints work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes critical import errors that were preventing route loading during application startup.

**Changes:**
- **nosana.py**: Corrected import path for `get_current_user` from `src.security.deps` (the actual location per line 192 of `deps.py`) instead of the incorrect `src.routes.auth` where the function doesn't exist
- **pricing_analytics.py**: Removed dependency on the deleted `pricing_calculator.py` module (removed in commit d3f6c5b7). The `calculate_request_cost_with_standard` function now uses pricing data directly from the `model_data` parameter (from the `model_pricing` database table), with a fallback to a default rate of $0.02 per 1K tokens

**Impact:**
Both fixes resolve startup import errors that were breaking route loading. The changes maintain backward compatibility - the pricing analytics service continues to work by using the pricing data from the database instead of the removed calculator module.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Both changes are straightforward import/dependency fixes that resolve actual runtime errors. The imports have been verified to exist in their new locations, and the pricing logic maintains the same functionality by using database-sourced pricing data instead of the removed module
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/routes/nosana.py | Fixed import error: `get_current_user` now correctly imported from `src.security.deps` instead of non-existent `src.routes.auth` |
| src/services/pricing_analytics.py | Removed dependency on deleted `pricing_calculator.py` module; now uses pricing from `model_data` with fallback to default rate |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as FastAPI App
    participant NosanaRoute as nosana.py
    participant SecurityDeps as security/deps.py
    participant PricingAnalytics as pricing_analytics.py
    participant ModelData as model_pricing (DB)
    
    Note over App,ModelData: Application Startup
    App->>NosanaRoute: Load routes
    NosanaRoute->>SecurityDeps: import get_current_user
    SecurityDeps-->>NosanaRoute: ✓ Function available
    NosanaRoute-->>App: ✓ Routes loaded
    
    App->>PricingAnalytics: Load pricing service
    Note over PricingAnalytics: Previously imported pricing_calculator (deleted)
    Note over PricingAnalytics: Now uses model_data from DB
    PricingAnalytics-->>App: ✓ Service loaded
    
    Note over App,ModelData: Runtime - Cost Calculation
    App->>PricingAnalytics: calculate_request_cost_with_standard(provider, model_data, tokens)
    PricingAnalytics->>PricingAnalytics: Check model_data for pricing
    alt Pricing data available
        PricingAnalytics->>PricingAnalytics: Use input_price_per_token & output_price_per_token
        PricingAnalytics-->>App: Return calculated costs
    else No pricing data
        PricingAnalytics->>PricingAnalytics: Use default rate (0.00002)
        PricingAnalytics-->>App: Return fallback costs
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->