### PR TITLE
fix(config): support BUTTER_ENABLED env var for Railway compatibility

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -249,13 +249,14 @@ class Config:
     # Butter.dev is a caching proxy for LLM APIs that identifies patterns in responses
     # and serves cached responses to reduce costs and improve latency.
     # See: https://butter.dev
-    BUTTER_DEV_ENABLED: bool = os.environ.get("BUTTER_DEV_ENABLED", "false").lower() in {
-        "1",
-        "true",
-        "yes",
-    }
+    # Supports both BUTTER_DEV_ENABLED and BUTTER_ENABLED env vars for compatibility
+    BUTTER_DEV_ENABLED: bool = (
+        os.environ.get("BUTTER_DEV_ENABLED", os.environ.get("BUTTER_ENABLED", "false"))
+        .lower()
+        in {"1", "true", "yes"}
+    )
     BUTTER_DEV_BASE_URL: str = os.environ.get(
-        "BUTTER_DEV_BASE_URL", "https://proxy.butter.dev/v1"
+        "BUTTER_DEV_BASE_URL", os.environ.get("BUTTER_PROXY_URL", "https://proxy.butter.dev/v1")
     )
     BUTTER_DEV_TIMEOUT: int = int(os.environ.get("BUTTER_DEV_TIMEOUT", "30"))
     # Enable automatic fallback to direct provider on Butter.dev errors


### PR DESCRIPTION
## Summary
- Support both `BUTTER_ENABLED` and `BUTTER_DEV_ENABLED` env vars for Butter.dev caching
- Support both `BUTTER_PROXY_URL` and `BUTTER_DEV_BASE_URL` env vars

The Railway deployment has `BUTTER_ENABLED=true` and `BUTTER_PROXY_URL` set, but the code was looking for `BUTTER_DEV_ENABLED` and `BUTTER_DEV_BASE_URL`. This fixes the toggle not working in production.

## Test plan
- [ ] Verify `BUTTER_DEV_ENABLED` still works when set directly
- [ ] Verify `BUTTER_ENABLED` is recognized as fallback
- [ ] Check that prompt cache toggle works in production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Butter.dev configuration flexibility to support multiple environment variables for service enablement and proxy URL customization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added Railway-compatible environment variable fallbacks for Butter.dev configuration. The code now checks `BUTTER_ENABLED` if `BUTTER_DEV_ENABLED` is not set, and checks `BUTTER_PROXY_URL` if `BUTTER_DEV_BASE_URL` is not set. This resolves the issue where Railway deployments with `BUTTER_ENABLED=true` were not recognized because the code only looked for `BUTTER_DEV_ENABLED`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes add backward-compatible environment variable fallbacks without modifying logic or breaking existing functionality. The implementation uses standard `os.environ.get()` with proper chaining and maintains the same default values.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/config/config.py | Added fallback env var support for `BUTTER_ENABLED` and `BUTTER_PROXY_URL` to fix Railway deployment compatibility |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application Startup
    participant Config as Config Class
    participant Env as Environment Variables
    participant Butter as Butter Client

    App->>Config: Load BUTTER_DEV_ENABLED
    Config->>Env: os.environ.get("BUTTER_DEV_ENABLED")
    alt BUTTER_DEV_ENABLED is set
        Env-->>Config: Return value
    else BUTTER_DEV_ENABLED not set
        Config->>Env: os.environ.get("BUTTER_ENABLED")
        Env-->>Config: Return value (or "false")
    end
    Config->>Config: Convert to boolean

    App->>Config: Load BUTTER_DEV_BASE_URL
    Config->>Env: os.environ.get("BUTTER_DEV_BASE_URL")
    alt BUTTER_DEV_BASE_URL is set
        Env-->>Config: Return value
    else BUTTER_DEV_BASE_URL not set
        Config->>Env: os.environ.get("BUTTER_PROXY_URL")
        Env-->>Config: Return value (or default URL)
    end

    App->>Butter: Initialize with Config
    Butter->>Config: Read BUTTER_DEV_ENABLED
    Butter->>Config: Read BUTTER_DEV_BASE_URL
    Note over Butter: Use butter.dev proxy if enabled
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->