### PR TITLE
feat: enable Butter.dev cache by default for all users

### DIFF
--- a/src/routes/butter_analytics.py
+++ b/src/routes/butter_analytics.py
@@ -142,7 +142,7 @@ async def get_cache_analytics(
             "total_savings_usd": round(total_savings, 6),
             "estimated_monthly_savings_usd": round(estimated_monthly_savings, 2),
             "top_cached_models": top_cached_models,
-            "cache_enabled": (user.get("preferences") or {}).get("enable_butter_cache", False),
+            "cache_enabled": (user.get("preferences") or {}).get("enable_butter_cache", True),  # Enabled by default
             "system_enabled": Config.BUTTER_DEV_ENABLED,
         }
 
@@ -174,7 +174,7 @@ async def get_cache_summary(
 
         user_id = user.get("id")
         preferences = user.get("preferences") or {}
-        cache_enabled = preferences.get("enable_butter_cache", False)
+        cache_enabled = preferences.get("enable_butter_cache", True)  # Enabled by default
 
         # If cache is not enabled, return minimal response
         if not cache_enabled or not Config.BUTTER_DEV_ENABLED:

--- a/src/routes/users.py
+++ b/src/routes/users.py
@@ -303,7 +303,7 @@ async def get_cache_settings_endpoint(api_key: str = Depends(get_api_key)):
 
         # Get user preferences
         preferences = user.get("preferences") or {}
-        enable_butter_cache = preferences.get("enable_butter_cache", False)
+        enable_butter_cache = preferences.get("enable_butter_cache", True)  # Enabled by default
 
         # Import here to avoid circular imports
         from src.config.config import Config

--- a/src/services/butter_client.py
+++ b/src/services/butter_client.py
@@ -123,7 +123,7 @@ def should_use_butter_cache(
 
     # Check user preference
     preferences = user.get("preferences") or {}
-    enable_cache = preferences.get("enable_butter_cache", False)
+    enable_cache = preferences.get("enable_butter_cache", True)  # Enabled by default
 
     if not enable_cache:
         return False, "user_preference_disabled"
@@ -153,7 +153,7 @@ def get_user_cache_preference(user: dict[str, Any] | None) -> bool:
         return False
 
     preferences = user.get("preferences") or {}
-    return preferences.get("enable_butter_cache", False)
+    return preferences.get("enable_butter_cache", True)  # Enabled by default
 
 
 def detect_cache_hit(response_time_seconds: float, threshold: float = 0.5) -> bool:

--- a/supabase/migrations/20260122000000_add_butter_cache_support.sql
+++ b/supabase/migrations/20260122000000_add_butter_cache_support.sql
@@ -106,17 +106,17 @@ AS $$
 DECLARE
     v_enabled BOOLEAN;
 BEGIN
-    SELECT COALESCE((preferences->>'enable_butter_cache')::boolean, false)
+    SELECT COALESCE((preferences->>'enable_butter_cache')::boolean, true)
     INTO v_enabled
     FROM public.users
     WHERE id = p_user_id;
 
-    RETURN COALESCE(v_enabled, false);
+    RETURN COALESCE(v_enabled, true);
 END;
 $$;
 
 COMMENT ON FUNCTION public.get_user_cache_preference IS
-    'Returns whether Butter.dev caching is enabled for a user. Defaults to false if not set.';
+    'Returns whether Butter.dev caching is enabled for a user. Defaults to true if not set.';
 
 -- ============================================================================
 -- 5. Create function to get cache savings for a user

--- a/tests/services/test_butter_client.py
+++ b/tests/services/test_butter_client.py
@@ -103,19 +103,19 @@ class TestShouldUseButterCache:
         assert use_cache is False
         assert reason == "user_preference_disabled"
 
-        # User with no preferences (defaults to disabled)
+        # User with no preferences (defaults to enabled)
         user = {"id": 1, "preferences": {}}
         use_cache, reason = should_use_butter_cache(user, "openrouter")
 
-        assert use_cache is False
-        assert reason == "user_preference_disabled"
+        assert use_cache is True
+        assert reason == "enabled"
 
-        # User with None preferences
+        # User with None preferences (defaults to enabled)
         user = {"id": 1, "preferences": None}
         use_cache, reason = should_use_butter_cache(user, "openrouter")
 
-        assert use_cache is False
-        assert reason == "user_preference_disabled"
+        assert use_cache is True
+        assert reason == "enabled"
 
     @patch("src.services.butter_client.Config")
     def test_incompatible_provider_returns_false(self, mock_config):
@@ -282,14 +282,14 @@ class TestGetUserCachePreference:
         user = {"id": 1, "preferences": {"enable_butter_cache": False}}
         assert get_user_cache_preference(user) is False
 
-    def test_returns_false_for_missing_preference(self):
-        """Test that False is returned when preference is not set."""
+    def test_returns_true_for_missing_preference(self):
+        """Test that True is returned when preference is not set (enabled by default)."""
         from src.services.butter_client import get_user_cache_preference
 
-        # No preferences
-        assert get_user_cache_preference({"id": 1}) is False
-        assert get_user_cache_preference({"id": 1, "preferences": {}}) is False
-        assert get_user_cache_preference({"id": 1, "preferences": None}) is False
+        # No preferences - defaults to enabled
+        assert get_user_cache_preference({"id": 1}) is True
+        assert get_user_cache_preference({"id": 1, "preferences": {}}) is True
+        assert get_user_cache_preference({"id": 1, "preferences": None}) is True
 
     def test_returns_false_for_none_user(self):
         """Test that False is returned for None user."""


### PR DESCRIPTION
## Summary
- Changed default value for `enable_butter_cache` from `False` to `True`
- Users can still opt-out via the Prompt Cache settings page
- Updated tests to reflect new default behavior

This makes caching opt-out instead of opt-in, maximizing cost savings for users.

## Test plan
- [ ] Verify new users get caching enabled by default
- [ ] Verify existing users without preference set get caching enabled
- [ ] Verify users can still disable caching via settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Changed Butter.dev LLM response caching from opt-in to opt-out by updating the default value of `enable_butter_cache` from `False` to `True` across all relevant code locations.

**What changed:**
- Python service layer (`butter_client.py`): Updated `should_use_butter_cache()` and `get_user_cache_preference()` functions to default to `True`
- API routes (`butter_analytics.py`, `users.py`): Updated analytics and settings endpoints to reflect new default
- Database layer (`20260122000000_add_butter_cache_support.sql`): Updated `get_user_cache_preference()` SQL function to return `true` by default
- Test suite (`test_butter_client.py`): Updated test expectations to verify new opt-out behavior

**Impact:**
- New users: Will have caching enabled automatically, maximizing cost savings from day one
- Existing users without preference: Will now get caching enabled (behavior change)
- Existing users with explicit preference: No change - their explicit choice is preserved
- Users can still disable caching via the `/user/cache-settings` endpoint

**Technical quality:**
- Changes are consistent across all layers (Python, SQL, tests)
- Tests comprehensively cover the new default behavior
- Comments clearly indicate the new default in code
- Database migration preserves backward compatibility

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - it's a well-executed, isolated change with comprehensive test coverage
- Score reflects the exceptional quality of this change: all default values updated consistently across Python code, SQL migrations, and tests; explicit user preferences are preserved; changes are thoroughly tested; the modification is isolated to a single feature with no side effects
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/services/butter_client.py | Changed default cache preference from `False` to `True` in eligibility logic and preference getter - core business logic change |
| supabase/migrations/20260122000000_add_butter_cache_support.sql | Updated database function to return `true` as default for cache preference - aligns with opt-out strategy |
| tests/services/test_butter_client.py | Updated test expectations to reflect new opt-out default - comprehensive coverage of new behavior |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API as API Endpoint
    participant ButterClient as Butter Client
    participant UserPrefs as User Preferences
    participant Provider as LLM Provider
    
    User->>API: Request (with API key)
    API->>UserPrefs: Get user preferences
    
    alt User has NO preference set
        UserPrefs-->>API: preferences.enable_butter_cache = undefined
        Note over API: NEW: Defaults to True (was False)
    else User explicitly set preference
        UserPrefs-->>API: preferences.enable_butter_cache = True/False
        Note over API: Respects explicit user choice
    end
    
    API->>ButterClient: should_use_butter_cache(user, provider)
    
    ButterClient->>ButterClient: Check system enabled (BUTTER_DEV_ENABLED)
    ButterClient->>ButterClient: Check user preference (default: True)
    ButterClient->>ButterClient: Check provider compatibility
    
    alt Cache enabled & compatible provider
        ButterClient-->>API: True, "enabled"
        API->>Provider: Route via Butter.dev proxy
        Provider-->>API: Cached/fresh response
        Note over API: Track cache hit/miss & savings
    else Cache disabled or incompatible
        ButterClient-->>API: False, reason
        API->>Provider: Direct to provider
        Provider-->>API: Response
    end
    
    API-->>User: Response with cost tracking
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->