### PR TITLE
fix: address code review comments - unused imports and send_email bug

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -444,6 +444,7 @@ def create_app() -> FastAPI:
         ("trial_analytics", "Trial Analytics"),  # Trial monitoring and abuse detection
         ("prometheus_data", "Prometheus Data API"),  # Grafana stack telemetry endpoints
         ("nosana", "Nosana GPU Computing"),  # Nosana deployments, jobs, and GPU marketplace
+        ("provider_credits", "Provider Credit Monitoring"),  # Monitor provider account balances
     ]
 
     loaded_count = 0

--- a/src/routes/provider_credits.py
+++ b/src/routes/provider_credits.py
@@ -13,7 +13,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
-from src.security.deps import get_current_user_with_role
+from src.security.deps import require_admin
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ class ProviderCreditsResponse(BaseModel):
 
 @router.get("/balance", response_model=ProviderCreditsResponse)
 async def get_provider_credit_balances(
-    current_user: dict = Depends(get_current_user_with_role(["admin", "super_admin"]))
+    current_user: dict = Depends(require_admin),
 ) -> ProviderCreditsResponse:
     """
     Get credit balances for all monitored providers.
@@ -86,7 +86,7 @@ async def get_provider_credit_balances(
 @router.get("/balance/{provider}", response_model=ProviderCreditBalance)
 async def get_provider_credit_balance(
     provider: str,
-    current_user: dict = Depends(get_current_user_with_role(["admin", "super_admin"])),
+    current_user: dict = Depends(require_admin),
 ) -> ProviderCreditBalance:
     """
     Get credit balance for a specific provider.
@@ -128,7 +128,7 @@ async def get_provider_credit_balance(
 @router.post("/balance/clear-cache")
 async def clear_provider_credit_cache(
     provider: str | None = None,
-    current_user: dict = Depends(get_current_user_with_role(["admin", "super_admin"])),
+    current_user: dict = Depends(require_admin),
 ) -> dict[str, Any]:
     """
     Clear the provider credit balance cache.

--- a/src/routes/provider_credits.py
+++ b/src/routes/provider_credits.py
@@ -1,0 +1,158 @@
+"""
+Provider credit balance endpoints for monitoring provider account balances.
+
+These endpoints allow administrators to check provider credit balances
+and receive alerts before credits run out.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from src.security.deps import get_current_user_with_role
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/provider-credits", tags=["provider-credits"])
+
+
+class ProviderCreditBalance(BaseModel):
+    """Provider credit balance information"""
+
+    provider: str = Field(..., description="Provider name")
+    balance: float | None = Field(None, description="Current balance in USD")
+    status: str = Field(..., description="Status: healthy, warning, critical, unknown")
+    checked_at: str = Field(..., description="When the balance was checked (ISO 8601)")
+    cached: bool = Field(False, description="Whether this is cached data")
+    error: str | None = Field(None, description="Error message if check failed")
+
+
+class ProviderCreditsResponse(BaseModel):
+    """Response containing all provider credit balances"""
+
+    providers: dict[str, ProviderCreditBalance] = Field(
+        ..., description="Map of provider name to credit balance"
+    )
+    timestamp: str = Field(..., description="Response timestamp (ISO 8601)")
+
+
+@router.get("/balance", response_model=ProviderCreditsResponse)
+async def get_provider_credit_balances(
+    current_user: dict = Depends(get_current_user_with_role(["admin", "super_admin"]))
+) -> ProviderCreditsResponse:
+    """
+    Get credit balances for all monitored providers.
+
+    This endpoint checks the current credit balance for all providers
+    that support credit-based billing (e.g., OpenRouter).
+
+    **Requires admin role**
+
+    Returns:
+        ProviderCreditsResponse with balance information for each provider
+    """
+    from datetime import datetime, timezone
+
+    from src.services.provider_credit_monitor import check_all_provider_credits
+
+    try:
+        balances = await check_all_provider_credits()
+
+        # Convert to response format
+        providers = {}
+        for provider, info in balances.items():
+            providers[provider] = ProviderCreditBalance(
+                provider=info["provider"],
+                balance=info.get("balance"),
+                status=info["status"],
+                checked_at=info["checked_at"].isoformat(),
+                cached=info.get("cached", False),
+                error=info.get("error"),
+            )
+
+        return ProviderCreditsResponse(
+            providers=providers, timestamp=datetime.now(timezone.utc).isoformat()
+        )
+
+    except Exception as e:
+        logger.error(f"Failed to get provider credit balances: {e}")
+        raise HTTPException(status_code=500, detail="Failed to retrieve credit balances")
+
+
+@router.get("/balance/{provider}", response_model=ProviderCreditBalance)
+async def get_provider_credit_balance(
+    provider: str,
+    current_user: dict = Depends(get_current_user_with_role(["admin", "super_admin"])),
+) -> ProviderCreditBalance:
+    """
+    Get credit balance for a specific provider.
+
+    **Requires admin role**
+
+    Args:
+        provider: Provider name (e.g., "openrouter")
+
+    Returns:
+        ProviderCreditBalance with balance information
+    """
+    from src.services.provider_credit_monitor import check_openrouter_credits
+
+    try:
+        if provider.lower() == "openrouter":
+            info = await check_openrouter_credits()
+        else:
+            raise HTTPException(
+                status_code=400, detail=f"Provider '{provider}' not supported for credit monitoring"
+            )
+
+        return ProviderCreditBalance(
+            provider=info["provider"],
+            balance=info.get("balance"),
+            status=info["status"],
+            checked_at=info["checked_at"].isoformat(),
+            cached=info.get("cached", False),
+            error=info.get("error"),
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to get credit balance for {provider}: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to retrieve balance for {provider}")
+
+
+@router.post("/balance/clear-cache")
+async def clear_provider_credit_cache(
+    provider: str | None = None,
+    current_user: dict = Depends(get_current_user_with_role(["admin", "super_admin"])),
+) -> dict[str, Any]:
+    """
+    Clear the provider credit balance cache.
+
+    This forces a fresh check on the next balance query.
+
+    **Requires admin role**
+
+    Args:
+        provider: Optional provider name to clear cache for. If not provided, clears all.
+
+    Returns:
+        Success message
+    """
+    from src.services.provider_credit_monitor import clear_credit_cache
+
+    try:
+        clear_credit_cache(provider)
+
+        return {
+            "success": True,
+            "message": f"Cleared credit cache for {provider if provider else 'all providers'}",
+        }
+
+    except Exception as e:
+        logger.error(f"Failed to clear credit cache: {e}")
+        raise HTTPException(status_code=500, detail="Failed to clear cache")

--- a/src/services/model_catalog_validator.py
+++ b/src/services/model_catalog_validator.py
@@ -1,0 +1,452 @@
+"""
+Model catalog validation service to prevent unavailable models from appearing in catalog.
+
+This service validates that models are actually available on their respective providers
+before adding them to the catalog, preventing 404/400 errors from non-existent models.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Cache validation results for this duration to avoid excessive API calls
+VALIDATION_CACHE_DURATION = timedelta(hours=1)
+
+# In-memory validation cache: model_id -> {"available": bool, "checked_at": datetime}
+_validation_cache: dict[str, dict[str, Any]] = {}
+
+
+async def validate_model_availability(
+    model_id: str, provider: str, source_gateway: str
+) -> dict[str, Any]:
+    """
+    Validate that a model is actually available on its provider.
+
+    Args:
+        model_id: The model identifier
+        provider: Provider name (e.g., "cerebras", "huggingface")
+        source_gateway: Source gateway name (e.g., "cerebras", "huggingface")
+
+    Returns:
+        Dictionary with validation result:
+        {
+            "model_id": str,
+            "provider": str,
+            "available": bool,
+            "checked_at": datetime,
+            "error": str | None
+        }
+    """
+    # Check cache first
+    cache_key = f"{provider}:{model_id}"
+    if cache_key in _validation_cache:
+        cached = _validation_cache[cache_key]
+        cache_age = datetime.now(timezone.utc) - cached["checked_at"]
+        if cache_age < VALIDATION_CACHE_DURATION:
+            logger.debug(f"Using cached validation for {cache_key}: available={cached['available']}")
+            return cached
+
+    # Perform validation based on provider
+    result = {
+        "model_id": model_id,
+        "provider": provider,
+        "available": False,
+        "checked_at": datetime.now(timezone.utc),
+        "error": None,
+    }
+
+    try:
+        if provider.lower() in ("cerebras", "cerebras-ai"):
+            result = await _validate_cerebras_model(model_id)
+        elif provider.lower() in ("huggingface", "hf", "hugging-face"):
+            result = await _validate_huggingface_model(model_id)
+        elif provider.lower() == "openrouter":
+            result = await _validate_openrouter_model(model_id)
+        else:
+            # For providers we don't have validation for, assume available
+            logger.warning(f"No validation implemented for provider '{provider}', assuming available")
+            result["available"] = True
+
+        # Cache the result
+        _validation_cache[cache_key] = result
+
+        return result
+
+    except Exception as e:
+        logger.error(f"Failed to validate model {model_id} on {provider}: {e}")
+        result["error"] = str(e)
+        result["available"] = False  # Fail closed - don't add if validation fails
+        return result
+
+
+async def _validate_cerebras_model(model_id: str) -> dict[str, Any]:
+    """Validate model availability on Cerebras"""
+    try:
+        from src.services.cerebras_client import get_cerebras_client
+
+        client = get_cerebras_client()
+
+        # Try to list models and check if our model is in the list
+        try:
+            models_response = client.models.list()
+            available_models = []
+
+            # Extract model IDs from response
+            if hasattr(models_response, "data"):
+                available_models = [
+                    model.id if hasattr(model, "id") else str(model)
+                    for model in models_response.data
+                ]
+            elif isinstance(models_response, list):
+                available_models = [
+                    model.get("id") if isinstance(model, dict) else str(model)
+                    for model in models_response
+                ]
+
+            # Check if model is available (case-insensitive)
+            model_id_lower = model_id.lower()
+            is_available = any(
+                model_id_lower == available_id.lower() for available_id in available_models
+            )
+
+            if not is_available:
+                logger.warning(
+                    f"Model '{model_id}' not found in Cerebras catalog. "
+                    f"Available models: {', '.join(available_models[:10])}"
+                )
+
+            return {
+                "model_id": model_id,
+                "provider": "cerebras",
+                "available": is_available,
+                "checked_at": datetime.now(timezone.utc),
+                "error": None if is_available else f"Model not found in Cerebras catalog",
+            }
+
+        except Exception as list_err:
+            logger.error(f"Failed to list Cerebras models: {list_err}")
+            # If listing fails, try making a test request (more expensive)
+            return await _validate_model_by_test_request(model_id, "cerebras")
+
+    except Exception as e:
+        logger.error(f"Failed to validate Cerebras model {model_id}: {e}")
+        return {
+            "model_id": model_id,
+            "provider": "cerebras",
+            "available": False,
+            "checked_at": datetime.now(timezone.utc),
+            "error": str(e),
+        }
+
+
+async def _validate_huggingface_model(model_id: str) -> dict[str, Any]:
+    """Validate model availability on HuggingFace"""
+    try:
+        import httpx
+
+        from src.config import Config
+
+        # Strip :hf-inference suffix if present
+        clean_model_id = model_id.replace(":hf-inference", "")
+
+        # Check if model exists via HuggingFace Hub API
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"https://huggingface.co/api/models/{clean_model_id}",
+                headers={"Authorization": f"Bearer {Config.HUG_API_KEY}"}
+                if Config.HUG_API_KEY
+                else {},
+                timeout=10.0,
+            )
+
+            if response.status_code == 200:
+                # Model exists on HuggingFace Hub
+                # Now check if it's available on the Inference Router
+                return await _validate_hf_inference_availability(clean_model_id)
+            elif response.status_code == 404:
+                logger.warning(f"Model '{clean_model_id}' not found on HuggingFace Hub")
+                return {
+                    "model_id": model_id,
+                    "provider": "huggingface",
+                    "available": False,
+                    "checked_at": datetime.now(timezone.utc),
+                    "error": "Model not found on HuggingFace Hub",
+                }
+            else:
+                logger.warning(f"Unexpected status code {response.status_code} checking HF model")
+                return {
+                    "model_id": model_id,
+                    "provider": "huggingface",
+                    "available": False,
+                    "checked_at": datetime.now(timezone.utc),
+                    "error": f"HTTP {response.status_code}",
+                }
+
+    except Exception as e:
+        logger.error(f"Failed to validate HuggingFace model {model_id}: {e}")
+        return {
+            "model_id": model_id,
+            "provider": "huggingface",
+            "available": False,
+            "checked_at": datetime.now(timezone.utc),
+            "error": str(e),
+        }
+
+
+async def _validate_hf_inference_availability(model_id: str) -> dict[str, Any]:
+    """Check if HuggingFace model is available on the Inference Router"""
+    try:
+        import httpx
+
+        from src.config import Config
+
+        if not Config.HUG_API_KEY:
+            # Can't validate without API key, assume available if on Hub
+            return {
+                "model_id": model_id,
+                "provider": "huggingface",
+                "available": True,
+                "checked_at": datetime.now(timezone.utc),
+                "error": None,
+            }
+
+        # Try a minimal test request to the Inference Router
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                "https://router.huggingface.co/v1/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {Config.HUG_API_KEY}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": f"{model_id}:hf-inference",
+                    "messages": [{"role": "user", "content": "test"}],
+                    "max_tokens": 1,
+                },
+                timeout=10.0,
+            )
+
+            # 200 = available, 400/404 = not available on router
+            if response.status_code == 200:
+                return {
+                    "model_id": model_id,
+                    "provider": "huggingface",
+                    "available": True,
+                    "checked_at": datetime.now(timezone.utc),
+                    "error": None,
+                }
+            elif response.status_code in (400, 404):
+                logger.warning(
+                    f"Model '{model_id}' exists on HF Hub but not available on Inference Router"
+                )
+                return {
+                    "model_id": model_id,
+                    "provider": "huggingface",
+                    "available": False,
+                    "checked_at": datetime.now(timezone.utc),
+                    "error": "Model not available on HF Inference Router",
+                }
+            else:
+                # Other errors - assume unavailable
+                return {
+                    "model_id": model_id,
+                    "provider": "huggingface",
+                    "available": False,
+                    "checked_at": datetime.now(timezone.utc),
+                    "error": f"HTTP {response.status_code}",
+                }
+
+    except Exception as e:
+        logger.error(f"Failed to validate HF Inference availability for {model_id}: {e}")
+        return {
+            "model_id": model_id,
+            "provider": "huggingface",
+            "available": False,
+            "checked_at": datetime.now(timezone.utc),
+            "error": str(e),
+        }
+
+
+async def _validate_openrouter_model(model_id: str) -> dict[str, Any]:
+    """Validate model availability on OpenRouter"""
+    try:
+        import httpx
+
+        from src.config import Config
+
+        if not Config.OPENROUTER_API_KEY:
+            logger.warning("OpenRouter API key not configured, cannot validate model")
+            return {
+                "model_id": model_id,
+                "provider": "openrouter",
+                "available": False,
+                "checked_at": datetime.now(timezone.utc),
+                "error": "API key not configured",
+            }
+
+        # Fetch OpenRouter model list
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                "https://openrouter.ai/api/v1/models",
+                headers={"Authorization": f"Bearer {Config.OPENROUTER_API_KEY}"},
+                timeout=10.0,
+            )
+            response.raise_for_status()
+
+            models_data = response.json()
+            available_models = [model.get("id") for model in models_data.get("data", [])]
+
+            # Check if model is in the list
+            is_available = model_id in available_models
+
+            if not is_available:
+                logger.warning(f"Model '{model_id}' not found in OpenRouter catalog")
+
+            return {
+                "model_id": model_id,
+                "provider": "openrouter",
+                "available": is_available,
+                "checked_at": datetime.now(timezone.utc),
+                "error": None if is_available else "Model not found in OpenRouter catalog",
+            }
+
+    except Exception as e:
+        logger.error(f"Failed to validate OpenRouter model {model_id}: {e}")
+        return {
+            "model_id": model_id,
+            "provider": "openrouter",
+            "available": False,
+            "checked_at": datetime.now(timezone.utc),
+            "error": str(e),
+        }
+
+
+async def _validate_model_by_test_request(model_id: str, provider: str) -> dict[str, Any]:
+    """
+    Validate model by making a minimal test request.
+    This is more expensive than checking catalogs, so use as fallback.
+    """
+    logger.info(f"Validating {model_id} on {provider} via test request")
+
+    try:
+        # Make minimal test request based on provider
+        if provider == "cerebras":
+            from src.services.cerebras_client import make_cerebras_request_openai
+
+            try:
+                make_cerebras_request_openai(
+                    messages=[{"role": "user", "content": "test"}],
+                    model=model_id,
+                    max_tokens=1,
+                )
+                return {
+                    "model_id": model_id,
+                    "provider": provider,
+                    "available": True,
+                    "checked_at": datetime.now(timezone.utc),
+                    "error": None,
+                }
+            except Exception as e:
+                error_str = str(e).lower()
+                if "not found" in error_str or "does not exist" in error_str:
+                    return {
+                        "model_id": model_id,
+                        "provider": provider,
+                        "available": False,
+                        "checked_at": datetime.now(timezone.utc),
+                        "error": "Model not found via test request",
+                    }
+                # Other errors don't necessarily mean unavailable
+                raise
+
+        # Add other providers as needed
+
+        return {
+            "model_id": model_id,
+            "provider": provider,
+            "available": False,
+            "checked_at": datetime.now(timezone.utc),
+            "error": "Test request validation not implemented",
+        }
+
+    except Exception as e:
+        logger.error(f"Test request validation failed for {model_id} on {provider}: {e}")
+        return {
+            "model_id": model_id,
+            "provider": provider,
+            "available": False,
+            "checked_at": datetime.now(timezone.utc),
+            "error": str(e),
+        }
+
+
+async def validate_models_batch(
+    models: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """
+    Validate a batch of models and filter out unavailable ones.
+
+    Args:
+        models: List of model dictionaries with 'id', 'provider_slug', 'source_gateway' keys
+
+    Returns:
+        List of validated models (only those that are available)
+    """
+    if not models:
+        return []
+
+    logger.info(f"Validating batch of {len(models)} models")
+
+    # Validate all models concurrently
+    validation_tasks = [
+        validate_model_availability(
+            model["id"], model.get("provider_slug", ""), model.get("source_gateway", "")
+        )
+        for model in models
+    ]
+
+    validation_results = await asyncio.gather(*validation_tasks, return_exceptions=True)
+
+    # Filter out unavailable models
+    validated_models = []
+    for model, result in zip(models, validation_results):
+        if isinstance(result, Exception):
+            logger.error(f"Validation failed for model {model['id']}: {result}")
+            continue
+
+        if result.get("available"):
+            validated_models.append(model)
+        else:
+            logger.warning(
+                f"Excluding model {model['id']} from catalog: {result.get('error', 'not available')}"
+            )
+
+    logger.info(
+        f"Validated {len(validated_models)}/{len(models)} models as available "
+        f"({len(models) - len(validated_models)} excluded)"
+    )
+
+    return validated_models
+
+
+def clear_validation_cache(model_id: str | None = None) -> None:
+    """
+    Clear the validation cache.
+
+    Args:
+        model_id: Specific model to clear, or None to clear all
+    """
+    if model_id:
+        # Clear all cache entries containing this model_id
+        keys_to_clear = [k for k in _validation_cache.keys() if model_id in k]
+        for key in keys_to_clear:
+            _validation_cache.pop(key, None)
+        logger.debug(f"Cleared validation cache for {model_id}")
+    else:
+        _validation_cache.clear()
+        logger.debug("Cleared all validation cache")

--- a/src/services/provider_credit_monitor.py
+++ b/src/services/provider_credit_monitor.py
@@ -1,0 +1,237 @@
+"""
+Provider credit monitoring service for tracking and alerting on provider account balance.
+
+This service monitors provider account credits to prevent service degradation from
+credit exhaustion. It sends alerts when credits fall below thresholds and helps
+ensure seamless failover before providers run out of credits.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from src.config import Config
+
+logger = logging.getLogger(__name__)
+
+# Credit thresholds for alerting (in USD)
+CREDIT_THRESHOLDS = {
+    "critical": 5.0,  # Alert immediately
+    "warning": 20.0,  # Alert but not urgent
+    "info": 50.0,  # Informational alert
+}
+
+# Time to cache credit balance checks (to avoid excessive API calls)
+CACHE_DURATION_MINUTES = 15
+
+# In-memory cache for credit balance
+_credit_balance_cache: dict[str, dict[str, Any]] = {}
+
+
+async def check_openrouter_credits() -> dict[str, Any]:
+    """
+    Check OpenRouter account credit balance.
+
+    Returns:
+        Dictionary with balance information:
+        {
+            "provider": "openrouter",
+            "balance": 123.45,
+            "status": "healthy" | "warning" | "critical" | "unknown",
+            "checked_at": datetime,
+            "cached": bool
+        }
+    """
+    provider = "openrouter"
+
+    # Check cache first
+    if provider in _credit_balance_cache:
+        cached = _credit_balance_cache[provider]
+        cache_age = datetime.now(timezone.utc) - cached["checked_at"]
+        if cache_age < timedelta(minutes=CACHE_DURATION_MINUTES):
+            logger.debug(f"Using cached credit balance for {provider}: ${cached['balance']:.2f}")
+            return {**cached, "cached": True}
+
+    # Fetch fresh balance
+    try:
+        import httpx
+
+        if not Config.OPENROUTER_API_KEY:
+            logger.warning(f"{provider}: API key not configured")
+            return {
+                "provider": provider,
+                "balance": None,
+                "status": "unknown",
+                "checked_at": datetime.now(timezone.utc),
+                "cached": False,
+                "error": "API key not configured"
+            }
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                "https://openrouter.ai/api/v1/auth/key",
+                headers={"Authorization": f"Bearer {Config.OPENROUTER_API_KEY}"},
+                timeout=10.0
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            # OpenRouter returns balance in credits object
+            balance = data.get("data", {}).get("limit_remaining")
+
+            if balance is None:
+                logger.warning(f"{provider}: Could not parse balance from API response")
+                return {
+                    "provider": provider,
+                    "balance": None,
+                    "status": "unknown",
+                    "checked_at": datetime.now(timezone.utc),
+                    "cached": False,
+                    "error": "Could not parse balance"
+                }
+
+            # Determine status based on thresholds
+            status = _determine_credit_status(balance)
+
+            result = {
+                "provider": provider,
+                "balance": balance,
+                "status": status,
+                "checked_at": datetime.now(timezone.utc),
+                "cached": False
+            }
+
+            # Update cache
+            _credit_balance_cache[provider] = result
+
+            # Log status
+            if status == "critical":
+                logger.error(f"{provider} credit balance CRITICAL: ${balance:.2f}")
+            elif status == "warning":
+                logger.warning(f"{provider} credit balance WARNING: ${balance:.2f}")
+            else:
+                logger.info(f"{provider} credit balance: ${balance:.2f}")
+
+            return result
+
+    except httpx.HTTPStatusError as e:
+        logger.error(f"Failed to check {provider} credits (HTTP {e.response.status_code}): {e}")
+        return {
+            "provider": provider,
+            "balance": None,
+            "status": "unknown",
+            "checked_at": datetime.now(timezone.utc),
+            "cached": False,
+            "error": f"HTTP {e.response.status_code}"
+        }
+    except Exception as e:
+        logger.error(f"Failed to check {provider} credits: {e}")
+        return {
+            "provider": provider,
+            "balance": None,
+            "status": "unknown",
+            "checked_at": datetime.now(timezone.utc),
+            "cached": False,
+            "error": str(e)
+        }
+
+
+def _determine_credit_status(balance: float) -> str:
+    """Determine credit status based on balance thresholds."""
+    if balance <= CREDIT_THRESHOLDS["critical"]:
+        return "critical"
+    elif balance <= CREDIT_THRESHOLDS["warning"]:
+        return "warning"
+    elif balance <= CREDIT_THRESHOLDS["info"]:
+        return "info"
+    else:
+        return "healthy"
+
+
+async def check_all_provider_credits() -> dict[str, dict[str, Any]]:
+    """
+    Check credit balance for all monitored providers.
+
+    Returns:
+        Dictionary mapping provider name to balance information
+    """
+    results = {}
+
+    # Check OpenRouter
+    results["openrouter"] = await check_openrouter_credits()
+
+    # TODO: Add other providers with credit-based billing
+    # results["portkey"] = await check_portkey_credits()
+    # results["featherless"] = await check_featherless_credits()
+
+    return results
+
+
+async def send_low_credit_alert(provider: str, balance: float, status: str) -> None:
+    """
+    Send alert notification for low provider credits.
+
+    Args:
+        provider: Provider name
+        balance: Current balance
+        status: Status level (critical, warning, info)
+    """
+    try:
+        # Import here to avoid circular dependencies
+        from src.utils.sentry_context import capture_provider_error
+
+        message = f"{provider.upper()} credit balance is {status.upper()}: ${balance:.2f}"
+
+        if status == "critical":
+            # For critical alerts, also try to send email notification
+            try:
+                from src.services.notification import send_email
+
+                await send_email(
+                    to_email=Config.ADMIN_EMAIL if hasattr(Config, 'ADMIN_EMAIL') else None,
+                    subject=f"URGENT: {provider} credits critically low",
+                    body=f"""
+                    <h2>Provider Credit Alert</h2>
+                    <p><strong>Provider:</strong> {provider}</p>
+                    <p><strong>Balance:</strong> ${balance:.2f}</p>
+                    <p><strong>Status:</strong> {status}</p>
+                    <p><strong>Action Required:</strong> Add credits immediately to prevent service disruption</p>
+                    <p><a href="https://openrouter.ai/settings/credits">Add Credits</a></p>
+                    """,
+                )
+                logger.info(f"Sent email alert for {provider} low credits")
+            except Exception as email_err:
+                logger.warning(f"Failed to send email alert for {provider}: {email_err}")
+
+        # Log to Sentry for monitoring
+        error = Exception(message)
+        capture_provider_error(
+            error,
+            provider=provider,
+            endpoint='credit_monitor',
+            extra_context={
+                'balance': balance,
+                'status': status,
+                'thresholds': CREDIT_THRESHOLDS
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Failed to send alert for {provider} low credits: {e}")
+
+
+def clear_credit_cache(provider: str | None = None) -> None:
+    """
+    Clear the credit balance cache.
+
+    Args:
+        provider: Specific provider to clear, or None to clear all
+    """
+    if provider:
+        _credit_balance_cache.pop(provider, None)
+        logger.debug(f"Cleared credit cache for {provider}")
+    else:
+        _credit_balance_cache.clear()
+        logger.debug("Cleared all credit caches")

--- a/src/services/provider_credit_monitor.py
+++ b/src/services/provider_credit_monitor.py
@@ -187,21 +187,27 @@ async def send_low_credit_alert(provider: str, balance: float, status: str) -> N
         if status == "critical":
             # For critical alerts, also try to send email notification
             try:
-                from src.services.notification import send_email
+                from src.services.notification import notification_service
 
-                await send_email(
-                    to_email=Config.ADMIN_EMAIL if hasattr(Config, 'ADMIN_EMAIL') else None,
-                    subject=f"URGENT: {provider} credits critically low",
-                    body=f"""
-                    <h2>Provider Credit Alert</h2>
-                    <p><strong>Provider:</strong> {provider}</p>
-                    <p><strong>Balance:</strong> ${balance:.2f}</p>
-                    <p><strong>Status:</strong> {status}</p>
-                    <p><strong>Action Required:</strong> Add credits immediately to prevent service disruption</p>
-                    <p><a href="https://openrouter.ai/settings/credits">Add Credits</a></p>
-                    """,
-                )
-                logger.info(f"Sent email alert for {provider} low credits")
+                admin_email = getattr(Config, 'ADMIN_EMAIL', None)
+                if not admin_email:
+                    logger.warning("ADMIN_EMAIL not configured, skipping email alert for critical credit balance")
+                elif notification_service:
+                    notification_service.send_email_notification(
+                        to_email=admin_email,
+                        subject=f"URGENT: {provider} credits critically low",
+                        body=f"""
+                        <h2>Provider Credit Alert</h2>
+                        <p><strong>Provider:</strong> {provider}</p>
+                        <p><strong>Balance:</strong> ${balance:.2f}</p>
+                        <p><strong>Status:</strong> {status}</p>
+                        <p><strong>Action Required:</strong> Add credits immediately to prevent service disruption</p>
+                        <p><a href="https://openrouter.ai/settings/credits">Add Credits</a></p>
+                        """,
+                    )
+                    logger.info(f"Sent email alert for {provider} low credits")
+                else:
+                    logger.warning("Notification service not initialized, skipping email alert")
             except Exception as email_err:
                 logger.warning(f"Failed to send email alert for {provider}: {email_err}")
 

--- a/tests/routes/test_provider_credits.py
+++ b/tests/routes/test_provider_credits.py
@@ -5,7 +5,6 @@ Tests for provider credit balance API endpoints.
 import pytest
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
-from fastapi.testclient import TestClient
 
 
 @pytest.fixture

--- a/tests/routes/test_provider_credits.py
+++ b/tests/routes/test_provider_credits.py
@@ -1,0 +1,258 @@
+"""
+Tests for provider credit balance API endpoints.
+"""
+
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def mock_admin_user():
+    """Mock admin user for testing"""
+    return {
+        "id": 1,
+        "email": "admin@test.com",
+        "role": "admin",
+        "tier": "max"
+    }
+
+
+@pytest.fixture
+def mock_super_admin_user():
+    """Mock super admin user for testing"""
+    return {
+        "id": 1,
+        "email": "superadmin@test.com",
+        "role": "super_admin",
+        "tier": "max"
+    }
+
+
+@pytest.fixture
+def mock_regular_user():
+    """Mock regular user for testing"""
+    return {
+        "id": 2,
+        "email": "user@test.com",
+        "role": "user",
+        "tier": "pro"
+    }
+
+
+class TestGetProviderCreditBalances:
+    """Test GET /api/provider-credits/balance endpoint"""
+
+    @pytest.mark.asyncio
+    async def test_get_balances_as_admin(self, client, mock_admin_user):
+        """Test retrieving all provider credit balances as admin"""
+        with patch("src.routes.provider_credits.get_current_user_with_role") as mock_auth, \
+             patch("src.routes.provider_credits.check_all_provider_credits") as mock_check:
+
+            # Mock authentication
+            mock_auth.return_value = AsyncMock(return_value=mock_admin_user)
+
+            # Mock credit check response
+            mock_check.return_value = {
+                "openrouter": {
+                    "provider": "openrouter",
+                    "balance": 123.45,
+                    "status": "healthy",
+                    "checked_at": datetime.now(timezone.utc),
+                    "cached": False
+                }
+            }
+
+            response = client.get(
+                "/api/provider-credits/balance",
+                headers={"Authorization": "Bearer admin-key"}
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert "providers" in data
+            assert "openrouter" in data["providers"]
+            assert data["providers"]["openrouter"]["balance"] == 123.45
+            assert data["providers"]["openrouter"]["status"] == "healthy"
+
+    @pytest.mark.asyncio
+    async def test_get_balances_with_warning_status(self, client, mock_admin_user):
+        """Test retrieving balance with warning status"""
+        with patch("src.routes.provider_credits.get_current_user_with_role") as mock_auth, \
+             patch("src.routes.provider_credits.check_all_provider_credits") as mock_check:
+
+            mock_auth.return_value = AsyncMock(return_value=mock_admin_user)
+
+            # Mock low balance
+            mock_check.return_value = {
+                "openrouter": {
+                    "provider": "openrouter",
+                    "balance": 15.0,
+                    "status": "warning",
+                    "checked_at": datetime.now(timezone.utc),
+                    "cached": False
+                }
+            }
+
+            response = client.get(
+                "/api/provider-credits/balance",
+                headers={"Authorization": "Bearer admin-key"}
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["providers"]["openrouter"]["status"] == "warning"
+            assert data["providers"]["openrouter"]["balance"] == 15.0
+
+    @pytest.mark.asyncio
+    async def test_get_balances_unauthorized(self, client, mock_regular_user):
+        """Test that non-admin users cannot access credit balances"""
+        with patch("src.routes.provider_credits.get_current_user_with_role") as mock_auth:
+            # Mock authentication to raise 403 for non-admin
+            mock_auth.side_effect = lambda roles: AsyncMock(
+                side_effect=Exception("Forbidden")
+            )
+
+            response = client.get(
+                "/api/provider-credits/balance",
+                headers={"Authorization": "Bearer user-key"}
+            )
+
+            # Should fail authentication
+            assert response.status_code in (401, 403, 500)
+
+
+class TestGetSpecificProviderBalance:
+    """Test GET /api/provider-credits/balance/{provider} endpoint"""
+
+    @pytest.mark.asyncio
+    async def test_get_openrouter_balance(self, client, mock_admin_user):
+        """Test retrieving OpenRouter specific balance"""
+        with patch("src.routes.provider_credits.get_current_user_with_role") as mock_auth, \
+             patch("src.routes.provider_credits.check_openrouter_credits") as mock_check:
+
+            mock_auth.return_value = AsyncMock(return_value=mock_admin_user)
+
+            mock_check.return_value = {
+                "provider": "openrouter",
+                "balance": 50.0,
+                "status": "info",
+                "checked_at": datetime.now(timezone.utc),
+                "cached": True
+            }
+
+            response = client.get(
+                "/api/provider-credits/balance/openrouter",
+                headers={"Authorization": "Bearer admin-key"}
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["provider"] == "openrouter"
+            assert data["balance"] == 50.0
+            assert data["status"] == "info"
+            assert data["cached"] is True
+
+    @pytest.mark.asyncio
+    async def test_get_unsupported_provider(self, client, mock_admin_user):
+        """Test retrieving balance for unsupported provider"""
+        with patch("src.routes.provider_credits.get_current_user_with_role") as mock_auth:
+            mock_auth.return_value = AsyncMock(return_value=mock_admin_user)
+
+            response = client.get(
+                "/api/provider-credits/balance/unsupported-provider",
+                headers={"Authorization": "Bearer admin-key"}
+            )
+
+            assert response.status_code == 400
+            assert "not supported" in response.json()["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_get_balance_with_error(self, client, mock_admin_user):
+        """Test handling errors during balance retrieval"""
+        with patch("src.routes.provider_credits.get_current_user_with_role") as mock_auth, \
+             patch("src.routes.provider_credits.check_openrouter_credits") as mock_check:
+
+            mock_auth.return_value = AsyncMock(return_value=mock_admin_user)
+
+            mock_check.return_value = {
+                "provider": "openrouter",
+                "balance": None,
+                "status": "unknown",
+                "checked_at": datetime.now(timezone.utc),
+                "cached": False,
+                "error": "API key not configured"
+            }
+
+            response = client.get(
+                "/api/provider-credits/balance/openrouter",
+                headers={"Authorization": "Bearer admin-key"}
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "unknown"
+            assert data["error"] == "API key not configured"
+
+
+class TestClearProviderCreditCache:
+    """Test POST /api/provider-credits/balance/clear-cache endpoint"""
+
+    @pytest.mark.asyncio
+    async def test_clear_all_cache(self, client, mock_admin_user):
+        """Test clearing all provider credit caches"""
+        with patch("src.routes.provider_credits.get_current_user_with_role") as mock_auth, \
+             patch("src.routes.provider_credits.clear_credit_cache") as mock_clear:
+
+            mock_auth.return_value = AsyncMock(return_value=mock_admin_user)
+
+            response = client.post(
+                "/api/provider-credits/balance/clear-cache",
+                headers={"Authorization": "Bearer admin-key"}
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is True
+            assert "all providers" in data["message"]
+
+            # Should have called clear_credit_cache with None
+            mock_clear.assert_called_once_with(None)
+
+    @pytest.mark.asyncio
+    async def test_clear_specific_provider_cache(self, client, mock_admin_user):
+        """Test clearing cache for specific provider"""
+        with patch("src.routes.provider_credits.get_current_user_with_role") as mock_auth, \
+             patch("src.routes.provider_credits.clear_credit_cache") as mock_clear:
+
+            mock_auth.return_value = AsyncMock(return_value=mock_admin_user)
+
+            response = client.post(
+                "/api/provider-credits/balance/clear-cache?provider=openrouter",
+                headers={"Authorization": "Bearer admin-key"}
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is True
+            assert "openrouter" in data["message"]
+
+            # Should have called clear_credit_cache with provider name
+            mock_clear.assert_called_once_with("openrouter")
+
+    @pytest.mark.asyncio
+    async def test_clear_cache_unauthorized(self, client, mock_regular_user):
+        """Test that non-admin users cannot clear cache"""
+        with patch("src.routes.provider_credits.get_current_user_with_role") as mock_auth:
+            mock_auth.side_effect = lambda roles: AsyncMock(
+                side_effect=Exception("Forbidden")
+            )
+
+            response = client.post(
+                "/api/provider-credits/balance/clear-cache",
+                headers={"Authorization": "Bearer user-key"}
+            )
+
+            # Should fail authentication
+            assert response.status_code in (401, 403, 500)

--- a/tests/services/test_model_catalog_validator.py
+++ b/tests/services/test_model_catalog_validator.py
@@ -112,11 +112,6 @@ class TestValidateModelAvailability:
             mock_inference_response = MagicMock()
             mock_inference_response.status_code = 400
 
-            async def mock_get_post(url, **kwargs):
-                if "huggingface.co/api" in url:
-                    return mock_hub_response
-                return mock_inference_response
-
             mock_client_instance = mock_client.return_value.__aenter__.return_value
             mock_client_instance.get = AsyncMock(return_value=mock_hub_response)
             mock_client_instance.post = AsyncMock(return_value=mock_inference_response)

--- a/tests/services/test_model_catalog_validator.py
+++ b/tests/services/test_model_catalog_validator.py
@@ -1,0 +1,361 @@
+"""
+Tests for model catalog validation service.
+"""
+
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.services.model_catalog_validator import (
+    validate_model_availability,
+    validate_models_batch,
+    clear_validation_cache,
+)
+
+
+class TestValidateModelAvailability:
+    """Test model availability validation"""
+
+    @pytest.mark.asyncio
+    async def test_validate_cerebras_model_available(self):
+        """Test validating available Cerebras model"""
+        with patch("src.services.model_catalog_validator.get_cerebras_client") as mock_client_fn:
+            # Mock Cerebras client response
+            mock_client = MagicMock()
+            mock_model = MagicMock()
+            mock_model.id = "llama3.1-8b"
+            mock_client.models.list.return_value.data = [mock_model]
+            mock_client_fn.return_value = mock_client
+
+            result = await validate_model_availability("llama3.1-8b", "cerebras", "cerebras")
+
+            assert result["available"] is True
+            assert result["model_id"] == "llama3.1-8b"
+            assert result["provider"] == "cerebras"
+            assert result["error"] is None
+
+    @pytest.mark.asyncio
+    async def test_validate_cerebras_model_unavailable(self):
+        """Test validating unavailable Cerebras model"""
+        with patch("src.services.model_catalog_validator.get_cerebras_client") as mock_client_fn:
+            # Mock Cerebras client with different models
+            mock_client = MagicMock()
+            mock_model = MagicMock()
+            mock_model.id = "llama3.1-8b"
+            mock_client.models.list.return_value.data = [mock_model]
+            mock_client_fn.return_value = mock_client
+
+            # Try to validate non-existent model
+            result = await validate_model_availability(
+                "non-existent-model", "cerebras", "cerebras"
+            )
+
+            assert result["available"] is False
+            assert result["model_id"] == "non-existent-model"
+            assert "not found" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_validate_huggingface_model_available(self):
+        """Test validating available HuggingFace model"""
+        with patch("httpx.AsyncClient") as mock_client:
+            # Mock HuggingFace Hub API response (200 = model exists)
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+
+            # Mock Inference Router response (200 = available on router)
+            mock_inference_response = MagicMock()
+            mock_inference_response.status_code = 200
+            mock_inference_response.raise_for_status = MagicMock()
+
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                return_value=mock_inference_response
+            )
+
+            result = await validate_model_availability(
+                "meta-llama/Llama-2-7b-chat-hf", "huggingface", "huggingface"
+            )
+
+            assert result["available"] is True
+            assert result["provider"] == "huggingface"
+
+    @pytest.mark.asyncio
+    async def test_validate_huggingface_model_not_on_hub(self):
+        """Test model not found on HuggingFace Hub"""
+        with patch("httpx.AsyncClient") as mock_client:
+            # Mock 404 response from Hub
+            mock_response = MagicMock()
+            mock_response.status_code = 404
+
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+
+            result = await validate_model_availability(
+                "fake/model", "huggingface", "huggingface"
+            )
+
+            assert result["available"] is False
+            assert "not found on HuggingFace Hub" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_validate_huggingface_model_not_on_inference_router(self):
+        """Test model exists on Hub but not available on Inference Router"""
+        with patch("httpx.AsyncClient") as mock_client:
+            # Mock Hub API response (200 = exists)
+            mock_hub_response = MagicMock()
+            mock_hub_response.status_code = 200
+
+            # Mock Inference Router response (400 = not available)
+            mock_inference_response = MagicMock()
+            mock_inference_response.status_code = 400
+
+            async def mock_get_post(url, **kwargs):
+                if "huggingface.co/api" in url:
+                    return mock_hub_response
+                return mock_inference_response
+
+            mock_client_instance = mock_client.return_value.__aenter__.return_value
+            mock_client_instance.get = AsyncMock(return_value=mock_hub_response)
+            mock_client_instance.post = AsyncMock(return_value=mock_inference_response)
+
+            result = await validate_model_availability(
+                "some-org/some-model", "huggingface", "huggingface"
+            )
+
+            assert result["available"] is False
+            assert "not available on HF Inference Router" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_validate_openrouter_model_available(self):
+        """Test validating available OpenRouter model"""
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "data": [
+                    {"id": "openai/gpt-4"},
+                    {"id": "anthropic/claude-3-opus"},
+                ]
+            }
+            mock_response.raise_for_status = MagicMock()
+
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+
+            result = await validate_model_availability(
+                "openai/gpt-4", "openrouter", "openrouter"
+            )
+
+            assert result["available"] is True
+            assert result["model_id"] == "openai/gpt-4"
+
+    @pytest.mark.asyncio
+    async def test_validate_openrouter_model_unavailable(self):
+        """Test validating unavailable OpenRouter model"""
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "data": [
+                    {"id": "openai/gpt-4"},
+                ]
+            }
+            mock_response.raise_for_status = MagicMock()
+
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+
+            result = await validate_model_availability(
+                "fake/model", "openrouter", "openrouter"
+            )
+
+            assert result["available"] is False
+            assert "not found in OpenRouter catalog" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_validate_unsupported_provider(self):
+        """Test validation for provider without validation implementation"""
+        result = await validate_model_availability(
+            "some-model", "unsupported-provider", "gateway"
+        )
+
+        # Should assume available for providers without validation
+        assert result["available"] is True
+        assert result["model_id"] == "some-model"
+        assert result["provider"] == "unsupported-provider"
+
+    @pytest.mark.asyncio
+    async def test_validation_caching(self):
+        """Test that validation results are cached"""
+        with patch("src.services.model_catalog_validator.get_cerebras_client") as mock_client_fn:
+            mock_client = MagicMock()
+            mock_model = MagicMock()
+            mock_model.id = "llama3.1-8b"
+            mock_client.models.list.return_value.data = [mock_model]
+            mock_client_fn.return_value = mock_client
+
+            # First call should hit API
+            result1 = await validate_model_availability("llama3.1-8b", "cerebras", "cerebras")
+            assert result1["available"] is True
+
+            # Second call should use cache
+            result2 = await validate_model_availability("llama3.1-8b", "cerebras", "cerebras")
+            assert result2["available"] is True
+
+            # Should only have called API once
+            assert mock_client.models.list.call_count == 1
+
+
+class TestValidateModelsBatch:
+    """Test batch model validation"""
+
+    @pytest.mark.asyncio
+    async def test_validate_batch_all_available(self):
+        """Test validating batch where all models are available"""
+        models = [
+            {
+                "id": "llama3.1-8b",
+                "provider_slug": "cerebras",
+                "source_gateway": "cerebras"
+            },
+            {
+                "id": "llama3.1-70b",
+                "provider_slug": "cerebras",
+                "source_gateway": "cerebras"
+            }
+        ]
+
+        with patch("src.services.model_catalog_validator.validate_model_availability") as mock_validate:
+            # Mock all as available
+            mock_validate.return_value = {
+                "available": True,
+                "model_id": "test",
+                "provider": "cerebras",
+                "checked_at": datetime.now(timezone.utc),
+                "error": None
+            }
+
+            result = await validate_models_batch(models)
+
+            assert len(result) == 2
+            assert all(model in result for model in models)
+
+    @pytest.mark.asyncio
+    async def test_validate_batch_some_unavailable(self):
+        """Test validating batch where some models are unavailable"""
+        models = [
+            {
+                "id": "available-model",
+                "provider_slug": "cerebras",
+                "source_gateway": "cerebras"
+            },
+            {
+                "id": "unavailable-model",
+                "provider_slug": "cerebras",
+                "source_gateway": "cerebras"
+            }
+        ]
+
+        async def mock_validate(model_id, provider, gateway):
+            if model_id == "available-model":
+                return {
+                    "available": True,
+                    "model_id": model_id,
+                    "provider": provider,
+                    "checked_at": datetime.now(timezone.utc),
+                    "error": None
+                }
+            else:
+                return {
+                    "available": False,
+                    "model_id": model_id,
+                    "provider": provider,
+                    "checked_at": datetime.now(timezone.utc),
+                    "error": "Model not found"
+                }
+
+        with patch("src.services.model_catalog_validator.validate_model_availability", side_effect=mock_validate):
+            result = await validate_models_batch(models)
+
+            # Only available model should be in result
+            assert len(result) == 1
+            assert result[0]["id"] == "available-model"
+
+    @pytest.mark.asyncio
+    async def test_validate_batch_empty_list(self):
+        """Test validating empty batch"""
+        result = await validate_models_batch([])
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_validate_batch_with_exceptions(self):
+        """Test batch validation handles exceptions gracefully"""
+        models = [
+            {
+                "id": "model1",
+                "provider_slug": "cerebras",
+                "source_gateway": "cerebras"
+            },
+            {
+                "id": "model2",
+                "provider_slug": "cerebras",
+                "source_gateway": "cerebras"
+            }
+        ]
+
+        async def mock_validate(model_id, provider, gateway):
+            if model_id == "model1":
+                raise Exception("Validation failed")
+            return {
+                "available": True,
+                "model_id": model_id,
+                "provider": provider,
+                "checked_at": datetime.now(timezone.utc),
+                "error": None
+            }
+
+        with patch("src.services.model_catalog_validator.validate_model_availability", side_effect=mock_validate):
+            result = await validate_models_batch(models)
+
+            # Only model2 should be in result (model1 threw exception)
+            assert len(result) == 1
+            assert result[0]["id"] == "model2"
+
+
+class TestValidationCacheManagement:
+    """Test validation cache management"""
+
+    def test_clear_specific_model_cache(self):
+        """Test clearing cache for specific model"""
+        from src.services.model_catalog_validator import _validation_cache
+
+        # Populate cache
+        _validation_cache["cerebras:model1"] = {"available": True}
+        _validation_cache["cerebras:model2"] = {"available": True}
+        _validation_cache["huggingface:model1"] = {"available": True}
+
+        # Clear specific model
+        clear_validation_cache("model1")
+
+        # model1 entries should be cleared
+        assert "cerebras:model1" not in _validation_cache
+        assert "huggingface:model1" not in _validation_cache
+        # model2 should remain
+        assert "cerebras:model2" in _validation_cache
+
+    def test_clear_all_validation_cache(self):
+        """Test clearing all validation cache"""
+        from src.services.model_catalog_validator import _validation_cache
+
+        # Populate cache
+        _validation_cache["cerebras:model1"] = {"available": True}
+        _validation_cache["huggingface:model2"] = {"available": True}
+
+        # Clear all
+        clear_validation_cache()
+
+        # All should be cleared
+        assert len(_validation_cache) == 0

--- a/tests/services/test_provider_credit_monitor.py
+++ b/tests/services/test_provider_credit_monitor.py
@@ -1,0 +1,272 @@
+"""
+Tests for provider credit monitoring service.
+"""
+
+import pytest
+from datetime import datetime, timezone, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.services.provider_credit_monitor import (
+    check_openrouter_credits,
+    check_all_provider_credits,
+    send_low_credit_alert,
+    clear_credit_cache,
+    _determine_credit_status,
+    CREDIT_THRESHOLDS,
+)
+
+
+class TestCreditStatusDetermination:
+    """Test credit status determination logic"""
+
+    def test_healthy_balance(self):
+        """Test that high balance returns healthy status"""
+        assert _determine_credit_status(100.0) == "healthy"
+        assert _determine_credit_status(51.0) == "healthy"
+
+    def test_info_balance(self):
+        """Test that moderate balance returns info status"""
+        assert _determine_credit_status(50.0) == "info"
+        assert _determine_credit_status(30.0) == "info"
+
+    def test_warning_balance(self):
+        """Test that low balance returns warning status"""
+        assert _determine_credit_status(20.0) == "warning"
+        assert _determine_credit_status(10.0) == "warning"
+
+    def test_critical_balance(self):
+        """Test that very low balance returns critical status"""
+        assert _determine_credit_status(5.0) == "critical"
+        assert _determine_credit_status(1.0) == "critical"
+        assert _determine_credit_status(0.0) == "critical"
+
+
+class TestOpenRouterCreditCheck:
+    """Test OpenRouter credit balance checking"""
+
+    @pytest.mark.asyncio
+    async def test_successful_credit_check(self):
+        """Test successful credit balance check"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": {
+                "limit_remaining": 123.45
+            }
+        }
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+            mock_response.raise_for_status = MagicMock()
+
+            result = await check_openrouter_credits()
+
+            assert result["provider"] == "openrouter"
+            assert result["balance"] == 123.45
+            assert result["status"] == "healthy"
+            assert not result["cached"]
+            assert "error" not in result
+
+    @pytest.mark.asyncio
+    async def test_credit_check_with_warning_balance(self):
+        """Test credit check with low balance triggering warning"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": {
+                "limit_remaining": 15.0
+            }
+        }
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+            mock_response.raise_for_status = MagicMock()
+
+            result = await check_openrouter_credits()
+
+            assert result["balance"] == 15.0
+            assert result["status"] == "warning"
+
+    @pytest.mark.asyncio
+    async def test_credit_check_with_critical_balance(self):
+        """Test credit check with very low balance triggering critical"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": {
+                "limit_remaining": 2.0
+            }
+        }
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+            mock_response.raise_for_status = MagicMock()
+
+            result = await check_openrouter_credits()
+
+            assert result["balance"] == 2.0
+            assert result["status"] == "critical"
+
+    @pytest.mark.asyncio
+    async def test_credit_check_without_api_key(self):
+        """Test credit check fails gracefully without API key"""
+        with patch("src.services.provider_credit_monitor.Config") as mock_config:
+            mock_config.OPENROUTER_API_KEY = None
+
+            result = await check_openrouter_credits()
+
+            assert result["provider"] == "openrouter"
+            assert result["balance"] is None
+            assert result["status"] == "unknown"
+            assert result["error"] == "API key not configured"
+
+    @pytest.mark.asyncio
+    async def test_credit_check_http_error(self):
+        """Test credit check handles HTTP errors"""
+        from httpx import HTTPStatusError, Response, Request
+
+        mock_request = Request("GET", "https://test.com")
+        mock_response = Response(500, request=mock_request)
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                side_effect=HTTPStatusError(
+                    "Server error",
+                    request=mock_request,
+                    response=mock_response
+                )
+            )
+
+            result = await check_openrouter_credits()
+
+            assert result["provider"] == "openrouter"
+            assert result["balance"] is None
+            assert result["status"] == "unknown"
+            assert "500" in result.get("error", "")
+
+    @pytest.mark.asyncio
+    async def test_credit_check_caching(self):
+        """Test that credit checks are cached"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": {
+                "limit_remaining": 50.0
+            }
+        }
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+            mock_response.raise_for_status = MagicMock()
+
+            # First call should hit the API
+            result1 = await check_openrouter_credits()
+            assert not result1["cached"]
+            assert result1["balance"] == 50.0
+
+            # Second call should use cache
+            result2 = await check_openrouter_credits()
+            assert result2["cached"]
+            assert result2["balance"] == 50.0
+
+            # Should only have called API once
+            assert mock_client.return_value.__aenter__.return_value.get.call_count == 1
+
+
+class TestCheckAllProviderCredits:
+    """Test checking all provider credits"""
+
+    @pytest.mark.asyncio
+    async def test_check_all_providers(self):
+        """Test checking all monitored providers"""
+        with patch("src.services.provider_credit_monitor.check_openrouter_credits") as mock_check:
+            mock_check.return_value = {
+                "provider": "openrouter",
+                "balance": 100.0,
+                "status": "healthy",
+                "checked_at": datetime.now(timezone.utc),
+                "cached": False
+            }
+
+            results = await check_all_provider_credits()
+
+            assert "openrouter" in results
+            assert results["openrouter"]["balance"] == 100.0
+            assert results["openrouter"]["status"] == "healthy"
+
+
+class TestLowCreditAlerts:
+    """Test low credit alerting system"""
+
+    @pytest.mark.asyncio
+    async def test_send_critical_alert(self):
+        """Test sending critical credit alert"""
+        with patch("src.services.provider_credit_monitor.capture_provider_error") as mock_capture, \
+             patch("src.services.provider_credit_monitor.send_email") as mock_email, \
+             patch("src.services.provider_credit_monitor.Config") as mock_config:
+
+            mock_config.ADMIN_EMAIL = "admin@test.com"
+
+            await send_low_credit_alert("openrouter", 2.0, "critical")
+
+            # Should capture error in Sentry
+            mock_capture.assert_called_once()
+            args, kwargs = mock_capture.call_args
+            assert "credit balance is CRITICAL" in str(args[0])
+            assert kwargs["provider"] == "openrouter"
+            assert kwargs["extra_context"]["balance"] == 2.0
+            assert kwargs["extra_context"]["status"] == "critical"
+
+    @pytest.mark.asyncio
+    async def test_send_warning_alert(self):
+        """Test sending warning credit alert"""
+        with patch("src.services.provider_credit_monitor.capture_provider_error") as mock_capture:
+            await send_low_credit_alert("openrouter", 15.0, "warning")
+
+            # Should capture in Sentry
+            mock_capture.assert_called_once()
+            args, kwargs = mock_capture.call_args
+            assert "credit balance is WARNING" in str(args[0])
+
+
+class TestCreditCacheManagement:
+    """Test credit cache management"""
+
+    def test_clear_specific_provider_cache(self):
+        """Test clearing cache for specific provider"""
+        from src.services.provider_credit_monitor import _credit_balance_cache
+
+        # Populate cache
+        _credit_balance_cache["openrouter"] = {
+            "balance": 50.0,
+            "checked_at": datetime.now(timezone.utc)
+        }
+        _credit_balance_cache["portkey"] = {
+            "balance": 100.0,
+            "checked_at": datetime.now(timezone.utc)
+        }
+
+        # Clear specific provider
+        clear_credit_cache("openrouter")
+
+        # Only openrouter should be cleared
+        assert "openrouter" not in _credit_balance_cache
+        assert "portkey" in _credit_balance_cache
+
+    def test_clear_all_provider_cache(self):
+        """Test clearing all provider caches"""
+        from src.services.provider_credit_monitor import _credit_balance_cache
+
+        # Populate cache
+        _credit_balance_cache["openrouter"] = {"balance": 50.0}
+        _credit_balance_cache["portkey"] = {"balance": 100.0}
+
+        # Clear all
+        clear_credit_cache()
+
+        # All should be cleared
+        assert len(_credit_balance_cache) == 0

--- a/tests/services/test_provider_credit_monitor.py
+++ b/tests/services/test_provider_credit_monitor.py
@@ -3,7 +3,7 @@ Tests for provider credit monitoring service.
 """
 
 import pytest
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from src.services.provider_credit_monitor import (
@@ -12,7 +12,6 @@ from src.services.provider_credit_monitor import (
     send_low_credit_alert,
     clear_credit_cache,
     _determine_credit_status,
-    CREDIT_THRESHOLDS,
 )
 
 
@@ -205,8 +204,9 @@ class TestLowCreditAlerts:
     @pytest.mark.asyncio
     async def test_send_critical_alert(self):
         """Test sending critical credit alert"""
+        mock_notification_service = MagicMock()
         with patch("src.services.provider_credit_monitor.capture_provider_error") as mock_capture, \
-             patch("src.services.provider_credit_monitor.send_email") as mock_email, \
+             patch("src.services.provider_credit_monitor.notification_service", mock_notification_service), \
              patch("src.services.provider_credit_monitor.Config") as mock_config:
 
             mock_config.ADMIN_EMAIL = "admin@test.com"


### PR DESCRIPTION
## Summary

This PR addresses code quality issues identified in the code reviews from PR #950 (which was merged before these fixes could be included).

## Changes

### 1. Removed Unused Imports/Variables
- `tests/services/test_provider_credit_monitor.py`: Removed unused `timedelta` and `CREDIT_THRESHOLDS` imports
- `tests/routes/test_provider_credits.py`: Removed unused `TestClient` import  
- `tests/services/test_model_catalog_validator.py`: Removed unused `mock_get_post` variable

### 2. Fixed Critical Bug: `send_email` Import Error
**Location:** `src/services/provider_credit_monitor.py:190`

**Issue:** The code imported a non-existent `send_email` function from the notification module, which would cause an `ImportError` at runtime when sending critical credit alerts.

**Fix:**
- Changed to import `notification_service` from the notification module
- Use `notification_service.send_email_notification()` method instead
- Added proper guard for `ADMIN_EMAIL` configuration (logs warning if not set)
- Added guard for notification service initialization state

### 3. Updated Test Mocking
- Updated `test_send_critical_alert` to mock `notification_service` instead of non-existent `send_email`

## Related

- Follow-up to PR #950 (merged before these fixes could be included)
- Addresses CodeQL warnings and Sentry code review comments

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * View and manage provider credit balances through new admin endpoints with real-time status updates and monitoring
  * Automatic validation of model availability across all supported providers before adding models to the catalog
  * Proactive provider credit monitoring system with threshold-based low-balance alerts and notifications
  * Enhanced error handling for payment-related failures with automatic provider credit status verification

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR claims to fix code review issues from PR #950, including unused imports and a critical `send_email` bug. While the unused import removals are valid, **the critical bug fix is incomplete and introduces a new bug**.

## What Was Changed

- **Removed unused imports/variables**: Successfully removed `timedelta` and `CREDIT_THRESHOLDS` from `tests/services/test_provider_credit_monitor.py`, `TestClient` from `tests/routes/test_provider_credits.py`, and unused `mock_get_post` variable from `tests/services/test_model_catalog_validator.py`
- **Attempted to fix `send_email` import**: Changed from importing non-existent `send_email` function to importing `notification_service` object

## Critical Issue Found

The PR description claims to fix the `send_email` import error, but **the fix introduces a new bug**. In `src/services/provider_credit_monitor.py:196`, the code calls:

```python
notification_service.send_email_notification(
    to_email=admin_email,
    subject=f"URGENT: {provider} credits critically low",
    body=f"""...""",  # ❌ Wrong parameter name
)
```

However, the actual method signature in `src/services/notification.py:346` is:

```python
def send_email_notification(
    self, to_email: str, subject: str, html_content: str, text_content: str = None
)
```

The parameter is `html_content`, not `body`. This will cause a `TypeError: send_email_notification() got an unexpected keyword argument 'body'` at runtime when critical credit alerts are triggered.

## Test Coverage Gap

The tests in `tests/services/test_provider_credit_monitor.py` mock `notification_service` but never actually call `send_email_notification()`, so this bug wasn't caught by the test suite.

<h3>Confidence Score: 1/5</h3>

- This PR has a critical bug that will cause runtime failures when provider credits run low
- The PR introduces a TypeError in the critical alert notification system by using the wrong parameter name (`body` instead of `html_content`). While unused imports were successfully removed, the main bug fix is incomplete and introduces a new regression. This will break production functionality when OpenRouter credits reach critical levels.
- `src/services/provider_credit_monitor.py` requires immediate attention - the `send_email_notification` call on line 196 uses incorrect parameter name

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/services/provider_credit_monitor.py | Critical bug in `send_email_notification` call - incorrect parameter name `body` instead of `html_content` will cause runtime error |
| tests/services/test_provider_credit_monitor.py | Removed unused imports (`timedelta`, `CREDIT_THRESHOLDS`), but missing test coverage for email notification functionality |
| tests/routes/test_provider_credits.py | Removed unused `TestClient` import - clean code quality improvement |
| tests/services/test_model_catalog_validator.py | Removed unused `mock_get_post` variable - code is cleaner and uses inline mocking instead |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API as Provider Credits API
    participant Monitor as Provider Credit Monitor
    participant OpenRouter as OpenRouter API
    participant NotificationSvc as Notification Service
    participant Sentry

    Note over Client,Sentry: Critical Credit Alert Flow

    Client->>API: GET /api/provider-credits/balance
    activate API
    API->>Monitor: check_all_provider_credits()
    activate Monitor
    Monitor->>Monitor: Check cache
    alt Cache expired or missing
        Monitor->>OpenRouter: GET /api/v1/auth/key
        activate OpenRouter
        OpenRouter-->>Monitor: {limit_remaining: 2.0}
        deactivate OpenRouter
        Monitor->>Monitor: _determine_credit_status(2.0)
        Monitor->>Monitor: Status = "critical"
        Monitor->>Monitor: Update cache
    end
    Monitor-->>API: {balance: 2.0, status: "critical"}
    deactivate Monitor
    API-->>Client: ProviderCreditsResponse
    deactivate API

    Note over Monitor,Sentry: Low Credit Alert Triggered

    Monitor->>NotificationSvc: send_email_notification(ADMIN_EMAIL)
    activate NotificationSvc
    Note right of NotificationSvc: ⚠️ BUG: Uses 'body=' param<br/>instead of 'html_content='<br/>Will cause TypeError!
    NotificationSvc--xMonitor: TypeError
    deactivate NotificationSvc
    
    Monitor->>Sentry: capture_provider_error()
    activate Sentry
    Sentry-->>Monitor: Logged
    deactivate Sentry

    Note over Client,Sentry: 402 Payment Error in OpenRouter Request

    Client->>API: POST /chat/completions
    activate API
    API->>OpenRouter: Chat completion request
    activate OpenRouter
    OpenRouter-->>API: 402 Payment Required
    deactivate OpenRouter
    
    API->>Monitor: check_openrouter_credits()
    activate Monitor
    Monitor->>OpenRouter: GET /api/v1/auth/key
    activate OpenRouter
    OpenRouter-->>Monitor: {limit_remaining: 0.5}
    deactivate OpenRouter
    Monitor-->>API: {status: "critical"}
    deactivate Monitor
    
    API->>Monitor: send_low_credit_alert()
    activate Monitor
    Monitor->>NotificationSvc: send_email_notification()
    activate NotificationSvc
    NotificationSvc--xMonitor: TypeError (bug)
    deactivate NotificationSvc
    Monitor->>Sentry: capture_provider_error()
    deactivate Monitor
    
    API-->>Client: 402 Error + Failover
    deactivate API
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->