### PR TITLE
fix: add Helicone and Vercel to pricing format mapping

### DIFF
--- a/src/services/pricing_normalization.py
+++ b/src/services/pricing_normalization.py
@@ -138,6 +138,8 @@ PROVIDER_PRICING_FORMATS = {
     "nebius": PricingFormat.PER_1M_TOKENS,
     "alibaba-cloud": PricingFormat.PER_1M_TOKENS,
     "morpheus": PricingFormat.PER_1M_TOKENS,
+    "helicone": PricingFormat.PER_1M_TOKENS,  # Helicone API returns per-1M pricing
+    "vercel-ai-gateway": PricingFormat.PER_1M_TOKENS,  # Vercel API returns per-token, but we convert to per-1M in client
 
     # Per-1K tokens
     "aihubmix": PricingFormat.PER_1K_TOKENS,


### PR DESCRIPTION
## Summary
Adds explicit entries for Helicone and Vercel AI Gateway in the `PROVIDER_PRICING_FORMATS` mapping in `pricing_normalization.py`.

## Changes
- Added `helicone` -> `PER_1M_TOKENS` mapping
- Added `vercel-ai-gateway` -> `PER_1M_TOKENS` mapping

## Why This Matters
While these providers already defaulted to `PER_1M_TOKENS`, explicitly listing them:

1. **Documents** the expected pricing format from each provider
2. **Ensures consistency** if the default ever changes
3. **Makes the codebase easier to understand** and maintain

## Technical Details
- **Helicone's public API** returns pricing in per-1M format directly (e.g., `prompt: 15` meaning $15/MTok)
- **Vercel's API** returns per-token pricing which is converted to per-1M in `vercel_ai_gateway_client.py` before being stored

## Test plan
- [x] Verified Helicone API returns correct per-1M pricing
- [x] Verified Vercel API returns per-token pricing that gets converted correctly
- [x] Manual pricing in `manual_pricing.json` already uses per-1M format for both providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pricing support for Helicone and Vercel AI Gateway providers, enabling accurate cost calculations for these services.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds explicit `helicone` and `vercel-ai-gateway` entries to the `PROVIDER_PRICING_FORMATS` mapping in `pricing_normalization.py`, documenting that both providers use per-1M token pricing format.

**Key Changes:**
- Added `"helicone": PricingFormat.PER_1M_TOKENS` with comment explaining Helicone API returns per-1M pricing
- Added `"vercel-ai-gateway": PricingFormat.PER_1M_TOKENS` with comment noting Vercel API returns per-token but is converted to per-1M in the client

**Technical Verification:**
- `helicone_client.py:164-173` confirms API returns per-1M format directly (e.g., `prompt: 15` means $15/MTok)
- `vercel_ai_gateway_client.py:169-171` confirms conversion from per-token to per-1M (multiplies by 1,000,000)
- Both providers already defaulted to per-1M, so this change is purely documentation
- No behavioral changes introduced

**Benefits:**
- Makes pricing format expectations explicit and self-documenting
- Prevents format confusion if defaults change
- Improves maintainability and code clarity

<h3>Confidence Score: 5/5</h3>

- Safe to merge - purely documentation change with no behavioral impact
- This PR adds explicit documentation entries to a pricing format mapping without changing any logic. The entries already defaulted to PER_1M_TOKENS via the fallback in `get_provider_format()`. Code inspection confirms both client implementations match the documented formats: Helicone returns per-1M directly, and Vercel converts per-token to per-1M. The change improves code clarity and maintainability with zero risk.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/services/pricing_normalization.py | Added explicit `helicone` and `vercel-ai-gateway` entries to `PROVIDER_PRICING_FORMATS` mapping, documenting their per-1M token pricing format |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PR as Pull Request
    participant PN as pricing_normalization.py
    participant PL as pricing_lookup.py
    participant HC as helicone_client.py
    participant VC as vercel_ai_gateway_client.py
    
    Note over PR,VC: PR adds explicit provider format mappings
    
    PR->>PN: Add helicone -> PER_1M_TOKENS
    PR->>PN: Add vercel-ai-gateway -> PER_1M_TOKENS
    
    Note over PL: When pricing lookup occurs
    PL->>PN: get_provider_format("helicone")
    PN-->>PL: PricingFormat.PER_1M_TOKENS
    PL->>PN: normalize_pricing_dict(raw_pricing, format)
    PN-->>PL: Normalized per-token pricing
    
    Note over HC: Helicone API integration
    HC->>HC: fetch_helicone_pricing_from_public_api()
    Note right of HC: API returns per-1M pricing<br/>(e.g., prompt: 15 = $15/MTok)
    HC->>PN: Uses PER_1M_TOKENS format (explicit)
    
    Note over VC: Vercel AI Gateway integration
    VC->>VC: fetch_vercel_pricing_from_public_api()
    Note right of VC: API returns per-token pricing<br/>(e.g., input: 0.000003)
    VC->>VC: Convert to per-1M (× 1,000,000)
    VC->>PN: Uses PER_1M_TOKENS format (explicit)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->