### PR TITLE
fix(migrations): recreate model_usage_analytics view after pricing consolidation

### DIFF
--- a/supabase/migrations/20260127000000_recreate_model_usage_analytics_view.sql
+++ b/supabase/migrations/20260127000000_recreate_model_usage_analytics_view.sql
@@ -165,3 +165,15 @@ BEGIN
         RAISE EXCEPTION 'Failed to create model_usage_analytics view';
     END IF;
 END $$;
+
+-- ============================================================================
+-- DOWN MIGRATION (for rollback)
+-- ============================================================================
+-- To rollback this migration, run the following:
+--
+-- DROP VIEW IF EXISTS "public"."model_usage_analytics";
+--
+-- Note: This will remove the analytics view. The /admin/model-usage-analytics
+-- endpoint and /model-analytics dashboard page will stop working until
+-- the view is recreated.
+-- ============================================================================

--- a/supabase/migrations/20260127000000_recreate_model_usage_analytics_view.sql
+++ b/supabase/migrations/20260127000000_recreate_model_usage_analytics_view.sql
@@ -155,7 +155,7 @@ BEGIN
         RAISE NOTICE '';
         RAISE NOTICE 'Summary:';
         RAISE NOTICE '  • View now uses model_pricing table for costs';
-        RAISE NOTICE '  • Pricing displayed as per-1K tokens';
+        RAISE NOTICE '  • Pricing displayed as per-1M tokens';
         RAISE NOTICE '  • Models with usage data: %', model_count;
         RAISE NOTICE '';
         RAISE NOTICE 'API Endpoint: GET /admin/model-usage-analytics';

--- a/supabase/migrations/20260127000000_recreate_model_usage_analytics_view.sql
+++ b/supabase/migrations/20260127000000_recreate_model_usage_analytics_view.sql
@@ -1,0 +1,167 @@
+-- ============================================================================
+-- Recreate Model Usage Analytics View
+-- ============================================================================
+-- Migration: 20260127000000
+-- Description: Recreates the model_usage_analytics view using the new
+--              model_pricing table after the pricing consolidation migration
+--              (20260121000003) dropped it without recreating.
+--
+-- This view provides comprehensive analytics for model usage including:
+--   - Request counts
+--   - Token usage (input/output totals and averages)
+--   - Cost calculations based on model_pricing table
+--   - Performance metrics
+--   - Time-series data for usage over time
+-- ============================================================================
+
+-- Drop view if it exists (for idempotency)
+DROP VIEW IF EXISTS "public"."model_usage_analytics";
+
+-- Create the model_usage_analytics view using model_pricing table
+CREATE VIEW "public"."model_usage_analytics" AS
+SELECT
+    -- Model identification
+    m.id as model_id,
+    m.model_name,
+    m.model_id as model_identifier,
+    m.provider_model_id,
+    p.name as provider_name,
+    p.slug as provider_slug,
+
+    -- Request counts
+    COUNT(ccr.id) as successful_requests,
+
+    -- Token usage breakdown
+    COALESCE(SUM(ccr.input_tokens), 0) as total_input_tokens,
+    COALESCE(SUM(ccr.output_tokens), 0) as total_output_tokens,
+    COALESCE(SUM(ccr.input_tokens + ccr.output_tokens), 0) as total_tokens,
+
+    -- Average token usage per request
+    ROUND(AVG(ccr.input_tokens), 2) as avg_input_tokens_per_request,
+    ROUND(AVG(ccr.output_tokens), 2) as avg_output_tokens_per_request,
+
+    -- Pricing (per 1M tokens for display - derived from per-token pricing)
+    -- model_pricing stores per-token, multiply by 1,000,000 for per-1M display
+    -- This matches the original view format for backward compatibility
+    COALESCE(mp.price_per_input_token * 1000000, 0) as input_token_price_per_1m,
+    COALESCE(mp.price_per_output_token * 1000000, 0) as output_token_price_per_1m,
+
+    -- Cost calculations (in USD)
+    -- model_pricing stores per-token pricing, so multiply tokens directly
+    ROUND(
+        CAST(
+            (COALESCE(SUM(ccr.input_tokens), 0) * COALESCE(mp.price_per_input_token, 0)) +
+            (COALESCE(SUM(ccr.output_tokens), 0) * COALESCE(mp.price_per_output_token, 0))
+            AS NUMERIC
+        ),
+        6
+    ) as total_cost_usd,
+
+    -- Cost breakdown
+    ROUND(
+        CAST(COALESCE(SUM(ccr.input_tokens), 0) * COALESCE(mp.price_per_input_token, 0) AS NUMERIC),
+        6
+    ) as input_cost_usd,
+    ROUND(
+        CAST(COALESCE(SUM(ccr.output_tokens), 0) * COALESCE(mp.price_per_output_token, 0) AS NUMERIC),
+        6
+    ) as output_cost_usd,
+
+    -- Average cost per request
+    ROUND(
+        CAST(
+            (COALESCE(SUM(ccr.input_tokens), 0) * COALESCE(mp.price_per_input_token, 0)) +
+            (COALESCE(SUM(ccr.output_tokens), 0) * COALESCE(mp.price_per_output_token, 0))
+            AS NUMERIC
+        ) / NULLIF(COUNT(ccr.id), 0),
+        6
+    ) as avg_cost_per_request_usd,
+
+    -- Performance metrics
+    ROUND(AVG(ccr.processing_time_ms), 2) as avg_processing_time_ms,
+
+    -- Model metadata
+    m.context_length,
+    m.modality,
+    m.health_status,
+    m.is_active,
+
+    -- Pricing metadata
+    mp.pricing_type,
+    mp.pricing_source,
+
+    -- Time tracking
+    MIN(ccr.created_at) as first_request_at,
+    MAX(ccr.created_at) as last_request_at
+
+FROM "public"."models" m
+INNER JOIN "public"."providers" p ON m.provider_id = p.id
+INNER JOIN "public"."chat_completion_requests" ccr ON m.id = ccr.model_id
+LEFT JOIN "public"."model_pricing" mp ON m.id = mp.model_id
+WHERE ccr.status = 'completed'  -- Only successful requests
+GROUP BY
+    m.id,
+    m.model_name,
+    m.model_id,
+    m.provider_model_id,
+    m.context_length,
+    m.modality,
+    m.health_status,
+    m.is_active,
+    p.name,
+    p.slug,
+    mp.price_per_input_token,
+    mp.price_per_output_token,
+    mp.pricing_type,
+    mp.pricing_source
+HAVING COUNT(ccr.id) > 0  -- Only models with at least 1 successful request
+ORDER BY successful_requests DESC, total_cost_usd DESC;
+
+-- Add helpful comment
+COMMENT ON VIEW "public"."model_usage_analytics" IS
+    'Comprehensive analytics view showing all models with at least one successful request. '
+    'Includes request counts, token usage breakdown (input/output), pricing from model_pricing table, '
+    'and calculated costs (total, input, output, per-request average). '
+    'Updated in real-time as new requests are completed. '
+    'Useful for cost analysis, usage tracking, and identifying most expensive/popular models. '
+    'Updated 2026-01-27 to use model_pricing table after pricing consolidation.';
+
+-- Grant appropriate permissions
+GRANT SELECT ON "public"."model_usage_analytics" TO authenticated;
+GRANT SELECT ON "public"."model_usage_analytics" TO anon;
+GRANT SELECT ON "public"."model_usage_analytics" TO service_role;
+
+-- Log success
+DO $$
+DECLARE
+    view_exists BOOLEAN;
+    model_count INTEGER;
+BEGIN
+    -- Check if view was created successfully
+    SELECT EXISTS (
+        SELECT 1 FROM information_schema.views
+        WHERE table_schema = 'public'
+          AND table_name = 'model_usage_analytics'
+    ) INTO view_exists;
+
+    IF view_exists THEN
+        -- Count models in the view
+        SELECT COUNT(*) INTO model_count FROM model_usage_analytics;
+
+        RAISE NOTICE '';
+        RAISE NOTICE '========================================';
+        RAISE NOTICE '✅ MODEL USAGE ANALYTICS VIEW RECREATED';
+        RAISE NOTICE '========================================';
+        RAISE NOTICE '';
+        RAISE NOTICE 'Summary:';
+        RAISE NOTICE '  • View now uses model_pricing table for costs';
+        RAISE NOTICE '  • Pricing displayed as per-1K tokens';
+        RAISE NOTICE '  • Models with usage data: %', model_count;
+        RAISE NOTICE '';
+        RAISE NOTICE 'API Endpoint: GET /admin/model-usage-analytics';
+        RAISE NOTICE 'Admin Dashboard: /model-analytics';
+        RAISE NOTICE '';
+    ELSE
+        RAISE EXCEPTION 'Failed to create model_usage_analytics view';
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary

The migration `20260121000003_remove_pricing_columns_from_models.sql` dropped the `model_usage_analytics` view when removing pricing columns from the models table, but never recreated it. This caused the `/model-analytics` admin dashboard page to break with "This page isn't working" error.

## Changes

- Created migration `20260127000000_recreate_model_usage_analytics_view.sql` that:
  - Recreates the `model_usage_analytics` view using the new `model_pricing` table
  - Uses `price_per_input_token` and `price_per_output_token` from `model_pricing`
  - Converts per-token pricing to per-1M for display compatibility with existing consumers
  - Adds `pricing_type` and `pricing_source` columns for additional context
  - Maintains backward compatibility with the existing API endpoint

## Test plan

- [ ] Apply migration to staging database
- [ ] Verify `/admin/model-usage-analytics` endpoint returns data
- [ ] Verify admin dashboard `/model-analytics` page loads and displays data
- [ ] Check that cost calculations are accurate

## Related

- Companion PR in admin-dashboard: https://github.com/Alpaca-Network/gatewayz-admin/pull/62

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model usage analytics view now available with comprehensive metrics including request counts, token consumption, performance times, and cost tracking across all models.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Recreates the `model_usage_analytics` view that was accidentally dropped by the pricing consolidation migration (20260121000003). The view now uses the `model_pricing` table instead of the removed pricing columns from the `models` table.

**Key Changes:**
- Recreates view with LEFT JOIN to `model_pricing` for pricing data
- Converts per-token pricing to per-1M format for backward compatibility (multiply by 1,000,000)
- Adds `pricing_type` and `pricing_source` columns from the new pricing schema
- Maintains all original analytics fields (request counts, token usage, costs, performance metrics)
- Includes comprehensive permissions grants and validation logic

**Minor Issue Found:**
- Line 158 has a typo: "per-1K tokens" should be "per-1M tokens"

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - fixes a broken admin dashboard endpoint
- The migration correctly recreates the dropped view using the new `model_pricing` table schema. The SQL syntax is valid, the joins are appropriate, and the pricing conversion logic (per-token to per-1M) maintains backward compatibility. The only issue is a minor typo in a NOTICE message that doesn't affect functionality. The view uses LEFT JOIN for `model_pricing` which prevents data loss if pricing data is missing.
- No files require special attention - the migration is straightforward and well-documented

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| supabase/migrations/20260127000000_recreate_model_usage_analytics_view.sql | Recreates `model_usage_analytics` view using `model_pricing` table after pricing consolidation; includes minor typo in notice message |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant M as Migration 20260121000003
    participant DB as Database
    participant V as model_usage_analytics View
    participant A as Admin Dashboard
    participant M2 as Migration 20260127000000

    Note over M,DB: Previous Migration (Pricing Consolidation)
    M->>DB: DROP COLUMN models.pricing_prompt CASCADE
    M->>V: View dropped (CASCADE effect)
    M->>DB: DROP COLUMN models.pricing_completion CASCADE
    M->>DB: CREATE VIEW models_with_pricing
    M->>DB: CREATE VIEW models_pricing_status
    Note over M,V: ❌ model_usage_analytics NOT recreated

    Note over A: Admin tries to access /model-analytics
    A->>DB: SELECT * FROM model_usage_analytics
    DB-->>A: ❌ ERROR: relation does not exist
    A-->>A: "This page isn't working"

    Note over M2,DB: This PR - Fix Migration
    M2->>DB: DROP VIEW IF EXISTS model_usage_analytics
    M2->>DB: CREATE VIEW model_usage_analytics AS SELECT...
    M2->>DB: JOIN models + providers + chat_completion_requests
    M2->>DB: LEFT JOIN model_pricing (new pricing source)
    M2->>DB: Calculate costs using mp.price_per_input_token
    M2->>DB: Display pricing as per-1M (multiply by 1,000,000)
    M2->>DB: GRANT SELECT permissions
    DB-->>M2: ✅ View created successfully

    Note over A: Admin accesses /model-analytics
    A->>DB: SELECT * FROM model_usage_analytics
    DB-->>A: ✅ Returns analytics data with pricing
    A-->>A: Dashboard displays correctly
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->