### PR TITLE
fix(butter): add missing providers to BUTTER_PROVIDER_CONFIG including onerouter

### DIFF
--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -595,6 +595,50 @@ BUTTER_PROVIDER_CONFIG = {
         "api_key_attr": "CHUTES_API_KEY",
         "base_url": "https://llm.chutes.ai/v1",
     },
+    "onerouter": {
+        "api_key_attr": "ONEROUTER_API_KEY",
+        "base_url": "https://llm.infron.ai/v1",
+    },
+    "aihubmix": {
+        "api_key_attr": "AIHUBMIX_API_KEY",
+        "base_url": "https://aihubmix.com/v1",
+    },
+    "near": {
+        "api_key_attr": "NEAR_API_KEY",
+        "base_url": "https://cloud-api.near.ai/v1",
+    },
+    "morpheus": {
+        "api_key_attr": "MORPHEUS_API_KEY",
+        "base_url": "https://api.mor.org/api/v1",
+    },
+    "simplismart": {
+        "api_key_attr": "SIMPLISMART_API_KEY",
+        "base_url": "https://api.simplismart.live",
+    },
+    "sybil": {
+        "api_key_attr": "SYBIL_API_KEY",
+        "base_url": "https://api.sybil.com/v1",
+    },
+    "nosana": {
+        "api_key_attr": "NOSANA_API_KEY",
+        "base_url": "https://dashboard.k8s.prd.nos.ci/api/v1",
+    },
+    "akash": {
+        "api_key_attr": "AKASH_API_KEY",
+        "base_url": "https://api.akashml.com/v1",
+    },
+    "anannas": {
+        "api_key_attr": "ANANNAS_API_KEY",
+        "base_url": "https://api.anannas.ai/v1",
+    },
+    "helicone": {
+        "api_key_attr": "HELICONE_API_KEY",
+        "base_url": "https://ai-gateway.helicone.ai/v1",
+    },
+    "aimo": {
+        "api_key_attr": "AIMO_API_KEY",
+        "base_url": "https://beta.aimo.network/api/v1",
+    },
 }
 
 

--- a/tests/routes/test_chat_butter_integration.py
+++ b/tests/routes/test_chat_butter_integration.py
@@ -50,6 +50,35 @@ class TestButterProviderConfig:
         assert BUTTER_PROVIDER_CONFIG["groq"]["api_key_attr"] == "GROQ_API_KEY"
         assert "groq.com" in BUTTER_PROVIDER_CONFIG["groq"]["base_url"]
 
+    def test_onerouter_config_exists(self):
+        """Test that OneRouter/Infron config is defined - this is the default provider."""
+        from src.routes.chat import BUTTER_PROVIDER_CONFIG
+
+        assert "onerouter" in BUTTER_PROVIDER_CONFIG
+        assert BUTTER_PROVIDER_CONFIG["onerouter"]["api_key_attr"] == "ONEROUTER_API_KEY"
+        assert "infron.ai" in BUTTER_PROVIDER_CONFIG["onerouter"]["base_url"]
+
+    def test_all_compatible_providers_have_config(self):
+        """Test that all providers in BUTTER_COMPATIBLE_PROVIDERS have a config entry."""
+        from src.routes.chat import BUTTER_PROVIDER_CONFIG
+        from src.services.butter_client import BUTTER_COMPATIBLE_PROVIDERS
+
+        # These providers are in compatible list but may not have Butter proxy config
+        # because they use special authentication or non-OpenAI API formats
+        providers_without_config = {
+            "cloudflare-workers-ai",  # Uses account-specific URL
+            "alpaca-network",  # Uses special auth
+            "vercel-ai-gateway",  # Uses Vercel-specific auth
+            "perplexity",  # Not commonly used
+        }
+
+        for provider in BUTTER_COMPATIBLE_PROVIDERS:
+            if provider not in providers_without_config:
+                assert provider in BUTTER_PROVIDER_CONFIG, (
+                    f"Provider '{provider}' is in BUTTER_COMPATIBLE_PROVIDERS "
+                    f"but missing from BUTTER_PROVIDER_CONFIG"
+                )
+
     def test_all_configs_have_required_fields(self):
         """Test that all provider configs have required fields."""
         from src.routes.chat import BUTTER_PROVIDER_CONFIG


### PR DESCRIPTION
## Summary
- Fixes Butter.dev caching not working because `onerouter` (the default provider) was in `BUTTER_COMPATIBLE_PROVIDERS` but missing from `BUTTER_PROVIDER_CONFIG`
- Adds 11 missing providers to `BUTTER_PROVIDER_CONFIG`:
  - **onerouter** - The default/first provider in failover chain (critical fix)
  - aihubmix, near, morpheus, simplismart, sybil, nosana, akash, anannas, helicone, aimo
- Adds tests to verify onerouter config exists and all compatible providers have config entries

## Root Cause
The cache eligibility check at line 2244 (`should_use_butter_cache()`) was returning `True` for onerouter, but the routing check at line 2274 (`attempt_provider in BUTTER_PROVIDER_CONFIG`) was failing because onerouter wasn't configured. This caused the system to skip Butter proxy routing entirely for the most common case.

## Test plan
- [x] Verify `test_onerouter_config_exists` passes
- [x] Verify `test_all_compatible_providers_have_config` passes
- [ ] Deploy and verify Butter.dev cache hits in production logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a critical bug in Butter.dev caching integration where `onerouter` (the default/first provider in the failover chain) was marked as compatible for caching but had no configuration entry, causing the system to skip Butter.dev proxy routing entirely.

**Key Changes:**
- Added 11 missing providers to `BUTTER_PROVIDER_CONFIG`: `onerouter`, `aihubmix`, `near`, `morpheus`, `simplismart`, `sybil`, `nosana`, `akash`, `anannas`, `helicone`, and `aimo`
- All new entries follow the standard format with `api_key_attr` and `base_url` fields
- Added test `test_onerouter_config_exists()` to verify `onerouter` configuration
- Added test `test_all_compatible_providers_have_config()` to prevent future regressions by validating all providers in `BUTTER_COMPATIBLE_PROVIDERS` have corresponding config entries (excluding 4 providers with special authentication requirements)

**Impact:**
Before this fix, when a request was eligible for Butter.dev caching and routed to `onerouter`, the code at line 2318 (`attempt_provider in BUTTER_PROVIDER_CONFIG`) would fail, causing the request to bypass Butter.dev entirely and go directly to the provider. This meant the most common case (default provider) was never using the cache, defeating the purpose of the integration.

**Consistency:**
All providers in `BUTTER_COMPATIBLE_PROVIDERS` now have corresponding `BUTTER_PROVIDER_CONFIG` entries, except for 4 providers that legitimately require special handling (`cloudflare-workers-ai`, `alpaca-network`, `vercel-ai-gateway`, `perplexity`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it fixes a critical bug in caching infrastructure
- Score of 5 reflects that this is a straightforward configuration fix with excellent test coverage. The changes add missing provider configurations following an established pattern, include comprehensive tests to prevent future regressions, and directly fix a documented bug where the default provider was bypassing the cache. No logic changes, no breaking changes, and the new tests validate both the specific fix and the general consistency of the configuration.
- No files require special attention - both files contain clean, well-tested configuration additions

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/routes/chat.py | Added 11 missing providers to `BUTTER_PROVIDER_CONFIG` including critical fix for `onerouter` (default provider) |
| tests/routes/test_chat_butter_integration.py | Added comprehensive tests for `onerouter` config and validation that all compatible providers have config entries |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ChatEndpoint as /v1/chat/completions
    participant ButterClient as should_use_butter_cache()
    participant ButterConfig as BUTTER_PROVIDER_CONFIG
    participant ButterProxy as Butter.dev Proxy
    participant Provider as Actual Provider (e.g., onerouter)

    User->>ChatEndpoint: POST chat completion request
    ChatEndpoint->>ButterClient: Check cache eligibility
    ButterClient->>ButterClient: Check BUTTER_COMPATIBLE_PROVIDERS
    alt onerouter in BUTTER_COMPATIBLE_PROVIDERS
        ButterClient-->>ChatEndpoint: True, "enabled"
        ChatEndpoint->>ButterConfig: Check BUTTER_PROVIDER_CONFIG["onerouter"]
        alt Before fix: onerouter missing
            ButterConfig-->>ChatEndpoint: None (KeyError)
            ChatEndpoint->>Provider: Direct request (no caching)
            Provider-->>ChatEndpoint: Response
        else After fix: onerouter present
            ButterConfig-->>ChatEndpoint: {api_key_attr, base_url}
            ChatEndpoint->>ButterProxy: Route through Butter.dev
            ButterProxy->>ButterProxy: Check cache
            alt Cache hit
                ButterProxy-->>ChatEndpoint: Cached response (fast)
            else Cache miss
                ButterProxy->>Provider: Forward to actual provider
                Provider-->>ButterProxy: Response
                ButterProxy->>ButterProxy: Store in cache
                ButterProxy-->>ChatEndpoint: Response
            end
        end
    else Provider not compatible
        ButterClient-->>ChatEndpoint: False, "provider_incompatible"
        ChatEndpoint->>Provider: Direct request
        Provider-->>ChatEndpoint: Response
    end
    ChatEndpoint-->>User: Stream response
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->