### PR TITLE
fix(pricing): resolve $0.00 pricing for Helicone, Vercel AI, and Anthropic gateways

### DIFF
--- a/src/data/manual_pricing.json
+++ b/src/data/manual_pricing.json
@@ -674,9 +674,65 @@
     }
   },
   "anthropic": {
+    "anthropic/claude-opus-4": {
+      "prompt": "15.00",
+      "completion": "75.00",
+      "request": "0",
+      "image": "0",
+      "context_length": 200000
+    },
+    "anthropic/claude-opus-4-1": {
+      "prompt": "15.00",
+      "completion": "75.00",
+      "request": "0",
+      "image": "0",
+      "context_length": 200000
+    },
+    "anthropic/claude-opus-4.5": {
+      "prompt": "5.00",
+      "completion": "25.00",
+      "request": "0",
+      "image": "0",
+      "context_length": 200000
+    },
+    "anthropic/claude-sonnet-4": {
+      "prompt": "3.00",
+      "completion": "15.00",
+      "request": "0",
+      "image": "0",
+      "context_length": 200000
+    },
+    "anthropic/claude-haiku-4.5": {
+      "prompt": "1.00",
+      "completion": "5.00",
+      "request": "0",
+      "image": "0",
+      "context_length": 200000
+    },
+    "anthropic/claude-3-7-sonnet": {
+      "prompt": "3.00",
+      "completion": "15.00",
+      "request": "0",
+      "image": "0",
+      "context_length": 200000
+    },
+    "anthropic/claude-3-5-sonnet": {
+      "prompt": "3.00",
+      "completion": "15.00",
+      "request": "0",
+      "image": "0",
+      "context_length": 200000
+    },
     "anthropic/claude-3-5-sonnet-20241022": {
       "prompt": "3.00",
       "completion": "15.00",
+      "request": "0",
+      "image": "0",
+      "context_length": 200000
+    },
+    "anthropic/claude-3-5-haiku": {
+      "prompt": "0.80",
+      "completion": "4.00",
       "request": "0",
       "image": "0",
       "context_length": 200000
@@ -688,6 +744,13 @@
       "image": "0",
       "context_length": 200000
     },
+    "anthropic/claude-3-opus": {
+      "prompt": "15.00",
+      "completion": "75.00",
+      "request": "0",
+      "image": "0",
+      "context_length": 200000
+    },
     "anthropic/claude-3-opus-20240229": {
       "prompt": "15.00",
       "completion": "75.00",
@@ -695,9 +758,23 @@
       "image": "0",
       "context_length": 200000
     },
+    "anthropic/claude-3-sonnet": {
+      "prompt": "3.00",
+      "completion": "15.00",
+      "request": "0",
+      "image": "0",
+      "context_length": 200000
+    },
     "anthropic/claude-3-sonnet-20240229": {
       "prompt": "3.00",
       "completion": "15.00",
+      "request": "0",
+      "image": "0",
+      "context_length": 200000
+    },
+    "anthropic/claude-3-haiku": {
+      "prompt": "0.25",
+      "completion": "1.25",
       "request": "0",
       "image": "0",
       "context_length": 200000

--- a/src/services/pricing_lookup.py
+++ b/src/services/pricing_lookup.py
@@ -18,6 +18,7 @@ GATEWAY_PROVIDERS = {
     "akash",
     "alibaba-cloud",
     "anannas",
+    "anthropic",  # Direct Anthropic API - needs cross-reference for model ID matching
     "clarifai",
     "cloudflare-workers-ai",
     "deepinfra",

--- a/src/services/pricing_normalization.py
+++ b/src/services/pricing_normalization.py
@@ -125,6 +125,7 @@ PROVIDER_PRICING_FORMATS = {
     "openrouter": PricingFormat.PER_TOKEN,  # FIXED: OpenRouter returns per-token pricing, not per-1M
 
     # Per-1M tokens (most common)
+    "anthropic": PricingFormat.PER_1M_TOKENS,  # Anthropic manual pricing is per-1M
     "deepinfra": PricingFormat.PER_1M_TOKENS,
     "featherless": PricingFormat.PER_1M_TOKENS,
     "together": PricingFormat.PER_1M_TOKENS,


### PR DESCRIPTION
## Summary
- Fixed $0.00 pricing display for Helicone, Vercel AI Gateway, and Anthropic models on `/models`
- Refactored `get_helicone_model_pricing()` to call the public API directly without `_is_building_catalog()` check
- Added `anthropic` to `GATEWAY_PROVIDERS` for cross-reference pricing support
- Added newer Anthropic model IDs (claude-opus-4, claude-opus-4.5, claude-sonnet-4, etc.) to manual_pricing.json

## Root Causes
1. **Helicone**: The `_is_building_catalog()` check was returning zeros during catalog build, but the Helicone public API doesn't have circular dependency issues
2. **Anthropic**: Was not in `GATEWAY_PROVIDERS` list and missing newer model IDs in manual pricing
3. **Vercel**: Manual pricing entries existed but model ID lookup patterns weren't matching

## Test plan
- [ ] Verify Helicone models show correct pricing on /models
- [ ] Verify Vercel AI Gateway models show correct pricing on /models
- [ ] Verify Anthropic models show correct pricing on /models
- [ ] Check that pricing values match expected rates:
  - Claude Opus 4: $15/$75 per MTok
  - Claude Opus 4.5: $5/$25 per MTok
  - Gemini 2.5 Flash: $0.30/$2.50 per MTok
  - GPT-4o: $2.50/$10 per MTok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed $0.00 pricing display for Helicone, Vercel AI Gateway, and Anthropic models on the `/models` endpoint by addressing three root causes:

**Key Changes:**
- Refactored `get_helicone_model_pricing()` to directly call Helicone's public API without the `_is_building_catalog()` check, which was unnecessarily returning zeros during catalog build
- Added `anthropic` to `GATEWAY_PROVIDERS` in `pricing_lookup.py` to enable cross-reference pricing for Anthropic models
- Added `anthropic` to `PROVIDER_PRICING_FORMATS` with `PER_1M_TOKENS` format for correct pricing normalization
- Extended manual pricing data with newer Anthropic model IDs including claude-opus-4, claude-opus-4.5, claude-sonnet-4, claude-haiku-4.5, and claude-3-7-sonnet

**Implementation Details:**
- The new Helicone pricing logic implements a smart fallback pattern: tries exact model ID match first, then strips provider prefix, then tries common provider prefixes (anthropic, openai, google, meta-llama)
- All pricing values match expected rates per the test plan (e.g., Claude Opus 4: $15/$75, Claude Opus 4.5: $5/$25)
- Vercel AI Gateway pricing entries already existed but now benefit from improved cross-reference logic

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk
- The changes are well-scoped and address a specific pricing display bug. The refactoring removes an unnecessary check that was causing zero pricing, and the manual pricing additions are straightforward data updates. The smart fallback pattern in Helicone pricing lookup is well-designed. Score is 4/5 rather than 5/5 because the removal of `_is_building_catalog()` check should be verified not to cause circular dependencies in edge cases, though the implementation appears sound.
- Pay close attention to `src/services/models.py` to ensure the removed `_is_building_catalog()` check doesn't introduce circular dependencies in edge cases

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/data/manual_pricing.json | Added newer Anthropic model IDs (claude-opus-4, claude-opus-4.5, claude-sonnet-4, etc.) with correct pricing per MTok |
| src/services/models.py | Refactored get_helicone_model_pricing() to call public API directly with fallback pattern matching, removing _is_building_catalog() check |
| src/services/pricing_lookup.py | Added `anthropic` to GATEWAY_PROVIDERS for cross-reference pricing support |
| src/services/pricing_normalization.py | Added `anthropic` to PROVIDER_PRICING_FORMATS with PER_1M_TOKENS format |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API as /models Endpoint
    participant Models as models.py
    participant Helicone as get_helicone_model_pricing()
    participant HeliconeAPI as fetch_helicone_pricing_from_public_api()
    participant ExternalAPI as Helicone Public API
    participant PricingLookup as pricing_lookup.py
    participant ManualPricing as manual_pricing.json

    Client->>API: GET /models
    API->>Models: fetch_models_from_helicone()
    Models->>Helicone: get_helicone_model_pricing(model_id)
    
    Note over Helicone: Removed _is_building_catalog() check
    
    Helicone->>HeliconeAPI: fetch_helicone_pricing_from_public_api()
    
    alt Cache Hit
        HeliconeAPI-->>Helicone: Return cached pricing_map
    else Cache Miss
        HeliconeAPI->>ExternalAPI: GET /v1/public/model-registry/models
        ExternalAPI-->>HeliconeAPI: Return model pricing data
        HeliconeAPI->>HeliconeAPI: Build pricing_map with model_id variations
        HeliconeAPI-->>Helicone: Return pricing_map
    end
    
    Helicone->>Helicone: Try exact match: model_id in pricing_map
    
    alt Exact Match Found
        Helicone-->>Models: Return pricing dict
    else Try Without Prefix
        Helicone->>Helicone: Extract model_name from model_id
        Helicone->>Helicone: Check model_name in pricing_map
        
        alt Match Found
            Helicone-->>Models: Return pricing dict
        else Try With Provider Prefixes
            loop For each prefix in [anthropic, openai, google, meta-llama]
                Helicone->>Helicone: Check prefix/model_name in pricing_map
                alt Match Found
                    Helicone-->>Models: Return pricing dict
                end
            end
            Helicone-->>Models: Return zero pricing (fallback)
        end
    end
    
    Models->>PricingLookup: enrich_model_with_pricing(model, "helicone")
    
    alt Manual Pricing Exists
        PricingLookup->>ManualPricing: get_model_pricing("helicone", model_id)
        ManualPricing-->>PricingLookup: Return manual pricing
        PricingLookup-->>Models: Return enriched model
    else Gateway Cross-Reference
        Note over PricingLookup: "anthropic" now in GATEWAY_PROVIDERS
        PricingLookup->>ManualPricing: Cross-reference with OpenRouter/manual pricing
        ManualPricing-->>PricingLookup: Return cross-referenced pricing
        PricingLookup-->>Models: Return enriched model or None
    end
    
    Models-->>API: Return model list with pricing
    API-->>Client: Return /models response
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->