### PR TITLE
fix(failover): move google-vertex to position 4 in failover chain

### DIFF
--- a/src/services/provider_failover.py
+++ b/src/services/provider_failover.py
@@ -47,6 +47,7 @@ FALLBACK_PROVIDER_PRIORITY: tuple[str, ...] = (
     "onerouter",
     "openai",  # Native OpenAI - try first for openai/* models
     "anthropic",  # Native Anthropic - try first for anthropic/* models
+    "google-vertex",
     "openrouter",  # Fallback for OpenAI/Anthropic models
     "cerebras",
     "huggingface",
@@ -57,7 +58,6 @@ FALLBACK_PROVIDER_PRIORITY: tuple[str, ...] = (
     "alibaba-cloud",
     "fireworks",
     "together",
-    "google-vertex",
 )
 FALLBACK_ELIGIBLE_PROVIDERS = set(FALLBACK_PROVIDER_PRIORITY)
 # Include 402 (Payment Required) to allow failover when provider credits are exhausted


### PR DESCRIPTION
## Summary
- Moves `google-vertex` from last position (14th) to 4th position in the failover chain
- New order: onerouter → openai → anthropic → **google-vertex** → openrouter → ...

## Reason
Prioritizing Google Vertex earlier improves failover reliability.

## Test plan
- [x] Existing tests should pass (no behavioral change, just priority order)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Repositioned `google-vertex` from position 14 (last) to position 4 in the `FALLBACK_PROVIDER_PRIORITY` tuple. The new failover order prioritizes Google Vertex AI immediately after the native providers (onerouter, openai, anthropic) and before the openrouter fallback.

**Key Changes:**
- `google-vertex` moved from last position to 4th position in failover chain
- New order: onerouter → openai → anthropic → **google-vertex** → openrouter → cerebras → huggingface → ... → together

**Impact:**
- Earlier failover attempts will now use Google Vertex AI, improving reliability when primary providers fail
- No behavioral changes to model routing rules or error handling logic
- Existing tests should continue to pass as they validate presence in the chain, not specific ordering

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple, low-risk reordering of providers in the failover priority list. It only modifies the position of `google-vertex` from last to 4th in a tuple constant. No logic changes, no new dependencies, and existing tests validate the provider is in the chain (not position-specific). The change aligns with the stated goal of improving failover reliability by prioritizing Google Vertex earlier.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/services/provider_failover.py | Moved `google-vertex` from position 14 to position 4 in failover priority chain, placing it after native providers (onerouter, openai, anthropic) and before openrouter fallback |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Gateway as Gatewayz Gateway
    participant Failover as Failover Logic
    participant Onerouter
    participant OpenAI as OpenAI (native)
    participant Anthropic as Anthropic (native)
    participant GoogleVertex as Google Vertex AI
    participant OpenRouter as OpenRouter (fallback)
    participant Others as Other Providers

    Client->>Gateway: Request to /chat/completions
    Gateway->>Failover: build_provider_failover_chain()
    
    Note over Failover: NEW ORDER (Position 4):<br/>1. onerouter<br/>2. openai<br/>3. anthropic<br/>4. google-vertex (MOVED UP)<br/>5. openrouter<br/>6-13. other providers

    alt Initial Provider Available
        Failover->>Onerouter: Try request (Position 1)
        alt Onerouter Success
            Onerouter-->>Client: Return response
        else Onerouter Fails (401/402/403/404/502/503/504)
            Onerouter-->>Failover: Failover triggered
            Failover->>OpenAI: Try request (Position 2)
            alt OpenAI Success
                OpenAI-->>Client: Return response
            else OpenAI Fails
                OpenAI-->>Failover: Failover triggered
                Failover->>Anthropic: Try request (Position 3)
                alt Anthropic Success
                    Anthropic-->>Client: Return response
                else Anthropic Fails
                    Anthropic-->>Failover: Failover triggered
                    Failover->>GoogleVertex: Try request (Position 4 - NEW)
                    alt GoogleVertex Success
                        GoogleVertex-->>Client: Return response
                    else GoogleVertex Fails
                        GoogleVertex-->>Failover: Failover triggered
                        Failover->>OpenRouter: Try request (Position 5)
                        alt OpenRouter Success
                            OpenRouter-->>Client: Return response
                        else OpenRouter Fails
                            OpenRouter-->>Failover: Continue chain
                            Failover->>Others: Try remaining providers
                            Others-->>Client: Return response or error
                        end
                    end
                end
            end
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->