### PR TITLE
fix: increase multi-provider catalog cache TTL from 15min to 1hr

### DIFF
--- a/src/cache.py
+++ b/src/cache.py
@@ -22,8 +22,8 @@ _models_cache = {
 _multi_provider_catalog_cache = {
     "data": [],
     "timestamp": None,
-    "ttl": 900,  # 15 minutes TTL for aggregated catalog snapshots
-    "stale_ttl": 1800,
+    "ttl": 3600,  # 1 hour TTL for aggregated catalog snapshots (increased from 15min to reduce expensive rebuilds)
+    "stale_ttl": 7200,  # 2 hours stale-while-revalidate
 }
 
 _featherless_models_cache = {


### PR DESCRIPTION
## Summary
- Increased cache TTL for `_multi_provider_catalog_cache` from 15 minutes to 1 hour
- Increased stale_ttl from 30 minutes to 2 hours
- The full catalog rebuild takes 60-120s when cold, causing frontend timeouts
- Longer TTL reduces how often this expensive operation happens

## Test plan
- [ ] Verify models endpoint returns cached data within TTL
- [ ] Check that stale-while-revalidate works for 2 hours

Related monorepo PR: https://github.com/Alpaca-Network/gatewayz-monorepo/pull/795

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased cache retention periods for multi-provider catalogs: fresh data now cached for 1 hour (previously 15 minutes) and stale data for up to 2 hours (previously 30 minutes) to enhance performance and reduce load times.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Increased cache TTL for `_multi_provider_catalog_cache` from 15 minutes to 1 hour, and extended stale-while-revalidate window from 30 minutes to 2 hours. This addresses a performance issue where the full catalog rebuild (which queries 30+ provider APIs in parallel) takes 60-120 seconds when cold, causing frontend timeouts.

**Key Changes:**
- `ttl`: 900s (15min) → 3600s (1hr) - reduces frequency of expensive cold rebuilds
- `stale_ttl`: 1800s (30min) → 7200s (2hr) - extends stale-while-revalidate window for better availability

**Impact:**
- Reduces how often the expensive `get_all_models_parallel()` operation runs
- Frontend users will experience fewer timeout issues
- Stale data can be served for up to 2 hours while revalidation happens in background
- Trade-off: Model catalog updates from providers will take up to 1 hour to appear (previously 15 minutes)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are simple, well-documented, and address a real performance issue. The TTL values are reasonable for a model catalog that doesn't change frequently. The stale-while-revalidate pattern ensures availability while preventing expensive rebuilds.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/cache.py | Increased multi-provider catalog cache TTL from 15min to 1hr and stale TTL from 30min to 2hr to reduce expensive rebuild operations |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Frontend
    participant API as API Endpoint
    participant Cache as Multi-Provider Cache
    participant Builder as Catalog Builder
    participant Providers as Provider APIs (30+)

    Frontend->>API: GET /models (gateway="all")
    API->>Cache: Check cache freshness
    
    alt Cache Fresh (< 1hr)
        Cache-->>API: Return cached catalog
        API-->>Frontend: Return models
    else Cache Stale but Usable (1hr - 2hr)
        Cache-->>API: Return stale catalog
        API->>Builder: Trigger background revalidation
        API-->>Frontend: Return stale models (fast response)
        Builder->>Providers: Fetch from all providers (60-120s)
        Providers-->>Builder: Return model data
        Builder->>Cache: Update cache (TTL=1hr, stale=2hr)
    else Cache Expired (> 2hr)
        API->>Builder: Build catalog (blocking)
        Builder->>Providers: Fetch from all providers (60-120s)
        Providers-->>Builder: Return model data
        Builder->>Cache: Update cache (TTL=1hr, stale=2hr)
        Builder-->>API: Return fresh catalog
        API-->>Frontend: Return models (slow response)
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->