### PR TITLE
fix: migrate pricing to model_pricing, adjust error logging, add tests

### DIFF
--- a/src/db/models_catalog_db.py
+++ b/src/db/models_catalog_db.py
@@ -114,7 +114,7 @@ def get_models_by_provider_slug(
 
         query = (
             supabase.table("models")
-            .select("*, providers!inner(*)")
+            .select("*, providers!inner(*), model_pricing(price_per_input_token, price_per_output_token)")
             .eq("providers.slug", provider_slug)
         )
 

--- a/tests/db/test_chat_completion_requests_enhanced_pricing.py
+++ b/tests/db/test_chat_completion_requests_enhanced_pricing.py
@@ -1,0 +1,167 @@
+"""
+Tests for chat_completion_requests_enhanced.py pricing column fixes
+
+Ensures that the backfill_request_costs function correctly uses the model_pricing
+table instead of the removed pricing_prompt/pricing_completion columns.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from src.db.chat_completion_requests_enhanced import backfill_request_costs
+
+
+class TestBackfillRequestCostsPricingFix:
+    """Test that backfill_request_costs uses model_pricing table correctly"""
+
+    @patch("src.db.chat_completion_requests_enhanced.get_supabase_client")
+    @patch("src.db.chat_completion_requests_enhanced.update_request_cost")
+    def test_backfill_uses_model_pricing_table(
+        self, mock_update_cost, mock_get_client
+    ):
+        """Test that backfill fetches pricing from model_pricing table"""
+        # Setup mock client
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        # Mock the requests without cost data
+        mock_requests_response = MagicMock()
+        mock_requests_response.data = [
+            {
+                "request_id": "req-123",
+                "model_id": 1,
+                "input_tokens": 100,
+                "output_tokens": 200,
+            }
+        ]
+
+        # Mock the pricing data from model_pricing table
+        mock_pricing_response = MagicMock()
+        mock_pricing_response.data = {
+            "price_per_input_token": 0.00003,  # $0.03 per 1K tokens
+            "price_per_output_token": 0.00006,  # $0.06 per 1K tokens
+        }
+
+        # Setup the mock chain for requests query
+        mock_table = MagicMock()
+        mock_select = MagicMock()
+        mock_is = MagicMock()
+        mock_eq = MagicMock()
+        mock_range = MagicMock()
+
+        mock_client.table.return_value = mock_table
+        mock_table.select.return_value = mock_select
+        mock_select.is_.return_value = mock_is
+        mock_is.eq.return_value = mock_eq
+        mock_eq.range.return_value = mock_range
+        mock_range.execute.return_value = mock_requests_response
+
+        # Setup mock for pricing query (second table call)
+        mock_pricing_table = MagicMock()
+        mock_pricing_select = MagicMock()
+        mock_pricing_eq = MagicMock()
+        mock_pricing_single = MagicMock()
+
+        # Make the second .table() call return the pricing table mock
+        mock_client.table.side_effect = [
+            mock_table,  # First call for requests
+            mock_pricing_table,  # Second call for pricing
+        ]
+
+        mock_pricing_table.select.return_value = mock_pricing_select
+        mock_pricing_select.eq.return_value = mock_pricing_eq
+        mock_pricing_eq.single.return_value = mock_pricing_single
+        mock_pricing_single.execute.return_value = mock_pricing_response
+
+        # Mock successful update
+        mock_update_cost.return_value = True
+
+        # Call the backfill function
+        result = backfill_request_costs(limit=10, offset=0)
+
+        # Assertions
+        assert result["processed"] == 1
+        assert result["updated"] == 1
+
+        # Verify it queried the model_pricing table
+        mock_pricing_table.select.assert_called_once_with(
+            "price_per_input_token, price_per_output_token"
+        )
+        mock_pricing_select.eq.assert_called_once_with("model_id", 1)
+
+        # Verify the cost calculation
+        # input_cost = 100 * 0.00003 = 0.003
+        # output_cost = 200 * 0.00006 = 0.012
+        # total_cost = 0.015
+        mock_update_cost.assert_called_once_with(
+            request_id="req-123",
+            cost_usd=0.015,
+            input_cost_usd=0.003,
+            output_cost_usd=0.012,
+            pricing_source="backfilled",
+        )
+
+    @patch("src.db.chat_completion_requests_enhanced.get_supabase_client")
+    @patch("src.db.chat_completion_requests_enhanced.update_request_cost")
+    def test_backfill_skips_when_no_pricing_data(
+        self, mock_update_cost, mock_get_client
+    ):
+        """Test that backfill skips requests when pricing data is missing"""
+        # Setup mock client
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        # Mock the requests without cost data
+        mock_requests_response = MagicMock()
+        mock_requests_response.data = [
+            {
+                "request_id": "req-456",
+                "model_id": 2,
+                "input_tokens": 50,
+                "output_tokens": 100,
+            }
+        ]
+
+        # Mock empty pricing data (model not found in model_pricing table)
+        mock_pricing_response = MagicMock()
+        mock_pricing_response.data = None
+
+        # Setup the mock chain
+        mock_table = MagicMock()
+        mock_select = MagicMock()
+        mock_is = MagicMock()
+        mock_eq = MagicMock()
+        mock_range = MagicMock()
+
+        mock_client.table.return_value = mock_table
+        mock_table.select.return_value = mock_select
+        mock_select.is_.return_value = mock_is
+        mock_is.eq.return_value = mock_eq
+        mock_eq.range.return_value = mock_range
+        mock_range.execute.return_value = mock_requests_response
+
+        # Setup pricing query mock
+        mock_pricing_table = MagicMock()
+        mock_pricing_select = MagicMock()
+        mock_pricing_eq = MagicMock()
+        mock_pricing_single = MagicMock()
+
+        mock_client.table.side_effect = [
+            mock_table,
+            mock_pricing_table,
+        ]
+
+        mock_pricing_table.select.return_value = mock_pricing_select
+        mock_pricing_select.eq.return_value = mock_pricing_eq
+        mock_pricing_eq.single.return_value = mock_pricing_single
+        mock_pricing_single.execute.return_value = mock_pricing_response
+
+        # Call the backfill function
+        result = backfill_request_costs(limit=10, offset=0)
+
+        # Assertions - should skip the request
+        assert result["processed"] == 1
+        assert result["updated"] == 0
+
+        # Should not call update_request_cost
+        mock_update_cost.assert_not_called()

--- a/tests/db/test_failover_db_pricing.py
+++ b/tests/db/test_failover_db_pricing.py
@@ -1,0 +1,243 @@
+"""
+Tests for failover_db.py pricing column fixes
+
+Ensures that get_providers_for_model correctly uses the model_pricing
+table instead of the removed pricing columns.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from src.db.failover_db import get_providers_for_model
+
+
+class TestFailoverDbPricingFix:
+    """Test that failover_db uses model_pricing table correctly"""
+
+    @patch("src.db.failover_db.get_supabase_client")
+    def test_get_providers_uses_model_pricing_table(self, mock_get_client):
+        """Test that get_providers_for_model fetches pricing from model_pricing table"""
+        # Setup mock client
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        # Mock response data with model_pricing relationship
+        mock_response = MagicMock()
+        mock_response.data = [
+            {
+                "id": 1,
+                "model_id": "gpt-4",
+                "provider_model_id": "openai/gpt-4",
+                "average_response_time_ms": 150,
+                "health_status": "healthy",
+                "success_rate": 98.5,
+                "is_active": True,
+                "supports_streaming": True,
+                "supports_function_calling": True,
+                "supports_vision": False,
+                "context_length": 8192,
+                "model_pricing": {
+                    "price_per_input_token": 0.00003,
+                    "price_per_output_token": 0.00006,
+                    "price_per_image": None,
+                    "price_per_request": None,
+                },
+                "providers": {
+                    "id": 1,
+                    "slug": "openrouter",
+                    "name": "OpenRouter",
+                    "health_status": "healthy",
+                    "average_response_time_ms": 150,
+                    "is_active": True,
+                    "supports_streaming": True,
+                    "supports_function_calling": True,
+                    "supports_vision": False,
+                },
+            }
+        ]
+
+        # Setup the mock chain
+        mock_table = MagicMock()
+        mock_select = MagicMock()
+        mock_eq1 = MagicMock()
+        mock_eq2 = MagicMock()
+        mock_eq3 = MagicMock()
+
+        mock_client.table.return_value = mock_table
+        mock_table.select.return_value = mock_select
+        mock_select.eq.return_value = mock_eq1
+        mock_eq1.eq.return_value = mock_eq2
+        mock_eq2.eq.return_value = mock_eq3
+        mock_eq3.execute.return_value = mock_response
+
+        # Call the function
+        providers = get_providers_for_model("gpt-4", active_only=True)
+
+        # Assertions
+        assert len(providers) == 1
+
+        provider = providers[0]
+        assert provider["model_id"] == "gpt-4"
+        assert provider["provider_slug"] == "openrouter"
+
+        # Verify pricing is correctly extracted from model_pricing table
+        assert provider["pricing_prompt"] == 0.00003
+        assert provider["pricing_completion"] == 0.00006
+        assert provider["pricing_image"] == 0.0
+        assert provider["pricing_request"] == 0.0
+
+        # Verify the query included model_pricing in select
+        select_call = mock_table.select.call_args[0][0]
+        assert "model_pricing" in select_call
+        assert "price_per_input_token" in select_call
+        assert "price_per_output_token" in select_call
+
+    @patch("src.db.failover_db.get_supabase_client")
+    def test_get_providers_handles_missing_pricing_data(self, mock_get_client):
+        """Test that get_providers_for_model handles models without pricing data"""
+        # Setup mock client
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        # Mock response with null model_pricing (model not in model_pricing table)
+        mock_response = MagicMock()
+        mock_response.data = [
+            {
+                "id": 2,
+                "model_id": "custom-model",
+                "provider_model_id": "custom/model",
+                "average_response_time_ms": 200,
+                "health_status": "healthy",
+                "success_rate": 95.0,
+                "is_active": True,
+                "supports_streaming": False,
+                "supports_function_calling": False,
+                "supports_vision": False,
+                "context_length": 4096,
+                "model_pricing": None,  # No pricing data
+                "providers": {
+                    "id": 2,
+                    "slug": "custom-provider",
+                    "name": "Custom Provider",
+                    "health_status": "healthy",
+                    "average_response_time_ms": 200,
+                    "is_active": True,
+                    "supports_streaming": False,
+                    "supports_function_calling": False,
+                    "supports_vision": False,
+                },
+            }
+        ]
+
+        # Setup the mock chain
+        mock_table = MagicMock()
+        mock_select = MagicMock()
+        mock_eq = MagicMock()
+
+        mock_client.table.return_value = mock_table
+        mock_table.select.return_value = mock_select
+        mock_select.eq.return_value = mock_eq
+        mock_eq.execute.return_value = mock_response
+
+        # Call the function
+        providers = get_providers_for_model("custom-model", active_only=False)
+
+        # Assertions - should handle None pricing gracefully
+        assert len(providers) == 1
+
+        provider = providers[0]
+        # Should default to 0.0 for all pricing fields
+        assert provider["pricing_prompt"] == 0.0
+        assert provider["pricing_completion"] == 0.0
+        assert provider["pricing_image"] == 0.0
+        assert provider["pricing_request"] == 0.0
+
+    @patch("src.db.failover_db.get_supabase_client")
+    def test_get_providers_sorts_by_pricing(self, mock_get_client):
+        """Test that providers are sorted by pricing (among other factors)"""
+        # Setup mock client
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        # Mock response with multiple providers, different pricing
+        mock_response = MagicMock()
+        mock_response.data = [
+            {
+                "id": 1,
+                "model_id": "llama-3-70b",
+                "provider_model_id": "meta/llama-3-70b",
+                "average_response_time_ms": 150,
+                "health_status": "healthy",
+                "success_rate": 98.0,
+                "is_active": True,
+                "supports_streaming": True,
+                "supports_function_calling": False,
+                "supports_vision": False,
+                "context_length": 8192,
+                "model_pricing": {
+                    "price_per_input_token": 0.00005,  # More expensive
+                    "price_per_output_token": 0.00010,
+                    "price_per_image": None,
+                    "price_per_request": None,
+                },
+                "providers": {
+                    "id": 1,
+                    "slug": "provider-a",
+                    "name": "Provider A",
+                    "health_status": "healthy",
+                    "average_response_time_ms": 150,
+                    "is_active": True,
+                    "supports_streaming": True,
+                    "supports_function_calling": False,
+                    "supports_vision": False,
+                },
+            },
+            {
+                "id": 2,
+                "model_id": "llama-3-70b",
+                "provider_model_id": "llama-3-70b",
+                "average_response_time_ms": 150,
+                "health_status": "healthy",
+                "success_rate": 98.0,
+                "is_active": True,
+                "supports_streaming": True,
+                "supports_function_calling": False,
+                "supports_vision": False,
+                "context_length": 8192,
+                "model_pricing": {
+                    "price_per_input_token": 0.00002,  # Cheaper
+                    "price_per_output_token": 0.00004,
+                    "price_per_image": None,
+                    "price_per_request": None,
+                },
+                "providers": {
+                    "id": 2,
+                    "slug": "provider-b",
+                    "name": "Provider B",
+                    "health_status": "healthy",
+                    "average_response_time_ms": 150,
+                    "is_active": True,
+                    "supports_streaming": True,
+                    "supports_function_calling": False,
+                    "supports_vision": False,
+                },
+            },
+        ]
+
+        # Setup the mock chain
+        mock_table = MagicMock()
+        mock_select = MagicMock()
+        mock_eq = MagicMock()
+
+        mock_client.table.return_value = mock_table
+        mock_table.select.return_value = mock_select
+        mock_select.eq.return_value = mock_eq
+        mock_eq.execute.return_value = mock_response
+
+        # Call the function
+        providers = get_providers_for_model("llama-3-70b", active_only=False)
+
+        # Assertions - cheaper provider should come first (same health, same speed)
+        assert len(providers) == 2
+        assert providers[0]["provider_slug"] == "provider-b"  # Cheaper
+        assert providers[1]["provider_slug"] == "provider-a"  # More expensive

--- a/tests/services/test_api_key_warnings.py
+++ b/tests/services/test_api_key_warnings.py
@@ -1,0 +1,105 @@
+"""
+Tests for API key configuration warning improvements
+
+Ensures that missing API keys for optional providers (OpenAI, Anthropic)
+are logged at DEBUG level instead of ERROR level, as these providers are optional.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from src.services.models import fetch_models_from_openai, fetch_models_from_anthropic
+
+
+class TestApiKeyWarnings:
+    """Test that optional API key warnings are logged at DEBUG level"""
+
+    @patch("src.services.models.Config")
+    @patch("src.services.models.logger")
+    def test_missing_openai_key_logged_as_debug(self, mock_logger, mock_config):
+        """Test that missing OpenAI API key is logged at DEBUG level, not ERROR"""
+        # Mock missing API key
+        mock_config.OPENAI_API_KEY = None
+
+        # Call should return None
+        result = fetch_models_from_openai()
+
+        assert result is None
+
+        # Verify debug was logged (not error)
+        mock_logger.debug.assert_called_once()
+        debug_message = mock_logger.debug.call_args[0][0]
+        assert "OpenAI API key not configured" in debug_message
+        assert "skipping" in debug_message.lower()
+
+        # Verify error was NOT logged
+        mock_logger.error.assert_not_called()
+
+    @patch("src.services.models.Config")
+    @patch("src.services.models.logger")
+    def test_missing_anthropic_key_logged_as_debug(self, mock_logger, mock_config):
+        """Test that missing Anthropic API key is logged at DEBUG level, not ERROR"""
+        # Mock missing API key
+        mock_config.ANTHROPIC_API_KEY = None
+
+        # Call should return None
+        result = fetch_models_from_anthropic()
+
+        assert result is None
+
+        # Verify debug was logged (not error)
+        mock_logger.debug.assert_called_once()
+        debug_message = mock_logger.debug.call_args[0][0]
+        assert "Anthropic API key not configured" in debug_message
+        assert "skipping" in debug_message.lower()
+
+        # Verify error was NOT logged
+        mock_logger.error.assert_not_called()
+
+    @patch("src.services.models.Config")
+    @patch("src.services.models.httpx.get")
+    @patch("src.services.models.logger")
+    def test_openai_with_valid_key_proceeds(self, mock_logger, mock_httpx, mock_config):
+        """Test that with valid OpenAI key, function proceeds normally"""
+        # Mock valid API key
+        mock_config.OPENAI_API_KEY = "sk-test-key"
+
+        # Mock successful API response
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": []}
+        mock_httpx.return_value = mock_response
+
+        # Call should not log debug about missing key
+        result = fetch_models_from_openai()
+
+        # Verify debug about missing key was NOT logged
+        debug_calls = [call[0][0] for call in mock_logger.debug.call_args_list]
+        assert not any(
+            "OpenAI API key not configured" in msg for msg in debug_calls
+        )
+
+    @patch("src.services.models.Config")
+    @patch("src.services.models.httpx.get")
+    @patch("src.services.models.logger")
+    def test_anthropic_with_valid_key_proceeds(
+        self, mock_logger, mock_httpx, mock_config
+    ):
+        """Test that with valid Anthropic key, function proceeds normally"""
+        # Mock valid API key
+        mock_config.ANTHROPIC_API_KEY = "sk-ant-test-key"
+
+        # Mock successful API response
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": [], "has_more": False}
+        mock_httpx.return_value = mock_response
+
+        # Call should not log debug about missing key
+        result = fetch_models_from_anthropic()
+
+        # Verify debug about missing key was NOT logged
+        debug_calls = [call[0][0] for call in mock_logger.debug.call_args_list]
+        assert not any(
+            "Anthropic API key not configured" in msg for msg in debug_calls
+        )

--- a/tests/services/test_modelz_error_handling.py
+++ b/tests/services/test_modelz_error_handling.py
@@ -1,0 +1,135 @@
+"""
+Tests for Modelz API 522 error handling improvements
+
+Ensures that temporary server errors (502, 503, 522) are logged at WARNING level
+instead of ERROR level, as these are expected when the provider is temporarily down.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+import httpx
+
+from src.services.modelz_client import get_modelz_tokens, fetch_models_from_modelz
+
+
+class TestModelzErrorHandling:
+    """Test improved error handling for Modelz API errors"""
+
+    @patch("src.services.modelz_client.httpx.get")
+    @patch("src.services.modelz_client.logger")
+    def test_522_error_logged_as_warning(self, mock_logger, mock_httpx_get):
+        """Test that 522 errors are logged at WARNING level, not ERROR"""
+        # Mock 522 response (CloudFlare origin server down)
+        mock_response = MagicMock()
+        mock_response.status_code = 522
+        mock_response.text = "Origin server connection timed out"
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "522 Server Error", request=MagicMock(), response=mock_response
+        )
+
+        mock_httpx_get.return_value = mock_response
+
+        # Call should raise HTTPException
+        with pytest.raises(Exception):
+            get_modelz_tokens()
+
+        # Verify warning was logged (not error)
+        mock_logger.warning.assert_called_once()
+        warning_message = mock_logger.warning.call_args[0][0]
+        assert "522" in warning_message
+        assert "temporarily unavailable" in warning_message.lower()
+
+    @patch("src.services.modelz_client.httpx.get")
+    @patch("src.services.modelz_client.logger")
+    def test_502_error_logged_as_warning(self, mock_logger, mock_httpx_get):
+        """Test that 502 errors are logged at WARNING level"""
+        # Mock 502 response (Bad Gateway)
+        mock_response = MagicMock()
+        mock_response.status_code = 502
+        mock_response.text = "Bad Gateway"
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "502 Server Error", request=MagicMock(), response=mock_response
+        )
+
+        mock_httpx_get.return_value = mock_response
+
+        # Call should raise HTTPException
+        with pytest.raises(Exception):
+            get_modelz_tokens()
+
+        # Verify warning was logged (not error)
+        mock_logger.warning.assert_called_once()
+        warning_message = mock_logger.warning.call_args[0][0]
+        assert "502" in warning_message
+
+    @patch("src.services.modelz_client.httpx.get")
+    @patch("src.services.modelz_client.logger")
+    def test_503_error_logged_as_warning(self, mock_logger, mock_httpx_get):
+        """Test that 503 errors are logged at WARNING level"""
+        # Mock 503 response (Service Unavailable)
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+        mock_response.text = "Service Temporarily Unavailable"
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "503 Server Error", request=MagicMock(), response=mock_response
+        )
+
+        mock_httpx_get.return_value = mock_response
+
+        # Call should raise HTTPException
+        with pytest.raises(Exception):
+            get_modelz_tokens()
+
+        # Verify warning was logged (not error)
+        mock_logger.warning.assert_called_once()
+        warning_message = mock_logger.warning.call_args[0][0]
+        assert "503" in warning_message
+
+    @patch("src.services.modelz_client.httpx.get")
+    @patch("src.services.modelz_client.logger")
+    def test_other_http_errors_logged_as_error(self, mock_logger, mock_httpx_get):
+        """Test that non-temporary errors (401, 404, etc) are still logged at ERROR level"""
+        # Mock 401 response (Unauthorized)
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "Unauthorized"
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "401 Client Error", request=MagicMock(), response=mock_response
+        )
+
+        mock_httpx_get.return_value = mock_response
+
+        # Call should raise HTTPException
+        with pytest.raises(Exception):
+            get_modelz_tokens()
+
+        # Verify error was logged (not warning)
+        mock_logger.error.assert_called_once()
+        error_message = mock_logger.error.call_args[0][0]
+        assert "401" in error_message
+
+    @patch("src.services.modelz_client.httpx.get")
+    @patch("src.services.modelz_client.logger")
+    async def test_fetch_models_handles_522_gracefully(
+        self, mock_logger, mock_httpx_get
+    ):
+        """Test that fetch_models_from_modelz handles 522 errors gracefully"""
+        # Mock 522 response
+        mock_response = MagicMock()
+        mock_response.status_code = 522
+        mock_response.text = "Origin server connection timed out"
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "522 Server Error", request=MagicMock(), response=mock_response
+        )
+
+        mock_httpx_get.return_value = mock_response
+
+        # Call should return empty list (not crash)
+        result = await fetch_models_from_modelz()
+
+        assert result == []
+
+        # Verify warning was logged
+        mock_logger.warning.assert_called()
+        warning_calls = [call[0][0] for call in mock_logger.warning.call_args_list]
+        assert any("522" in msg for msg in warning_calls)


### PR DESCRIPTION
## Summary
- Migrates pricing lookups to the model_pricing table and updates pricing extraction across the codebase
- Downgrades temporary provider errors (502/503/522) from errors to warnings for Modelz integration
- Logs missing API keys for optional providers (OpenAI/Anthropic) at DEBUG level instead of ERROR
- Adds comprehensive tests for pricing backfill, pricing queries, error handling, and optional API key warnings

## Issues Fixed
Based on Sentry analysis from 2026-01-28 to 2026-01-29:

### 🔴 High Priority - Database Pricing Fix (100 occurrences)
**Sentry Issue**: GATEWAYZ-BACKEND-4NP
**Error**: Could not find the 'pricing_completion' column of 'models' in the schema cache

**Root Cause**: The `pricing_prompt`, `pricing_completion`, `pricing_image`, and `pricing_request` columns were removed from the `models` table in migration `20260121000003_remove_pricing_columns_from_models.sql`, but several functions were still attempting to query these columns directly.

**Files Fixed**:
- `src/db/chat_completion_requests_enhanced.py` - Updated `backfill_request_costs()` to fetch pricing from `model_pricing` table
- `src/db/failover_db.py` - Updated `get_providers_for_model()` to LEFT JOIN with `model_pricing` table
- `src/db/models_catalog_db.py` - Updated `get_models_by_provider_slug()` to include `model_pricing` relationship
- `src/services/models.py` - Updated `_convert_db_model_to_raw()` to extract pricing from `model_pricing` relationship

### 🟡 Medium Priority - Modelz API Errors (9 occurrences)
**Sentry Issue**: GATEWAYZ-BACKEND-4NS
**Error**: `HTTP error from Modelz API: 522`

**Root Cause**: 522 errors (CloudFlare origin server down) and similar 502/503 errors are temporary infrastructure issues and should not be logged as errors.

**Files Fixed**:
- `src/services/modelz_client.py` - Downgraded 502/503/522 errors to WARNING level with clear messaging about temporary unavailability

### 🟡 Medium Priority - API Key Configuration Warnings (8 occurrences each)
**Sentry Issues**: GATEWAYZ-BACKEND-4NR (Anthropic), GATEWAYZ-BACKEND-4NQ (OpenAI)
**Errors**: `Anthropic API key not configured` / `OpenAI API key not configured`

**Root Cause**: These providers are optional, so missing API keys should not be logged as errors during normal catalog sync operations.

**Files Fixed**:
- `src/services/models.py` - Changed `fetch_models_from_anthropic()` and `fetch_models_from_openai()` to log at DEBUG level with "skipping" message

## Test Coverage
Added comprehensive test suites for all fixes:

✅ **Database Pricing Fixes**
- `tests/db/test_chat_completion_requests_enhanced_pricing.py` - Tests backfill function uses `model_pricing` table
- `tests/db/test_failover_db_pricing.py` - Tests failover queries use `model_pricing` table and handle missing data

✅ **Error Handling**
- `tests/services/test_modelz_error_handling.py` - Tests 502/503/522 errors logged at WARNING level
- `tests/services/test_api_key_warnings.py` - Tests optional API key warnings logged at DEBUG level

## Test Plan
- [x] Run all new tests to verify correct behavior
- [x] Verify pricing data is correctly extracted from `model_pricing` table
- [x] Verify Modelz temporary errors are logged at WARNING level
- [x] Verify optional API key warnings are logged at DEBUG level
- [ ] Monitor Sentry for reduction in error counts after deployment
- [ ] Verify catalog sync still works correctly with new pricing queries

## Deployment Notes
- No database migrations required (uses existing `model_pricing` table)
- No API changes or breaking changes
- Safe to deploy immediately
- Expected outcome: Sentry errors should drop from ~125 to near zero

## Related Issues
Resolves Sentry issues:
- GATEWAYZ-BACKEND-4NP (100 occurrences) - Database schema error
- GATEWAYZ-BACKEND-4NS (9 occurrences) - Modelz 522 errors
- GATEWAYZ-BACKEND-4NR (8 occurrences) - Anthropic key warning
- GATEWAYZ-BACKEND-4NQ (8 occurrences) - OpenAI key warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

📎 **Task**: https://www.terragonlabs.com/task/b0556c5a-0e2b-40da-b7c0-76b07a08f13e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Pricing calculations now use a dedicated pricing data source for improved accuracy.
  * Temporary Modelz API server errors (502, 503, 522) logged as warnings rather than errors.
  * Missing optional API keys logged at debug level to reduce noise in logs.

* **Tests**
  * Added comprehensive test coverage for pricing data handling and API error scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes critical database schema errors caused by the migration that removed pricing columns from the `models` table (migration `20260121000003_remove_pricing_columns_from_models.sql`). The `model_pricing` table is now the single source of truth for pricing data.

**Key Changes:**
- Updated `backfill_request_costs()` to query `model_pricing` table instead of removed columns
- Modified `get_providers_for_model()` to use LEFT JOIN with `model_pricing` table 
- Updated `get_models_by_provider_slug()` to include `model_pricing` relationship
- Changed `_convert_db_model_to_raw()` to extract pricing from `model_pricing` relationship
- Downgraded Modelz temporary errors (502/503/522) from ERROR to WARNING level
- Changed optional API key warnings (OpenAI, Anthropic) from ERROR to DEBUG level

**Architecture:**
All database queries now properly reference the `model_pricing` table via LEFT JOINs or explicit queries. Missing pricing data is handled gracefully with fallbacks to 0.0 or debug logging.

**Test Coverage:**
Comprehensive test suites added for all fixes, covering both success and edge cases (missing pricing data, temporary errors, missing API keys).

**Minor Performance Note:**
The `backfill_request_costs()` function has an N+1 query pattern (queries pricing individually per request). Consider batch fetching for large backfills in the future.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minimal risk - fixes critical production errors with proper test coverage
- Score reflects solid fixes for database schema errors with comprehensive tests. Minor performance consideration (N+1 query) doesn't affect correctness but could be optimized for large-scale backfills. All changes properly handle edge cases (missing pricing data, null values).
- src/db/chat_completion_requests_enhanced.py - consider optimizing N+1 query pattern for production backfills

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/db/chat_completion_requests_enhanced.py | Fixed to query `model_pricing` table instead of removed columns. Potential N+1 query issue: loops through requests and makes individual pricing queries. |
| src/db/failover_db.py | Updated to LEFT JOIN `model_pricing` table, properly handles missing pricing data with fallback to 0.0 |
| src/services/models.py | Extracts pricing from `model_pricing` relationship, handles None gracefully. Changed API key warnings from ERROR to DEBUG level |
| src/services/modelz_client.py | Downgraded 502/503/522 temporary errors to WARNING level instead of ERROR |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application Code
    participant DB as Supabase (PostgreSQL)
    participant MP as model_pricing Table
    participant Models as models Table
    
    Note over App,Models: Database Schema Migration (20260121000003)
    Models->>Models: DROP COLUMN pricing_prompt
    Models->>Models: DROP COLUMN pricing_completion
    Models->>Models: DROP COLUMN pricing_image
    Models->>Models: DROP COLUMN pricing_request
    Note over Models: Pricing columns removed,<br/>model_pricing is now single source
    
    Note over App,MP: Fix 1: backfill_request_costs()
    App->>DB: SELECT requests without cost
    DB-->>App: Return requests with model_id
    loop For each request
        App->>MP: SELECT pricing WHERE model_id = ?
        MP-->>App: Return price_per_input_token, price_per_output_token
        Note over App: Calculate: cost = (input_tokens * input_price) + (output_tokens * output_price)
        App->>DB: UPDATE request SET cost_usd = calculated_cost
    end
    
    Note over App,Models: Fix 2: get_providers_for_model()
    App->>Models: SELECT * WITH model_pricing LEFT JOIN
    Models->>MP: LEFT JOIN on model_id
    MP-->>Models: Return pricing data (or NULL)
    Models-->>App: Return model + pricing data
    Note over App: Extract pricing from model_pricing relationship,<br/>default to 0.0 if NULL
    
    Note over App,Models: Fix 3: get_models_by_provider_slug()
    App->>Models: SELECT * WITH model_pricing LEFT JOIN
    Models->>MP: LEFT JOIN on model_id
    MP-->>Models: Return pricing data
    Models-->>App: Return models with pricing
    
    Note over App: Fix 4: Logging Level Changes
    App->>App: Missing OpenAI API key → DEBUG (was ERROR)
    App->>App: Missing Anthropic API key → DEBUG (was ERROR)
    App->>App: Modelz 502/503/522 → WARNING (was ERROR)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->