### PR TITLE
perf: parallel provider fetching + circuit breaker + local cache fall…

### DIFF
--- a/src/services/local_memory_cache.py
+++ b/src/services/local_memory_cache.py
@@ -1,0 +1,283 @@
+"""
+Local In-Memory Cache with Stale-While-Revalidate Support
+
+Provides a fast, thread-safe in-memory cache that serves as a fallback when
+Redis is unavailable. Implements stale-while-revalidate pattern for better
+availability.
+
+Features:
+- LRU eviction when max entries exceeded
+- TTL-based expiration with grace period for stale data
+- Thread-safe operations
+- Automatic cleanup of expired entries
+- Stale-while-revalidate pattern
+
+Usage:
+    cache = get_local_cache()
+
+    # Set with TTL (60 seconds) and stale TTL (additional 300 seconds)
+    cache.set("key", {"data": "value"}, ttl=60, stale_ttl=300)
+
+    # Get returns (value, is_stale)
+    value, is_stale = cache.get("key")
+    if value:
+        if is_stale:
+            # Trigger background refresh
+            pass
+        return value
+"""
+
+import logging
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from threading import Lock
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CacheEntry:
+    """Single cache entry with expiration tracking."""
+    value: Any
+    expires_at: float  # When entry becomes stale
+    stale_expires_at: float  # When entry is removed entirely
+    created_at: float
+
+
+class LocalMemoryCache:
+    """
+    Thread-safe in-memory cache with LRU eviction and stale-while-revalidate.
+
+    This cache serves as a fallback when Redis is unavailable or slow,
+    ensuring the API can still respond with cached data.
+    """
+
+    def __init__(
+        self,
+        max_entries: int = 1000,
+        default_ttl: float = 300.0,  # 5 minutes
+        default_stale_ttl: float = 3600.0,  # 1 hour stale grace period
+    ):
+        self.max_entries = max_entries
+        self.default_ttl = default_ttl
+        self.default_stale_ttl = default_stale_ttl
+        self._cache: OrderedDict[str, CacheEntry] = OrderedDict()
+        self._lock = Lock()
+        self._stats = {
+            "hits": 0,
+            "stale_hits": 0,
+            "misses": 0,
+            "sets": 0,
+            "evictions": 0,
+            "expirations": 0,
+        }
+
+        logger.info(
+            f"Local memory cache initialized: "
+            f"max_entries={max_entries}, "
+            f"default_ttl={default_ttl}s, "
+            f"default_stale_ttl={default_stale_ttl}s"
+        )
+
+    def get(self, key: str) -> tuple[Any | None, bool]:
+        """
+        Get value from cache.
+
+        Returns:
+            Tuple of (value, is_stale):
+            - (value, False): Fresh data
+            - (value, True): Stale data (still usable, but should refresh)
+            - (None, False): No data (cache miss)
+        """
+        with self._lock:
+            entry = self._cache.get(key)
+
+            if entry is None:
+                self._stats["misses"] += 1
+                return None, False
+
+            now = time.time()
+
+            # Check if completely expired (past stale window)
+            if now > entry.stale_expires_at:
+                # Remove expired entry
+                del self._cache[key]
+                self._stats["expirations"] += 1
+                self._stats["misses"] += 1
+                return None, False
+
+            # Move to end (LRU update)
+            self._cache.move_to_end(key)
+
+            # Check if stale but still usable
+            if now > entry.expires_at:
+                self._stats["stale_hits"] += 1
+                logger.debug(f"Local cache STALE HIT: {key}")
+                return entry.value, True
+
+            # Fresh data
+            self._stats["hits"] += 1
+            logger.debug(f"Local cache HIT: {key}")
+            return entry.value, False
+
+    def set(
+        self,
+        key: str,
+        value: Any,
+        ttl: float | None = None,
+        stale_ttl: float | None = None,
+    ) -> None:
+        """
+        Set value in cache with TTL.
+
+        Args:
+            key: Cache key
+            value: Value to cache
+            ttl: Time until data is considered stale (uses default if None)
+            stale_ttl: Additional time stale data is kept (uses default if None)
+        """
+        ttl = ttl if ttl is not None else self.default_ttl
+        stale_ttl = stale_ttl if stale_ttl is not None else self.default_stale_ttl
+
+        now = time.time()
+        entry = CacheEntry(
+            value=value,
+            expires_at=now + ttl,
+            stale_expires_at=now + ttl + stale_ttl,
+            created_at=now,
+        )
+
+        with self._lock:
+            # Check if we need to evict entries
+            while len(self._cache) >= self.max_entries:
+                # Remove oldest (LRU)
+                oldest_key = next(iter(self._cache))
+                del self._cache[oldest_key]
+                self._stats["evictions"] += 1
+                logger.debug(f"Local cache EVICTED: {oldest_key}")
+
+            self._cache[key] = entry
+            self._cache.move_to_end(key)
+            self._stats["sets"] += 1
+            logger.debug(f"Local cache SET: {key} (ttl={ttl}s, stale_ttl={stale_ttl}s)")
+
+    def delete(self, key: str) -> bool:
+        """Delete a key from cache."""
+        with self._lock:
+            if key in self._cache:
+                del self._cache[key]
+                logger.debug(f"Local cache DELETE: {key}")
+                return True
+            return False
+
+    def clear(self) -> int:
+        """Clear all entries from cache."""
+        with self._lock:
+            count = len(self._cache)
+            self._cache.clear()
+            logger.info(f"Local cache CLEARED: {count} entries removed")
+            return count
+
+    def cleanup_expired(self) -> int:
+        """Remove all expired entries."""
+        now = time.time()
+        removed = 0
+
+        with self._lock:
+            # Create list of keys to remove (can't modify during iteration)
+            expired_keys = [
+                key for key, entry in self._cache.items()
+                if now > entry.stale_expires_at
+            ]
+
+            for key in expired_keys:
+                del self._cache[key]
+                removed += 1
+
+            if removed > 0:
+                self._stats["expirations"] += removed
+                logger.info(f"Local cache cleanup: {removed} expired entries removed")
+
+        return removed
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get cache statistics."""
+        with self._lock:
+            total_requests = (
+                self._stats["hits"] +
+                self._stats["stale_hits"] +
+                self._stats["misses"]
+            )
+            hit_rate = (
+                (self._stats["hits"] + self._stats["stale_hits"]) / total_requests
+                if total_requests > 0 else 0
+            )
+
+            return {
+                "entries": len(self._cache),
+                "max_entries": self.max_entries,
+                "hits": self._stats["hits"],
+                "stale_hits": self._stats["stale_hits"],
+                "misses": self._stats["misses"],
+                "sets": self._stats["sets"],
+                "evictions": self._stats["evictions"],
+                "expirations": self._stats["expirations"],
+                "hit_rate": round(hit_rate * 100, 2),
+                "total_requests": total_requests,
+            }
+
+    def reset_stats(self) -> None:
+        """Reset statistics counters."""
+        with self._lock:
+            self._stats = {
+                "hits": 0,
+                "stale_hits": 0,
+                "misses": 0,
+                "sets": 0,
+                "evictions": 0,
+                "expirations": 0,
+            }
+
+
+# Global local cache instance
+_local_cache: LocalMemoryCache | None = None
+
+
+def get_local_cache() -> LocalMemoryCache:
+    """Get the global local memory cache instance."""
+    global _local_cache
+    if _local_cache is None:
+        _local_cache = LocalMemoryCache(
+            max_entries=500,  # Keep up to 500 entries
+            default_ttl=900.0,  # 15 minutes fresh
+            default_stale_ttl=3600.0,  # 1 hour stale grace period
+        )
+    return _local_cache
+
+
+# Convenience functions for catalog caching
+
+def get_local_catalog(provider: str) -> tuple[list[dict] | None, bool]:
+    """
+    Get cached catalog from local memory.
+
+    Returns:
+        Tuple of (catalog, is_stale)
+    """
+    cache = get_local_cache()
+    key = f"catalog:{provider}"
+    return cache.get(key)
+
+
+def set_local_catalog(
+    provider: str,
+    catalog: list[dict],
+    ttl: float = 900.0,  # 15 minutes fresh
+    stale_ttl: float = 3600.0,  # 1 hour stale
+) -> None:
+    """Cache catalog in local memory."""
+    cache = get_local_cache()
+    key = f"catalog:{provider}"
+    cache.set(key, catalog, ttl=ttl, stale_ttl=stale_ttl)

--- a/src/services/parallel_catalog_fetch.py
+++ b/src/services/parallel_catalog_fetch.py
@@ -1,0 +1,243 @@
+"""
+Parallel Catalog Fetching
+
+Fetches model catalogs from multiple providers in parallel with:
+- Concurrent execution using ThreadPoolExecutor
+- Circuit breaker integration for failing providers
+- Timeout protection per provider
+- Graceful degradation on failures
+
+This replaces the sequential provider fetching that caused 499 timeouts.
+"""
+
+import asyncio
+import logging
+import time
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
+from typing import Any
+
+from src.services.models import get_cached_models
+from src.utils.circuit_breaker import get_provider_circuit_breaker
+
+logger = logging.getLogger(__name__)
+
+# All supported providers
+ALL_PROVIDERS = [
+    "openrouter",
+    "onerouter",
+    "featherless",
+    "deepinfra",
+    "chutes",
+    "groq",
+    "fireworks",
+    "together",
+    "google-vertex",
+    "cerebras",
+    "nebius",
+    "xai",
+    "novita",
+    "hug",
+    "aimo",
+    "near",
+    "fal",
+    "helicone",
+    "anannas",
+    "aihubmix",
+    "vercel-ai-gateway",
+    "alibaba",
+    "simplismart",
+    "openai",
+    "anthropic",
+    "clarifai",
+    "sybil",
+    "morpheus",
+]
+
+# Thread pool for parallel fetching
+_executor: ThreadPoolExecutor | None = None
+
+
+def get_executor() -> ThreadPoolExecutor:
+    """Get or create thread pool executor."""
+    global _executor
+    if _executor is None:
+        # Use max 10 workers to avoid overwhelming the database
+        _executor = ThreadPoolExecutor(max_workers=10, thread_name_prefix="catalog_fetch")
+        logger.info("Created catalog fetch thread pool with 10 workers")
+    return _executor
+
+
+def fetch_provider_with_circuit_breaker(
+    provider: str,
+    timeout: float = 30.0,
+) -> tuple[str, list[dict[str, Any]]]:
+    """
+    Fetch models for a single provider with circuit breaker protection.
+
+    Args:
+        provider: Provider slug
+        timeout: Maximum time to wait for this provider
+
+    Returns:
+        Tuple of (provider, models) - models is empty list on failure
+    """
+    breaker = get_provider_circuit_breaker()
+
+    # Check circuit breaker first
+    if breaker.should_skip(provider):
+        logger.info(f"Skipping {provider} (circuit breaker open)")
+        return provider, []
+
+    start_time = time.time()
+
+    try:
+        models = get_cached_models(provider)
+        elapsed = time.time() - start_time
+
+        if models:
+            breaker.record_success(provider)
+            logger.debug(f"Fetched {len(models)} models from {provider} in {elapsed:.2f}s")
+            return provider, models
+        else:
+            # Empty result is not necessarily a failure (some providers have no models)
+            logger.debug(f"No models from {provider} (elapsed: {elapsed:.2f}s)")
+            return provider, []
+
+    except Exception as e:
+        elapsed = time.time() - start_time
+        breaker.record_failure(provider, str(e))
+        logger.warning(f"Error fetching {provider} (elapsed: {elapsed:.2f}s): {e}")
+        return provider, []
+
+
+async def fetch_all_providers_parallel(
+    providers: list[str] | None = None,
+    timeout_per_provider: float = 30.0,
+    overall_timeout: float = 45.0,
+) -> dict[str, list[dict[str, Any]]]:
+    """
+    Fetch catalogs from all providers in parallel.
+
+    Args:
+        providers: List of providers to fetch (defaults to ALL_PROVIDERS)
+        timeout_per_provider: Max time per provider fetch
+        overall_timeout: Max total time for all fetches
+
+    Returns:
+        Dict mapping provider names to their model lists
+    """
+    providers = providers or ALL_PROVIDERS
+    executor = get_executor()
+    results: dict[str, list[dict[str, Any]]] = {}
+
+    start_time = time.time()
+    logger.info(f"Starting parallel fetch for {len(providers)} providers")
+
+    # Create futures for all providers
+    loop = asyncio.get_event_loop()
+    tasks = []
+
+    for provider in providers:
+        future = loop.run_in_executor(
+            executor,
+            fetch_provider_with_circuit_breaker,
+            provider,
+            timeout_per_provider,
+        )
+        tasks.append((provider, future))
+
+    # Wait for all with overall timeout
+    try:
+        # Gather all results with timeout
+        pending_futures = [task[1] for task in tasks]
+        done, pending = await asyncio.wait(
+            pending_futures,
+            timeout=overall_timeout,
+            return_when=asyncio.ALL_COMPLETED,
+        )
+
+        # Process completed tasks
+        for provider, future in tasks:
+            try:
+                if future in done:
+                    provider_name, models = future.result()
+                    results[provider_name] = models
+                else:
+                    # Task didn't complete in time
+                    logger.warning(f"Provider {provider} timed out after {overall_timeout}s")
+                    results[provider] = []
+                    # Record as failure for circuit breaker
+                    breaker = get_provider_circuit_breaker()
+                    breaker.record_failure(provider, "timeout")
+            except Exception as e:
+                logger.warning(f"Error getting result for {provider}: {e}")
+                results[provider] = []
+
+        # Cancel any remaining pending tasks
+        for future in pending:
+            future.cancel()
+
+    except asyncio.TimeoutError:
+        logger.error(f"Overall timeout ({overall_timeout}s) exceeded for parallel fetch")
+        # Return whatever we have
+        for provider, _ in tasks:
+            if provider not in results:
+                results[provider] = []
+
+    elapsed = time.time() - start_time
+    total_models = sum(len(models) for models in results.values())
+    successful_providers = sum(1 for models in results.values() if models)
+
+    logger.info(
+        f"Parallel fetch complete: {successful_providers}/{len(providers)} providers, "
+        f"{total_models} total models in {elapsed:.2f}s"
+    )
+
+    return results
+
+
+def merge_provider_results(results: dict[str, list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    """
+    Merge results from multiple providers into a single list.
+
+    Args:
+        results: Dict mapping provider names to model lists
+
+    Returns:
+        Combined list of all models
+    """
+    all_models = []
+    for provider, models in results.items():
+        all_models.extend(models)
+
+    logger.debug(f"Merged {len(all_models)} models from {len(results)} providers")
+    return all_models
+
+
+async def fetch_and_merge_all_providers(
+    timeout: float = 45.0,
+) -> list[dict[str, Any]]:
+    """
+    Convenience function to fetch all providers and merge results.
+
+    Args:
+        timeout: Overall timeout for all fetches
+
+    Returns:
+        List of all models from all providers
+    """
+    results = await fetch_all_providers_parallel(
+        providers=ALL_PROVIDERS,
+        timeout_per_provider=30.0,
+        overall_timeout=timeout,
+    )
+    return merge_provider_results(results)
+
+
+def get_circuit_breaker_status() -> dict[str, Any]:
+    """Get status of all circuit breakers for monitoring."""
+    breaker = get_provider_circuit_breaker()
+    return {
+        "open_circuits": breaker.get_open_circuits(),
+        "all_status": breaker.get_all_status(),
+    }

--- a/src/utils/circuit_breaker.py
+++ b/src/utils/circuit_breaker.py
@@ -1,0 +1,206 @@
+"""
+Circuit Breaker Pattern Implementation
+
+Prevents cascading failures by tracking provider health and automatically
+skipping providers that are consistently failing.
+
+Usage:
+    breaker = get_provider_circuit_breaker()
+
+    if breaker.should_skip("openrouter"):
+        return []  # Skip this provider
+
+    try:
+        result = fetch_provider_models("openrouter")
+        breaker.record_success("openrouter")
+        return result
+    except Exception as e:
+        breaker.record_failure("openrouter")
+        raise
+"""
+
+import logging
+import time
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ProviderState:
+    """Track health state for a single provider."""
+    failure_count: int = 0
+    last_failure_time: float = 0.0
+    last_success_time: float = 0.0
+    consecutive_failures: int = 0
+    is_open: bool = False  # True = circuit is open (skip provider)
+    total_requests: int = 0
+    total_failures: int = 0
+
+
+class ProviderCircuitBreaker:
+    """
+    Circuit breaker for provider health management.
+
+    States:
+    - CLOSED: Normal operation, requests go through
+    - OPEN: Provider is failing, skip requests for recovery_timeout
+    - HALF_OPEN: After recovery_timeout, allow one request to test
+
+    Configuration:
+    - failure_threshold: Number of consecutive failures before opening circuit
+    - recovery_timeout: Seconds to wait before trying again
+    - success_threshold: Successes needed in half-open to close circuit
+    """
+
+    def __init__(
+        self,
+        failure_threshold: int = 3,
+        recovery_timeout: float = 300.0,  # 5 minutes
+        success_threshold: int = 1,
+    ):
+        self.failure_threshold = failure_threshold
+        self.recovery_timeout = recovery_timeout
+        self.success_threshold = success_threshold
+        self._states: dict[str, ProviderState] = {}
+        self._lock = Lock()
+
+        logger.info(
+            f"Circuit breaker initialized: "
+            f"failure_threshold={failure_threshold}, "
+            f"recovery_timeout={recovery_timeout}s"
+        )
+
+    def _get_state(self, provider: str) -> ProviderState:
+        """Get or create provider state."""
+        if provider not in self._states:
+            self._states[provider] = ProviderState()
+        return self._states[provider]
+
+    def should_skip(self, provider: str) -> bool:
+        """
+        Check if provider should be skipped due to circuit being open.
+
+        Returns:
+            True if provider should be skipped (circuit open)
+            False if provider should be tried (circuit closed or half-open)
+        """
+        with self._lock:
+            state = self._get_state(provider)
+
+            if not state.is_open:
+                return False
+
+            # Check if recovery timeout has passed
+            elapsed = time.time() - state.last_failure_time
+            if elapsed >= self.recovery_timeout:
+                # Move to half-open state - allow one request
+                logger.info(
+                    f"Circuit breaker HALF-OPEN for {provider} "
+                    f"(recovery timeout elapsed: {elapsed:.1f}s)"
+                )
+                return False
+
+            # Circuit still open
+            logger.debug(
+                f"Circuit breaker OPEN for {provider} "
+                f"(wait {self.recovery_timeout - elapsed:.1f}s more)"
+            )
+            return True
+
+    def record_success(self, provider: str) -> None:
+        """Record a successful request to provider."""
+        with self._lock:
+            state = self._get_state(provider)
+            state.last_success_time = time.time()
+            state.consecutive_failures = 0
+            state.total_requests += 1
+
+            if state.is_open:
+                # Close the circuit on success (half-open → closed)
+                state.is_open = False
+                logger.info(f"Circuit breaker CLOSED for {provider} (success after recovery)")
+
+    def record_failure(self, provider: str, error: str | None = None) -> None:
+        """Record a failed request to provider."""
+        with self._lock:
+            state = self._get_state(provider)
+            state.failure_count += 1
+            state.consecutive_failures += 1
+            state.last_failure_time = time.time()
+            state.total_requests += 1
+            state.total_failures += 1
+
+            if state.consecutive_failures >= self.failure_threshold:
+                if not state.is_open:
+                    state.is_open = True
+                    logger.warning(
+                        f"Circuit breaker OPENED for {provider} "
+                        f"(consecutive failures: {state.consecutive_failures}, "
+                        f"error: {error or 'unknown'})"
+                    )
+
+    def reset(self, provider: str) -> None:
+        """Manually reset circuit for a provider."""
+        with self._lock:
+            if provider in self._states:
+                self._states[provider] = ProviderState()
+                logger.info(f"Circuit breaker RESET for {provider}")
+
+    def reset_all(self) -> None:
+        """Reset all circuit breakers."""
+        with self._lock:
+            self._states.clear()
+            logger.info("All circuit breakers RESET")
+
+    def get_status(self, provider: str) -> dict[str, Any]:
+        """Get status for a specific provider."""
+        with self._lock:
+            state = self._get_state(provider)
+            return {
+                "provider": provider,
+                "is_open": state.is_open,
+                "consecutive_failures": state.consecutive_failures,
+                "total_failures": state.total_failures,
+                "total_requests": state.total_requests,
+                "last_failure_time": state.last_failure_time,
+                "last_success_time": state.last_success_time,
+                "failure_rate": (
+                    state.total_failures / state.total_requests
+                    if state.total_requests > 0 else 0
+                ),
+            }
+
+    def get_all_status(self) -> dict[str, dict[str, Any]]:
+        """Get status for all tracked providers."""
+        with self._lock:
+            return {
+                provider: self.get_status(provider)
+                for provider in self._states
+            }
+
+    def get_open_circuits(self) -> list[str]:
+        """Get list of providers with open circuits."""
+        with self._lock:
+            return [
+                provider for provider, state in self._states.items()
+                if state.is_open
+            ]
+
+
+# Global circuit breaker instance
+_circuit_breaker: ProviderCircuitBreaker | None = None
+
+
+def get_provider_circuit_breaker() -> ProviderCircuitBreaker:
+    """Get the global provider circuit breaker instance."""
+    global _circuit_breaker
+    if _circuit_breaker is None:
+        _circuit_breaker = ProviderCircuitBreaker(
+            failure_threshold=3,  # Open after 3 consecutive failures
+            recovery_timeout=300.0,  # Wait 5 minutes before retry
+            success_threshold=1,  # Close after 1 success
+        )
+    return _circuit_breaker


### PR DESCRIPTION
…back

CRITICAL PERFORMANCE FIXES for 499 timeout errors:

1. Parallel Provider Fetching (src/services/parallel_catalog_fetch.py)
   - Replaces sequential 25+ provider fetches with concurrent execution
   - Uses ThreadPoolExecutor with 10 workers
   - Overall timeout of 45s instead of potential 1500s (25 × 60s)
   - Graceful degradation on individual provider failures

2. Circuit Breaker Pattern (src/utils/circuit_breaker.py)
   - Tracks provider health status
   - Opens circuit after 3 consecutive failures
   - 5-minute recovery timeout before retry
   - Prevents cascading failures from slow/failing providers

3. Local Memory Cache Fallback (src/services/local_memory_cache.py)
   - LRU cache with max 500 entries
   - Stale-while-revalidate pattern (15min fresh, 1hr stale grace)
   - Serves cached data when Redis is slow/unavailable
   - Thread-safe with automatic expiration cleanup

4. Updated model_catalog_cache.py
   - Multi-tier caching: Redis → Local Memory → Database
   - Local cache is updated on Redis hits for fallback
   - Stale data served immediately while fresh data loads

5. Updated catalog.py
   - Uses parallel fetch when cache misses for gateway=all
   - Circuit breaker protection on individual provider fetches
   - Reduces worst-case response time from 1500s to ~45s

Root cause: Sequential provider fetching caused 499 errors when cache missed because 25+ providers were fetched one-by-one, each with 60s timeout potential.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Reliability Improvements**
  * Implemented parallel fetching of provider catalogs with a 45-second timeout, replacing sequential requests for faster data retrieval.
  * Added multi-tier caching strategy with local in-memory cache as a fallback to improve response times and reduce latency.
  * Introduced resilience mechanism to gracefully handle provider failures and automatically skip unavailable providers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses critical 499 timeout errors by replacing sequential provider fetching with parallel execution and adding multi-tier caching fallbacks.

**Key Changes:**
- **Parallel Fetching**: `parallel_catalog_fetch.py` uses ThreadPoolExecutor (10 workers) to fetch 29 providers concurrently, reducing worst-case time from 1500s to ~45s
- **Circuit Breaker**: `circuit_breaker.py` tracks provider health and skips failing providers after 3 consecutive failures for 5 minutes
- **Local Memory Cache**: `local_memory_cache.py` provides thread-safe LRU cache (500 entries) with stale-while-revalidate pattern as Redis fallback
- **Multi-Tier Caching**: Updated `model_catalog_cache.py` to check Redis → Local Memory → Database in sequence
- **Integration**: `catalog.py` now uses parallel fetch when aggregated cache misses for `gateway=all`

**Issues Found:**
- Circuit breaker only applied to openrouter in `catalog.py`, not the 20+ other individual provider fetches
- Empty results trigger circuit breaker failures, which could open circuits during cache warming
- `timeout_per_provider` parameter in parallel fetch is not actually enforced

The performance improvements are significant and the multi-tier caching strategy is sound. The main concerns are incomplete circuit breaker coverage and the aggressive failure recording for empty results.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with some monitoring recommended for circuit breaker behavior
- Code quality is high with proper thread safety and good architectural patterns. The issues are non-critical: incomplete circuit breaker coverage and overly aggressive failure detection won't break functionality but may cause unnecessary circuit opening. The performance improvements are substantial and well-implemented.
- Pay attention to `src/routes/catalog.py` to ensure circuit breaker is applied consistently to all providers, and monitor circuit breaker behavior in production to tune failure thresholds

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/utils/circuit_breaker.py | added circuit breaker implementation with proper thread safety and timeout handling |
| src/services/parallel_catalog_fetch.py | added parallel fetching with ThreadPoolExecutor, but `get_cached_models` is not thread-safe when called from threads |
| src/routes/catalog.py | integrated parallel fetching and circuit breaker, but circuit breaker only applied to openrouter provider |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant catalog.py
    participant parallel_fetch
    participant circuit_breaker
    participant local_cache
    participant Redis
    participant Database
    participant ThreadPool

    Client->>catalog.py: GET /models?gateway=all
    catalog.py->>Redis: Check aggregated cache
    
    alt Cache Hit
        Redis-->>catalog.py: Return cached models
        catalog.py-->>Client: Return models
    else Cache Miss
        catalog.py->>parallel_fetch: fetch_and_merge_all_providers(timeout=45s)
        parallel_fetch->>ThreadPool: Create 10 worker threads
        
        loop For each provider (29 providers)
            parallel_fetch->>circuit_breaker: should_skip(provider)?
            
            alt Circuit Open
                circuit_breaker-->>parallel_fetch: Skip provider
            else Circuit Closed
                circuit_breaker-->>parallel_fetch: Proceed
                parallel_fetch->>Redis: get_cached_models(provider)
                
                alt Redis Hit
                    Redis-->>parallel_fetch: Return models
                    parallel_fetch->>local_cache: Update local cache
                    parallel_fetch->>circuit_breaker: record_success(provider)
                else Redis Miss
                    Redis->>local_cache: Check local memory
                    
                    alt Local Hit (fresh/stale)
                        local_cache-->>parallel_fetch: Return models
                    else Local Miss
                        local_cache->>Database: Fetch provider catalog
                        Database-->>local_cache: Return DB models
                        local_cache->>Redis: Cache in Redis
                        local_cache->>local_cache: Cache locally
                        local_cache-->>parallel_fetch: Return models
                    end
                end
            end
        end
        
        parallel_fetch->>parallel_fetch: Merge all provider results
        parallel_fetch-->>catalog.py: Return merged models
        catalog.py-->>Client: Return models
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->