### PR TITLE
fix(db): remove references to dropped models.model_id column

### DIFF
--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -1923,7 +1923,7 @@ async def get_request_counts_by_model_admin(admin_user: dict = Depends(require_a
 
         result = (
             client.table("chat_completion_requests")
-            .select("model_id, models!inner(id, model_name, model_id, providers!inner(name, slug))")
+            .select("model_id, models!inner(id, model_name, provider_model_id, providers!inner(name, slug))")
             .execute()
         )
 

--- a/src/services/pricing.py
+++ b/src/services/pricing.py
@@ -150,10 +150,11 @@ def _get_pricing_from_database(model_id: str, candidate_ids: set[str]) -> dict[s
                 with track_database_query(table="models", operation="select"):
                     # Query models table with JOIN to model_pricing table
                     # PostgREST syntax: select model_pricing(*) creates a nested object
+                    # Note: model_id column was removed - now use model_name as canonical identifier
                     result = (
                         client.table("models")
-                        .select("id, model_id, model_pricing(price_per_input_token, price_per_output_token)")
-                        .eq("model_id", candidate)
+                        .select("id, model_name, model_pricing(price_per_input_token, price_per_output_token)")
+                        .eq("model_name", candidate)
                         .eq("is_active", True)
                         .limit(1)
                         .execute()
@@ -200,11 +201,11 @@ def _get_pricing_from_database(model_id: str, candidate_ids: set[str]) -> dict[s
                         "source": "database"
                     }
 
-                # Try provider_model_id if model_id didn't match
+                # Try provider_model_id if model_name didn't match
                 with track_database_query(table="models", operation="select"):
                     result = (
                         client.table("models")
-                        .select("id, model_id, model_pricing(price_per_input_token, price_per_output_token)")
+                        .select("id, model_name, model_pricing(price_per_input_token, price_per_output_token)")
                         .eq("provider_model_id", candidate)
                         .eq("is_active", True)
                         .limit(1)

--- a/src/services/pricing_lookup.py
+++ b/src/services/pricing_lookup.py
@@ -223,10 +223,11 @@ def _get_pricing_from_database(model_id: str) -> dict[str, str] | None:
         client = get_supabase_client()
 
         # Query models table with JOIN to model_pricing table
+        # Note: model_id column was removed - now use model_name as canonical identifier
         result = (
             client.table("models")
-            .select("id, model_id, model_pricing(price_per_input_token, price_per_output_token)")
-            .eq("model_id", model_id)
+            .select("id, model_name, model_pricing(price_per_input_token, price_per_output_token)")
+            .eq("model_name", model_id)
             .eq("is_active", True)
             .limit(1)
             .execute()


### PR DESCRIPTION
## Summary
- Fixes `column models.model_id does not exist` errors occurring in production after migration `20260131000002_drop_model_id_column.sql`
- Updates 4 files that were still referencing the removed `models.model_id` column to use `model_name` (now the canonical identifier) or `provider_model_id` instead
- Preserves references to foreign key columns `model_pricing.model_id` and `chat_completion_requests.model_id` which still exist and point to `models.id`

## Changes
- **src/services/pricing_lookup.py**: Changed `_get_pricing_from_database()` to query by `model_name` instead of `model_id`
- **src/services/pricing.py**: Updated two database queries to use `model_name` for lookups
- **src/routes/admin.py**: Fixed join query to select `provider_model_id` instead of non-existent `model_id`  
- **src/db/chat_completion_requests.py**: Removed `model_id` from SELECT and OR filter conditions in `get_model_id_by_name()`

## Related
- Follows up on commit da03b97 which removed the `model_id` column from the models table
- Related to PR #1017 (refactor: remove redundant model_id and top_provider columns)

## Test plan
- [ ] Verify no `column models.model_id does not exist` errors in Railway logs after deployment
- [ ] Test pricing lookups work correctly via `/v1/chat/completions` endpoint
- [ ] Verify admin endpoints return expected data
- [ ] Run test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes references to the dropped `models.model_id` column following migration `20260131000002_drop_model_id_column.sql`. The changes correctly update 4 files to use `model_name` (now the canonical identifier) or `provider_model_id` instead.

## Key Changes
- `src/services/pricing_lookup.py`: Changed database query to filter by `model_name` instead of `model_id`
- `src/services/pricing.py`: Updated two queries to use `model_name` for pricing lookups
- `src/routes/admin.py`: Fixed join query to select `provider_model_id` instead of `model_id`
- `src/db/chat_completion_requests.py`: Removed `model_id` from SELECT clauses and OR filter conditions

## Critical Issues Found
Two additional files were missed in this PR that still reference the dropped column:
- `src/routes/admin.py:2015` - fallback query still selects `model_id`
- `src/routes/monitoring.py:1055` - model query still includes `model_id`

These will cause `column models.model_id does not exist` errors in production.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge - will cause runtime errors in admin and monitoring endpoints
- While the 4 changed files are correct, the PR misses 2 critical references to the dropped `models.model_id` column in `src/routes/admin.py:2015` and `src/routes/monitoring.py:1055`, which will cause database errors in production
- src/routes/admin.py (line 2015) and src/routes/monitoring.py (line 1055) both need fixes before merging

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/db/chat_completion_requests.py | Correctly removed models.model_id references from queries and filters |
| src/services/pricing.py | Updated pricing queries to use model_name instead of model_id |
| src/services/pricing_lookup.py | Fixed database query to use model_name for pricing lookup |
| src/routes/admin.py | Fixed one query but missed another critical reference to models.model_id on line 2015 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API as API Endpoint
    participant Pricing as Pricing Service
    participant PricingLookup as Pricing Lookup
    participant ChatDB as Chat Completion DB
    participant Admin as Admin Route
    participant DB as PostgreSQL (models table)

    Note over DB: Migration 20260131000002:<br/>DROP COLUMN model_id

    Client->>API: Request pricing/chat
    API->>Pricing: get_pricing_from_database()
    Pricing->>DB: SELECT model_name, model_pricing<br/>WHERE model_name = ?
    Note over Pricing,DB: ✅ Changed from model_id to model_name
    DB-->>Pricing: pricing data
    Pricing-->>API: pricing info

    Client->>API: Request model lookup
    API->>ChatDB: get_model_id_by_name()
    ChatDB->>DB: SELECT id, provider_model_id, model_name<br/>WHERE model_name ILIKE ?
    Note over ChatDB,DB: ✅ Removed model_id from SELECT and OR filter
    DB-->>ChatDB: model data
    ChatDB-->>API: model id

    Client->>Admin: Admin query
    Admin->>DB: SELECT model_name, provider_model_id<br/>FROM models JOIN chat_completion_requests
    Note over Admin,DB: ✅ Changed from model_id to provider_model_id
    DB-->>Admin: aggregated data
    Admin-->>Client: admin dashboard data
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->