### PR TITLE
Added hard timeout upon start of the application

### DIFF
--- a/src/services/background_tasks.py
+++ b/src/services/background_tasks.py
@@ -315,6 +315,15 @@ async def update_full_model_catalog_loop() -> None:
     
     REFRESH_INTERVAL_SECONDS = 14 * 60  # 14 minutes
     
+    # CRITICAL FIX: Add startup delay to prevent 502 Bad Gateway
+    # Wait for app to fully boot and pass health checks before hitting DB
+    logger.info("Waiting 60s before first model catalog refresh...")
+    try:
+        await asyncio.sleep(60)
+    except asyncio.CancelledError:
+        logger.info("Model catalog refresh task cancelled during startup delay")
+        return
+    
     while True:
         try:
             # Check if we should stop


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application startup reliability to ensure proper system initialization before database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added a 60-second startup delay in `update_full_model_catalog_loop()` before the first model catalog refresh to prevent 502 Bad Gateway errors during application initialization.

**Changes:**
- Introduced `asyncio.sleep(60)` with proper cancellation handling before the main refresh loop begins
- Added logging to indicate the startup delay is in progress
- Maintains graceful shutdown capability if task is cancelled during the delay period

**How it works:**
The background task now waits for the application to fully boot and pass health checks before attempting to hit the database. This prevents database queries from interfering with the critical startup sequence and health check endpoints, which were previously causing 502 errors when the app was still initializing.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple, defensive fix that adds a hardcoded startup delay. It properly handles cancellation and follows existing patterns in the codebase. However, a hardcoded 60-second delay is not ideal - it would be better to wait for actual application readiness signals rather than using a fixed timeout
- No files require special attention

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Startup as Application Startup
    participant BG as Background Task Init
    participant CLoop as Catalog Refresh Loop
    participant DB as Database
    participant Cache as Redis Cache

    Startup->>BG: Start catalog refresh task
    BG->>CLoop: Create async task
    
    Note over CLoop: NEW: 60s startup delay
    CLoop->>CLoop: Wait 60 seconds
    Note over CLoop: Allows app to fully boot<br/>and pass health checks
    
    alt Task cancelled during startup
        CLoop-->>BG: Exit gracefully
    else Startup delay complete
        CLoop->>CLoop: Enter refresh loop
        
        Note over CLoop: Runs every 14 minutes
        CLoop->>DB: Fetch all models
        DB-->>CLoop: Return model data
        CLoop->>CLoop: Transform models
        CLoop->>Cache: Cache models with 15min TTL
        Cache-->>CLoop: Success
        CLoop->>CLoop: Sleep 14 minutes
        
        Note over CLoop: Loop repeats until shutdown
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->