### PR TITLE
Fix Rate Limit

### DIFF
--- a/src/routes/rate_limits.py
+++ b/src/routes/rate_limits.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from datetime import datetime, timezone
 from typing import Any
@@ -29,69 +30,78 @@ router = APIRouter()
 # =============================================================================
 
 
+def _fetch_user_rate_limits_sync(api_key: str) -> dict | None:
+    """Synchronous helper to fetch all user rate limit data in a thread."""
+    user = get_user(api_key)
+    if not user:
+        return None
+
+    configs = get_user_rate_limit_configs(user["id"])
+
+    enhanced_configs = []
+    for config in configs:
+        usage_stats = {
+            "minute": get_rate_limit_usage_stats(config["api_key"], "minute"),
+            "hour": get_rate_limit_usage_stats(config["api_key"], "hour"),
+            "day": get_rate_limit_usage_stats(config["api_key"], "day"),
+        }
+
+        enhanced_configs.append(
+            {
+                **config,
+                "usage_stats": usage_stats,
+                "current_status": {
+                    "requests_remaining_minute": max(
+                        0,
+                        config["rate_limit_config"].get("requests_per_minute", 60)
+                        - usage_stats["minute"]["total_requests"],
+                    ),
+                    "tokens_remaining_minute": max(
+                        0,
+                        config["rate_limit_config"].get("tokens_per_minute", 10000)
+                        - usage_stats["minute"]["total_tokens"],
+                    ),
+                    "requests_remaining_hour": max(
+                        0,
+                        config["rate_limit_config"].get("requests_per_hour", 1000)
+                        - usage_stats["hour"]["total_requests"],
+                    ),
+                    "tokens_remaining_hour": max(
+                        0,
+                        config["rate_limit_config"].get("tokens_per_hour", 100000)
+                        - usage_stats["hour"]["total_tokens"],
+                    ),
+                    "requests_remaining_day": max(
+                        0,
+                        config["rate_limit_config"].get("requests_per_day", 10000)
+                        - usage_stats["day"]["total_requests"],
+                    ),
+                    "tokens_remaining_day": max(
+                        0,
+                        config["rate_limit_config"].get("tokens_per_day", 1000000)
+                        - usage_stats["day"]["total_tokens"],
+                    ),
+                },
+            }
+        )
+
+    return {"user": user, "configs": enhanced_configs}
+
+
 @router.get("/user/rate-limits", tags=["authentication"])
 async def get_user_rate_limits_advanced(api_key: str = Depends(get_api_key)):
     """Get advanced rate limit configuration and status for user's API keys"""
     try:
-        user = get_user(api_key)
-        if not user:
+        # FIX (2026-02-05): Run all synchronous DB queries in a thread
+        # to prevent blocking the event loop and causing 499/500 errors
+        result = await asyncio.to_thread(_fetch_user_rate_limits_sync, api_key)
+        if result is None:
             raise HTTPException(status_code=401, detail="Invalid API key")
-
-        # Get rate limit configurations for all user's keys
-        configs = get_user_rate_limit_configs(user["id"])
-
-        # Get current usage stats for each key
-        enhanced_configs = []
-        for config in configs:
-            usage_stats = {
-                "minute": get_rate_limit_usage_stats(config["api_key"], "minute"),
-                "hour": get_rate_limit_usage_stats(config["api_key"], "hour"),
-                "day": get_rate_limit_usage_stats(config["api_key"], "day"),
-            }
-
-            enhanced_configs.append(
-                {
-                    **config,
-                    "usage_stats": usage_stats,
-                    "current_status": {
-                        "requests_remaining_minute": max(
-                            0,
-                            config["rate_limit_config"].get("requests_per_minute", 60)
-                            - usage_stats["minute"]["total_requests"],
-                        ),
-                        "tokens_remaining_minute": max(
-                            0,
-                            config["rate_limit_config"].get("tokens_per_minute", 10000)
-                            - usage_stats["minute"]["total_tokens"],
-                        ),
-                        "requests_remaining_hour": max(
-                            0,
-                            config["rate_limit_config"].get("requests_per_hour", 1000)
-                            - usage_stats["hour"]["total_requests"],
-                        ),
-                        "tokens_remaining_hour": max(
-                            0,
-                            config["rate_limit_config"].get("tokens_per_hour", 100000)
-                            - usage_stats["hour"]["total_tokens"],
-                        ),
-                        "requests_remaining_day": max(
-                            0,
-                            config["rate_limit_config"].get("requests_per_day", 10000)
-                            - usage_stats["day"]["total_requests"],
-                        ),
-                        "tokens_remaining_day": max(
-                            0,
-                            config["rate_limit_config"].get("tokens_per_day", 1000000)
-                            - usage_stats["day"]["total_tokens"],
-                        ),
-                    },
-                }
-            )
 
         return {
             "status": "success",
-            "user_id": user["id"],
-            "rate_limit_configs": enhanced_configs,
+            "user_id": result["user"]["id"],
+            "rate_limit_configs": result["configs"],
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
 
@@ -108,12 +118,12 @@ async def update_user_rate_limits_advanced(
 ):
     """Update rate limit configuration for a specific API key"""
     try:
-        user = get_user(api_key)
+        user = await asyncio.to_thread(get_user, api_key)
         if not user:
             raise HTTPException(status_code=401, detail="Invalid API key")
 
         # Verify the user owns the key
-        key_to_update = get_api_key_by_id(key_id, user["id"])
+        key_to_update = await asyncio.to_thread(get_api_key_by_id, key_id, user["id"])
         if not key_to_update:
             raise HTTPException(status_code=404, detail="API key not found")
 
@@ -138,7 +148,9 @@ async def update_user_rate_limits_advanced(
                 )
 
         # Update rate limit configuration
-        success = update_rate_limit_config(key_to_update["api_key"], rate_limit_config)
+        success = await asyncio.to_thread(
+            update_rate_limit_config, key_to_update["api_key"], rate_limit_config
+        )
 
         if not success:
             raise HTTPException(status_code=500, detail="Failed to update rate limit configuration")
@@ -164,7 +176,7 @@ async def bulk_update_user_rate_limits(
 ):
     """Bulk update rate limit configuration for all user's API keys"""
     try:
-        user = get_user(api_key)
+        user = await asyncio.to_thread(get_user, api_key)
         if not user:
             raise HTTPException(status_code=401, detail="Invalid API key")
 
@@ -189,7 +201,9 @@ async def bulk_update_user_rate_limits(
                 )
 
         # Bulk update rate limit configurations
-        updated_count = bulk_update_rate_limit_configs(user["id"], rate_limit_config)
+        updated_count = await asyncio.to_thread(
+            bulk_update_rate_limit_configs, user["id"], rate_limit_config
+        )
 
         return {
             "status": "success",
@@ -212,12 +226,12 @@ async def get_api_key_rate_limit_usage(
 ):
     """Get detailed rate limit usage statistics for a specific API key"""
     try:
-        user = get_user(api_key)
+        user = await asyncio.to_thread(get_user, api_key)
         if not user:
             raise HTTPException(status_code=401, detail="Invalid API key")
 
         # Verify the user owns the key
-        key_to_check = get_api_key_by_id(key_id, user["id"])
+        key_to_check = await asyncio.to_thread(get_api_key_by_id, key_id, user["id"])
         if not key_to_check:
             raise HTTPException(status_code=404, detail="API key not found")
 
@@ -227,11 +241,11 @@ async def get_api_key_rate_limit_usage(
                 status_code=400, detail="Invalid time window. Must be 'minute', 'hour', or 'day'"
             )
 
-        # Get usage statistics
-        usage_stats = get_rate_limit_usage_stats(key_to_check["api_key"], time_window)
-
-        # Get rate limit configuration
-        rate_limit_config = get_rate_limit_config(key_to_check["api_key"])
+        # Get usage statistics and config in parallel threads
+        usage_stats, rate_limit_config = await asyncio.gather(
+            asyncio.to_thread(get_rate_limit_usage_stats, key_to_check["api_key"], time_window),
+            asyncio.to_thread(get_rate_limit_config, key_to_check["api_key"]),
+        )
 
         return {
             "status": "success",
@@ -254,7 +268,7 @@ async def get_api_key_rate_limit_usage(
 async def get_system_rate_limits(admin_user: dict = Depends(require_admin)):
     """Get system-wide rate limiting statistics"""
     try:
-        stats = get_system_rate_limit_stats()
+        stats = await asyncio.to_thread(get_system_rate_limit_stats)
 
         return {
             "status": "success",
@@ -276,7 +290,7 @@ async def get_rate_limit_alerts_endpoint(
 ):
     """Get rate limit alerts for monitoring"""
     try:
-        alerts = get_rate_limit_alerts(api_key, resolved, limit)
+        alerts = await asyncio.to_thread(get_rate_limit_alerts, api_key, resolved, limit)
 
         return {
             "status": "success",
@@ -356,7 +370,7 @@ async def get_admin_rate_limit_config(
     try:
         if api_key:
             # Get config for specific API key
-            config = get_rate_limit_config(api_key)
+            config = await asyncio.to_thread(get_rate_limit_config, api_key)
             return {
                 "status": "success",
                 "api_key": api_key[:15] + "...",
@@ -398,7 +412,9 @@ async def set_admin_rate_limit_config(
         config_dict = request.config.model_dump()
 
         # Update rate limit configuration
-        success = update_rate_limit_config(request.api_key, config_dict)
+        success = await asyncio.to_thread(
+            update_rate_limit_config, request.api_key, config_dict
+        )
 
         if not success:
             raise HTTPException(
@@ -441,7 +457,9 @@ async def reset_rate_limit_config(
     """
     try:
         # Reset to default configuration
-        success = update_rate_limit_config(api_key, DEFAULT_RATE_LIMIT_CONFIG)
+        success = await asyncio.to_thread(
+            update_rate_limit_config, api_key, DEFAULT_RATE_LIMIT_CONFIG
+        )
 
         if not success:
             raise HTTPException(
@@ -490,7 +508,7 @@ async def update_admin_rate_limits(
         config_dict = request.config.model_dump()
 
         # Use the set_user_rate_limits function
-        set_user_rate_limits(request.api_key, config_dict)
+        await asyncio.to_thread(set_user_rate_limits, request.api_key, config_dict)
 
         logger.info(
             f"Admin {admin_user.get('username')} updated rate limits for key {request.api_key[:15]}..."
@@ -529,14 +547,15 @@ async def delete_rate_limits(
     - Success status
     - The key will use default rate limits going forward
     """
-    try:
+    def _delete_rate_limits_sync(target_api_key: str) -> dict:
+        """Synchronous helper to delete rate limits in a thread."""
         from src.config.supabase_config import get_supabase_client
 
         client = get_supabase_client()
 
         # Try to delete from rate_limits table
         try:
-            result = client.table("rate_limits").delete().eq("api_key", api_key).execute()
+            result = client.table("rate_limits").delete().eq("api_key", target_api_key).execute()
             deleted_from_rate_limits = len(result.data) > 0 if result.data else False
         except Exception as e:
             logger.debug(f"Could not delete from rate_limits table: {e}")
@@ -550,13 +569,21 @@ async def delete_rate_limits(
                     "rate_limit_config": None,
                     "updated_at": datetime.now(timezone.utc).isoformat(),
                 })
-                .eq("api_key", api_key)
+                .eq("api_key", target_api_key)
                 .execute()
             )
             reset_in_api_keys = len(result.data) > 0 if result.data else False
         except Exception as e:
             logger.debug(f"Could not reset rate_limit_config in api_keys_new: {e}")
             reset_in_api_keys = False
+
+        return {
+            "deleted_from_rate_limits": deleted_from_rate_limits,
+            "reset_in_api_keys": reset_in_api_keys,
+        }
+
+    try:
+        result = await asyncio.to_thread(_delete_rate_limits_sync, api_key)
 
         logger.info(
             f"Admin {admin_user.get('username')} deleted rate limits for key {api_key[:15]}..."
@@ -566,8 +593,8 @@ async def delete_rate_limits(
             "status": "success",
             "message": "Rate limits deleted successfully. Key will use default limits.",
             "api_key": api_key[:15] + "...",
-            "deleted_from_rate_limits": deleted_from_rate_limits,
-            "reset_in_api_keys": reset_in_api_keys,
+            "deleted_from_rate_limits": result["deleted_from_rate_limits"],
+            "reset_in_api_keys": result["reset_in_api_keys"],
             "default_config": DEFAULT_RATE_LIMIT_CONFIG,
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
@@ -600,7 +627,10 @@ async def get_users_rate_limits(
     - List of users with their rate limit configurations
     - Pagination info
     """
-    try:
+    def _fetch_users_rate_limits_sync(
+        q_limit: int, q_offset: int, q_user_id: int | None, q_has_custom: bool | None
+    ) -> dict:
+        """Synchronous helper to fetch all user rate limits in a thread."""
         from src.config.supabase_config import get_supabase_client
 
         client = get_supabase_client()
@@ -608,57 +638,48 @@ async def get_users_rate_limits(
         # Try query with rate_limit_config column first, fallback without it
         rate_limit_config_available = True
         try:
-            # Build query for api_keys_new table
             query = client.table("api_keys_new").select(
                 "id, api_key, key_name, user_id, rate_limit_config, environment_tag, created_at"
             )
 
-            if user_id is not None:
-                query = query.eq("user_id", user_id)
+            if q_user_id is not None:
+                query = query.eq("user_id", q_user_id)
 
-            # Apply has_custom_config filter at database level if possible
-            if has_custom_config is not None:
-                if has_custom_config:
+            if q_has_custom is not None:
+                if q_has_custom:
                     query = query.not_.is_("rate_limit_config", "null")
                 else:
                     query = query.is_("rate_limit_config", "null")
 
-            # Execute query - fetch one extra to determine has_more
-            result = query.range(offset, offset + limit).execute()
+            result = query.range(q_offset, q_offset + q_limit).execute()
             api_keys = result.data or []
         except Exception as e:
-            # rate_limit_config column may not exist
             if "rate_limit_config" in str(e):
                 logger.debug(f"rate_limit_config column not available: {e}")
                 rate_limit_config_available = False
-                # Fallback query without rate_limit_config
                 query = client.table("api_keys_new").select(
                     "id, api_key, key_name, user_id, environment_tag, created_at"
                 )
 
-                if user_id is not None:
-                    query = query.eq("user_id", user_id)
+                if q_user_id is not None:
+                    query = query.eq("user_id", q_user_id)
 
-                # Skip has_custom_config filter when column doesn't exist
-                result = query.range(offset, offset + limit).execute()
+                result = query.range(q_offset, q_offset + q_limit).execute()
                 api_keys = result.data or []
             else:
                 raise
 
-        # Determine if there are more records and trim to limit
-        has_more = len(api_keys) > limit
-        api_keys = api_keys[:limit]
+        q_has_more = len(api_keys) > q_limit
+        api_keys = api_keys[:q_limit]
 
-        # Format response
         users_rate_limits = []
         for key in api_keys:
             if rate_limit_config_available:
                 config = key.get("rate_limit_config") or DEFAULT_RATE_LIMIT_CONFIG
-                has_custom = key.get("rate_limit_config") is not None
+                key_has_custom = key.get("rate_limit_config") is not None
             else:
-                # Try to get config from rate_limit_configs table
                 config = DEFAULT_RATE_LIMIT_CONFIG
-                has_custom = False
+                key_has_custom = False
                 try:
                     config_result = (
                         client.table("rate_limit_configs")
@@ -676,7 +697,7 @@ async def get_users_rate_limits(
                             "tokens_per_hour": cfg.get("max_tokens", 1000000),
                             "tokens_per_day": cfg.get("max_tokens", 1000000) * 24,
                         }
-                        has_custom = True
+                        key_has_custom = True
                 except Exception:
                     pass
 
@@ -686,19 +707,26 @@ async def get_users_rate_limits(
                 "key_name": key.get("key_name"),
                 "user_id": key["user_id"],
                 "environment_tag": key.get("environment_tag"),
-                "has_custom_config": has_custom,
+                "has_custom_config": key_has_custom,
                 "config": config,
                 "created_at": key.get("created_at"),
             })
 
+        return {"users": users_rate_limits, "has_more": q_has_more}
+
+    try:
+        result = await asyncio.to_thread(
+            _fetch_users_rate_limits_sync, limit, offset, user_id, has_custom_config
+        )
+
         return {
             "status": "success",
-            "total": len(users_rate_limits),
-            "users": users_rate_limits,
+            "total": len(result["users"]),
+            "users": result["users"],
             "pagination": {
                 "limit": limit,
                 "offset": offset,
-                "has_more": has_more,
+                "has_more": result["has_more"],
             },
             "filters": {
                 "user_id": user_id,


### PR DESCRIPTION
With a single uvicorn worker, the entire application runs on one asyncio event loop. When any synchronous I/O call (Supabase HTTP request) runs directly in an async handler, it blocks the entire event loop for ~50-500ms per call. During that time, no other requests can be processed, leading to cascading timeouts (499/500). Wrapping these in asyncio.to_thread() offloads them to a thread pool, keeping the event loop free for other requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized rate-limiting operations for faster response times through parallel data fetching and result caching.
  * Improved system health check and configuration refresh handling to prevent blocking behavior.

* **Bug Fixes**
  * Resolved timeout errors in rate-limit and system endpoints during high request concurrency.
  * Enhanced stability and reliability of rate-limiting operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes critical event loop blocking issues that were causing 499/500 errors under concurrent load. With a single uvicorn worker, synchronous Supabase HTTP calls in async handlers were blocking the event loop for 50-500ms per call, preventing other requests (including chat completions) from being processed.

**Key Changes:**
- Wrapped all synchronous DB operations in `asyncio.to_thread()` across rate limiting endpoints and system endpoints
- Refactored complex multi-query operations into dedicated sync helper functions for cleaner thread execution
- Used `asyncio.gather()` to parallelize independent thread operations for better performance
- Added `inspect.iscoroutinefunction()` check in `system.py` to properly distinguish async vs sync fetch functions
- Eliminated duplicate `get_user()` calls in rate limiting service by fetching once and reusing the result
- Removed fallback rate limiting logic in favor of direct sliding window results, simplifying the code path

**Performance Impact:**
- Event loop remains responsive during DB operations
- Concurrent requests no longer time out when admin/monitoring pages are accessed
- Reduces cascade failures from blocked event loop

<h3>Confidence Score: 4/5</h3>

- Safe to merge with monitoring - fixes critical production issue but requires runtime validation
- The threading changes correctly address the event loop blocking issue and follow Python best practices. The Supabase client has thread safety built-in. However, the change in `rate_limiting.py` that removes fallback rate limiting logic (lines 180-202) in favor of direct results needs careful monitoring in production to ensure rate limiting still functions correctly under all scenarios.
- Pay attention to `src/services/rate_limiting.py` - the removal of fallback rate limiting logic should be monitored to ensure rate limits work correctly

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/routes/rate_limits.py | Wrapped all synchronous Supabase DB calls in `asyncio.to_thread()` to prevent event loop blocking. Refactored complex queries into helper functions for cleaner threading. Used `asyncio.gather()` for parallel thread execution where appropriate. |
| src/routes/system.py | Added `inspect.iscoroutinefunction()` check to properly handle both sync and async fetch functions. Wrapped sync functions in `asyncio.to_thread()` and wrapped pricing health monitor calls in threads. |
| src/services/rate_limiting.py | Critical fix: wrapped all DB calls in `asyncio.to_thread()`, eliminated duplicate `get_user()` calls, and removed fallback rate limiting logic in favor of direct sliding window results. Introduced helper method to reuse fetched user data. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant FastAPI as FastAPI (Event Loop)
    participant Thread as Thread Pool
    participant Supabase as Supabase HTTP API
    
    Note over Client,Supabase: BEFORE: Synchronous blocking calls
    Client->>FastAPI: GET /user/rate-limits
    FastAPI->>Supabase: get_user(api_key) [BLOCKS EVENT LOOP 50-500ms]
    Supabase-->>FastAPI: user data
    FastAPI->>Supabase: get_user_rate_limit_configs() [BLOCKS]
    Supabase-->>FastAPI: configs
    FastAPI->>Supabase: get_rate_limit_usage_stats() x3 [BLOCKS]
    Supabase-->>FastAPI: stats
    Note over FastAPI: Event loop blocked ~200-1000ms total
    Note over FastAPI: Other requests timeout (499/500)
    FastAPI-->>Client: response
    
    Note over Client,Supabase: AFTER: Non-blocking with asyncio.to_thread()
    Client->>FastAPI: GET /user/rate-limits
    FastAPI->>Thread: asyncio.to_thread(_fetch_user_rate_limits_sync)
    Note over FastAPI: Event loop FREE to handle other requests
    Thread->>Supabase: get_user(api_key) [in thread]
    Supabase-->>Thread: user data
    Thread->>Supabase: get_user_rate_limit_configs() [in thread]
    Supabase-->>Thread: configs
    Thread->>Supabase: get_rate_limit_usage_stats() x3 [in thread]
    Supabase-->>Thread: stats
    Thread-->>FastAPI: combined result
    Note over FastAPI: No event loop blocking
    Note over FastAPI: Chat completions continue normally
    FastAPI-->>Client: response
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->