### PR TITLE
feat(observability): add Redis OpenTelemetry instrumentation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,6 +50,7 @@ opentelemetry-instrumentation>=0.49b0
 opentelemetry-instrumentation-fastapi>=0.49b0
 opentelemetry-instrumentation-httpx>=0.49b0
 opentelemetry-instrumentation-requests>=0.49b0
+opentelemetry-instrumentation-redis>=0.49b0
 opentelemetry-exporter-otlp>=1.28.0
 
 # Loki Logging


### PR DESCRIPTION
Add automatic Redis cache operation tracing via opentelemetry-instrumentation-redis. This enables visibility of Redis cache operations (GET, SET, etc.) in Tempo traces, complementing the existing Prometheus cache metrics and Loki logs.

Changes:
- Add opentelemetry-instrumentation-redis>=0.49b0 to requirements.txt
- Update OpenTelemetryConfig to initialize Redis instrumentation
- Gracefully handle missing Redis instrumentation package

When TEMPO_ENABLED=true, Redis operations will automatically appear as spans in distributed traces, allowing correlation with API requests and cache performance analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added optional Redis cache operation tracing support to the observability system. The system gracefully handles cases where the tracing package is unavailable, ensuring continued operation without disruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds Redis cache operation tracing to the OpenTelemetry instrumentation stack by integrating `opentelemetry-instrumentation-redis`. Redis operations (GET, SET, HGET, INCR, etc.) will now appear as spans in Tempo distributed traces when `TEMPO_ENABLED=true`, complementing the existing Prometheus cache metrics and Loki logs.

**Key changes:**
- Added `opentelemetry-instrumentation-redis>=0.49b0` to `requirements.txt` alongside other OpenTelemetry instrumentation packages
- Updated `OpenTelemetryConfig.initialize()` to call `RedisInstrumentor().instrument()` after HTTP client instrumentation
- Implemented graceful fallback with nested try-except blocks to handle missing package installation
- Added informative logging at different levels (info for success, warning for failures, debug for unavailable package)
- Updated module docstring and class docstring to document Redis tracing capability

**Implementation approach:**
The Redis instrumentation follows the same pattern as existing HTTP client instrumentation (`HTTPXClientInstrumentor`, `RequestsInstrumentor`). The instrumentor automatically wraps the `redis` package's client methods to create spans, requiring no changes to existing Redis usage code throughout the codebase (`src/config/redis_config.py`, `src/services/rate_limiting.py`, etc.).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-implemented with proper error handling, graceful degradation, and follow established patterns. The Redis instrumentation is wrapped in multiple layers of exception handling (outer OpenTelemetry initialization try-except, inner Redis-specific try-except) ensuring the application continues functioning even if instrumentation fails. The implementation is non-invasive and adds observability without modifying existing Redis usage code.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| requirements.txt | Added `opentelemetry-instrumentation-redis>=0.49b0` dependency for Redis tracing |
| src/config/opentelemetry_config.py | Integrated Redis instrumentation with graceful fallback handling for missing package |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as FastAPI App
    participant OTel as OpenTelemetryConfig
    participant Redis as Redis Client
    participant Tempo as Tempo (OTLP Endpoint)

    Note over App: Application Startup
    App->>OTel: initialize()
    
    alt TEMPO_ENABLED=true
        OTel->>OTel: Initialize TracerProvider
        OTel->>OTel: Configure OTLP Exporter
        OTel->>OTel: HTTPXClientInstrumentor().instrument()
        OTel->>OTel: RequestsInstrumentor().instrument()
        
        alt Redis Instrumentation Available
            OTel->>OTel: RedisInstrumentor().instrument()
            Note over OTel: Redis operations will be traced
        else Package Not Installed
            Note over OTel: Log debug message, continue gracefully
        end
        
        OTel->>App: instrument_fastapi(app)
        Note over OTel: OpenTelemetry ready
    else TEMPO_ENABLED=false
        Note over OTel: Skip initialization
    end
    
    Note over App: Runtime - API Request with Cache
    App->>Redis: cache.get(key)
    Note over Redis: Span created: redis.get
    Redis-->>App: Cache value or None
    Redis->>Tempo: Export span trace
    
    App->>Redis: cache.set(key, value, ttl)
    Note over Redis: Span created: redis.set
    Redis-->>App: Success
    Redis->>Tempo: Export span trace
    
    Note over Tempo: Redis operations visible<br/>in distributed traces
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->