### PR TITLE
fix: add concurrency gate

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -404,6 +404,11 @@ class Config:
     REDIS_SOCKET_TIMEOUT = int(os.environ.get("REDIS_SOCKET_TIMEOUT", "5"))
     REDIS_SOCKET_CONNECT_TIMEOUT = int(os.environ.get("REDIS_SOCKET_CONNECT_TIMEOUT", "5"))
 
+    # Concurrency Control (global server-level admission gate)
+    CONCURRENCY_LIMIT = int(os.environ.get("CONCURRENCY_LIMIT", "20"))
+    CONCURRENCY_QUEUE_SIZE = int(os.environ.get("CONCURRENCY_QUEUE_SIZE", "50"))
+    CONCURRENCY_QUEUE_TIMEOUT = float(os.environ.get("CONCURRENCY_QUEUE_TIMEOUT", "10.0"))
+
     # Pricing Sync Scheduler Configuration - DEPRECATED 2026-02 (Phase 3, Issue #1063)
     # Pricing is now synced via model sync (provider_model_sync_service.py)
 

--- a/src/main.py
+++ b/src/main.py
@@ -219,6 +219,20 @@ def create_app() -> FastAPI:
     app.add_middleware(RequestTimeoutMiddleware, timeout_seconds=55.0)
     logger.info("  ⏱️  Request timeout middleware enabled (55s timeout to prevent 504 errors)")
 
+    # Add concurrency control middleware (global admission gate)
+    from src.middleware.concurrency_middleware import ConcurrencyMiddleware
+
+    app.add_middleware(
+        ConcurrencyMiddleware,
+        limit=Config.CONCURRENCY_LIMIT,
+        queue_size=Config.CONCURRENCY_QUEUE_SIZE,
+        queue_timeout=Config.CONCURRENCY_QUEUE_TIMEOUT,
+    )
+    logger.info(
+        f"  🚦 Concurrency middleware enabled "
+        f"(limit={Config.CONCURRENCY_LIMIT}, queue={Config.CONCURRENCY_QUEUE_SIZE})"
+    )
+
     # Add request ID middleware for error tracking and correlation
     from src.middleware.request_id_middleware import RequestIDMiddleware
 

--- a/src/middleware/concurrency_middleware.py
+++ b/src/middleware/concurrency_middleware.py
@@ -1,0 +1,179 @@
+"""
+Concurrency Control Middleware
+
+Global server-level admission gate using asyncio.Semaphore.
+Limits the number of requests processed concurrently with a bounded queue
+for overflow, preventing resource exhaustion under bot/attack traffic.
+
+Returns 503 Service Unavailable (not 429) because this is server capacity
+protection, not rate limiting. Existing rate limiters handle per-key 429s.
+
+This is a pure ASGI middleware (not BaseHTTPMiddleware) for minimal overhead
+and proper streaming support.
+"""
+
+import asyncio
+import json
+import logging
+import time
+
+from prometheus_client import Counter, Gauge
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+logger = logging.getLogger(__name__)
+
+# Prometheus metrics for concurrency monitoring
+concurrency_active = Gauge(
+    "concurrency_active_requests",
+    "Number of requests currently being processed",
+)
+concurrency_queued = Gauge(
+    "concurrency_queued_requests",
+    "Number of requests waiting in the admission queue",
+)
+concurrency_rejected = Counter(
+    "concurrency_rejected_total",
+    "Total requests rejected due to server overload",
+    ["reason"],
+)
+
+# Paths exempt from concurrency control (monitoring must always work)
+CONCURRENCY_EXEMPT_PATHS = frozenset({
+    "/health",
+    "/metrics",
+    "/ready",
+})
+
+
+class ConcurrencyMiddleware:
+    """
+    Global concurrency gate that limits simultaneous request processing.
+
+    Behavior:
+    - Slot available: acquire immediately and process
+    - Slots full, queue has room: wait up to queue_timeout seconds
+    - Slots full, queue full: immediate 503
+    - Queue timeout exceeded: 503
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        limit: int = 20,
+        queue_size: int = 50,
+        queue_timeout: float = 10.0,
+    ):
+        self.app = app
+        self.semaphore = asyncio.Semaphore(limit)
+        self.limit = limit
+        self.queue_size = queue_size
+        self.queue_timeout = queue_timeout
+        self._waiting = 0
+        logger.info(
+            f"Concurrency middleware initialized "
+            f"(limit={limit}, queue={queue_size}, timeout={queue_timeout}s)"
+        )
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+
+        # Exempt monitoring endpoints
+        if path in CONCURRENCY_EXEMPT_PATHS:
+            await self.app(scope, receive, send)
+            return
+
+        # Also exempt paths that start with exempt prefixes (e.g. /health/detailed)
+        if any(path.startswith(p) for p in CONCURRENCY_EXEMPT_PATHS):
+            await self.app(scope, receive, send)
+            return
+
+        # Fast path: try non-blocking acquire
+        acquired = self.semaphore._value > 0
+        if acquired:
+            try:
+                self.semaphore._value -= 1
+                concurrency_active.inc()
+                try:
+                    await self.app(scope, receive, send)
+                finally:
+                    self.semaphore.release()
+                    concurrency_active.dec()
+                return
+            except Exception:
+                # If the fast-path manipulation failed, fall through to normal path
+                self.semaphore._value += 1
+                concurrency_active.dec()
+
+        # Queue is full — reject immediately
+        if self._waiting >= self.queue_size:
+            method = scope.get("method", "UNKNOWN")
+            concurrency_rejected.labels(reason="queue_full").inc()
+            logger.warning(
+                f"Concurrency gate REJECT (queue full): {method} {path} "
+                f"(active={self.limit - self.semaphore._value}, queued={self._waiting})"
+            )
+            await self._send_503(scope, send, "Server at capacity, please retry")
+            return
+
+        # Queue the request with timeout
+        self._waiting += 1
+        concurrency_queued.inc()
+        wait_start = time.monotonic()
+
+        try:
+            await asyncio.wait_for(
+                self.semaphore.acquire(),
+                timeout=self.queue_timeout,
+            )
+        except asyncio.TimeoutError:
+            self._waiting -= 1
+            concurrency_queued.dec()
+            method = scope.get("method", "UNKNOWN")
+            wait_time = time.monotonic() - wait_start
+            concurrency_rejected.labels(reason="queue_timeout").inc()
+            logger.warning(
+                f"Concurrency gate REJECT (queue timeout {wait_time:.1f}s): "
+                f"{method} {path}"
+            )
+            await self._send_503(scope, send, "Server busy, please retry")
+            return
+
+        # Acquired after waiting — process the request
+        self._waiting -= 1
+        concurrency_queued.dec()
+        concurrency_active.inc()
+
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            self.semaphore.release()
+            concurrency_active.dec()
+
+    @staticmethod
+    async def _send_503(scope: Scope, send: Send, message: str) -> None:
+        """Send a 503 Service Unavailable response."""
+        body = json.dumps({
+            "error": {
+                "message": message,
+                "type": "server_overload",
+                "code": 503,
+            }
+        }).encode()
+
+        await send({
+            "type": "http.response.start",
+            "status": 503,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode()),
+                (b"retry-after", b"5"),
+            ],
+        })
+        await send({
+            "type": "http.response.body",
+            "body": body,
+        })


### PR DESCRIPTION
Add concurrency gate and cache stampede protection to prevent 429/499 cascades

Adds a global ConcurrencyMiddleware (asyncio.Semaphore) that limits simultaneous request processing to prevent resource exhaustion under bot/attack traffic. Excess requests queue briefly, then get 503 instead of overwhelming the server.

Also fixes the cache invalidation thundering herd: model sync was invalidating the full catalog cache 35+ times (once per provider). Now invalidates each provider individually during the loop and does full/unique/stats invalidation only once at the end. Cache rebuild paths use threading. Lock to ensure only one thread rebuilds on cache miss while others wait for the result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-side concurrency controls with configurable request limits, queue sizes, and timeouts via environment variables.
  * Server now rejects excess requests with appropriate 503 responses when concurrency limits are reached.
  * Implemented cache stampede protection for model catalog operations, improving performance during heavy load scenarios.
  * Optimized cache invalidation during bulk model synchronization to reduce unnecessary cascading updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds global concurrency limiting via `ConcurrencyMiddleware` (asyncio.Semaphore) to prevent resource exhaustion under high traffic, and implements cache stampede protection using threading locks to prevent redundant database queries after cache invalidation.

**Key Changes:**
- **Concurrency Gate**: New middleware limits simultaneous request processing (default: 20 active, 50 queued, 10s timeout). Returns 503 on overload instead of 429 since this is capacity protection, not rate limiting.
- **Cache Stampede Fix**: Model catalog cache rebuild now uses threading locks with double-checked locking pattern, ensuring only one thread rebuilds on cache miss while others wait.
- **Batch Invalidation Optimization**: `sync_all_providers` now invalidates global caches (`full_catalog`, `unique_models`, `stats`) once at the end instead of 35+ times per provider, preventing cache invalidation thundering herd.

**Critical Issues Found:**
- `ConcurrencyMiddleware` has race conditions in the `_waiting` counter (lines 71, 112-120, 122-154) - multiple coroutines can increment it simultaneously, bypassing the queue size limit
- Direct access to `semaphore._value` (private attribute) is brittle and breaks encapsulation (lines 95-109)
- Exception handling between metrics decrement and semaphore release could cause state drift (lines 150-154)

The cache stampede protection changes look solid, but the concurrency middleware needs thread-safety fixes before production use.

<h3>Confidence Score: 2/5</h3>

- This PR has critical concurrency bugs in the new middleware that could cause overload protection to fail under heavy traffic
- Score reflects multiple critical race conditions in `ConcurrencyMiddleware`: the `_waiting` counter lacks synchronization (allowing queue overflow), unsafe access to private `semaphore._value` attribute, and potential state drift from exception handling. While the cache stampede protection is well-implemented, the concurrency gate could fail in production and actually make cascading failures worse by allowing more requests through than intended.
- Pay close attention to `src/middleware/concurrency_middleware.py` - all race conditions must be fixed before merging

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/middleware/concurrency_middleware.py | New concurrency middleware with critical race conditions in `_waiting` counter and unsafe `semaphore._value` access. Needs thread-safety fixes and proper exception handling. |
| src/config/config.py | Adds three new configuration parameters for concurrency control with reasonable defaults (limit=20, queue=50, timeout=10.0s). |
| src/main.py | Registers the new concurrency middleware with config-based parameters. Integration looks correct. |
| src/services/model_catalog_cache.py | Adds threading locks for cache stampede protection. Implements double-checked locking pattern correctly for `get_cached_full_catalog`, `get_cached_unique_models`, and provider/gateway catalog functions. |
| src/services/model_catalog_sync.py | Introduces `batch_mode` parameter to prevent redundant cache invalidations. `sync_all_providers` now invalidates global caches once at the end instead of per-provider, eliminating thundering herd. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant ConcurrencyMW as Concurrency Middleware
    participant Semaphore
    participant App as FastAPI App
    participant Cache as Model Catalog Cache
    participant Lock as Threading Lock
    participant DB as Database

    Note over Client,DB: Request Flow with Concurrency Gate

    Client->>ConcurrencyMW: HTTP Request
    
    alt Exempt Path (/health, /metrics)
        ConcurrencyMW->>App: Pass through immediately
        App-->>Client: Response
    else Non-Exempt Path
        ConcurrencyMW->>Semaphore: Check availability
        
        alt Slot Available (Fast Path)
            Semaphore-->>ConcurrencyMW: Acquire (non-blocking)
            Note over ConcurrencyMW: Increment active counter
            ConcurrencyMW->>App: Process request
            App-->>ConcurrencyMW: Response
            Note over ConcurrencyMW: Decrement active counter
            ConcurrencyMW->>Semaphore: Release
            ConcurrencyMW-->>Client: Response
            
        else Slots Full
            alt Queue Not Full
                Note over ConcurrencyMW: Increment waiting counter
                ConcurrencyMW->>Semaphore: Acquire (with timeout)
                
                alt Acquired Before Timeout
                    Semaphore-->>ConcurrencyMW: Acquired
                    Note over ConcurrencyMW: Decrement waiting, increment active
                    ConcurrencyMW->>App: Process request
                    App-->>ConcurrencyMW: Response
                    Note over ConcurrencyMW: Decrement active counter
                    ConcurrencyMW->>Semaphore: Release
                    ConcurrencyMW-->>Client: Response
                else Timeout
                    Semaphore-->>ConcurrencyMW: TimeoutError
                    Note over ConcurrencyMW: Decrement waiting counter
                    ConcurrencyMW-->>Client: 503 Service Unavailable
                end
                
            else Queue Full
                ConcurrencyMW-->>Client: 503 Service Unavailable (immediate)
            end
        end
    end

    Note over Client,DB: Cache Stampede Protection Flow

    Client->>App: GET /catalog/models
    App->>Cache: get_cached_full_catalog()
    Cache->>Cache: Check Redis (MISS)
    Cache->>Cache: Check Local Memory (MISS)
    
    Cache->>Lock: Acquire rebuild lock
    Lock-->>Cache: Lock acquired
    
    Cache->>Cache: Double-check Redis
    alt Cache Rebuilt by Another Thread
        Cache-->>App: Return cached data
    else Still Missing
        Cache->>DB: Fetch all models
        DB-->>Cache: Model data
        Cache->>Cache: Transform to API format
        Cache->>Cache: Populate Redis + Local
        Cache-->>App: Return fresh data
    end
    
    Cache->>Lock: Release lock
    App-->>Client: Model catalog response

    Note over Client,DB: Model Sync with Batch Cache Invalidation

    participant Sync as Model Sync Service
    
    Sync->>Sync: sync_all_providers(batch_mode=True)
    
    loop For Each Provider
        Sync->>Sync: sync_provider_models(batch_mode=True)
        Sync->>DB: Upsert provider models
        DB-->>Sync: Success
        Sync->>Cache: Invalidate provider-specific cache only
        Note over Sync,Cache: Skip full/unique/stats invalidation
    end
    
    Note over Sync,Cache: After ALL providers synced
    Sync->>Cache: invalidate_full_catalog()
    Sync->>Cache: invalidate_unique_models()
    Sync->>Cache: invalidate_catalog_stats()
    Note over Sync,Cache: Global invalidation happens ONCE (not 35+ times)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->