### PR TITLE
feat: expose Redis INFO and catalog cache metrics to Prometheus

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -313,7 +313,10 @@ def create_app() -> FastAPI:
         - Rate limiting metrics
         - Provider health metrics
         - Business metrics (credits, tokens, subscriptions)
+        - Redis INFO metrics (memory, keyspace, clients, commands)
         """
+        # Refresh Redis INFO gauges on each scrape
+        prometheus_metrics.collect_redis_info()
         return Response(generate_latest(REGISTRY), media_type="text/plain; charset=utf-8")
 
     logger.info("  [OK] Prometheus metrics endpoint at /metrics")


### PR DESCRIPTION
Adds 10 Redis server metrics (redis_up, redis_memory_used_bytes, redis_keyspace_hits/misses, redis_connected_clients, etc.) scraped from Redis INFO on each /metrics request. Also instruments ModelCatalogCache to increment the existing catalog_cache_hits_total, catalog_cache_misses_total, catalog_cache_invalidations_total, and catalog_cache_size_bytes Prometheus counters on every cache operation.

These metrics feed the Redis-Cache Grafana dashboard which was previously showing no data because the backend wasn't exposing them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Redis monitoring metrics to the Prometheus endpoint, including uptime, memory usage, client connections, and command processing statistics.
  * Enhanced model catalog cache observability with metrics tracking for cache hits, misses, invalidations, and size across gateways.
  * Redis health status now reflected in metrics collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR instruments Redis server health and catalog cache operations for Prometheus monitoring, enabling the Redis-Cache Grafana dashboard to display real-time metrics.

**Key changes:**
- Added 10 Redis INFO gauges (`redis_up`, `redis_memory_used_bytes`, `redis_keyspace_hits_total`, `redis_keyspace_misses_total`, `redis_connected_clients`, `redis_commands_processed_total`, `redis_expired_keys_total`, `redis_evicted_keys_total`, `redis_uptime_in_seconds`, `redis_memory_max_bytes`) scraped via `collect_redis_info()` on each `/metrics` request
- Instrumented `ModelCatalogCache` to increment existing Prometheus counters (`catalog_cache_hits_total`, `catalog_cache_misses_total`, `catalog_cache_invalidations_total`, `catalog_cache_size_bytes`) on every cache operation using lazy-loaded imports to avoid circular dependencies
- The `/metrics` endpoint now calls `collect_redis_info()` before generating the Prometheus response to ensure fresh Redis server metrics

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- The implementation is clean, follows existing patterns, handles errors gracefully (Redis failures are non-fatal), uses lazy loading to prevent circular dependencies, and adds valuable observability without introducing any logical issues or breaking changes
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/main.py | Added `collect_redis_info()` call on each `/metrics` scrape to refresh Redis INFO gauges before exporting |
| src/services/prometheus_metrics.py | Added 10 Redis INFO gauges (memory, keyspace, clients, commands) and `collect_redis_info()` function to populate them |
| src/services/model_catalog_cache.py | Added lazy-loaded Prometheus instrumentation for catalog cache hits, misses, invalidations, and size on every cache operation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Prometheus
    participant MetricsEndpoint as /metrics endpoint
    participant PrometheusMetrics as prometheus_metrics.py
    participant RedisConfig as redis_config.py
    participant RedisServer as Redis Server
    participant ModelCatalogCache as model_catalog_cache.py
    participant CatalogRoute as /catalog route

    Note over Prometheus,RedisServer: Redis INFO Metrics Flow
    Prometheus->>MetricsEndpoint: GET /metrics (scrape request)
    MetricsEndpoint->>PrometheusMetrics: collect_redis_info()
    PrometheusMetrics->>RedisConfig: get_redis_client()
    RedisConfig-->>PrometheusMetrics: Redis client
    PrometheusMetrics->>RedisServer: client.ping()
    RedisServer-->>PrometheusMetrics: pong
    PrometheusMetrics->>PrometheusMetrics: redis_up.set(1)
    PrometheusMetrics->>RedisServer: client.info()
    RedisServer-->>PrometheusMetrics: Redis INFO dict
    PrometheusMetrics->>PrometheusMetrics: Update 10 gauges (memory, keyspace, clients, etc)
    MetricsEndpoint->>PrometheusMetrics: generate_latest(REGISTRY)
    PrometheusMetrics-->>MetricsEndpoint: Prometheus text format
    MetricsEndpoint-->>Prometheus: Metrics response

    Note over CatalogRoute,ModelCatalogCache: Catalog Cache Metrics Flow
    CatalogRoute->>ModelCatalogCache: get_full_catalog()
    ModelCatalogCache->>ModelCatalogCache: _ensure_prom() (lazy load)
    ModelCatalogCache->>RedisServer: redis_client.get(key)
    alt Cache Hit
        RedisServer-->>ModelCatalogCache: cached data
        ModelCatalogCache->>PrometheusMetrics: catalog_cache_hits.labels(gateway="all").inc()
    else Cache Miss
        RedisServer-->>ModelCatalogCache: None
        ModelCatalogCache->>PrometheusMetrics: catalog_cache_misses.labels(gateway="all").inc()
    end
    
    Note over CatalogRoute,ModelCatalogCache: Cache Set Flow
    CatalogRoute->>ModelCatalogCache: set_full_catalog(catalog)
    ModelCatalogCache->>RedisServer: redis_client.setex(key, ttl, data)
    ModelCatalogCache->>PrometheusMetrics: catalog_cache_size_bytes.labels(gateway="all").set(size)
    
    Note over CatalogRoute,ModelCatalogCache: Cache Invalidation Flow
    CatalogRoute->>ModelCatalogCache: invalidate_full_catalog()
    ModelCatalogCache->>RedisServer: redis_client.delete(key)
    ModelCatalogCache->>PrometheusMetrics: catalog_cache_invalidations.labels(gateway="all", reason="model_sync").inc()
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->