### PR TITLE
Fix/fix redis endpoint

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -318,8 +318,10 @@ def create_app() -> FastAPI:
         - Business metrics (credits, tokens, subscriptions)
         - Redis INFO metrics (memory, keyspace, clients, commands)
         """
-        # Refresh Redis INFO gauges on each scrape
-        prometheus_metrics.collect_redis_info()
+        # Refresh Redis INFO gauges on each scrape (run in threadpool to avoid blocking)
+        import asyncio
+
+        await asyncio.to_thread(prometheus_metrics.collect_redis_info)
         return Response(generate_latest(REGISTRY), media_type="text/plain; charset=utf-8")
 
     logger.info("  [OK] Prometheus metrics endpoint at /metrics")

--- a/src/services/prometheus_metrics.py
+++ b/src/services/prometheus_metrics.py
@@ -726,15 +726,15 @@ redis_connected_clients = get_or_create_metric(
     "Number of connected client connections",
 )
 
-redis_expired_keys_total = get_or_create_metric(
+redis_expired_keys = get_or_create_metric(
     Gauge,
-    "redis_expired_keys_total",
+    "redis_expired_keys",
     "Total number of keys expired by TTL",
 )
 
-redis_evicted_keys_total = get_or_create_metric(
+redis_evicted_keys = get_or_create_metric(
     Gauge,
-    "redis_evicted_keys_total",
+    "redis_evicted_keys",
     "Total number of keys evicted due to maxmemory policy",
 )
 
@@ -1861,8 +1861,8 @@ def collect_redis_info():
 
         redis_memory_used_bytes.set(info.get("used_memory", 0))
         redis_connected_clients.set(info.get("connected_clients", 0))
-        redis_expired_keys_total.set(info.get("expired_keys", 0))
-        redis_evicted_keys_total.set(info.get("evicted_keys", 0))
+        redis_expired_keys.set(info.get("expired_keys", 0))
+        redis_evicted_keys.set(info.get("evicted_keys", 0))
 
     except Exception as e:
         redis_up.set(0)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Redis INFO gauge collection is now processed asynchronously in a thread pool, preventing potential blocking of the metrics endpoint and improving overall system responsiveness and monitoring reliability.

* **Refactor**
  * Simplified Redis metrics naming conventions for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed Redis metrics endpoint issues by preventing blocking I/O and correcting metric naming conventions.

**Key changes:**
- Made Redis INFO metrics collection non-blocking by running `collect_redis_info()` in a threadpool using `asyncio.to_thread()`
- Renamed `redis_expired_keys_total` and `redis_evicted_keys_total` to remove the `_total` suffix, aligning with Prometheus naming conventions (Gauges should not use `_total` suffix; only Counters should)

**Minor issue:**
- Contains a redundant `import asyncio` statement within the metrics endpoint function (line 322), as `asyncio` is already imported at module level

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - fixes critical blocking I/O issue
- The changes are well-focused and address legitimate issues: preventing blocking operations on the metrics endpoint (which could cause timeouts) and correcting Prometheus metric naming conventions. The only issue is a minor style concern with a redundant import that has no functional impact.
- No files require special attention - all changes are safe and straightforward

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/main.py | Added async Redis metrics collection using asyncio.to_thread() to prevent blocking the metrics endpoint. Import of asyncio is redundant as it's already imported at the top of the file. |
| src/services/prometheus_metrics.py | Renamed Redis metrics from `redis_expired_keys_total` and `redis_evicted_keys_total` to remove `_total` suffix, aligning with Prometheus Gauge naming conventions (Gauges should not have `_total` suffix). |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Prometheus
    participant API as FastAPI App
    participant Metrics as prometheus_metrics
    participant Redis
    
    Prometheus->>API: GET /metrics
    Note over API: Metrics endpoint handler
    API->>Metrics: asyncio.to_thread(collect_redis_info)
    Note over API,Metrics: Run in threadpool to prevent blocking
    Metrics->>Redis: ping()
    Redis-->>Metrics: pong
    Metrics->>Metrics: redis_up.set(1)
    Metrics->>Redis: info()
    Redis-->>Metrics: Redis INFO stats
    Metrics->>Metrics: redis_memory_used_bytes.set()
    Metrics->>Metrics: redis_connected_clients.set()
    Metrics->>Metrics: redis_expired_keys.set()
    Metrics->>Metrics: redis_evicted_keys.set()
    Note over Metrics: Gauge metrics (no _total suffix)
    Metrics-->>API: Redis metrics updated
    API->>API: generate_latest(REGISTRY)
    API-->>Prometheus: Prometheus metrics text format
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->