### PR TITLE
fix: skip featherless from scheduled sync to prevent OOM crash

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -430,6 +430,17 @@ class Config:
     # Recommended: 15-30 minutes for balance between freshness and API rate limits
     MODEL_SYNC_INTERVAL_MINUTES: int = int(os.environ.get("MODEL_SYNC_INTERVAL_MINUTES", "30"))
 
+    # Providers to skip during scheduled sync (comma-separated slugs).
+    # Featherless is skipped by default because it returns 17,796 models in
+    # a single API call (~50MB), which causes OOM on Railway containers.
+    # Their models are already in the DB from initial sync and rarely change.
+    # Set to empty string to sync all providers: MODEL_SYNC_SKIP_PROVIDERS=""
+    MODEL_SYNC_SKIP_PROVIDERS: set[str] = {
+        s.strip() for s in
+        os.environ.get("MODEL_SYNC_SKIP_PROVIDERS", "featherless").split(",")
+        if s.strip()
+    }
+
     # Pricing Sync Configuration - DEPRECATED 2026-02 (Phase 3, Issue #1063)
     # Pricing is now synced via model sync (provider_model_sync_service.py)
     # No separate pricing sync configuration needed

--- a/src/services/model_catalog_sync.py
+++ b/src/services/model_catalog_sync.py
@@ -700,12 +700,20 @@ def sync_all_providers(
         Dictionary with overall sync results
     """
     try:
+        from src.config.config import Config
+
         # Get providers to sync
         if provider_slugs:
             providers_to_sync = provider_slugs
         else:
-            # Use all providers that have fetch functions
-            providers_to_sync = list(PROVIDER_FETCH_FUNCTIONS.keys())
+            # Use all providers that have fetch functions, minus skipped ones
+            skip_set = Config.MODEL_SYNC_SKIP_PROVIDERS
+            all_providers = list(PROVIDER_FETCH_FUNCTIONS.keys())
+            providers_to_sync = [p for p in all_providers if p not in skip_set]
+            if skip_set:
+                logger.info(
+                    f"Skipping {len(skip_set)} providers from sync: {', '.join(sorted(skip_set))}"
+                )
 
         logger.info(f"Starting model sync for {len(providers_to_sync)} providers...")
 


### PR DESCRIPTION
Featherless returns 17,796 models in a single API response (~50MB), which causes the Railway container to OOM after the 30-minute sync cycle. Their models are already in the DB from initial sync and rarely change.

Added MODEL_SYNC_SKIP_PROVIDERS env var (default: "featherless") to exclude memory-heavy providers from scheduled sync. Set to empty string to sync all providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to customize which model providers are skipped during scheduled synchronization. Featherless provider is excluded by default, and the skip list can be modified through configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR prevents OOM crashes during scheduled sync by skipping memory-heavy providers like Featherless (17,796 models, ~50MB response).

**Key Changes:**
- Added `MODEL_SYNC_SKIP_PROVIDERS` config (default: "featherless") to exclude providers from scheduled sync
- Modified `sync_all_providers()` to filter out skipped providers only when `provider_slugs=None` (scheduled sync)
- Manual syncs via API endpoints can still sync featherless by explicitly passing provider slugs

**Implementation Details:**
- Skip list only applies to automatic scheduled sync, not manual/admin-triggered syncs
- Featherless models remain in DB from initial sync and can be manually updated if needed
- Clear logging indicates which providers are skipped
- Configuration is comma-separated for future extensibility

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean and well-contained. It only affects scheduled sync behavior, preserves manual sync flexibility, includes proper logging, and addresses a critical OOM issue with a simple, configurable solution
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/config/config.py | Added `MODEL_SYNC_SKIP_PROVIDERS` config with default "featherless" to prevent OOM |
| src/services/model_catalog_sync.py | Updated `sync_all_providers` to filter out providers in skip list during scheduled sync |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Scheduler as APScheduler
    participant SyncService as scheduled_sync.py
    participant CatalogSync as model_catalog_sync.py
    participant Config as config.py
    participant Provider as Provider APIs
    participant DB as Database

    Note over Scheduler,DB: Scheduled Model Sync (Every 30 minutes)
    
    Scheduler->>SyncService: run_scheduled_model_sync()
    SyncService->>CatalogSync: sync_all_providers(provider_slugs=None, dry_run=False)
    
    Note over CatalogSync: Check if specific providers requested
    alt provider_slugs is None
        CatalogSync->>Config: Get MODEL_SYNC_SKIP_PROVIDERS
        Config-->>CatalogSync: {"featherless"}
        CatalogSync->>CatalogSync: Get all providers from PROVIDER_FETCH_FUNCTIONS
        CatalogSync->>CatalogSync: Filter: [p for p in all_providers if p not in skip_set]
        Note over CatalogSync: Featherless excluded from sync list
        CatalogSync->>CatalogSync: Log: "Skipping 1 providers from sync: featherless"
    else provider_slugs provided
        Note over CatalogSync: Skip list is bypassed, sync requested providers
    end
    
    loop For each provider (excluding skipped)
        CatalogSync->>Provider: Fetch models from API
        Provider-->>CatalogSync: Model data (non-featherless: ~few MB)
        CatalogSync->>DB: Upsert models to database
        DB-->>CatalogSync: Success
    end
    
    CatalogSync-->>SyncService: Sync results
    SyncService->>SyncService: Update metrics (_last_sync_status)
    SyncService-->>Scheduler: Complete
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->