### PR TITLE
fix: remove redundant asyncio imports causing UnboundLocalError in chat

### DIFF
--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -2362,9 +2362,7 @@ async def chat_completions(
 
                     # OPTIMIZATION: Fetch full catalog once instead of making N calls for disjoint providers.
                     # This prevents 499 errors caused by sequential DB fetches when cache is cold.
-                    # CRITICAL FIX: Run in thread to avoid blocking event loop during DB fetch
-                    import asyncio
-
+                    # Run in thread to avoid blocking event loop during DB fetch
                     all_models_catalog = await asyncio.to_thread(get_cached_models, "all") or []
                     all_model_ids = {m.get("id") for m in all_models_catalog}
 
@@ -3753,9 +3751,7 @@ async def unified_responses(
 
                 # OPTIMIZATION: Fetch full catalog once instead of making N calls for disjoint providers.
                 # This prevents 499 errors caused by sequential DB fetches when cache is cold.
-                # CRITICAL FIX: Run in thread to avoid blocking event loop during DB fetch
-                import asyncio
-
+                # Run in thread to avoid blocking event loop during DB fetch
                 all_models_catalog = await asyncio.to_thread(get_cached_models, "all") or []
                 all_model_ids = {m.get("id") for m in all_models_catalog}
 


### PR DESCRIPTION
Two `import asyncio` statements inside the chat_completions function (lines 2366 and 3757) shadowed the module-level import. Python's compiler marked asyncio as a local variable for the entire function scope, so asyncio.gather() on line 1803 raised UnboundLocalError before the inner imports had a chance to execute.

This also fixes the "coroutine '_to_thread' was never awaited" and "coroutine 'get_api_key_id_with_retry' was never awaited" warnings, which occurred because the gather() crash left the coroutines unawaited.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code optimization with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a critical `UnboundLocalError` in the `chat_completions` function by removing two redundant `import asyncio` statements that were shadowing the module-level import.

## The Bug
Python's scoping rules mark variables as local for the entire function scope when they're assigned anywhere in that function. The `import asyncio` statements at lines 2366 and 3757 caused Python's compiler to treat `asyncio` as a local variable throughout the `chat_completions` function. This meant that when `asyncio.gather()` was called at line 1803 (before the inner imports executed), it raised `UnboundLocalError: local variable 'asyncio' referenced before assignment`.

## The Fix
- Removed redundant `import asyncio` on line 2365 (inside `chat_completions`)
- Removed redundant `import asyncio` on line 3754 (inside `unified_responses`)
- The module-level `import asyncio` at line 1 is sufficient for the entire file

## Impact
- Fixes the `UnboundLocalError` crash in chat completions
- Resolves "coroutine was never awaited" warnings for `_to_thread` and `get_api_key_id_with_retry` that occurred because the `asyncio.gather()` crash prevented proper coroutine execution
- Critical fix for production stability

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a straightforward bug fix removing redundant imports
- The fix correctly addresses a well-understood Python scoping issue. Removing redundant local imports that shadow module-level imports is a best practice. The module-level `import asyncio` at line 1 provides all necessary asyncio functionality. No logic changes, no new code added - only removal of problematic duplicate imports.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/routes/chat.py | Removed redundant `import asyncio` statements that caused UnboundLocalError when `asyncio.gather()` was called earlier in function scope |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant FastAPI
    participant ChatFunction as chat_completions()
    participant AsyncIO as asyncio module
    participant DBThread as get_cached_models (thread)
    
    Client->>FastAPI: POST /chat/completions
    FastAPI->>ChatFunction: Execute handler
    
    Note over ChatFunction: Module-level import: asyncio
    
    rect rgb(255, 200, 200)
        Note over ChatFunction: BEFORE FIX: Line 2365
        ChatFunction->>ChatFunction: import asyncio (shadows module)
        Note over ChatFunction: Python marks asyncio as LOCAL variable
    end
    
    ChatFunction->>AsyncIO: asyncio.gather() at line 1803
    Note over AsyncIO: UnboundLocalError!<br/>asyncio is local but not yet assigned
    
    rect rgb(200, 255, 200)
        Note over ChatFunction: AFTER FIX
        ChatFunction->>AsyncIO: asyncio.gather() at line 1803 ✓
        AsyncIO-->>ChatFunction: Returns user, api_key_id, trial
        
        ChatFunction->>AsyncIO: asyncio.to_thread() at line 2366 ✓
        AsyncIO->>DBThread: get_cached_models("all")
        DBThread-->>AsyncIO: Returns models catalog
        AsyncIO-->>ChatFunction: Returns catalog
    end
    
    ChatFunction-->>FastAPI: Response
    FastAPI-->>Client: Chat completion
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->