### PR TITLE
exposed profile_lifecycle method to main

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -84,8 +84,6 @@ if Config.SENTRY_ENABLED and Config.SENTRY_DSN:
         traces_sampler=sentry_traces_sampler,
         # Reduced profiling: 5% (down from default)
         profiles_sample_rate=0.05,
-        # Set profile_lifecycle to "trace" to run profiler during transactions
-        profile_lifecycle="trace",
     )
     logger.info(
         f"✅ Sentry initialized with adaptive sampling "


### PR DESCRIPTION
Took out the profile lifecycle to reduce health violation checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated error and performance monitoring configuration to simplify profiler lifecycle settings while maintaining profiling activity levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the Sentry SDK initialization in `src/main.py` by removing the `profile_lifecycle="trace"` option. With this removed, profiling is no longer explicitly tied to transaction traces, which reduces profiling/health-check overhead while leaving the existing adaptive `traces_sampler` logic and `profiles_sample_rate=0.05` intact.

No functional issues were found in this change; it is a narrow configuration adjustment localized to Sentry startup.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is limited to removing a single optional Sentry init parameter (`profile_lifecycle`) and does not affect request routing, auth, or core business logic; the remaining Sentry configuration stays valid.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/main.py | Removes the `profile_lifecycle="trace"` Sentry SDK init option, reducing profiling/health overhead while keeping adaptive tracing sampler and profiling sample rate. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Main as src/main.py
    participant Config as src.config.Config
    participant Sentry as sentry_sdk

    Main->>Config: read SENTRY_ENABLED, SENTRY_DSN
    alt Sentry enabled
        Main->>Sentry: init() with traces_sampler and profiles_sample_rate
        Note over Sentry: profile_lifecycle option removed
    else Sentry disabled
        Main-->>Main: log "Sentry disabled"
    end
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b292cd65-880f-4b4d-b2f7-a28cb17a33c4))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5fabd0d3-856d-4413-ab88-1b5755d16dde))

<!-- /greptile_comment -->