### PR TITLE
fix(sentry): use 'description' instead of 'name' in Span.__init__() for sentry-sdk 2.0.0

### DIFF
--- a/src/utils/sentry_insights.py
+++ b/src/utils/sentry_insights.py
@@ -98,7 +98,7 @@ def trace_database_query(
 
     with sentry_sdk.start_span(
         op=span_op,
-        name=query,
+        description=query,
         origin="manual",
     ) as span:
         # Set required db.system attribute for Sentry Queries Insights
@@ -219,7 +219,7 @@ def trace_cache_operation(
 
     with sentry_sdk.start_span(
         op=operation,
-        name=key_description,
+        description=key_description,
         origin="manual",
     ) as span:
         # Set cache.key as array (required by Sentry spec)
@@ -392,7 +392,7 @@ def trace_queue_publish(
 
     with sentry_sdk.start_span(
         op="queue.publish",
-        name=destination,
+        description=destination,
         origin="manual",
     ) as span:
         # Set required attributes for queue monitoring
@@ -475,7 +475,7 @@ def trace_queue_process(
         with sentry_sdk.start_transaction(transaction):
             with sentry_sdk.start_span(
                 op="queue.process",
-                name=destination,
+                description=destination,
                 origin="manual",
             ) as span:
                 _set_queue_process_attributes(
@@ -492,7 +492,7 @@ def trace_queue_process(
         # No trace headers, create a standalone span
         with sentry_sdk.start_span(
             op="queue.process",
-            name=destination,
+            description=destination,
             origin="manual",
         ) as span:
             _set_queue_process_attributes(

--- a/tests/utils/test_sentry_insights.py
+++ b/tests/utils/test_sentry_insights.py
@@ -64,7 +64,8 @@ class TestDatabaseQueryInsights:
             mock_sentry.start_span.assert_called_once()
             call_kwargs = mock_sentry.start_span.call_args[1]
             assert call_kwargs["op"] == "db.postgresql"
-            assert call_kwargs["name"] == "SELECT * FROM users WHERE id = ?"
+            # Note: sentry-sdk 2.0.0 uses 'description', newer versions use 'name'
+            assert call_kwargs["description"] == "SELECT * FROM users WHERE id = ?"
 
     def test_trace_database_query_sets_required_attributes(self):
         """Test that db.system attribute is set for Sentry Queries Insights."""
@@ -132,7 +133,8 @@ class TestCacheInsights:
             mock_sentry.start_span.assert_called_once()
             call_kwargs = mock_sentry.start_span.call_args[1]
             assert call_kwargs["op"] == "cache.get"
-            assert call_kwargs["name"] == "user:123"
+            # Note: sentry-sdk 2.0.0 uses 'description', newer versions use 'name'
+            assert call_kwargs["description"] == "user:123"
 
             # Verify cache.hit and cache.key were set
             mock_span.set_data.assert_any_call("cache.key", ["user:123"])
@@ -201,7 +203,8 @@ class TestCacheInsights:
                 pass
 
             call_kwargs = mock_sentry.start_span.call_args[1]
-            assert call_kwargs["name"] == "user:1, user:2, user:3"
+            # Note: sentry-sdk 2.0.0 uses 'description', newer versions use 'name'
+            assert call_kwargs["description"] == "user:1, user:2, user:3"
 
             mock_span.set_data.assert_any_call("cache.key", ["user:1", "user:2", "user:3"])
 
@@ -260,7 +263,8 @@ class TestQueueMonitoring:
 
             call_kwargs = mock_sentry.start_span.call_args[1]
             assert call_kwargs["op"] == "queue.publish"
-            assert call_kwargs["name"] == "notifications"
+            # Note: sentry-sdk 2.0.0 uses 'description', newer versions use 'name'
+            assert call_kwargs["description"] == "notifications"
 
             mock_span.set_data.assert_any_call("messaging.destination.name", "notifications")
             mock_span.set_data.assert_any_call("messaging.system", "redis")
@@ -286,7 +290,8 @@ class TestQueueMonitoring:
 
             call_kwargs = mock_sentry.start_span.call_args[1]
             assert call_kwargs["op"] == "queue.process"
-            assert call_kwargs["name"] == "notifications"
+            # Note: sentry-sdk 2.0.0 uses 'description', newer versions use 'name'
+            assert call_kwargs["description"] == "notifications"
 
             mock_span.set_data.assert_any_call("messaging.destination.name", "notifications")
             mock_span.set_data.assert_any_call("messaging.message.retry.count", 2)


### PR DESCRIPTION
## Summary

- Fixed `Span.__init__() got an unexpected keyword argument 'name'` error that was causing 401 responses on `/v1/chat/completions` endpoints
- The sentry-sdk 2.0.0 uses `description` parameter in `Span.__init__()`, while the `name` parameter was only added in sentry-sdk 2.15.0
- Updated all 5 occurrences of `name=` to `description=` in `src/utils/sentry_insights.py`
- Updated corresponding test assertions in `tests/utils/test_sentry_insights.py`

## Root Cause

The error was traced through:
1. `/v1/chat/completions` endpoint
2. Security deps (API key validation)
3. `get_user()` in `db/users.py`
4. `track_database_query()` in `prometheus_metrics.py`
5. `trace_supabase_query()` in `sentry_insights.py`
6. `sentry_sdk.start_span(name=...)` - the incompatible parameter

## Test plan

- [x] Verified syntax is correct for both source and test files
- [ ] Run tests: `pytest tests/utils/test_sentry_insights.py -v`
- [ ] Verify `/v1/chat/completions` endpoint responds correctly after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal instrumentation for database queries, cache operations, and queue event tracing to use current Sentry monitoring standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed `Span.__init__() got an unexpected keyword argument 'name'` error by updating all `sentry_sdk.start_span()` calls to use `description` parameter instead of `name`, which is the correct parameter for sentry-sdk 2.0.0. The issue was causing 401 responses on `/v1/chat/completions` endpoints because the error occurred during database query tracing in the authentication flow.

**Changes made:**
- Updated 5 occurrences in `src/utils/sentry_insights.py` (lines 101, 222, 395, 478, 495)
- Updated corresponding test assertions in `tests/utils/test_sentry_insights.py`
- Added helpful comments in tests explaining the version-specific parameter difference

The fix properly addresses the root cause and ensures compatibility with the pinned sentry-sdk version (2.0.0) in `requirements.txt`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is a simple, well-tested parameter rename that directly addresses a critical production bug. All changes are consistent, accompanied by comprehensive test updates, and align perfectly with the sentry-sdk 2.0.0 API documented in the PR description.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/utils/sentry_insights.py | Changed 5 occurrences of `name=` to `description=` in `sentry_sdk.start_span()` calls to fix compatibility with sentry-sdk 2.0.0 |
| tests/utils/test_sentry_insights.py | Updated 5 test assertions to check for `description` parameter instead of `name`, with comments explaining sentry-sdk version difference |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->