### PR TITLE
Added pricing look up to allow pricing to populate efficiently

### DIFF
--- a/src/services/pricing_lookup.py
+++ b/src/services/pricing_lookup.py
@@ -208,10 +208,10 @@ def _get_pricing_from_database(model_id: str) -> dict[str, str] | None:
         model_id: Model identifier (e.g., "nosana/meta-llama/Llama-3.3-70B-Instruct")
 
     Returns:
-        Pricing dictionary normalized to per-1M format (for backward compatibility):
+        Pricing dictionary in per-token format (consistent with all other sources):
         {
-            "prompt": "0.90",  # per-1M
-            "completion": "0.90",  # per-1M
+            "prompt": "0.0000009",  # per-token
+            "completion": "0.0000009",  # per-token
             "request": "0",
             "image": "0"
         }
@@ -253,15 +253,12 @@ def _get_pricing_from_database(model_id: str) -> dict[str, str] | None:
         if prompt_price is None or completion_price is None:
             return None
 
-        # Convert per-token to per-1M for backward compatibility
+        # Return per-token format (consistent with manual and cross-reference sources)
         # Database stores per-token (e.g., 0.0000009)
-        # API returns per-1M (e.g., "0.90")
-        prompt_per_1m = float(prompt_price) * 1_000_000
-        completion_per_1m = float(completion_price) * 1_000_000
-
+        # Frontend handles conversion to per-million for display
         return {
-            "prompt": str(prompt_per_1m),
-            "completion": str(completion_per_1m),
+            "prompt": str(prompt_price),
+            "completion": str(completion_price),
             "request": "0",
             "image": "0"
         }


### PR DESCRIPTION
1. Backend: Fix _get_pricing_from_database() (PRIMARY FIX)
File: gatewayz-backend/src/services/pricing_lookup.py (lines 203-267)

Remove the * 1_000_000 multiplication so database pricing is returned in per-token format, consistent with all other sources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pricing data handling for internal consistency across sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed `_get_pricing_from_database()` in `src/services/pricing_lookup.py` to return per-token pricing format instead of per-1M format, ensuring consistency with the other two pricing sources (`get_model_pricing()` and `_get_cross_reference_pricing()` which both return per-token format). 

- Removed the multiplication by 1,000,000 that was converting database per-token prices to per-1M format
- Updated function documentation to reflect per-token format return values (e.g., "0.0000009" instead of "0.90")
- Updated comments to clarify that frontend handles the conversion to per-million for display purposes

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change correctly fixes a pricing format inconsistency by removing an unnecessary multiplication. The fix aligns database pricing with manual and cross-reference pricing sources (all now return per-token format). Documentation and comments were properly updated to reflect the change.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/services/pricing_lookup.py | Removed multiplication by 1,000,000 to return per-token pricing format consistently with other pricing sources (manual and cross-reference) |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->