### PR TITLE
feat: sync pricing to model_pricing table during model sync

### DIFF
--- a/supabase/migrations/20260212100000_backfill_model_pricing_from_metadata.sql
+++ b/supabase/migrations/20260212100000_backfill_model_pricing_from_metadata.sql
@@ -1,0 +1,73 @@
+-- ============================================================================
+-- Backfill model_pricing from metadata.pricing_raw
+-- ============================================================================
+-- Migration: 20260212100000
+-- Description: One-time backfill of the model_pricing table using pricing
+--              data already stored in models.metadata->'pricing_raw'.
+--
+-- Background: The sync service stores per-token pricing in
+--   models.metadata->'pricing_raw' but never populated model_pricing.
+--   The model_usage_analytics view JOINs to model_pricing, so all costs
+--   showed as $0. Going forward, bulk_upsert_models() now writes to
+--   model_pricing after every sync. This migration backfills existing data.
+-- ============================================================================
+
+INSERT INTO model_pricing (
+    model_id,
+    price_per_input_token,
+    price_per_output_token,
+    price_per_image_token,
+    price_per_request,
+    pricing_source,
+    pricing_type
+)
+SELECT
+    m.id AS model_id,
+    COALESCE(CAST(m.metadata->'pricing_raw'->>'prompt' AS NUMERIC), 0)
+        AS price_per_input_token,
+    COALESCE(CAST(m.metadata->'pricing_raw'->>'completion' AS NUMERIC), 0)
+        AS price_per_output_token,
+    CAST(m.metadata->'pricing_raw'->>'image' AS NUMERIC)
+        AS price_per_image_token,
+    CAST(m.metadata->'pricing_raw'->>'request' AS NUMERIC)
+        AS price_per_request,
+    'provider' AS pricing_source,
+    CASE
+        WHEN COALESCE(CAST(m.metadata->'pricing_raw'->>'prompt' AS NUMERIC), 0) > 0
+          OR COALESCE(CAST(m.metadata->'pricing_raw'->>'completion' AS NUMERIC), 0) > 0
+        THEN 'paid'
+        ELSE 'free'
+    END AS pricing_type
+FROM models m
+WHERE m.metadata->'pricing_raw' IS NOT NULL
+  AND m.metadata->'pricing_raw'->>'prompt' IS NOT NULL
+ON CONFLICT (model_id)
+DO UPDATE SET
+    price_per_input_token  = EXCLUDED.price_per_input_token,
+    price_per_output_token = EXCLUDED.price_per_output_token,
+    price_per_image_token  = EXCLUDED.price_per_image_token,
+    price_per_request      = EXCLUDED.price_per_request,
+    pricing_source         = EXCLUDED.pricing_source,
+    pricing_type           = EXCLUDED.pricing_type,
+    last_updated           = NOW();
+
+-- Report results
+DO $$
+DECLARE
+    total_rows INTEGER;
+    paid_rows  INTEGER;
+    free_rows  INTEGER;
+BEGIN
+    SELECT COUNT(*) INTO total_rows FROM model_pricing;
+    SELECT COUNT(*) INTO paid_rows  FROM model_pricing WHERE pricing_type = 'paid';
+    SELECT COUNT(*) INTO free_rows  FROM model_pricing WHERE pricing_type = 'free';
+
+    RAISE NOTICE '';
+    RAISE NOTICE '==========================================';
+    RAISE NOTICE 'model_pricing backfill complete';
+    RAISE NOTICE '==========================================';
+    RAISE NOTICE '  Total entries: %', total_rows;
+    RAISE NOTICE '  Paid models:   %', paid_rows;
+    RAISE NOTICE '  Free models:   %', free_rows;
+    RAISE NOTICE '';
+END $$;


### PR DESCRIPTION
The sync service stores pricing in metadata.pricing_raw but never populated the model_pricing table. This caused $0 pricing in the model_usage_analytics view which JOINs to model_pricing.

- Add _sync_pricing_to_model_pricing() called after bulk_upsert_models
- Add backfill migration to populate model_pricing from existing data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic synchronization of pricing information when models are updated, ensuring pricing data consistency across the catalog.

* **Chores**
  * Historical pricing data backfilled from existing model metadata to maintain data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes $0 pricing in the `model_usage_analytics` view by bridging the gap between `metadata.pricing_raw` (where the sync service stores pricing) and the `model_pricing` table (which the analytics view JOINs to). It adds a Python function `_sync_pricing_to_model_pricing()` that runs after every `bulk_upsert_models` call, plus a one-time SQL backfill migration for existing data.

- The Python sync function is well-structured: properly handles string-to-float conversion, optional fields, chunked upserts, and non-fatal error handling
- The backfill migration's `WHERE` clause is stricter than the Python function — it requires `prompt IS NOT NULL`, potentially skipping models with only completion pricing
- Together with the prior migration (`20260212000000`) that added a `metadata.pricing_raw` fallback to the analytics view, this forms a complete fix for the $0 pricing issue

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it fixes a real data integrity gap with minimal risk, though the migration has a minor filtering inconsistency.
- The Python code is solid with proper error handling, chunked processing, and non-fatal failure modes. The migration is idempotent (ON CONFLICT) and well-documented. The one issue found is a minor filter mismatch in the migration that could skip completion-only models, but these are likely rare and would self-heal on the next sync cycle.
- `supabase/migrations/20260212100000_backfill_model_pricing_from_metadata.sql` has a WHERE clause that is more restrictive than the Python sync function.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/db/models_catalog_db.py | Adds `_sync_pricing_to_model_pricing()` called after `bulk_upsert_models`. The function correctly extracts pricing from `metadata.pricing_raw`, converts string values to floats, handles optional fields (image, request), classifies pricing type, and upserts in 500-row chunks. Error handling is non-fatal so pricing sync failure won't block model sync. No issues found in the Python code. |
| supabase/migrations/20260212100000_backfill_model_pricing_from_metadata.sql | One-time backfill migration to populate `model_pricing` from `metadata.pricing_raw`. Uses `ON CONFLICT` for idempotency. Has a filtering inconsistency: the `WHERE` clause requires `prompt IS NOT NULL`, which is stricter than the Python sync function and would skip completion-only models. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Sync as Model Catalog Sync
    participant BU as bulk_upsert_models()
    participant Models as models table
    participant SP as _sync_pricing_to_model_pricing()
    participant MP as model_pricing table
    participant View as model_usage_analytics view

    Sync->>BU: models_data (with metadata.pricing_raw)
    BU->>Models: UPSERT deduplicated models
    Models-->>BU: upserted models (with IDs)
    BU->>SP: upserted_models
    SP->>SP: Extract pricing_raw from metadata
    SP->>SP: Convert to float, classify paid/free
    SP->>MP: UPSERT pricing rows (500-row chunks)
    Note over View: Analytics view JOINs models ↔ model_pricing
    View->>Models: INNER JOIN
    View->>MP: LEFT JOIN (now populated)
    View-->>View: Correct cost calculations
```

<sub>Last reviewed commit: 3cd015b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->