### PR TITLE
fix: resolve backend

### DIFF
--- a/src/services/models.py
+++ b/src/services/models.py
@@ -968,8 +968,8 @@ def get_cached_unique_models_catalog():
     cache = get_model_catalog_cache()
 
     try:
-        # Try cache first
-        cached = cache.get_full_catalog()
+        # Try cache first (using distinctive unique models key)
+        cached = cache.get_unique_models_catalog()
         if cached is not None:
             # Check if cached data has the unique models structure
             if cached and isinstance(cached, list) and len(cached) > 0:
@@ -991,8 +991,8 @@ def get_cached_unique_models_catalog():
         if query_time > 1.0:
             logger.warning(f"Slow unique models fetch: {query_time:.2f}s (threshold: 1.0s)")
 
-        # Cache result (TTL: 900 seconds = 15 minutes)
-        cache.set_full_catalog(api_models, ttl=900)
+        # Cache result (TTL: 900 seconds = 15 minutes) using distinctive unique models key
+        cache.set_unique_models_catalog(api_models, ttl=900)
 
         return api_models
 


### PR DESCRIPTION
fix: resolve backend cache key collision between flat and unique model catalogs

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Resolves cache key collision between flat and unique model catalogs by introducing dedicated `get_unique_models_catalog()` and `set_unique_models_catalog()` methods that use `PREFIX_UNIQUE` key instead of reusing `PREFIX_FULL_CATALOG`.

**Changes:**
- Added `get_unique_models_catalog()` and `set_unique_models_catalog()` methods to `ModelCatalogCache` class
- Updated `get_cached_unique_models_catalog()` in `models.py` to use new dedicated methods instead of `get_full_catalog()` and `set_full_catalog()`
- Uses distinctive cache key `models:unique` to prevent overwriting flat catalog data

**Critical Issue:**
- `get_unique_models_catalog()` is defined twice (lines 230 and 336), causing the second definition to override the first
- Missing corresponding `set_unique_models_catalog()` method after the duplicate getter at line 336

<h3>Confidence Score: 1/5</h3>

- Critical bug - duplicate method definition will cause runtime errors
- The duplicate `get_unique_models_catalog()` method at line 336 overrides the first definition, and the missing `set_unique_models_catalog()` setter after it breaks the intended cache pattern. This will cause the cache to malfunction.
- src/services/model_catalog_cache.py requires immediate attention - remove duplicate getter at line 336 and add missing setter method

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/services/model_catalog_cache.py | added unique models cache methods but contains duplicate `get_unique_models_catalog()` at line 336 and missing `set_unique_models_catalog()` setter |
| src/services/models.py | correctly updated to use new `get_unique_models_catalog()` and `set_unique_models_catalog()` methods to prevent cache key collision |

</details>



<h3>Flowchart</h3>

```mermaid
flowchart TD
    A[get_cached_unique_models_catalog] --> B{Check Cache}
    B -->|Hit| C[cache.get_unique_models_catalog]
    B -->|Miss| D[Fetch from Database]
    C --> E{Has 'providers' array?}
    E -->|Yes| F[Return Cached Data]
    E -->|No| D
    D --> G[get_all_unique_models_for_catalog]
    G --> H[transform_unique_models_batch]
    H --> I[cache.set_unique_models_catalog]
    I --> J[Return Fresh Data]
    
    C -.->|Uses| K[PREFIX_UNIQUE: 'models:unique']
    I -.->|Uses| K
    
    L[Old Implementation] -.->|Used| M[PREFIX_FULL_CATALOG: 'models:catalog:full']
    L -.->|Caused| N[Cache Key Collision]
    
    style K fill:#90EE90
    style M fill:#FFB6C1
    style N fill:#FF6B6B
```

<sub>Last reviewed commit: 9d58b99</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->