### PR TITLE
fix: restore process metrics + add peer.service for service graph + h…

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -309,10 +309,18 @@ def create_app() -> FastAPI:
         that let you click from a metric datapoint to the trace in Tempo).
         Prometheus requests OpenMetrics when --enable-feature=exemplar-storage is set.
         """
-        # Refresh Redis INFO gauges on each scrape (run in threadpool to avoid blocking)
+        # Refresh Redis INFO gauges on each scrape (run in threadpool to avoid blocking).
+        # Hard cap at 5 s so a slow Upstash round-trip never causes the Prometheus scrape
+        # to time out (scrape_timeout=10s in prometheus.yml → up{job="gatewayz_production"}=0).
         import asyncio
 
-        await asyncio.to_thread(prometheus_metrics.collect_redis_info)
+        try:
+            await asyncio.wait_for(
+                asyncio.to_thread(prometheus_metrics.collect_redis_info),
+                timeout=5.0,
+            )
+        except asyncio.TimeoutError:
+            pass  # Serve stale Redis gauges rather than miss the scrape window
 
         # Content negotiation: serve OpenMetrics when requested (carries exemplars),
         # fall back to Prometheus text format for backward compatibility

--- a/src/services/provider_span_enricher.py
+++ b/src/services/provider_span_enricher.py
@@ -1,0 +1,204 @@
+"""
+ProviderSpanEnricher — OpenTelemetry SpanProcessor that adds peer.service
+to outbound HTTP spans targeting known AI providers.
+
+WHY THIS IS NEEDED
+──────────────────
+Tempo's metrics_generator service-graph processor builds topology edges by
+looking for traces that contain CLIENT spans with a ``peer.service`` attribute.
+When ``peer.service = "openai"`` is present on a child span of the incoming
+FastAPI request span (service.name = "gatewayz-backend"), Tempo generates the
+edge gatewayz-backend → openai and emits:
+
+    traces_service_graph_request_total{client="gatewayz-backend",server="openai"}
+    traces_service_graph_request_failed_total{...}
+    traces_service_graph_request_duration_seconds_bucket{...}
+
+These metrics are what the Grafana "Service Graph & Topology" section reads.
+
+Without peer.service the AI providers are external HTTP endpoints that don't
+propagate traceparent back, so Tempo sees only one service in each trace and
+draws no edges — the dependency map stays blank.
+
+HOW IT WORKS
+────────────
+opentelemetry-instrumentation-httpx is already installed and activated in
+opentelemetry_config.py. Every outbound HTTPX call already produces a CLIENT
+span.  This SpanProcessor intercepts spans on_end, checks whether the URL host
+matches a known AI provider, and writes peer.service into the span attributes.
+Because SpanProcessor.on_end receives a ReadableSpan we use the internal
+_attributes dict (same approach used by OTel contrib processors).
+"""
+
+import logging
+from urllib.parse import urlparse
+
+try:
+    from opentelemetry.sdk.trace import ReadableSpan
+    from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+    from opentelemetry.trace import SpanKind
+
+    OPENTELEMETRY_AVAILABLE = True
+except ImportError:
+    OPENTELEMETRY_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
+
+# Maps lowercase hostname (or hostname suffix) → canonical peer.service name.
+# Tempo will use this value as the "server" label in service-graph metrics and
+# as the node label in the Live Service Dependency Map panel.
+_PROVIDER_HOST_MAP: dict[str, str] = {
+    # OpenAI family
+    "api.openai.com": "openai",
+    "api.openai.azure.com": "azure-openai",
+    # Anthropic
+    "api.anthropic.com": "anthropic",
+    # OpenRouter (aggregator — single edge, not per-model)
+    "openrouter.ai": "openrouter",
+    "api.openrouter.ai": "openrouter",
+    # Groq
+    "api.groq.com": "groq",
+    # Mistral
+    "api.mistral.ai": "mistral",
+    # Together AI
+    "api.together.ai": "together-ai",
+    "api.together.xyz": "together-ai",
+    # Perplexity
+    "api.perplexity.ai": "perplexity",
+    # Cohere
+    "api.cohere.com": "cohere",
+    "api.cohere.ai": "cohere",
+    # Google (Gemini / Vertex)
+    "generativelanguage.googleapis.com": "google-gemini",
+    "us-central1-aiplatform.googleapis.com": "google-vertex",
+    # Fireworks AI
+    "api.fireworks.ai": "fireworks",
+    # DeepSeek
+    "api.deepseek.com": "deepseek",
+    # xAI (Grok)
+    "api.x.ai": "xai",
+    # Cerebras
+    "api.cerebras.ai": "cerebras",
+    # Featherless
+    "inference.featherless.ai": "featherless",
+    # Hyperbolic
+    "api.hyperbolic.xyz": "hyperbolic",
+    # Novita
+    "api.novita.ai": "novita",
+    # HuggingFace
+    "api.huggingface.co": "huggingface",
+    "huggingface.co": "huggingface",
+    # Portkey (proxy/gateway)
+    "api.portkey.ai": "portkey",
+    # Replicate
+    "api.replicate.com": "replicate",
+    # AI21
+    "api.ai21.com": "ai21",
+    # Upstash (Redis)
+    # Not an AI provider, but useful to see in topology
+    "upstash.io": "upstash-redis",
+    # Supabase (Postgres)
+    "supabase.co": "supabase",
+    # Stripe
+    "api.stripe.com": "stripe",
+    # Sentry
+    "sentry.io": "sentry",
+}
+
+
+def _resolve_peer_service(host: str) -> str | None:
+    """
+    Return the canonical provider name for a given hostname, or None if
+    the host is not a known external dependency.
+
+    Checks exact match first, then suffix match (e.g. any *.supabase.co).
+    """
+    host = host.lower()
+    if host in _PROVIDER_HOST_MAP:
+        return _PROVIDER_HOST_MAP[host]
+    # Suffix match — handles regional subdomains like us-east-1.supabase.co
+    for pattern, service in _PROVIDER_HOST_MAP.items():
+        if host.endswith("." + pattern) or host == pattern:
+            return service
+    return None
+
+
+class ProviderSpanEnricher:
+    """
+    OpenTelemetry SpanProcessor that annotates outbound HTTP CLIENT spans with
+    ``peer.service`` so Tempo's service-graph processor can draw edges between
+    gatewayz-backend and each AI provider it calls.
+
+    Usage (in opentelemetry_config.py):
+        tracer_provider.add_span_processor(ProviderSpanEnricher())
+    """
+
+    if OPENTELEMETRY_AVAILABLE:
+        from opentelemetry.sdk.trace import Span as _SdkSpan
+
+        def on_start(self, span: "_SdkSpan", parent_context=None) -> None:  # noqa: F811
+            pass  # Nothing to do on start
+
+        def on_end(self, span: "ReadableSpan") -> None:  # noqa: F811
+            try:
+                # Only enrich CLIENT spans (outbound HTTP requests)
+                if span.kind != SpanKind.CLIENT:
+                    return
+
+                attrs = span.attributes or {}
+
+                # Skip spans that already have peer.service
+                if attrs.get("peer.service"):
+                    return
+
+                # Extract host from OTel HTTP semantic conventions
+                # OTel 1.x: http.url  |  OTel 2.x: url.full + server.address
+                host: str | None = None
+
+                url = attrs.get("http.url") or attrs.get("url.full")
+                if url:
+                    try:
+                        host = urlparse(str(url)).hostname
+                    except Exception:
+                        pass
+
+                if not host:
+                    host = attrs.get("server.address") or attrs.get("net.peer.name")
+                    if host:
+                        host = str(host)
+
+                if not host:
+                    return
+
+                peer_service = _resolve_peer_service(host)
+                if peer_service:
+                    # SpanProcessor.on_end receives a ReadableSpan whose internal
+                    # _attributes dict is still mutable at this stage (before export).
+                    span._attributes["peer.service"] = peer_service
+                    logger.debug(
+                        "ProviderSpanEnricher: %s → peer.service=%s",
+                        host,
+                        peer_service,
+                    )
+            except Exception:
+                pass  # Never break tracing for enrichment failures
+
+        def shutdown(self) -> None:
+            pass
+
+        def force_flush(self, timeout_millis: int = 30000) -> bool:
+            return True
+
+    else:
+        # OTel not available — no-op stubs so the class can always be imported
+        def on_start(self, span, parent_context=None) -> None:
+            pass
+
+        def on_end(self, span) -> None:
+            pass
+
+        def shutdown(self) -> None:
+            pass
+
+        def force_flush(self, timeout_millis: int = 30000) -> bool:
+            return True


### PR DESCRIPTION
fix: restore process metrics + add peer.service for service graph + harden scrape target

Root cause 1 — process metrics showing "No data" in Grafana CPU/Saturation panels:
  prometheus_metrics.py cleared ALL collectors from the Prometheus registry on
  import (including Python's built-in ProcessCollector) to work around uvicorn
  --reload duplicate-registration errors. This deleted process_cpu_seconds_total,
  process_resident_memory_bytes, process_open_fds, process_max_fds, and
  process_start_time_seconds from /metrics entirely.

  Fix: after the clearing loop, explicitly re-register ProcessCollector,
  PlatformCollector, and GCCollector. These provide:
    - process_cpu_seconds_total  → CPU Usage % gauge
    - process_resident_memory_bytes  → Backend Process Memory (RSS)
    - process_open_fds / process_max_fds  → File Descriptor Utilization %
    - process_start_time_seconds  → Process Uptime (restart indicator)

Root cause 2 — Service Graph blank (Live Service Dependency Map shows no edges):
  Tempo's service-graph processor only generates edges when CLIENT spans have a
  peer.service attribute. HTTPX instrumentation was already active (spans existed)
  but lacked peer.service, so Tempo saw every trace as single-service and drew
  no edges. AI providers don't propagate traceparent back, so there are no
  matching SERVER spans either.

  Fix: new src/services/provider_span_enricher.py — a SpanProcessor that runs
  on_end for every CLIENT span, resolves the URL host against a map of 25+ known
  AI provider hostnames, and writes peer.service into the span attributes before
  export. Registered in opentelemetry_config.py BEFORE the batch exporter so the
  attribute is present when Tempo indexes the span.

  Covered providers: openai, anthropic, openrouter, groq, mistral, together-ai,
  perplexity, cohere, google-gemini, google-vertex, fireworks, deepseek, xai,
  cerebras, featherless, hyperbolic, novita, huggingface, portkey, replicate,
  ai21, azure-openai, upstash-redis, supabase, stripe, sentry.

  Result: Tempo will emit traces_service_graph_request_total{client="gatewayz-backend",
  server="openai"} etc., which feeds the Service-to-Service RPS, Error Rate, and
  Cross-Service Latency panels, and draws edges in the Live Service Dependency Map.

Root cause 3 — up{job="gatewayz_production"} intermittently 0 (scrape DOWN):
  collect_redis_info() was called with no timeout. If Upstash Redis latency
  exceeds ~9s the /metrics response breaches the 10s scrape_timeout, making
  Prometheus mark the target as DOWN and losing all process_* metrics as well.

  Fix: wrapped asyncio.to_thread(collect_redis_info) in asyncio.wait_for(timeout=5.0).
  If Redis is slow the endpoint serves stale Redis gauges but responds within
  budget, keeping up=1 and all other metrics intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added service attribution enrichment for AI provider HTTP traces, improving distributed tracing visibility and service graph generation.

* **Bug Fixes**
  * Implemented timeout protection for metrics collection to improve endpoint reliability.
  * Restored process-level metrics exposure after registry updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three critical observability issues affecting Grafana dashboards:

1. **Process metrics restored** — Re-registers ProcessCollector/PlatformCollector/GCCollector after registry clearing to fix "No data" in CPU/Saturation panels (`process_cpu_seconds_total`, `process_resident_memory_bytes`, `process_open_fds`, `process_max_fds`)

2. **Service graph enabled** — New `ProviderSpanEnricher` SpanProcessor adds `peer.service` to outbound HTTP CLIENT spans for 25+ AI providers (OpenAI, Anthropic, OpenRouter, etc.), allowing Tempo's metrics_generator to build topology edges and populate the Live Service Dependency Map

3. **Scrape stability hardened** — Wraps `collect_redis_info()` in 5-second timeout to prevent slow Upstash Redis responses from breaching the 10s Prometheus scrape window (avoids `up{job="gatewayz_production"}=0`)

The implementation is well-documented with clear rationale for each fix. The span enricher correctly uses OTel semantic conventions and gracefully handles missing OpenTelemetry dependencies.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk — targeted observability fixes with no behavioral changes to core functionality
- All changes are defensive, additive, and scoped to observability/monitoring. Process collector re-registration is wrapped in try/except, timeout prevents scrape failures, and span enricher is non-blocking (catches all exceptions). The redundant condition check in provider_span_enricher.py:121 is a minor style issue that doesn't affect correctness.
- No files require special attention — all changes are isolated to monitoring/tracing infrastructure

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/services/provider_span_enricher.py | New SpanProcessor that enriches CLIENT spans with `peer.service` attributes for 25+ AI providers to enable Tempo service graph edges |
| src/services/prometheus_metrics.py | Re-registers ProcessCollector, PlatformCollector, and GCCollector after clearing registry to restore process_* metrics for Grafana CPU/Saturation panels |
| src/config/opentelemetry_config.py | Registers ProviderSpanEnricher before batch exporter so `peer.service` is present when Tempo indexes spans for service graph generation |
| src/main.py | Wraps `collect_redis_info()` in 5-second timeout to prevent slow Upstash responses from causing Prometheus scrape failures (keeps `up=1`) |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant P as Prometheus
    participant API as FastAPI /metrics
    participant R as Redis (Upstash)
    participant T as Tempo
    participant HTTPX as HTTPX (AI Provider Calls)

    Note over P,API: 1. Process Metrics Restored
    P->>API: GET /metrics (10s timeout)
    API->>API: Re-register ProcessCollector<br/>PlatformCollector, GCCollector
    API-->>P: process_cpu_seconds_total<br/>process_resident_memory_bytes<br/>process_open_fds

    Note over P,R: 2. Scrape Stability (Timeout Guard)
    P->>API: GET /metrics
    API->>R: asyncio.wait_for(collect_redis_info, 5s)
    alt Redis responds < 5s
        R-->>API: INFO metrics
        API-->>P: redis_* + all other metrics (up=1)
    else Redis timeout > 5s
        API-->>API: TimeoutError caught, serve stale gauges
        API-->>P: redis_* (stale) + all other metrics (up=1)
    end

    Note over HTTPX,T: 3. Service Graph (peer.service)
    HTTPX->>HTTPX: httpx.post("api.openai.com")
    HTTPX->>HTTPX: ProviderSpanEnricher.on_end()<br/>span._attributes["peer.service"] = "openai"
    HTTPX->>T: Export span with peer.service
    T->>T: metrics_generator builds edge<br/>gatewayz-backend → openai
    T-->>T: traces_service_graph_request_total{<br/>client="gatewayz-backend",<br/>server="openai"}
```

<sub>Last reviewed commit: 4f60eb6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->