### PR TITLE
Claude/check redis model limit w kl3z

### DIFF
--- a/src/db/models_catalog_db.py
+++ b/src/db/models_catalog_db.py
@@ -51,7 +51,10 @@ SUPABASE_PAGE_SIZE = 1000  # Supabase PostgREST default max rows per request
 # Maximum total wall-clock seconds allowed for any single paginated DB operation.
 # Individual HTTP requests are already bounded to 30 s by the httpx client in
 # supabase_config; this constant caps the *aggregate* time across all page fetches.
-DB_QUERY_TIMEOUT_SECONDS: float = 120.0
+# NOTE: The hot path now uses rebuild_full_catalog_from_providers() which assembles
+# per-provider catalogs (small queries). This timeout mainly applies to
+# get_all_models_for_catalog() used by admin endpoints and legacy callers.
+DB_QUERY_TIMEOUT_SECONDS: float = 300.0
 
 # Retry config for catalog DB reads: up to 2 retries (3 total attempts),
 # 0.5s -> 1.0s exponential backoff on transient connection/timeout errors.

--- a/src/routes/catalog.py
+++ b/src/routes/catalog.py
@@ -394,14 +394,12 @@ for _key, _cfg in GATEWAY_REGISTRY.items():
     for _alias in _cfg.get("aliases", []):
         _GATEWAY_SLUG_RESOLUTION[_alias] = _fetch_slug
 
-# Entries in GATEWAY_REGISTRY that do not yet have a get_cached_models() implementation are
-# excluded so the generic fetch loop does not attempt to call them.
+# Entries in GATEWAY_REGISTRY that do not yet have a fetch function in
+# PROVIDER_FETCH_FUNCTIONS (model_catalog_sync.py) are excluded so the
+# generic fetch loop does not attempt to call them.
 _REGISTRY_KEYS_WITHOUT_FETCH: frozenset[str] = frozenset(
     {
-        "canopywave",
         "notdiamond",
-        "cloudflare-workers-ai",
-        "zai",
         "alpaca",
     }
 )

--- a/src/services/background_tasks.py
+++ b/src/services/background_tasks.py
@@ -398,14 +398,13 @@ async def update_full_model_catalog_loop() -> None:
                         "Background Refresh: %d consecutive empty results - "
                         "cache may go stale!", consecutive_errors
                     )
-                continue
-
-            elapsed = time.monotonic() - refresh_start
-            consecutive_errors = 0
-            logger.info(
-                f"✅ Background Refresh: Updated catalog with {len(api_models)} models "
-                f"(took {elapsed:.1f}s)"
-            )
+            else:
+                elapsed = time.monotonic() - refresh_start
+                consecutive_errors = 0
+                logger.info(
+                    f"✅ Background Refresh: Updated catalog with {len(api_models)} models "
+                    f"(took {elapsed:.1f}s)"
+                )
 
         except Exception as e:
             consecutive_errors += 1

--- a/src/services/background_tasks.py
+++ b/src/services/background_tasks.py
@@ -344,12 +344,15 @@ async def update_full_model_catalog_loop() -> None:
     - Prevents cache TTL (15m) from expiring during user requests.
     - Eliminates the "thundering herd" of DB queries when cache is cold.
     - Acts as a DB connection keep-alive during idle periods.
-    - Resource usage is negligible (one efficient query every 14m).
+    - Resource usage is negligible (parallel per-provider fetches every 14m).
+
+    Uses rebuild_full_catalog_from_providers() which assembles the catalog
+    from individually-cached per-provider chunks, avoiding the single-giant-
+    query timeout that truncates results at ~3600 of 17k+ models.
     """
     import time
 
-    from src.db.models_catalog_db import get_all_models_for_catalog, transform_db_models_batch
-    from src.services.model_catalog_cache import cache_full_catalog
+    from src.services.model_catalog_cache import rebuild_full_catalog_from_providers
 
     logger.info("Starting model catalog background refresh loop (interval: 14m)")
 
@@ -376,37 +379,26 @@ async def update_full_model_catalog_loop() -> None:
             refresh_start = time.monotonic()
             logger.info("🔄 Background Refresh: Updating full model catalog...")
 
-            # 1. Fetch from DB (optimized query)
-            # Use dedicated DB executor to avoid starving the default thread pool
+            # Rebuild full catalog by assembling per-provider catalogs.
+            # Each provider is fetched individually (from Redis cache or small DB
+            # queries) and merged. This avoids the single-giant-query timeout that
+            # truncates results at ~3600 of 17k+ models.
+            # Per-provider caches are populated as a side-effect, so the separate
+            # _split_and_cache_gateway_catalogs step is no longer needed.
             loop = asyncio.get_running_loop()
-            db_models = await loop.run_in_executor(_db_executor, get_all_models_for_catalog, False)
+            api_models = await loop.run_in_executor(
+                _db_executor, rebuild_full_catalog_from_providers
+            )
 
-            if not db_models:
-                logger.warning("Background Refresh: DB returned 0 models - skipping cache update")
+            if not api_models:
+                logger.warning("Background Refresh: rebuild returned 0 models - skipping")
                 consecutive_errors += 1
                 if consecutive_errors >= 3:
                     logger.error(
-                        "Background Refresh: %d consecutive empty results from DB - "
+                        "Background Refresh: %d consecutive empty results - "
                         "cache may go stale!", consecutive_errors
                     )
                 continue
-
-            # 2. Transform to API format (in executor to avoid blocking event loop)
-            # transform_db_models_batch processes 13k+ models with pricing enrichment
-            # which is CPU-intensive. Running on the event loop blocks ALL requests.
-            api_models = await loop.run_in_executor(_db_executor, transform_db_models_batch, db_models)
-
-            # 3. Update full catalog cache
-            # We set TTL to 15m, but we refresh every 14m to ensure overlap
-            cache_full_catalog(api_models, ttl=900)
-
-            # 4. Derive and cache individual gateway catalogs from the full catalog.
-            # This keeps ALL gateway caches warm with ZERO additional DB queries.
-            # Previously, gateway caches went stale and triggered 31 separate DB
-            # queries + pricing enrichment on next access.
-            await loop.run_in_executor(
-                _db_executor, _split_and_cache_gateway_catalogs, api_models
-            )
 
             elapsed = time.monotonic() - refresh_start
             consecutive_errors = 0

--- a/src/services/model_catalog_cache.py
+++ b/src/services/model_catalog_cache.py
@@ -1261,8 +1261,10 @@ def rebuild_full_catalog_from_providers() -> list[dict[str, Any]]:
     # --- Step 2: Fetch per-provider catalogs in parallel ---
     # get_cached_provider_catalog already has Redis → local memory → DB fallback
     # and per-provider stampede protection, so we just call it for each slug.
-    # Cap concurrency to avoid exhausting the connection pool (50 max connections).
-    MAX_WORKERS = 5
+    # With 30+ providers, use 10 workers to complete in ~3 batches while leaving
+    # plenty of headroom in the connection pool (50 max connections). Most providers
+    # will hit Redis cache (sub-ms), so only a few use DB connections simultaneously.
+    MAX_WORKERS = 10
     all_models: list[dict[str, Any]] = []
     provider_counts: dict[str, int] = {}
     failed_providers: list[str] = []

--- a/src/services/model_catalog_cache.py
+++ b/src/services/model_catalog_cache.py
@@ -1134,7 +1134,7 @@ def get_cached_full_catalog() -> list[dict[str, Any]] | None:
     from src.services.local_memory_cache import get_local_catalog, set_local_catalog
     from src.utils.step_logger import StepLogger
 
-    step_logger = StepLogger("Cache: Fetch Full Catalog", total_steps=5)
+    step_logger = StepLogger("Cache: Fetch Full Catalog", total_steps=3)
     step_logger.start(cache_type="full_catalog")
 
     cache = get_model_catalog_cache()
@@ -1174,34 +1174,156 @@ def get_cached_full_catalog() -> list[dict[str, Any]] | None:
             step_logger.complete(source="redis_after_lock", models=len(cached))
             return cached
 
-        step_logger.step(3, "Fetching from database", cache_layer="database")
+        # Rebuild full catalog by assembling per-provider catalogs.
+        # Each provider is fetched individually (small, fast queries that never
+        # hit the 120s wall-clock deadline) instead of one giant all-models query.
+        step_logger.step(3, "Rebuilding from per-provider caches", cache_layer="provider_assembly")
         try:
-            from src.db.models_catalog_db import (
-                get_all_models_for_catalog,
-                transform_db_models_batch,
-            )
-
-            db_models = get_all_models_for_catalog(include_inactive=False)
-            step_logger.success(db_models=len(db_models))
-
-            # Step 4: Transform to API format
-            step_logger.step(4, "Transforming models to API format", count=len(db_models))
-            api_models = transform_db_models_batch(db_models)
+            api_models = rebuild_full_catalog_from_providers()
             step_logger.success(api_models=len(api_models))
 
-            # Step 5: Populate caches
-            step_logger.step(5, "Populating caches", targets="redis+local")
-            cache.set_full_catalog(api_models, ttl=ModelCatalogCache.TTL_FULL_CATALOG)
-            set_local_catalog("all", api_models)
-            step_logger.success(redis="updated", local="updated", ttl=ModelCatalogCache.TTL_FULL_CATALOG)
-
-            step_logger.complete(source="database", models=len(api_models), cache_status="populated")
+            step_logger.complete(source="provider_assembly", models=len(api_models), cache_status="populated")
             return api_models
 
         except Exception as e:
-            step_logger.failure(e, source="database")
-            logger.error(f"Error fetching catalog from database: {e}")
+            step_logger.failure(e, source="provider_assembly")
+            logger.error(f"Error rebuilding catalog from providers: {e}")
             return []
+
+
+def rebuild_full_catalog_from_providers() -> list[dict[str, Any]]:
+    """
+    Build the full catalog by assembling individually-cached per-provider catalogs.
+
+    This avoids the single-giant-query timeout issue in get_all_models_for_catalog()
+    by fetching each provider separately (small, fast queries) and merging.
+
+    Flow:
+    1. Get list of known provider slugs from the database
+    2. Fetch each provider's catalog (from Redis cache or DB on miss via
+       get_cached_provider_catalog which has its own Redis → local → DB fallback)
+    3. Merge all providers into a single list
+    4. Cache the merged result as the full catalog in Redis + local memory
+    5. Return the complete catalog
+
+    Each per-provider query is small (100-5000 rows) and well within the
+    DB_QUERY_TIMEOUT_SECONDS deadline, unlike the monolithic all-models query
+    which times out at ~3600 rows for 17k+ model catalogs.
+
+    Returns:
+        Complete merged catalog (all providers), or empty list on total failure.
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+    from src.services.local_memory_cache import set_local_catalog
+
+    cache = get_model_catalog_cache()
+
+    # --- Step 1: Discover provider slugs ---
+    # Use the database as the authoritative source of active provider slugs.
+    # This avoids hardcoding the list and automatically picks up new providers.
+    provider_slugs: list[str] = []
+    try:
+        from src.config.supabase_config import get_client_for_query
+
+        supabase = get_client_for_query(read_only=True)
+        response = (
+            supabase.table("providers")
+            .select("slug")
+            .eq("is_active", True)
+            .execute()
+        )
+        provider_slugs = [
+            row["slug"] for row in (response.data or []) if row.get("slug")
+        ]
+        logger.info(
+            f"rebuild_full_catalog_from_providers: discovered {len(provider_slugs)} "
+            f"active provider slugs from database"
+        )
+    except Exception as e:
+        logger.warning(
+            f"rebuild_full_catalog_from_providers: failed to fetch provider slugs "
+            f"from database ({e}), falling back to PROVIDER_SLUGS from catalog"
+        )
+        try:
+            from src.routes.catalog import PROVIDER_SLUGS
+            provider_slugs = list(PROVIDER_SLUGS)
+        except Exception:
+            logger.error(
+                "rebuild_full_catalog_from_providers: cannot determine provider slugs, "
+                "aborting rebuild"
+            )
+            return []
+
+    if not provider_slugs:
+        logger.warning("rebuild_full_catalog_from_providers: no provider slugs found")
+        return []
+
+    # --- Step 2: Fetch per-provider catalogs in parallel ---
+    # get_cached_provider_catalog already has Redis → local memory → DB fallback
+    # and per-provider stampede protection, so we just call it for each slug.
+    # Cap concurrency to avoid exhausting the connection pool (50 max connections).
+    MAX_WORKERS = 5
+    all_models: list[dict[str, Any]] = []
+    provider_counts: dict[str, int] = {}
+    failed_providers: list[str] = []
+
+    def _fetch_provider(slug: str) -> tuple[str, list[dict[str, Any]]]:
+        """Fetch a single provider's catalog (runs in thread pool)."""
+        try:
+            models = get_cached_provider_catalog(slug) or []
+            return (slug, models)
+        except Exception as exc:
+            logger.warning(
+                f"rebuild_full_catalog_from_providers: failed to fetch {slug}: {exc}"
+            )
+            return (slug, [])
+
+    import time as _time
+    fetch_start = _time.monotonic()
+
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+        futures = {
+            executor.submit(_fetch_provider, slug): slug
+            for slug in provider_slugs
+        }
+        for future in as_completed(futures):
+            slug = futures[future]
+            try:
+                slug, models = future.result(timeout=120)
+                if models:
+                    all_models.extend(models)
+                    provider_counts[slug] = len(models)
+                else:
+                    failed_providers.append(slug)
+            except Exception as exc:
+                logger.warning(
+                    f"rebuild_full_catalog_from_providers: {slug} future failed: {exc}"
+                )
+                failed_providers.append(slug)
+
+    fetch_elapsed = _time.monotonic() - fetch_start
+
+    logger.info(
+        f"rebuild_full_catalog_from_providers: assembled {len(all_models)} models "
+        f"from {len(provider_counts)} providers in {fetch_elapsed:.1f}s "
+        f"(failed: {len(failed_providers)})"
+    )
+    if failed_providers:
+        logger.warning(
+            f"rebuild_full_catalog_from_providers: providers with 0 models: "
+            f"{failed_providers}"
+        )
+
+    # --- Step 3: Cache the assembled full catalog ---
+    if all_models:
+        cache.set_full_catalog(all_models, ttl=ModelCatalogCache.TTL_FULL_CATALOG)
+        set_local_catalog("all", all_models)
+        logger.info(
+            f"rebuild_full_catalog_from_providers: cached full catalog "
+            f"({len(all_models)} models, TTL={ModelCatalogCache.TTL_FULL_CATALOG}s)"
+        )
+
+    return all_models
 
 
 def invalidate_full_catalog() -> bool:
@@ -3108,6 +3230,7 @@ __all__ = [
     # Full catalog
     "cache_full_catalog",
     "get_cached_full_catalog",
+    "rebuild_full_catalog_from_providers",
     "invalidate_full_catalog",
     # Provider catalog
     "cache_provider_catalog",

--- a/tests/services/test_rebuild_full_catalog.py
+++ b/tests/services/test_rebuild_full_catalog.py
@@ -1,0 +1,241 @@
+"""
+Tests for rebuild_full_catalog_from_providers()
+
+Verifies that the full model catalog is correctly assembled from individually-
+cached per-provider catalogs, avoiding the single-giant-query timeout that
+truncates results.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Sample data helpers
+# ---------------------------------------------------------------------------
+
+def _make_models(provider_slug: str, count: int) -> list[dict]:
+    """Generate a list of fake model dicts for a given provider."""
+    return [
+        {
+            "id": f"{provider_slug}/model-{i}",
+            "name": f"Model {i}",
+            "source_gateway": provider_slug,
+            "provider_slug": provider_slug,
+            "context_length": 4096,
+            "pricing": {"prompt": "0.001", "completion": "0.002"},
+            "is_active": True,
+        }
+        for i in range(count)
+    ]
+
+
+SAMPLE_PROVIDERS_DB = [
+    {"slug": "openai"},
+    {"slug": "anthropic"},
+    {"slug": "openrouter"},
+]
+
+
+def _mock_supabase_response(data):
+    """Build a mock supabase client that returns *data* from providers query."""
+    client = MagicMock()
+    response = MagicMock()
+    response.data = data
+    client.table.return_value.select.return_value.eq.return_value.execute.return_value = response
+    return client
+
+
+def _provider_catalog_side_effect(slug):
+    """Default side effect: deterministic model counts per provider."""
+    counts = {"openai": 3, "anthropic": 2, "openrouter": 5}
+    count = counts.get(slug, 0)
+    return _make_models(slug, count) if count else []
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestRebuildFullCatalogFromProviders:
+    """Tests for rebuild_full_catalog_from_providers()."""
+
+    def test_assembles_all_providers(self):
+        """All provider models are merged into a single catalog."""
+        mock_client = _mock_supabase_response(SAMPLE_PROVIDERS_DB)
+
+        with patch("src.config.supabase_config.get_client_for_query", return_value=mock_client), \
+             patch("src.services.model_catalog_cache.get_cached_provider_catalog", side_effect=_provider_catalog_side_effect), \
+             patch("src.services.model_catalog_cache.get_model_catalog_cache") as mock_cache_cls, \
+             patch("src.services.local_memory_cache.set_local_catalog"):
+            mock_cache_cls.return_value = MagicMock()
+
+            from src.services.model_catalog_cache import rebuild_full_catalog_from_providers
+            result = rebuild_full_catalog_from_providers()
+
+        # 3 + 2 + 5 = 10 models total
+        assert len(result) == 10
+        slugs = {m["source_gateway"] for m in result}
+        assert slugs == {"openai", "anthropic", "openrouter"}
+
+    def test_caches_result_in_redis_and_local(self):
+        """Assembled catalog is cached in both Redis and local memory."""
+        mock_client = _mock_supabase_response(SAMPLE_PROVIDERS_DB)
+        mock_cache = MagicMock()
+
+        with patch("src.config.supabase_config.get_client_for_query", return_value=mock_client), \
+             patch("src.services.model_catalog_cache.get_cached_provider_catalog", side_effect=_provider_catalog_side_effect), \
+             patch("src.services.model_catalog_cache.get_model_catalog_cache", return_value=mock_cache), \
+             patch("src.services.local_memory_cache.set_local_catalog") as mock_set_local:
+
+            from src.services.model_catalog_cache import rebuild_full_catalog_from_providers
+            result = rebuild_full_catalog_from_providers()
+
+        mock_cache.set_full_catalog.assert_called_once()
+        assert len(mock_cache.set_full_catalog.call_args[0][0]) == 10
+        mock_set_local.assert_called_once_with("all", result)
+
+    def test_partial_provider_failure(self):
+        """If some providers fail, others still contribute to the catalog."""
+        mock_client = _mock_supabase_response(SAMPLE_PROVIDERS_DB)
+
+        def _side_effect(slug):
+            if slug == "anthropic":
+                raise RuntimeError("connection refused")
+            counts = {"openai": 3, "openrouter": 5}
+            return _make_models(slug, counts.get(slug, 0))
+
+        with patch("src.config.supabase_config.get_client_for_query", return_value=mock_client), \
+             patch("src.services.model_catalog_cache.get_cached_provider_catalog", side_effect=_side_effect), \
+             patch("src.services.model_catalog_cache.get_model_catalog_cache", return_value=MagicMock()), \
+             patch("src.services.local_memory_cache.set_local_catalog"):
+
+            from src.services.model_catalog_cache import rebuild_full_catalog_from_providers
+            result = rebuild_full_catalog_from_providers()
+
+        # anthropic failed, but openai (3) + openrouter (5) = 8
+        assert len(result) == 8
+        slugs = {m["source_gateway"] for m in result}
+        assert "anthropic" not in slugs
+        assert "openai" in slugs
+        assert "openrouter" in slugs
+
+    def test_all_providers_empty_returns_empty(self):
+        """If every provider returns empty, result is empty and nothing is cached."""
+        mock_client = _mock_supabase_response(SAMPLE_PROVIDERS_DB)
+        mock_cache = MagicMock()
+
+        with patch("src.config.supabase_config.get_client_for_query", return_value=mock_client), \
+             patch("src.services.model_catalog_cache.get_cached_provider_catalog", return_value=[]), \
+             patch("src.services.model_catalog_cache.get_model_catalog_cache", return_value=mock_cache), \
+             patch("src.services.local_memory_cache.set_local_catalog"):
+
+            from src.services.model_catalog_cache import rebuild_full_catalog_from_providers
+            result = rebuild_full_catalog_from_providers()
+
+        assert result == []
+        mock_cache.set_full_catalog.assert_not_called()
+
+    def test_empty_provider_list_returns_empty(self):
+        """If no provider slugs are discovered, return empty immediately."""
+        mock_client = _mock_supabase_response([])  # No providers
+
+        with patch("src.config.supabase_config.get_client_for_query", return_value=mock_client), \
+             patch("src.services.model_catalog_cache.get_model_catalog_cache", return_value=MagicMock()):
+
+            from src.services.model_catalog_cache import rebuild_full_catalog_from_providers
+            result = rebuild_full_catalog_from_providers()
+
+        assert result == []
+
+    def test_db_discovery_failure_falls_back_to_registry(self):
+        """If DB slug query fails, falls back to GATEWAY_REGISTRY keys."""
+        mock_registry = {
+            "openai": {"name": "OpenAI"},
+            "anthropic": {"name": "Anthropic"},
+            "openrouter": {"name": "OpenRouter"},
+        }
+
+        with patch("src.config.supabase_config.get_client_for_query", side_effect=Exception("DB down")), \
+             patch("src.routes.catalog.GATEWAY_REGISTRY", mock_registry), \
+             patch("src.services.model_catalog_cache.get_cached_provider_catalog", side_effect=_provider_catalog_side_effect) as mock_fetch, \
+             patch("src.services.model_catalog_cache.get_model_catalog_cache", return_value=MagicMock()), \
+             patch("src.services.local_memory_cache.set_local_catalog"):
+
+            from src.services.model_catalog_cache import rebuild_full_catalog_from_providers
+            result = rebuild_full_catalog_from_providers()
+
+        assert len(result) == 10
+        assert mock_fetch.call_count == 3
+
+    def test_providers_with_zero_models_handled_gracefully(self):
+        """Providers returning 0 models don't break the assembly."""
+        mock_client = _mock_supabase_response(SAMPLE_PROVIDERS_DB)
+
+        def _side_effect(slug):
+            if slug == "openai":
+                return _make_models("openai", 5)
+            return []  # anthropic and openrouter return empty
+
+        with patch("src.config.supabase_config.get_client_for_query", return_value=mock_client), \
+             patch("src.services.model_catalog_cache.get_cached_provider_catalog", side_effect=_side_effect), \
+             patch("src.services.model_catalog_cache.get_model_catalog_cache", return_value=MagicMock()), \
+             patch("src.services.local_memory_cache.set_local_catalog"):
+
+            from src.services.model_catalog_cache import rebuild_full_catalog_from_providers
+            result = rebuild_full_catalog_from_providers()
+
+        assert len(result) == 5
+        assert all(m["source_gateway"] == "openai" for m in result)
+
+    def test_does_not_use_provider_slugs_with_overrides(self):
+        """Fallback uses GATEWAY_REGISTRY.keys() not PROVIDER_SLUGS
+        (which has huggingface->hug override that doesn't match DB slugs)."""
+        mock_registry = {"huggingface": {"name": "Hugging Face"}}
+
+        with patch("src.config.supabase_config.get_client_for_query", side_effect=Exception("DB down")), \
+             patch("src.routes.catalog.GATEWAY_REGISTRY", mock_registry), \
+             patch("src.services.model_catalog_cache.get_cached_provider_catalog", return_value=_make_models("huggingface", 3)) as mock_fetch, \
+             patch("src.services.model_catalog_cache.get_model_catalog_cache", return_value=MagicMock()), \
+             patch("src.services.local_memory_cache.set_local_catalog"):
+
+            from src.services.model_catalog_cache import rebuild_full_catalog_from_providers
+            result = rebuild_full_catalog_from_providers()
+
+        # Should call with "huggingface" (DB slug), not "hug" (PROVIDER_SLUGS override)
+        mock_fetch.assert_called_once_with("huggingface")
+        assert len(result) == 3
+
+
+class TestRebuildIntegrationWithGetCachedFullCatalog:
+    """Test that get_cached_full_catalog() correctly calls rebuild on cache miss."""
+
+    def test_cache_hit_does_not_trigger_rebuild(self):
+        """Redis cache hit returns immediately without rebuilding."""
+        mock_cache = MagicMock()
+        mock_cache.get_full_catalog.return_value = [{"id": "cached-model"}]
+
+        with patch("src.services.model_catalog_cache.get_model_catalog_cache", return_value=mock_cache), \
+             patch("src.services.local_memory_cache.set_local_catalog"), \
+             patch("src.services.local_memory_cache.get_local_catalog", return_value=(None, False)):
+
+            from src.services.model_catalog_cache import get_cached_full_catalog
+            result = get_cached_full_catalog()
+
+        assert result == [{"id": "cached-model"}]
+
+    def test_cache_miss_triggers_rebuild(self):
+        """Cache miss triggers rebuild_full_catalog_from_providers."""
+        mock_cache = MagicMock()
+        mock_cache.get_full_catalog.return_value = None  # Cache miss
+
+        with patch("src.services.model_catalog_cache.get_model_catalog_cache", return_value=mock_cache), \
+             patch("src.services.local_memory_cache.get_local_catalog", return_value=(None, False)), \
+             patch("src.services.local_memory_cache.set_local_catalog"), \
+             patch("src.services.model_catalog_cache.rebuild_full_catalog_from_providers", return_value=_make_models("openai", 5)) as mock_rebuild:
+
+            from src.services.model_catalog_cache import get_cached_full_catalog
+            result = get_cached_full_catalog()
+
+        mock_rebuild.assert_called_once()
+        assert len(result) == 5

--- a/tests/services/test_rebuild_full_catalog.py
+++ b/tests/services/test_rebuild_full_catalog.py
@@ -6,7 +6,6 @@ cached per-provider catalogs, avoiding the single-giant-query timeout that
 truncates results.
 """
 
-import pytest
 from unittest.mock import MagicMock, patch
 
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a per-provider catalog rebuild to assemble the full model catalog from provider caches.
  * Enabled canopywave, zai, and cloudflare-workers-ai to be fetched by the generic provider loop.

* **Improvements**
  * Catalog loading now assembles from per-provider caches for better reliability and to avoid large-query timeouts.
  * Increased database query timeout to accommodate larger catalogs.

* **Bug Fixes**
  * Logs a warning and tracks consecutive empty-rebuilds when a rebuild returns zero models.

* **Tests**
  * Added comprehensive tests for the rebuild and caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactors full model catalog assembly to avoid timeout issues by building from individually-cached per-provider catalogs instead of a single giant query. This resolves the truncation problem where 17k+ model catalogs were timing out at ~3600 rows.

**Key Changes:**
- Added `rebuild_full_catalog_from_providers()` that fetches 30+ providers in parallel (10 workers) and merges results
- Updated `get_cached_full_catalog()`, background refresh loop, and startup preload to use the new rebuild function
- Removed now-redundant `_split_and_cache_gateway_catalogs()` calls since per-provider caches are populated as side-effect
- Increased `DB_QUERY_TIMEOUT_SECONDS` from 120s to 300s for legacy callers
- Enabled 3 additional providers (canopywave, cloudflare-workers-ai, zai) by removing them from exclusion list
- Comprehensive test coverage with 9 test cases covering success, partial failures, and edge cases

**Issues Found:**
- Variable shadowing bug on line 1303 in `model_catalog_cache.py` where `slug` is reassigned, breaking the futures mapping

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing variable shadowing bug that breaks provider tracking
- Score reflects the presence of a critical variable shadowing bug in the new `rebuild_full_catalog_from_providers()` function that will cause incorrect provider attribution in logs and failed_providers tracking. The bug doesn't break core functionality (models are still assembled) but corrupts metadata. Otherwise the refactoring is well-designed with excellent test coverage.
- Fix the variable shadowing bug in `src/services/model_catalog_cache.py` lines 1303-1308 before merging

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/db/models_catalog_db.py | Increased DB_QUERY_TIMEOUT_SECONDS from 120 to 300 with updated comment explaining it applies to legacy callers |
| src/routes/catalog.py | Removed canopywave, cloudflare-workers-ai, zai from _REGISTRY_KEYS_WITHOUT_FETCH (now have fetch functions) |
| src/services/background_tasks.py | Simplified update_full_model_catalog_loop to use rebuild_full_catalog_from_providers, eliminating transform and split steps |
| src/services/model_catalog_cache.py | Added rebuild_full_catalog_from_providers with parallel per-provider fetching; has variable shadowing bug on line 1303 |
| src/services/startup.py | Updated startup to use rebuild_full_catalog_from_providers, removed _split_and_cache_gateway_catalogs call |
| tests/services/test_rebuild_full_catalog.py | Comprehensive test coverage for rebuild_full_catalog_from_providers with 9 scenarios including failures and edge cases |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User Request / Background Task] --> B{Check Redis Cache}
    B -->|Hit| C[Return Cached Full Catalog]
    B -->|Miss| D[rebuild_full_catalog_from_providers]
    D --> E[Query DB for Active Provider Slugs]
    E -->|Success| F[30+ Provider Slugs]
    E -->|Failure| G[Fallback to GATEWAY_REGISTRY]
    F --> H[ThreadPoolExecutor 10 Workers]
    G --> H
    H --> I[Parallel Fetch Per-Provider]
    I --> J1[get_cached_provider_catalog slug1]
    I --> J2[get_cached_provider_catalog slug2]
    I --> J3[get_cached_provider_catalog slug3]
    I --> J4[... 30+ providers]
    J1 --> K{Provider Cache Hit?}
    J2 --> K
    J3 --> K
    J4 --> K
    K -->|Hit| L[Return from Redis/Local]
    K -->|Miss| M[Small DB Query for Provider]
    L --> N[Merge All Provider Catalogs]
    M --> N
    N --> O[Cache Full Catalog in Redis + Local]
    O --> P[Return 17k+ Models]
    
    style D fill:#e1f5ff
    style H fill:#fff4e1
    style N fill:#e1ffe1
    style O fill:#ffe1e1
```

<sub>Last reviewed commit: 51fd470</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->