### PR TITLE
fix(billing): fix subscription upgrade proration double-credit

### DIFF
--- a/src/services/payments.py
+++ b/src/services/payments.py
@@ -2044,7 +2044,7 @@ class StripeService:
                     "tier": new_tier,
                     # Signal to webhook handlers that allowance was already reset by this endpoint.
                     # The webhook handler checks this timestamp and skips allowance reset if it
-                    # was set within the last 60 seconds.
+                    # was set within the last 120 seconds.
                     "allowance_handled_at": allowance_handled_at,
                     "allowance_handled_by": "upgrade_subscription",
                 },
@@ -2391,7 +2391,11 @@ class StripeService:
                 # Calculate how much of the old allowance was used
                 old_used = max(0.0, old_tier_allowance - old_remaining_allowance)
 
-                # Calculate what is being forfeited (unused old allowance exceeding new tier)
+                # Calculate what is being forfeited (unused old allowance exceeding new tier).
+                # Design decision: on downgrade, we only forfeit the excess above the new
+                # tier's allowance. The user keeps the new tier's full capacity as their
+                # starting balance, so they are never worse off than a fresh subscriber on
+                # the lower tier. Purchased credits are never touched by this calculation.
                 forfeited_allowance = max(0.0, old_remaining_allowance - new_allowance)
 
                 logger.info(


### PR DESCRIPTION
## Summary
- Allowance is SET to new tier (not incremented by difference) — prevents double-crediting
- Webhook guards with 120s timestamp window prevent duplicate allowance resets
- Proration invoices (`billing_reason='subscription_update'`) skip allowance reset
- Fetches Stripe's actual proration amount for audit verification

Closes #1141 (C5)

## Test plan
- [ ] Verify upgrade sets allowance to new tier value
- [ ] Confirm webhook doesn't double-reset after upgrade
- [ ] Check purchased_credits remain untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed subscription upgrade/downgrade double-crediting by: (1) setting allowance to new tier value instead of incrementing, (2) adding 120-second webhook deduplication guard via `allowance_handled_at` metadata, (3) skipping allowance reset for proration invoices (`billing_reason='subscription_update'`), and (4) fetching Stripe's proration amount for audit verification.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor documentation inconsistency
- The fix correctly addresses the double-crediting issue with multiple defensive layers (metadata timestamp guard, billing_reason check). One comment mismatch (60s vs 120s) needs correction but doesn't affect runtime behavior.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/services/payments.py | Comprehensive fix preventing double-crediting on subscription tier changes via webhook deduplication and billing_reason checks |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API as upgrade_subscription endpoint
    participant Stripe
    participant Webhook as subscription.updated webhook
    participant Invoice as invoice.paid webhook
    
    User->>API: POST /upgrade to new tier
    API->>API: Set allowance_handled_at timestamp
    API->>Stripe: Modify subscription with metadata
    API->>API: SET allowance to new tier (replace old)
    API->>API: Log SUBSCRIPTION_UPGRADE transaction
    API-->>User: Success response
    
    Note over Stripe: Stripe processes subscription change
    
    Stripe->>Webhook: subscription.updated event
    Webhook->>Webhook: Check allowance_handled_at metadata
    alt Within 120s window
        Webhook->>Webhook: Skip allowance reset (already handled)
    else Outside window
        Webhook->>Webhook: Reset allowance
    end
    
    Stripe->>Invoice: invoice.paid (billing_reason=subscription_update)
    Invoice->>Invoice: Check billing_reason
    alt billing_reason == subscription_update
        Invoice->>Invoice: Skip allowance reset (proration invoice)
    else Regular renewal
        Invoice->>Invoice: Check allowance_handled_at (120s guard)
        Invoice->>Invoice: Reset allowance if not recently handled
    end
```

<sub>Last reviewed commit: f25db0a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->