### PR TITLE
fix(billing): move image pricing to manual_pricing.json

### DIFF
--- a/src/data/manual_pricing.json
+++ b/src/data/manual_pricing.json
@@ -1715,6 +1715,30 @@
       "pricing_model": "per_minute"
     }
   },
+  "image_pricing": {
+    "deepinfra": {
+      "stable-diffusion-3.5-large": {"per_image": 0.035},
+      "stable-diffusion-3.5-medium": {"per_image": 0.02},
+      "stabilityai/sd3.5": {"per_image": 0.035},
+      "stabilityai/sd3.5-large": {"per_image": 0.035},
+      "stabilityai/sd3.5-medium": {"per_image": 0.02},
+      "default": {"per_image": 0.025}
+    },
+    "fal": {
+      "flux/schnell": {"per_image": 0.003},
+      "flux/dev": {"per_image": 0.025},
+      "flux-pro": {"per_image": 0.05},
+      "fal-ai/flux/schnell": {"per_image": 0.003},
+      "fal-ai/flux/dev": {"per_image": 0.025},
+      "fal-ai/flux-pro": {"per_image": 0.05},
+      "default": {"per_image": 0.025}
+    },
+    "google-vertex": {
+      "imagegeneration@006": {"per_image": 0.02},
+      "imagen-3.0-generate-001": {"per_image": 0.04},
+      "default": {"per_image": 0.03}
+    }
+  },
   "_metadata": {
     "last_updated": "2026-01-26",
     "note": "Manual pricing data for providers that don't expose pricing via API. Near AI and Alibaba Cloud pricing are now fetched dynamically from API but kept here as fallback.",

--- a/src/routes/images.py
+++ b/src/routes/images.py
@@ -86,10 +86,11 @@ def get_image_cost(provider: str, model: str, num_images: int = 1) -> tuple[floa
     is_fallback = False
 
     # --- Tier 1: config-driven pricing from manual_pricing.json ---
-    config_price = get_image_pricing(provider, model)
-    if config_price is not None:
+    config_result = get_image_pricing(provider, model)
+    if config_result is not None:
+        config_price, config_is_fallback = config_result
         total_cost = config_price * num_images
-        return total_cost, config_price, False
+        return total_cost, config_price, config_is_fallback
 
     # --- Tier 2+: hardcoded fallback (deprecated) ---
     logger.warning(

--- a/src/routes/images.py
+++ b/src/routes/images.py
@@ -19,6 +19,7 @@ from src.services.image_generation_client import (
     make_google_vertex_image_request,
     process_image_generation_response,
 )
+from src.services.pricing_lookup import get_image_pricing
 from src.utils.ai_tracing import AIRequestType, AITracer
 from src.utils.performance_tracker import PerformanceTracker
 
@@ -27,10 +28,13 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-# Provider-specific image generation pricing (cost per image in USD)
-# Based on provider pricing pages as of Jan 2025
-# TODO: Move to database-driven pricing for easier updates
-IMAGE_COST_PER_IMAGE = {
+# DEPRECATED: Hardcoded image pricing fallback.
+# Canonical image pricing now lives in src/data/manual_pricing.json under the
+# "image_pricing" key.  This dict is kept only as a last-resort fallback during
+# the transition period.  It will be removed once all pricing is confirmed to be
+# served from manual_pricing.json.  Do NOT add new entries here -- update
+# manual_pricing.json instead.
+_HARDCODED_IMAGE_COST_PER_IMAGE = {
     "deepinfra": {
         "stable-diffusion-3.5-large": 0.035,
         "stable-diffusion-3.5-medium": 0.02,
@@ -64,6 +68,12 @@ def get_image_cost(provider: str, model: str, num_images: int = 1) -> tuple[floa
     """
     Calculate the cost for image generation.
 
+    Pricing lookup order:
+      1. manual_pricing.json  (``image_pricing`` section, via ``get_image_pricing()``)
+      2. Hardcoded fallback   (``_HARDCODED_IMAGE_COST_PER_IMAGE`` -- deprecated)
+      3. Provider default     (``"default"`` key in hardcoded dict)
+      4. Unknown-provider     (``UNKNOWN_PROVIDER_DEFAULT_COST``)
+
     Args:
         provider: Image generation provider (deepinfra, fal, google-vertex)
         model: Model name
@@ -73,8 +83,21 @@ def get_image_cost(provider: str, model: str, num_images: int = 1) -> tuple[floa
         Tuple of (total_cost, cost_per_image, is_fallback_pricing)
         is_fallback_pricing is True when using default/unknown pricing
     """
-    provider_pricing = IMAGE_COST_PER_IMAGE.get(provider, {})
     is_fallback = False
+
+    # --- Tier 1: config-driven pricing from manual_pricing.json ---
+    config_price = get_image_pricing(provider, model)
+    if config_price is not None:
+        total_cost = config_price * num_images
+        return total_cost, config_price, False
+
+    # --- Tier 2+: hardcoded fallback (deprecated) ---
+    logger.warning(
+        f"Image pricing not found in manual_pricing.json, falling back to hardcoded dict: "
+        f"provider={provider}, model={model}"
+    )
+
+    provider_pricing = _HARDCODED_IMAGE_COST_PER_IMAGE.get(provider, {})
 
     if model in provider_pricing:
         cost_per_image = provider_pricing[model]


### PR DESCRIPTION
## Summary
- Moves image pricing data into `manual_pricing.json` under `image_pricing` key
- Adds `get_image_pricing()` function in pricing_lookup.py
- Hardcoded dict kept as deprecated fallback with warning log
- Changes require config update instead of code deploy

Closes #1139 (A7)

## Test plan
- [ ] Verify pricing loads from manual_pricing.json
- [ ] Check fallback to hardcoded dict with warning log
- [ ] Confirm image costs match previous values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moves image generation pricing from a hardcoded dict in `src/routes/images.py` to the existing `manual_pricing.json` config file under a new `image_pricing` key, and adds a `get_image_pricing()` lookup function in `pricing_lookup.py`. The hardcoded dict is retained as a deprecated fallback with a warning log.

- The pricing values in `manual_pricing.json` exactly match the previous hardcoded values, so no pricing changes are introduced.
- **Bug**: The `is_fallback` flag returned by `get_image_cost()` has changed semantics — when an unknown model hits a provider-level `"default"` entry in the JSON config, the function now returns `is_fallback=False` instead of `True`. This breaks `test_get_image_cost_unknown_model_uses_provider_default` and silently changes the `used_fallback_pricing` field in the API response, which may affect downstream monitoring.
- The new `get_image_pricing()` function is well-structured with proper error handling and follows the existing patterns in `pricing_lookup.py`.
- No unit tests were added for the new `get_image_pricing()` function.

<h3>Confidence Score: 2/5</h3>

- This PR introduces a behavioral change to the `is_fallback` flag in billing responses that will break an existing test and may affect monitoring.
- The pricing data migration itself is clean and values are correct, but the `is_fallback` semantics change in `get_image_cost()` is a logic bug that breaks an existing test (`test_get_image_cost_unknown_model_uses_provider_default`) and silently alters the `used_fallback_pricing` API response field. This is a billing-adjacent change that warrants careful review before merging.
- Pay close attention to `src/routes/images.py` — the `is_fallback` flag logic in `get_image_cost()` has changed behavior for provider-default pricing lookups.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/routes/images.py | Adds config-driven pricing tier to `get_image_cost()` and renames hardcoded dict; `is_fallback` flag semantics changed for provider-default pricing, breaking an existing test and altering API response behavior. |
| src/services/pricing_lookup.py | New `get_image_pricing()` function with correct lookup logic (exact match -> provider default -> None); minor misleading comment about key lowercasing behavior. |
| src/data/manual_pricing.json | Adds `image_pricing` section with per-image costs for deepinfra, fal, and google-vertex providers; values match the previously hardcoded dict exactly. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["get_image_cost(provider, model, n)"] --> B["Tier 1: get_image_pricing()"]
    B --> C{Found in manual_pricing.json?}
    C -->|Yes| D["Return (price*n, price, False)"]
    C -->|No| E["⚠️ Log warning: fallback to hardcoded"]
    E --> F["Tier 2: _HARDCODED_IMAGE_COST_PER_IMAGE"]
    F --> G{Exact model match?}
    G -->|Yes| H["Return (cost*n, cost, False)"]
    G -->|No| I{Provider default exists?}
    I -->|Yes| J["Return (default*n, default, True)"]
    I -->|No| K["Tier 3: UNKNOWN_PROVIDER_DEFAULT_COST"]
    K --> L["Return (0.05*n, 0.05, True)"]

    style D fill:#d4edda
    style E fill:#fff3cd
    style J fill:#fff3cd
    style L fill:#f8d7da
```

<sub>Last reviewed commit: 8cf499c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->