### PR TITLE
fix(billing): add billing to audio transcription endpoints

### DIFF
--- a/src/routes/audio.py
+++ b/src/routes/audio.py
@@ -69,8 +69,8 @@ BYTES_PER_MINUTE_ESTIMATE = 1_000_000  # 1MB per minute
 
 # Uncompressed formats (WAV, FLAC) have much higher bitrates
 UNCOMPRESSED_BYTES_PER_MINUTE = {
-    ".wav": 10_000_000,   # ~10MB/min at 16-bit 44.1kHz stereo
-    ".flac": 5_000_000,   # ~5MB/min (lossless compression varies)
+    ".wav": 10_000_000,  # ~10MB/min at 16-bit 44.1kHz stereo
+    ".flac": 5_000_000,  # ~5MB/min (lossless compression varies)
 }
 
 
@@ -214,9 +214,7 @@ async def _deduct_audio_credits(
         )
     except Exception as e:
         # Unexpected error in billing - fail safe, don't give away free transcription
-        logger.error(
-            f"[{request_id}] Unexpected error in credit deduction: {e}", exc_info=True
-        )
+        logger.error(f"[{request_id}] Unexpected error in credit deduction: {e}", exc_info=True)
         raise HTTPException(
             status_code=500,
             detail="Billing error occurred. Please try again or contact support.",
@@ -329,8 +327,7 @@ async def create_transcription(
         user = await loop.run_in_executor(executor, get_user, api_key)
         if not user:
             if (
-                Config.IS_TESTING
-                or os.environ.get("TESTING", "").lower() in {"1", "true", "yes"}
+                Config.IS_TESTING or os.environ.get("TESTING", "").lower() in {"1", "true", "yes"}
             ) and api_key.lower().startswith("test"):
                 user = {
                     "id": 0,
@@ -498,7 +495,7 @@ async def create_transcription(
             except OSError as cleanup_err:
                 logger.warning(f"[{request_id}] Failed to clean up temp file: {cleanup_err}")
         # Clean up executor
-        if 'executor' in locals():
+        if "executor" in locals():
             executor.shutdown(wait=False)
 
 
@@ -586,8 +583,7 @@ async def create_transcription_base64(
         user = await loop.run_in_executor(executor, get_user, api_key)
         if not user:
             if (
-                Config.IS_TESTING
-                or os.environ.get("TESTING", "").lower() in {"1", "true", "yes"}
+                Config.IS_TESTING or os.environ.get("TESTING", "").lower() in {"1", "true", "yes"}
             ) and api_key.lower().startswith("test"):
                 user = {
                     "id": 0,
@@ -664,9 +660,7 @@ async def create_transcription_base64(
             actual_duration = estimated_duration
 
         # Calculate actual cost based on real/estimated duration
-        total_cost, cost_per_minute, used_fallback_pricing = get_audio_cost(
-            model, actual_duration
-        )
+        total_cost, cost_per_minute, used_fallback_pricing = get_audio_cost(model, actual_duration)
 
         # --- Billing: deduct credits ---
         elapsed_ms = int(elapsed * 1000)
@@ -723,5 +717,5 @@ async def create_transcription_base64(
             except OSError as cleanup_err:
                 logger.warning(f"[{request_id}] Failed to clean up temp file: {cleanup_err}")
         # Clean up executor
-        if 'executor' in locals():
+        if "executor" in locals():
             executor.shutdown(wait=False)


### PR DESCRIPTION
## Summary
- Adds full billing to `/v1/audio/transcriptions` and `/v1/audio/transcriptions/base64`
- Auth changed from optional to required (`get_api_key`)
- Pricing: $0.006/min (Whisper), duration estimated from file size if not in response
- Pre-flight credit check, post-transcription deduction, gateway_usage in response

Closes #1144 (F1)

## Test plan
- [ ] Verify auth is now required (401 without API key)
- [ ] Check credit deduction occurs after successful transcription
- [ ] Verify pre-flight check rejects users with insufficient credits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added billing infrastructure to audio transcription endpoints (`/v1/audio/transcriptions` and `/v1/audio/transcriptions/base64`). Authentication changed from optional to required (`get_api_key`), implementing credit pre-flight checks with 10% buffer, duration estimation from file size as fallback, and post-transcription credit deduction following fail-safe patterns.

**Key changes:**
- Auth enforcement: switched from `get_optional_api_key` to `get_api_key` 
- Billing logic: pre-flight credit check, duration estimation (1MB/min for compressed, 10MB/min for WAV, 5MB/min for FLAC), pricing at $0.006/min for Whisper models
- Usage tracking: records usage with token equivalents (100 tokens/minute), increments API key usage counter
- Response enrichment: adds `gateway_usage` object with cost breakdown and balance info
- Tracing: integrates cost tracking into existing AI tracing infrastructure

**Issues found:**
- `ThreadPoolExecutor` cleanup may fail if exception occurs before executor initialization (lines 502, 727)
- Unused `background_tasks` parameter in both endpoints
- Unbounded `ThreadPoolExecutor()` without `max_workers` limit

<h3>Confidence Score: 3/5</h3>

- This PR is moderately safe to merge with fixes needed for executor cleanup logic
- The billing implementation follows established patterns from images.py and includes proper fail-safe mechanisms. However, executor cleanup in finally blocks has a logic flaw where it may fail if exceptions occur early (before executor initialization). The unused background_tasks parameter should be removed. The core billing logic is sound and includes appropriate safety buffers and error handling.
- Pay close attention to `src/routes/audio.py` executor cleanup logic in finally blocks (lines 502, 727)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/routes/audio.py | Added comprehensive billing system to audio transcription endpoints with auth enforcement, credit pre-checks, and usage tracking. Found executor cleanup issues and unused parameters. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Audio Transcription Request] --> B[Validate User Auth]
    B --> C{User Valid?}
    C -->|No| D[401 Unauthorized]
    C -->|Yes| E[Estimate Duration from File Size]
    E --> F[Calculate Estimated Cost]
    F --> G{Credits >= Cost * 1.1?}
    G -->|No| H[402 Payment Required]
    G -->|Yes| I[Call Whisper API]
    I --> J{API Success?}
    J -->|No| K[502 Bad Gateway]
    J -->|Yes| L[Get Actual Duration]
    L --> M[Calculate Final Cost]
    M --> N[Deduct Credits]
    N --> O{Deduction Success?}
    O -->|No| P[402/500 Error]
    O -->|Yes| Q[Record Usage Metrics]
    Q --> R[Increment API Key Usage]
    R --> S[Fetch Updated Balance]
    S --> T[Return Transcription + Gateway Usage]
```

<sub>Last reviewed commit: 58200e5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->