### PR TITLE
fix(billing): add resolution-aware image pricing

### DIFF
--- a/src/routes/images.py
+++ b/src/routes/images.py
@@ -59,43 +59,69 @@ IMAGE_COST_PER_IMAGE = {
 # to avoid revenue loss on new expensive models
 UNKNOWN_PROVIDER_DEFAULT_COST = 0.05
 
+# Resolution-based cost multipliers relative to 1024x1024 base rate
+# Higher resolutions require more compute and should cost more
+RESOLUTION_MULTIPLIERS = {
+    "256x256": 0.5,
+    "512x512": 0.75,
+    "1024x1024": 1.0,    # Base rate
+    "1024x1792": 1.5,    # HD portrait
+    "1792x1024": 1.5,    # HD landscape
+    "2048x2048": 2.0,    # Ultra HD
+}
+# Default multiplier for unknown/unrecognized sizes (backwards compatible)
+DEFAULT_RESOLUTION_MULTIPLIER = 1.0
 
-def get_image_cost(provider: str, model: str, num_images: int = 1) -> tuple[float, float, bool]:
+
+def get_image_cost(
+    provider: str, model: str, num_images: int = 1, size: str = None
+) -> tuple[float, float, bool, float]:
     """
-    Calculate the cost for image generation.
+    Calculate the cost for image generation with resolution-aware pricing.
 
     Args:
         provider: Image generation provider (deepinfra, fal, google-vertex)
         model: Model name
         num_images: Number of images to generate
+        size: Image resolution string (e.g. "1024x1024"). If None, uses default multiplier of 1.0.
 
     Returns:
-        Tuple of (total_cost, cost_per_image, is_fallback_pricing)
+        Tuple of (total_cost, cost_per_image, is_fallback_pricing, resolution_multiplier)
         is_fallback_pricing is True when using default/unknown pricing
+        resolution_multiplier is the multiplier applied based on the requested size
     """
     provider_pricing = IMAGE_COST_PER_IMAGE.get(provider, {})
     is_fallback = False
 
     if model in provider_pricing:
-        cost_per_image = provider_pricing[model]
+        base_cost_per_image = provider_pricing[model]
     elif "default" in provider_pricing:
-        cost_per_image = provider_pricing["default"]
+        base_cost_per_image = provider_pricing["default"]
         is_fallback = True
         logger.warning(
             f"Using default pricing for unknown model: provider={provider}, model={model}, "
-            f"cost_per_image={cost_per_image}"
+            f"base_cost_per_image={base_cost_per_image}"
         )
     else:
         # Unknown provider - use conservative high default to avoid revenue loss
-        cost_per_image = UNKNOWN_PROVIDER_DEFAULT_COST
+        base_cost_per_image = UNKNOWN_PROVIDER_DEFAULT_COST
         is_fallback = True
         logger.warning(
             f"Using fallback pricing for unknown provider: provider={provider}, model={model}, "
-            f"cost_per_image={cost_per_image}"
+            f"base_cost_per_image={base_cost_per_image}"
         )
 
+    # Apply resolution-based multiplier
+    if size is not None:
+        resolution_multiplier = RESOLUTION_MULTIPLIERS.get(
+            size.lower().strip(), DEFAULT_RESOLUTION_MULTIPLIER
+        )
+    else:
+        resolution_multiplier = DEFAULT_RESOLUTION_MULTIPLIER
+
+    cost_per_image = base_cost_per_image * resolution_multiplier
     total_cost = cost_per_image * num_images
-    return total_cost, cost_per_image, is_fallback
+    return total_cost, cost_per_image, is_fallback, resolution_multiplier
 
 
 @router.post("/images/generations", response_model=ImageGenerationResponse, tags=["images"])
@@ -223,8 +249,10 @@ async def generate_images(
                 req.provider if req.provider else "deepinfra"
             )  # Default to DeepInfra for images
 
-            # Calculate estimated cost for pre-flight check
-            estimated_cost, cost_per_image, _ = get_image_cost(provider, model, req.n)
+            # Calculate estimated cost for pre-flight check (resolution-aware)
+            estimated_cost, cost_per_image, _, resolution_multiplier = get_image_cost(
+                provider, model, req.n, size=req.size
+            )
 
             # Check if user has enough credits
             # Note: This is a pre-flight check. Actual deduction happens after generation.
@@ -301,9 +329,9 @@ async def generate_images(
                 # Calculate inference latency
                 elapsed = max(0.001, time.monotonic() - start)
 
-                # Calculate actual cost using provider pricing for tracing
-                trace_total_cost, trace_cost_per_image, _ = get_image_cost(
-                    actual_provider, model, req.n
+                # Calculate actual cost using provider pricing for tracing (resolution-aware)
+                trace_total_cost, trace_cost_per_image, _, _ = get_image_cost(
+                    actual_provider, model, req.n, size=req.size
                 )
                 # Set cost and metadata on trace using actual USD cost
                 trace_ctx.set_cost(trace_total_cost)
@@ -327,8 +355,18 @@ async def generate_images(
             )
 
             # Calculate actual cost using the provider that was used (may differ from requested)
-            total_cost, cost_per_image, used_fallback_pricing = get_image_cost(
-                actual_provider, model, req.n
+            # Resolution multiplier is applied based on requested size
+            total_cost, cost_per_image, used_fallback_pricing, resolution_multiplier = get_image_cost(
+                actual_provider, model, req.n, size=req.size
+            )
+
+            # Audit log: resolution-adjusted pricing for billing transparency
+            logger.info(
+                f"Image pricing: provider={actual_provider}, model={model}, "
+                f"size={req.size}, resolution_multiplier={resolution_multiplier}, "
+                f"cost_per_image=${cost_per_image:.4f}, num_images={req.n}, "
+                f"total_cost=${total_cost:.4f}, fallback_pricing={used_fallback_pricing}, "
+                f"user_id={user.get('id')}"
             )
 
             # Token-equivalent for rate limiting: use 100 tokens per image as a standardized unit
@@ -390,6 +428,8 @@ async def generate_images(
                 "user_api_key": f"{api_key[:10]}...",
                 "images_generated": req.n,
                 "used_fallback_pricing": used_fallback_pricing,
+                "size": req.size,
+                "resolution_multiplier": resolution_multiplier,
             }
 
             return processed_response

--- a/src/routes/images.py
+++ b/src/routes/images.py
@@ -64,10 +64,10 @@ UNKNOWN_PROVIDER_DEFAULT_COST = 0.05
 RESOLUTION_MULTIPLIERS = {
     "256x256": 0.5,
     "512x512": 0.75,
-    "1024x1024": 1.0,    # Base rate
-    "1024x1792": 1.5,    # HD portrait
-    "1792x1024": 1.5,    # HD landscape
-    "2048x2048": 2.0,    # Ultra HD
+    "1024x1024": 1.0,  # Base rate
+    "1024x1792": 1.5,  # HD portrait
+    "1792x1024": 1.5,  # HD landscape
+    "2048x2048": 2.0,  # Ultra HD
 }
 # Default multiplier for unknown/unrecognized sizes (backwards compatible)
 DEFAULT_RESOLUTION_MULTIPLIER = 1.0
@@ -356,8 +356,8 @@ async def generate_images(
 
             # Calculate actual cost using the provider that was used (may differ from requested)
             # Resolution multiplier is applied based on requested size
-            total_cost, cost_per_image, used_fallback_pricing, resolution_multiplier = get_image_cost(
-                actual_provider, model, req.n, size=req.size
+            total_cost, cost_per_image, used_fallback_pricing, resolution_multiplier = (
+                get_image_cost(actual_provider, model, req.n, size=req.size)
             )
 
             # Audit log: resolution-adjusted pricing for billing transparency


### PR DESCRIPTION
## Summary
- Adds resolution multipliers: 256x256=0.5x, 512x512=0.75x, 1024x1024=1.0x, 2048x2048=2.0x
- `get_image_cost()` accepts `size` param, applies multiplier to base cost
- Resolution info included in `gateway_usage` response metadata
- Backwards compatible: `size=None` → multiplier 1.0

Closes #1144 (F2)

## Test plan
- [ ] Verify 2048x2048 costs 2x the base rate
- [ ] Verify unknown sizes use default multiplier (1.0)
- [ ] Run updated image pricing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added resolution-aware image pricing that applies multipliers based on requested image size (256x256=0.5x, 512x512=0.75x, 1024x1024=1.0x, 1024x1792/1792x1024=1.5x, 2048x2048=2.0x). The `get_image_cost()` function now accepts a `size` parameter and returns the resolution multiplier as a fourth return value. Unknown sizes default to 1.0x multiplier for backwards compatibility.

Key changes:
- Resolution multipliers defined in `RESOLUTION_MULTIPLIERS` dictionary
- `get_image_cost()` signature updated with optional `size` parameter and returns 4-tuple
- All call sites updated to pass `req.size` and handle 4-tuple return
- Resolution info (`size`, `resolution_multiplier`) included in `gateway_usage` metadata
- Audit logging added for billing transparency
- Comprehensive test coverage for all multipliers, edge cases, and backwards compatibility

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-implemented feature with comprehensive testing and backwards compatibility
- Clean implementation with proper separation of concerns, backwards compatibility (size=None defaults to 1.0x), comprehensive test coverage including edge cases, and no breaking changes to existing functionality
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/routes/images.py | Added resolution-aware pricing with multipliers (0.5x-2.0x), included resolution metadata in response, backwards compatible |
| tests/routes/test_images.py | Comprehensive test coverage for resolution multipliers, backwards compatibility, and edge cases |

</details>



<sub>Last reviewed commit: b2ad511</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->