### PR TITLE
fix(pyroscope): remove duplicate service_name tag causing 400 push er…

### DIFF
--- a/src/services/pyroscope_config.py
+++ b/src/services/pyroscope_config.py
@@ -13,7 +13,7 @@ What you see in Grafana
 -----------------------
 1.  Inference Profiling dashboard — continuous flamegraph broken down by all
     tags applied at sampling time:
-        service_name – always "gatewayz-backend"          (init_pyroscope)
+        service_name – always "gatewayz-backend"          (application_name → implicit)
         environment  – Railway environment                 (init_pyroscope)
         endpoint     – normalised URL path                 (observability_middleware)
         method       – HTTP verb  (GET, POST, …)           (observability_middleware)
@@ -99,12 +99,14 @@ def init_pyroscope() -> bool:
         environment = os.getenv("RAILWAY_ENVIRONMENT", "local")
 
         configure_kwargs: dict = {
+            # application_name becomes the `service_name` label in Pyroscope 1.x push API.
+            # Do NOT also set service_name in tags — that creates a duplicate label
+            # which causes Pyroscope to return 400 on every push.
             "application_name": "gatewayz-backend",
             "server_address": server_address,
-            # Tags applied to every sample this process emits.
-            # These appear as filter labels in the Grafana Pyroscope UI.
+            # Extra tags applied to every sample (environment only — service_name
+            # is already set implicitly by application_name above).
             "tags": {
-                "service_name": "gatewayz-backend",
                 "environment": environment,
             },
             # 100 Hz = one sample every 10 ms.  This is the pyroscope default


### PR DESCRIPTION
…rors

The pyroscope-io SDK maps `application_name` → `service_name` label in Pyroscope 1.x's push.v1 gRPC API.  We were also explicitly passing `service_name` inside `tags{}`, producing a duplicate label in the protobuf payload.  Pyroscope 1.x rejects any push with conflicting labels with HTTP 400 — visible as the flood of:

  POST /push.v1.PusherService/Push  400  3ms

in the Pyroscope service access logs.

Fix: remove `service_name` from the explicit tags dict.  `application_name` already handles it.  Only `environment` needs to be an explicit tag.

TCP proxy is NOT needed — Railway's HTTP proxy supports HTTP/2 (required for gRPC).  The 400s were a label-format issue, not a transport issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a configuration issue causing duplicate labels that resulted in request errors.

* **Documentation**
  * Updated comments to clarify label mapping behavior in the monitoring configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes HTTP 400 errors by removing duplicate `service_name` tag from Pyroscope configuration. The pyroscope-io SDK automatically maps `application_name` → `service_name` label in Pyroscope 1.x's push.v1 gRPC API, so explicitly passing `service_name` in the tags dict created a conflicting duplicate label that Pyroscope rejected.

**Key changes:**
- Removed `"service_name": "gatewayz-backend"` from the `tags` dict (line 110)
- Added clear comments explaining that `application_name` implicitly sets `service_name`
- Updated docstring to reflect that `service_name` is now set implicitly via `application_name`
- Confirmed Railway's HTTP proxy supports HTTP/2 (no TCP proxy needed for gRPC)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it fixes a critical production bug with a minimal, well-documented change
- The fix correctly addresses the root cause (duplicate label in protobuf payload) with a single-line removal. The change is well-documented with clear comments explaining the SDK behavior, and the PR description provides excellent context about the error symptoms and verification
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/services/pyroscope_config.py | Removed duplicate `service_name` tag that was causing HTTP 400 errors from Pyroscope 1.x push API |

</details>



<sub>Last reviewed commit: 33edbff</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->