### PR TITLE
feat(profiling): instrument all Redis/cache layers with Pyroscope tags

### DIFF
--- a/src/services/auth_cache.py
+++ b/src/services/auth_cache.py
@@ -18,6 +18,8 @@ import json
 import logging
 from typing import Any
 
+from src.services.pyroscope_config import tag_wrapper
+
 logger = logging.getLogger(__name__)
 
 # Cache TTL in seconds
@@ -60,7 +62,8 @@ def cache_user_by_privy_id(privy_id: str, user_data: dict[str, Any]) -> bool:
             return False
 
         cache_key = f"{PRIVY_ID_CACHE_PREFIX}{privy_id}"
-        redis_client.setex(cache_key, AUTH_CACHE_TTL, json.dumps(user_data))
+        with tag_wrapper({"cache_layer": "auth", "cache_op": "write"}):
+            redis_client.setex(cache_key, AUTH_CACHE_TTL, json.dumps(user_data))
         logger.debug(f"Cached user data for Privy ID: {privy_id}")
         return True
     except Exception as e:
@@ -83,7 +86,8 @@ def get_cached_user_by_privy_id(privy_id: str) -> dict[str, Any] | None:
             return None
 
         cache_key = f"{PRIVY_ID_CACHE_PREFIX}{privy_id}"
-        cached_data = redis_client.get(cache_key)
+        with tag_wrapper({"cache_layer": "auth", "cache_op": "read"}):
+            cached_data = redis_client.get(cache_key)
 
         if cached_data:
             user_data = json.loads(cached_data)
@@ -112,7 +116,8 @@ def cache_user_by_username(username: str, user_data: dict[str, Any]) -> bool:
             return False
 
         cache_key = f"{USERNAME_CACHE_PREFIX}{username}"
-        redis_client.setex(cache_key, AUTH_CACHE_TTL, json.dumps(user_data))
+        with tag_wrapper({"cache_layer": "auth", "cache_op": "write"}):
+            redis_client.setex(cache_key, AUTH_CACHE_TTL, json.dumps(user_data))
         logger.debug(f"Cached user data for username: {username}")
         return True
     except Exception as e:
@@ -135,7 +140,8 @@ def get_cached_user_by_username(username: str) -> dict[str, Any] | None:
             return None
 
         cache_key = f"{USERNAME_CACHE_PREFIX}{username}"
-        cached_data = redis_client.get(cache_key)
+        with tag_wrapper({"cache_layer": "auth", "cache_op": "read"}):
+            cached_data = redis_client.get(cache_key)
 
         if cached_data:
             user_data = json.loads(cached_data)
@@ -203,7 +209,8 @@ def cache_user_by_api_key(api_key: str, user_data: dict[str, Any], ttl: int | No
             return False
 
         cache_key = f"{API_KEY_USER_PREFIX}{api_key}"
-        redis_client.setex(cache_key, ttl or USER_CACHE_TTL, json.dumps(user_data))
+        with tag_wrapper({"cache_layer": "auth", "cache_op": "write"}):
+            redis_client.setex(cache_key, ttl or USER_CACHE_TTL, json.dumps(user_data))
         logger.debug(f"Cached user data for API key: {api_key[:15]}...")
         return True
     except Exception as e:
@@ -229,7 +236,8 @@ def get_cached_user_by_api_key(api_key: str) -> dict[str, Any] | None:
             return None
 
         cache_key = f"{API_KEY_USER_PREFIX}{api_key}"
-        cached_data = redis_client.get(cache_key)
+        with tag_wrapper({"cache_layer": "auth", "cache_op": "read"}):
+            cached_data = redis_client.get(cache_key)
 
         if cached_data:
             user_data = json.loads(cached_data)
@@ -263,7 +271,8 @@ def invalidate_api_key_cache(api_key: str) -> bool:
             return False
 
         cache_key = f"{API_KEY_USER_PREFIX}{api_key}"
-        redis_client.delete(cache_key)
+        with tag_wrapper({"cache_layer": "auth", "cache_op": "delete"}):
+            redis_client.delete(cache_key)
         logger.debug(f"Invalidated API key cache: {api_key[:15]}...")
         return True
     except Exception as e:
@@ -300,7 +309,8 @@ def cache_api_key_validation(
             "cached_at": json.dumps(None),  # Placeholder for timestamp
         }
 
-        redis_client.setex(cache_key, ttl or API_KEY_CACHE_TTL, json.dumps(validation_data))
+        with tag_wrapper({"cache_layer": "auth", "cache_op": "write"}):
+            redis_client.setex(cache_key, ttl or API_KEY_CACHE_TTL, json.dumps(validation_data))
         logger.debug(f"Cached API key validation: {api_key[:15]}... (valid: {is_valid})")
         return True
     except Exception as e:
@@ -323,7 +333,8 @@ def get_cached_api_key_validation(api_key: str) -> dict[str, Any] | None:
             return None
 
         cache_key = f"{API_KEY_CACHE_PREFIX}{api_key}"
-        cached_data = redis_client.get(cache_key)
+        with tag_wrapper({"cache_layer": "auth", "cache_op": "read"}):
+            cached_data = redis_client.get(cache_key)
 
         if cached_data:
             validation_data = json.loads(cached_data)
@@ -353,7 +364,8 @@ def cache_user_by_id(user_id: int, user_data: dict[str, Any], ttl: int | None = 
             return False
 
         cache_key = f"{USER_ID_CACHE_PREFIX}{user_id}"
-        redis_client.setex(cache_key, ttl or USER_CACHE_TTL, json.dumps(user_data))
+        with tag_wrapper({"cache_layer": "auth", "cache_op": "write"}):
+            redis_client.setex(cache_key, ttl or USER_CACHE_TTL, json.dumps(user_data))
         logger.debug(f"Cached user data for user ID: {user_id}")
         return True
     except Exception as e:
@@ -376,7 +388,8 @@ def get_cached_user_by_id(user_id: int) -> dict[str, Any] | None:
             return None
 
         cache_key = f"{USER_ID_CACHE_PREFIX}{user_id}"
-        cached_data = redis_client.get(cache_key)
+        with tag_wrapper({"cache_layer": "auth", "cache_op": "read"}):
+            cached_data = redis_client.get(cache_key)
 
         if cached_data:
             user_data = json.loads(cached_data)
@@ -407,7 +420,8 @@ def invalidate_user_by_id(user_id: int) -> bool:
 
         # Invalidate user ID cache
         user_cache_key = f"{USER_ID_CACHE_PREFIX}{user_id}"
-        redis_client.delete(user_cache_key)
+        with tag_wrapper({"cache_layer": "auth", "cache_op": "delete"}):
+            redis_client.delete(user_cache_key)
 
         # Note: We can't easily invalidate API key caches without knowing the keys
         # Consider adding a user_id -> api_keys mapping if needed


### PR DESCRIPTION
Wraps every Redis I/O operation in the five hot-path cache layers with pyroscope.tag_wrapper() so their CPU cost is visible as named segments in the Pyroscope flamegraph — no new dashboard panels needed, the existing Inference-Call-Profile and Inference-Profiling flamegraphs pick these up.

Tags applied:
  cache_layer  — auth | rate_limit | model_catalog | response_cache | trial_analytics
  cache_op     — read | write | delete

Cache layers instrumented:

auth_cache.py (every request)
  - get/set/delete: api_key → user, user_id → user, privy_id → user, username → user, api_key validation

rate_limiting.py (every request — uses asyncio.to_thread pipelines)
  - _get_burst_state    → read  (token bucket hget)
  - _consume_token      → write (token bucket hset + expire)
  - _get_current_counts → read  (sliding window pipeline get)
  - _update_counters    → write (sliding window pipeline incr + expire)

model_catalog_cache.py (every inference request)
  - get/set/invalidate: full_catalog, provider_catalog

response_cache.py (inference — Redis-backed with Sentry span compat)
  - Redis get/set: both Sentry-instrumented and bare paths wrapped

trials.py — trial analytics summary
  - get_cache, set_cache, delete_cache on trial:analytics:summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal observability and monitoring across cache layer operations to improve system reliability and performance insights. Added instrumentation tagging to cache read, write, and delete operations across multiple system components, enabling better tracking and analysis of cache behavior without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wraps all Redis I/O operations across five hot-path cache layers with `pyroscope.tag_wrapper()` to expose cache performance in Pyroscope flamegraphs. Each operation is tagged with `cache_layer` (auth, rate_limit, model_catalog, response_cache, trial_analytics) and `cache_op` (read, write, delete), enabling flamegraph filtering to identify CPU cost per cache layer and operation type.

**Key changes:**
- **auth_cache.py**: All API key, user ID, Privy ID, and username lookup operations tagged (executed on every request)
- **rate_limiting.py**: Redis pipeline operations in burst limit and sliding window checks tagged (wrapped inside `asyncio.to_thread` contexts)
- **model_catalog_cache.py**: Full catalog and per-provider catalog cache operations tagged
- **response_cache.py**: Both Sentry-traced and non-traced Redis get/set paths instrumented (preserves existing Sentry span nesting)
- **trials.py**: Trial analytics summary cache operations tagged

**Implementation details:**
- `tag_wrapper()` returns `nullcontext()` when Pyroscope is disabled or unavailable, ensuring zero runtime impact when profiling is off
- Tags are applied at the correct scope: wrapping synchronous Redis calls that are executed via `asyncio.to_thread()`
- Existing Sentry tracing in `response_cache.py` is preserved; Pyroscope tags wrap the outer Redis operation while Sentry spans remain nested inside
- All changes maintain existing error handling and logging behavior

<h3>Confidence Score: 5/5</h3>

- Safe to merge - non-invasive observability instrumentation with automatic fallback to no-op when disabled
- Implementation is thoroughly safe: tag_wrapper returns nullcontext() when Pyroscope is unavailable (zero runtime impact), all existing error handling and Sentry tracing preserved, changes only add context manager wrappers without modifying Redis operation logic, and nested contexts in response_cache.py are correctly ordered (Pyroscope outer, Sentry inner)
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/db/trials.py | Wrapped trial analytics cache operations (get/set/delete) with `cache_layer: trial_analytics` tags |
| src/services/auth_cache.py | Instrumented all auth cache functions (API key, user ID, Privy ID, username lookups) with `cache_layer: auth` tags |
| src/services/model_catalog_cache.py | Added Pyroscope tags to full catalog and per-provider catalog cache operations with `cache_layer: model_catalog` |
| src/services/rate_limiting.py | Wrapped Redis pipeline operations in burst limit and sliding window checks with `cache_layer: rate_limit` tags |
| src/services/response_cache.py | Instrumented Redis cache operations (both Sentry-traced and non-traced paths) with `cache_layer: response_cache` tags |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Request] --> B{Auth Cache Layer}
    B -->|cache_op: read| B1[Check API Key/User Cache]
    B1 --> C{Rate Limit Layer}
    
    C -->|cache_op: read| C1[Get Burst State Pipeline]
    C -->|cache_op: read| C2[Get Sliding Window Counts]
    C1 --> C3{Tokens Available?}
    C2 --> C3
    C3 -->|Yes| C4[cache_op: write - Consume Token]
    C4 --> D{Model Catalog Cache}
    
    D -->|cache_op: read| D1[Get Full/Provider Catalog]
    D1 --> E{Response Cache Layer}
    
    E -->|cache_op: read| E1[Check Redis for Cached Response]
    E1 -->|Miss| F[Execute Inference]
    F --> E2[cache_op: write - Store Response]
    E1 -->|Hit| G[Return Cached Response]
    E2 --> G
    
    G --> H[Response]
    
    B -->|Cache Miss| B2[cache_op: write - Cache User Data]
    B2 --> C
    
    I[Trial Analytics Request] --> J{Trial Analytics Cache}
    J -->|cache_op: read| J1[Get Analytics Summary]
    J1 -->|Miss| J2[Compute Analytics]
    J2 --> J3[cache_op: write - Cache Summary]
    J3 --> K[Return Analytics]
    J1 -->|Hit| K
    
    style B fill:#e1f5ff
    style C fill:#ffe1e1
    style D fill:#fff4e1
    style E fill:#e8ffe1
    style J fill:#f3e1ff
```

<sub>Last reviewed commit: 54f769a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->