### PR TITLE
feat: pricing audit system + stale model auto-deactivation

### DIFF
--- a/src/db/models_catalog_db.py
+++ b/src/db/models_catalog_db.py
@@ -433,10 +433,12 @@ def process_stale_models(
     if ids_to_reset:
         for i in range(0, len(ids_to_reset), 500):
             chunk = ids_to_reset[i : i + 500]
-            supabase.table("models").update({
-                "last_seen_in_provider_at": now,
-                "consecutive_missing_count": 0,
-            }).in_("id", chunk).execute()
+            supabase.table("models").update(
+                {
+                    "last_seen_in_provider_at": now,
+                    "consecutive_missing_count": 0,
+                }
+            ).in_("id", chunk).execute()
         result["reset"] = len(ids_to_reset)
 
     # Batch update: increment missing models
@@ -449,19 +451,23 @@ def process_stale_models(
         for count_val, id_list in by_count.items():
             for i in range(0, len(id_list), 500):
                 chunk = id_list[i : i + 500]
-                supabase.table("models").update({
-                    "consecutive_missing_count": count_val,
-                }).in_("id", chunk).execute()
+                supabase.table("models").update(
+                    {
+                        "consecutive_missing_count": count_val,
+                    }
+                ).in_("id", chunk).execute()
         result["incremented"] = len(ids_to_increment)
 
     # Batch update: deactivate models that exceeded threshold
     if ids_to_deactivate:
         for i in range(0, len(ids_to_deactivate), 500):
             chunk = ids_to_deactivate[i : i + 500]
-            supabase.table("models").update({
-                "is_active": False,
-                "consecutive_missing_count": deactivation_threshold,
-            }).in_("id", chunk).execute()
+            supabase.table("models").update(
+                {
+                    "is_active": False,
+                    "consecutive_missing_count": deactivation_threshold,
+                }
+            ).in_("id", chunk).execute()
         result["deactivated"] = len(ids_to_deactivate)
         logger.info(
             f"Deactivated {len(ids_to_deactivate)} stale models for provider_id={provider_id} "

--- a/src/db/models_catalog_db.py
+++ b/src/db/models_catalog_db.py
@@ -359,6 +359,118 @@ def activate_model(model_id: int) -> dict[str, Any] | None:
     return update_model(model_id, {"is_active": True})
 
 
+def process_stale_models(
+    provider_id: int,
+    seen_provider_model_ids: set[str],
+    deactivation_threshold: int = 3,
+) -> dict[str, Any]:
+    """
+    Track and deactivate models that are no longer listed by a provider.
+
+    After a successful provider sync, call this with the set of model IDs
+    that were returned by the provider API.  Models in the DB for this
+    provider that are NOT in the set get their consecutive_missing_count
+    incremented.  Once the count reaches the threshold, they are
+    soft-deactivated (is_active = false).
+
+    Args:
+        provider_id: The provider's database ID.
+        seen_provider_model_ids: Set of provider_model_id values returned
+            by the provider API in this sync cycle.
+        deactivation_threshold: Number of consecutive misses before
+            deactivation (default: 3).
+
+    Returns:
+        Dict with counts: reset, incremented, deactivated.
+    """
+    from datetime import UTC, datetime
+
+    supabase = get_client_for_query(read_only=False)
+    now = datetime.now(UTC).isoformat()
+    result = {"reset": 0, "incremented": 0, "deactivated": 0}
+
+    # Fetch all active models for this provider
+    all_active: list[dict] = []
+    page_size = SUPABASE_PAGE_SIZE
+    offset = 0
+    while True:
+        batch = (
+            supabase.table("models")
+            .select("id, provider_model_id, consecutive_missing_count")
+            .eq("provider_id", provider_id)
+            .eq("is_active", True)
+            .range(offset, offset + page_size - 1)
+            .execute()
+        ).data or []
+        all_active.extend(batch)
+        if len(batch) < page_size:
+            break
+        offset += page_size
+
+    if not all_active:
+        return result
+
+    # Split into seen vs unseen
+    ids_to_reset: list[int] = []
+    ids_to_increment: list[tuple[int, int]] = []  # (id, new_count)
+    ids_to_deactivate: list[int] = []
+
+    for model in all_active:
+        db_id = model["id"]
+        pmid = model.get("provider_model_id", "")
+
+        if pmid in seen_provider_model_ids:
+            # Model is still listed — reset counter
+            ids_to_reset.append(db_id)
+        else:
+            new_count = (model.get("consecutive_missing_count") or 0) + 1
+            if new_count >= deactivation_threshold:
+                ids_to_deactivate.append(db_id)
+            else:
+                ids_to_increment.append((db_id, new_count))
+
+    # Batch update: reset seen models
+    if ids_to_reset:
+        for i in range(0, len(ids_to_reset), 500):
+            chunk = ids_to_reset[i : i + 500]
+            supabase.table("models").update({
+                "last_seen_in_provider_at": now,
+                "consecutive_missing_count": 0,
+            }).in_("id", chunk).execute()
+        result["reset"] = len(ids_to_reset)
+
+    # Batch update: increment missing models
+    # Unfortunately Supabase doesn't support per-row values in batch,
+    # so we update each count value in groups
+    if ids_to_increment:
+        by_count: dict[int, list[int]] = {}
+        for db_id, new_count in ids_to_increment:
+            by_count.setdefault(new_count, []).append(db_id)
+        for count_val, id_list in by_count.items():
+            for i in range(0, len(id_list), 500):
+                chunk = id_list[i : i + 500]
+                supabase.table("models").update({
+                    "consecutive_missing_count": count_val,
+                }).in_("id", chunk).execute()
+        result["incremented"] = len(ids_to_increment)
+
+    # Batch update: deactivate models that exceeded threshold
+    if ids_to_deactivate:
+        for i in range(0, len(ids_to_deactivate), 500):
+            chunk = ids_to_deactivate[i : i + 500]
+            supabase.table("models").update({
+                "is_active": False,
+                "consecutive_missing_count": deactivation_threshold,
+            }).in_("id", chunk).execute()
+        result["deactivated"] = len(ids_to_deactivate)
+        logger.info(
+            f"Deactivated {len(ids_to_deactivate)} stale models for provider_id={provider_id} "
+            f"(missing for {deactivation_threshold}+ consecutive syncs)"
+        )
+
+    return result
+
+
 def update_model_health(
     model_id: int,
     health_status: str,

--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -2587,9 +2587,47 @@ async def get_model_usage_analytics(
 
 
 # ============================================================================
-# ADMIN PRICING SCHEDULER - Automated Pricing Sync (Phase 2.5/Phase 3)
+# ADMIN PRICING AUDIT - Compare provider vs DB pricing
 # ============================================================================
-# Endpoints to monitor and control the automated pricing sync scheduler
+
+
+@router.get("/admin/pricing-audit", tags=["admin"])
+async def run_pricing_audit(
+    admin_user: dict = Depends(require_admin),
+    gateway: str = Query(
+        None,
+        description="Specific gateway(s) to audit, comma-separated (e.g. 'openrouter,deepinfra'). Omit to audit all.",
+    ),
+    threshold: float = Query(
+        0.0,
+        description="Minimum percentage difference to flag as a mismatch (default: 0% = exact match)",
+        ge=0.0,
+        le=100.0,
+    ),
+):
+    """
+    Run a pricing audit comparing live provider catalogs against database pricing.
+
+    Returns a report grouped by gateway/provider with:
+    - Summary stats (total models, mismatches, missing)
+    - Per-gateway breakdown with individual model mismatches
+    - Pricing shown in both per-token and per-million-token formats
+
+    Requires admin authentication.
+    """
+    from src.services.pricing_audit import run_pricing_audit as execute_audit
+
+    gateways = None
+    if gateway:
+        gateways = [g.strip().lower() for g in gateway.split(",") if g.strip()]
+
+    report = await asyncio.to_thread(
+        execute_audit,
+        gateways=gateways,
+        threshold_percent=threshold,
+    )
+
+    return report
 
 
 # ============================================================================

--- a/src/services/model_catalog_sync.py
+++ b/src/services/model_catalog_sync.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
 
+from src.config.supabase_config import get_client_for_query
 from src.db.models_catalog_db import bulk_upsert_models
 from src.db.providers_db import (
     create_provider,
@@ -735,6 +736,7 @@ def sync_provider_models(
         )
 
         # Sync to database (unless dry run)
+        stale_result: dict[str, Any] = {}
         if not dry_run:
             logger.info(f"[{provider_slug.upper()}] Starting database sync...")
             db_sync_start = time.time()
@@ -751,6 +753,54 @@ def sync_provider_models(
 
             # Pricing is now synced directly during model sync via metadata.pricing_raw
             # The separate pricing sync service has been deprecated
+
+            # ── Stale model tracking ──────────────────────────────────
+            # Mark models that disappeared from the provider API.
+            # Safety guard: only run if we fetched at least 50% of the
+            # existing active models (avoids mass-deactivation on partial
+            # API failures or rate-limited responses).
+            try:
+                from src.db.models_catalog_db import process_stale_models
+
+                seen_ids = {m["provider_model_id"] for m in db_models if m.get("provider_model_id")}
+
+                # Count existing active models for this provider
+                existing_active = (
+                    get_client_for_query(read_only=True)
+                    .table("models")
+                    .select("id", count="exact")
+                    .eq("provider_id", provider["id"])
+                    .eq("is_active", True)
+                    .execute()
+                )
+                existing_count = existing_active.count or 0
+
+                if existing_count > 0 and len(seen_ids) >= existing_count * 0.5:
+                    stale_result = process_stale_models(
+                        provider_id=provider["id"],
+                        seen_provider_model_ids=seen_ids,
+                        deactivation_threshold=3,
+                    )
+                    if stale_result.get("deactivated", 0) > 0:
+                        logger.warning(
+                            f"[{provider_slug.upper()}] Stale model cleanup | "
+                            f"Reset: {stale_result['reset']} | "
+                            f"Incremented: {stale_result['incremented']} | "
+                            f"Deactivated: {stale_result['deactivated']}"
+                        )
+                    else:
+                        logger.info(
+                            f"[{provider_slug.upper()}] Stale tracking | "
+                            f"Reset: {stale_result.get('reset', 0)} | "
+                            f"Incremented: {stale_result.get('incremented', 0)}"
+                        )
+                elif existing_count > 0:
+                    logger.warning(
+                        f"[{provider_slug.upper()}] Skipping stale detection: "
+                        f"fetched {len(seen_ids)} < 50% of {existing_count} existing active models"
+                    )
+            except Exception as stale_e:
+                logger.error(f"[{provider_slug.upper()}] Stale model tracking failed: {stale_e}")
 
             # Invalidate caches to ensure fresh data is served on next request.
             # In batch_mode, only invalidate provider-specific cache (no cascade
@@ -794,7 +844,7 @@ def sync_provider_models(
             f"Overall Rate: {models_per_sec:.0f} models/sec"
         )
 
-        return {
+        result = {
             "success": True,
             "provider": provider_slug,
             "provider_id": provider["id"],
@@ -807,6 +857,9 @@ def sync_provider_models(
             "total_duration": total_duration,
             "models_per_sec": round(models_per_sec, 2),
         }
+        if stale_result:
+            result["stale_tracking"] = stale_result
+        return result
 
     except Exception as e:
         logger.error(f"Error syncing models for {provider_slug}: {e}", exc_info=True)

--- a/src/services/model_catalog_sync.py
+++ b/src/services/model_catalog_sync.py
@@ -751,7 +751,9 @@ def sync_provider_models(
                 )
                 pre_sync_active_count = existing_active.count or 0
             except Exception as count_e:
-                logger.warning(f"[{provider_slug.upper()}] Failed to count active models: {count_e}")
+                logger.warning(
+                    f"[{provider_slug.upper()}] Failed to count active models: {count_e}"
+                )
 
             logger.info(f"[{provider_slug.upper()}] Starting database sync...")
             db_sync_start = time.time()

--- a/src/services/model_catalog_sync.py
+++ b/src/services/model_catalog_sync.py
@@ -738,6 +738,21 @@ def sync_provider_models(
         # Sync to database (unless dry run)
         stale_result: dict[str, Any] = {}
         if not dry_run:
+            # Count existing active models BEFORE upsert for accurate stale detection
+            pre_sync_active_count = 0
+            try:
+                existing_active = (
+                    get_client_for_query(read_only=False)
+                    .table("models")
+                    .select("id", count="exact")
+                    .eq("provider_id", provider["id"])
+                    .eq("is_active", True)
+                    .execute()
+                )
+                pre_sync_active_count = existing_active.count or 0
+            except Exception as count_e:
+                logger.warning(f"[{provider_slug.upper()}] Failed to count active models: {count_e}")
+
             logger.info(f"[{provider_slug.upper()}] Starting database sync...")
             db_sync_start = time.time()
             synced_models = bulk_upsert_models(db_models)
@@ -757,25 +772,14 @@ def sync_provider_models(
             # ── Stale model tracking ──────────────────────────────────
             # Mark models that disappeared from the provider API.
             # Safety guard: only run if we fetched at least 50% of the
-            # existing active models (avoids mass-deactivation on partial
+            # pre-sync active models (avoids mass-deactivation on partial
             # API failures or rate-limited responses).
             try:
                 from src.db.models_catalog_db import process_stale_models
 
                 seen_ids = {m["provider_model_id"] for m in db_models if m.get("provider_model_id")}
 
-                # Count existing active models for this provider
-                existing_active = (
-                    get_client_for_query(read_only=True)
-                    .table("models")
-                    .select("id", count="exact")
-                    .eq("provider_id", provider["id"])
-                    .eq("is_active", True)
-                    .execute()
-                )
-                existing_count = existing_active.count or 0
-
-                if existing_count > 0 and len(seen_ids) >= existing_count * 0.5:
+                if pre_sync_active_count > 0 and len(seen_ids) >= pre_sync_active_count * 0.5:
                     stale_result = process_stale_models(
                         provider_id=provider["id"],
                         seen_provider_model_ids=seen_ids,
@@ -794,10 +798,10 @@ def sync_provider_models(
                             f"Reset: {stale_result.get('reset', 0)} | "
                             f"Incremented: {stale_result.get('incremented', 0)}"
                         )
-                elif existing_count > 0:
+                elif pre_sync_active_count > 0:
                     logger.warning(
                         f"[{provider_slug.upper()}] Skipping stale detection: "
-                        f"fetched {len(seen_ids)} < 50% of {existing_count} existing active models"
+                        f"fetched {len(seen_ids)} < 50% of {pre_sync_active_count} existing active models"
                     )
             except Exception as stale_e:
                 logger.error(f"[{provider_slug.upper()}] Stale model tracking failed: {stale_e}")

--- a/src/services/pricing_audit.py
+++ b/src/services/pricing_audit.py
@@ -293,7 +293,9 @@ def _match_models(
                 if did in matched_db_ids:
                     continue
                 if pid in remaining_provider and did in remaining_db:
-                    matched.append((remaining_provider.pop(pid), remaining_db.pop(did), "strip_prefix"))
+                    matched.append(
+                        (remaining_provider.pop(pid), remaining_db.pop(did), "strip_prefix")
+                    )
                     matched_prov_ids.add(pid)
                     matched_db_ids.add(did)
 
@@ -308,8 +310,10 @@ def _match_models(
 
 
 def _to_decimal(value: Any) -> Decimal | None:
-    """Safely convert a pricing value to Decimal."""
-    if value is None or value == "" or value == "0" or value == 0:
+    """Safely convert a pricing value to Decimal. Returns None for missing data."""
+    if value is None or value == "":
+        return None
+    if value == "0" or value == 0:
         return Decimal("0")
     try:
         d = Decimal(str(value))
@@ -379,7 +383,9 @@ def _guess_unmatched_reason(model_id: str, source: str, other_ids: set[str]) -> 
             return "Contains colon in ID (stripped by DB clean_model_name during sync) — may exist under cleaned name"
         if "(" in model_id:
             return "Contains parenthetical info (stripped by DB clean_model_name) — may exist under cleaned name"
-        return "Model exists in provider API but not found in database — may not have been synced yet"
+        return (
+            "Model exists in provider API but not found in database — may not have been synced yet"
+        )
     else:
         return "Model exists in database but provider no longer lists it — may have been removed or renamed"
 
@@ -534,10 +540,12 @@ def _raw_fetch_provider(gateway: str) -> list[dict]:
 
         pricing = _extract_raw_pricing(raw, gateway, provider_format, normalize_to_per_token)
 
-        models.append({
-            "id": model_id,
-            "pricing": pricing,
-        })
+        models.append(
+            {
+                "id": model_id,
+                "pricing": pricing,
+            }
+        )
 
     logger.info(f"Raw fetched {len(models)} models from {gateway} API")
     return models
@@ -577,7 +585,7 @@ def _extract_raw_pricing(
                 if normalized is not None:
                     pricing["prompt"] = str(normalized)
             except (InvalidOperation, ValueError):
-                pass
+                pass  # Skip malformed pricing values
         if cents_out is not None:
             try:
                 dollars_per_1m = float(Decimal(str(cents_out)) / Decimal("100"))
@@ -585,13 +593,21 @@ def _extract_raw_pricing(
                 if normalized is not None:
                     pricing["completion"] = str(normalized)
             except (InvalidOperation, ValueError):
-                pass
+                pass  # Skip malformed pricing values
         return pricing
 
     # Generic pattern: pricing.input/output or pricing.prompt/completion
     # For most providers: values are per-1M tokens, need normalization to per-token
-    prompt_val = raw_pricing.get("prompt") if raw_pricing.get("prompt") is not None else raw_pricing.get("input")
-    completion_val = raw_pricing.get("completion") if raw_pricing.get("completion") is not None else raw_pricing.get("output")
+    prompt_val = (
+        raw_pricing.get("prompt")
+        if raw_pricing.get("prompt") is not None
+        else raw_pricing.get("input")
+    )
+    completion_val = (
+        raw_pricing.get("completion")
+        if raw_pricing.get("completion") is not None
+        else raw_pricing.get("output")
+    )
 
     # Some providers use cents_per_input_token format (groq, fireworks)
     if prompt_val is None:
@@ -600,7 +616,7 @@ def _extract_raw_pricing(
             try:
                 prompt_val = float(cents_in) / 100  # cents → dollars per 1M
             except (ValueError, TypeError):
-                pass
+                pass  # Skip non-numeric pricing values
 
     if completion_val is None:
         cents_out = raw_pricing.get("cents_per_output_token")
@@ -608,7 +624,7 @@ def _extract_raw_pricing(
             try:
                 completion_val = float(cents_out) / 100  # cents → dollars per 1M
             except (ValueError, TypeError):
-                pass
+                pass  # Skip non-numeric pricing values
 
     # Normalize to per-token
     if prompt_val is not None:
@@ -636,7 +652,10 @@ def _fetch_db_models_by_gateway() -> dict[str, list[dict]]:
             provider = raw_model.get("providers") or {}
             slug = provider.get("slug", "unknown")
 
-            from src.services.pricing_normalization import get_provider_format, normalize_to_per_token
+            from src.services.pricing_normalization import (
+                get_provider_format,
+                normalize_to_per_token,
+            )
 
             metadata = raw_model.get("metadata") or {}
             pricing_raw = metadata.get("pricing_raw") if isinstance(metadata, dict) else None
@@ -661,8 +680,13 @@ def _fetch_db_models_by_gateway() -> dict[str, list[dict]]:
             if not pricing.get("prompt") and raw_model.get("pricing_original_prompt") is not None:
                 norm = normalize_to_per_token(raw_model["pricing_original_prompt"], provider_fmt)
                 pricing["prompt"] = str(norm) if norm is not None else None
-            if not pricing.get("completion") and raw_model.get("pricing_original_completion") is not None:
-                norm = normalize_to_per_token(raw_model["pricing_original_completion"], provider_fmt)
+            if (
+                not pricing.get("completion")
+                and raw_model.get("pricing_original_completion") is not None
+            ):
+                norm = normalize_to_per_token(
+                    raw_model["pricing_original_completion"], provider_fmt
+                )
                 pricing["completion"] = str(norm) if norm is not None else None
 
             model_entry = {
@@ -711,22 +735,26 @@ def _audit_gateway(
     # Process unmatched provider models
     for m in sorted(unmatched_prov, key=lambda x: x.get("id", "")):
         mid = m.get("id", "")
-        result.unmatched_provider.append(UnmatchedModel(
-            model_id=mid,
-            source="provider",
-            reason=_guess_unmatched_reason(mid, "provider", all_db_ids),
-            pricing=_pricing_summary(m),
-        ))
+        result.unmatched_provider.append(
+            UnmatchedModel(
+                model_id=mid,
+                source="provider",
+                reason=_guess_unmatched_reason(mid, "provider", all_db_ids),
+                pricing=_pricing_summary(m),
+            )
+        )
 
     # Process unmatched DB models
     for m in sorted(unmatched_db, key=lambda x: x.get("id", "")):
         mid = m.get("id", "")
-        result.unmatched_db.append(UnmatchedModel(
-            model_id=mid,
-            source="database",
-            reason=_guess_unmatched_reason(mid, "database", all_prov_ids),
-            pricing=_pricing_summary(m),
-        ))
+        result.unmatched_db.append(
+            UnmatchedModel(
+                model_id=mid,
+                source="database",
+                reason=_guess_unmatched_reason(mid, "database", all_prov_ids),
+                pricing=_pricing_summary(m),
+            )
+        )
 
     # Compare pricing for matched models
     for prov_model, db_model, match_method in matched_pairs:
@@ -739,12 +767,14 @@ def _audit_gateway(
         # Skip models where provider has no pricing data
         if prov_pricing["prompt"] is None and prov_pricing["completion"] is None:
             result.models_without_pricing += 1
-            result.matched_models.append(MatchedModel(
-                provider_id=prov_id,
-                db_id=db_id,
-                match_method=match_method,
-                pricing_status="no_provider_pricing",
-            ))
+            result.matched_models.append(
+                MatchedModel(
+                    provider_id=prov_id,
+                    db_id=db_id,
+                    match_method=match_method,
+                    pricing_status="no_provider_pricing",
+                )
+            )
             continue
 
         result.models_with_pricing += 1
@@ -760,51 +790,59 @@ def _audit_gateway(
             if db_val is None:
                 if prov_val > 0:
                     has_mismatch = True
-                    result.mismatches.append(PricingMismatch(
-                        model_id=prov_id,
-                        db_model_id=db_id,
-                        gateway=gateway,
-                        field=price_field,
-                        provider_price=str(prov_val),
-                        db_price="MISSING",
-                        difference_percent=100.0,
-                        provider_price_per_million=_per_million(prov_val),
-                        db_price_per_million="MISSING",
-                    ))
+                    result.mismatches.append(
+                        PricingMismatch(
+                            model_id=prov_id,
+                            db_model_id=db_id,
+                            gateway=gateway,
+                            field=price_field,
+                            provider_price=str(prov_val),
+                            db_price="MISSING",
+                            difference_percent=100.0,
+                            provider_price_per_million=_per_million(prov_val),
+                            db_price_per_million="MISSING",
+                        )
+                    )
                 continue
 
             diff_pct = _calc_diff_percent(prov_val, db_val)
 
             if diff_pct > threshold:
                 has_mismatch = True
-                result.mismatches.append(PricingMismatch(
-                    model_id=prov_id,
-                    db_model_id=db_id,
-                    gateway=gateway,
-                    field=price_field,
-                    provider_price=str(prov_val),
-                    db_price=str(db_val),
-                    difference_percent=round(diff_pct, 2),
-                    provider_price_per_million=_per_million(prov_val),
-                    db_price_per_million=_per_million(db_val),
-                ))
+                result.mismatches.append(
+                    PricingMismatch(
+                        model_id=prov_id,
+                        db_model_id=db_id,
+                        gateway=gateway,
+                        field=price_field,
+                        provider_price=str(prov_val),
+                        db_price=str(db_val),
+                        difference_percent=round(diff_pct, 2),
+                        provider_price_per_million=_per_million(prov_val),
+                        db_price_per_million=_per_million(db_val),
+                    )
+                )
 
         if has_mismatch:
             result.models_mismatched += 1
-            result.matched_models.append(MatchedModel(
-                provider_id=prov_id,
-                db_id=db_id,
-                match_method=match_method,
-                pricing_status="mismatch",
-            ))
+            result.matched_models.append(
+                MatchedModel(
+                    provider_id=prov_id,
+                    db_id=db_id,
+                    match_method=match_method,
+                    pricing_status="mismatch",
+                )
+            )
         else:
             result.models_matched += 1
-            result.matched_models.append(MatchedModel(
-                provider_id=prov_id,
-                db_id=db_id,
-                match_method=match_method,
-                pricing_status="match",
-            ))
+            result.matched_models.append(
+                MatchedModel(
+                    provider_id=prov_id,
+                    db_id=db_id,
+                    match_method=match_method,
+                    pricing_status="match",
+                )
+            )
 
     return result
 
@@ -836,9 +874,7 @@ def run_pricing_audit(
 
     all_gateways = _get_all_gateways()
     if gateways:
-        target_gateways = {
-            g: all_gateways.get(g, g) for g in gateways if g in all_gateways
-        }
+        target_gateways = {g: all_gateways.get(g, g) for g in gateways if g in all_gateways}
     else:
         target_gateways = all_gateways
 
@@ -858,10 +894,7 @@ def run_pricing_audit(
     fetch_errors: dict[str, str] = {}
 
     with ThreadPoolExecutor(max_workers=10) as executor:
-        futures = {
-            executor.submit(_fetch_provider_models, gw): gw
-            for gw in target_gateways
-        }
+        futures = {executor.submit(_fetch_provider_models, gw): gw for gw in target_gateways}
         try:
             for future in as_completed(futures, timeout=180):
                 gw = futures[future]
@@ -950,41 +983,49 @@ def _serialize_report(report: PricingAuditReport) -> dict[str, Any]:
     for gw, gw_result in report.gateways.items():
         mismatches_list = []
         for m in gw_result.mismatches:
-            mismatches_list.append({
-                "model_id": m.model_id,
-                "db_model_id": m.db_model_id,
-                "field": m.field,
-                "provider_price_per_token": m.provider_price,
-                "db_price_per_token": m.db_price,
-                "provider_price_per_million": m.provider_price_per_million,
-                "db_price_per_million": m.db_price_per_million,
-                "difference_percent": m.difference_percent,
-            })
+            mismatches_list.append(
+                {
+                    "model_id": m.model_id,
+                    "db_model_id": m.db_model_id,
+                    "field": m.field,
+                    "provider_price_per_token": m.provider_price,
+                    "db_price_per_token": m.db_price,
+                    "provider_price_per_million": m.provider_price_per_million,
+                    "db_price_per_million": m.db_price_per_million,
+                    "difference_percent": m.difference_percent,
+                }
+            )
 
         unmatched_provider_list = []
         for u in gw_result.unmatched_provider:
-            unmatched_provider_list.append({
-                "model_id": u.model_id,
-                "reason": u.reason,
-                "pricing": u.pricing,
-            })
+            unmatched_provider_list.append(
+                {
+                    "model_id": u.model_id,
+                    "reason": u.reason,
+                    "pricing": u.pricing,
+                }
+            )
 
         unmatched_db_list = []
         for u in gw_result.unmatched_db:
-            unmatched_db_list.append({
-                "model_id": u.model_id,
-                "reason": u.reason,
-                "pricing": u.pricing,
-            })
+            unmatched_db_list.append(
+                {
+                    "model_id": u.model_id,
+                    "reason": u.reason,
+                    "pricing": u.pricing,
+                }
+            )
 
         matched_list = []
         for m in gw_result.matched_models:
-            matched_list.append({
-                "provider_id": m.provider_id,
-                "db_id": m.db_id,
-                "match_method": m.match_method,
-                "pricing_status": m.pricing_status,
-            })
+            matched_list.append(
+                {
+                    "provider_id": m.provider_id,
+                    "db_id": m.db_id,
+                    "match_method": m.match_method,
+                    "pricing_status": m.pricing_status,
+                }
+            )
 
         result["gateways"][gw] = {
             "display_name": gw_result.gateway_display_name,

--- a/src/services/pricing_audit.py
+++ b/src/services/pricing_audit.py
@@ -1,0 +1,991 @@
+"""
+Pricing Audit Service
+
+Compares live provider pricing against database pricing to detect mismatches.
+
+Flow:
+1. Fetch live catalog from each provider's API (OpenRouter, DeepInfra, etc.)
+2. Fetch all models from the database via get_all_models_for_catalog()
+3. Normalize IDs on both sides (the DB applies clean_model_name during sync)
+4. Match models using multi-pass ID normalization
+5. Compare pricing per model, grouped by provider/gateway
+6. Flag models where DB pricing differs from provider pricing
+7. Report unmatched models with reasons
+
+All pricing is compared in per-token format (canonical system format).
+"""
+
+import logging
+import re
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_THRESHOLD_PERCENT = 0.0
+
+
+# ── Data classes ────────────────────────────────────────────────────────────
+
+
+@dataclass
+class PricingMismatch:
+    """A single model with mismatched pricing between provider and database."""
+
+    model_id: str
+    db_model_id: str
+    gateway: str
+    field: str  # "prompt" or "completion"
+    provider_price: str
+    db_price: str
+    difference_percent: float
+    provider_price_per_million: str
+    db_price_per_million: str
+
+
+@dataclass
+class UnmatchedModel:
+    """A model that exists only in one source (provider or DB)."""
+
+    model_id: str
+    source: str  # "provider" or "database"
+    reason: str
+    pricing: dict[str, str] | None = None
+
+
+@dataclass
+class MatchedModel:
+    """A model that was matched between provider and DB."""
+
+    provider_id: str
+    db_id: str
+    match_method: str  # "exact", "normalized", "cleaned"
+    pricing_status: str  # "match", "mismatch", "no_provider_pricing"
+
+
+@dataclass
+class GatewayAuditResult:
+    """Audit result for a single gateway/provider."""
+
+    gateway: str
+    gateway_display_name: str
+    provider_model_count: int = 0
+    db_model_count: int = 0
+    total_models: int = 0
+    models_with_pricing: int = 0
+    models_without_pricing: int = 0
+    models_matched: int = 0
+    models_mismatched: int = 0
+    models_only_in_provider: int = 0
+    models_only_in_db: int = 0
+    mismatches: list[PricingMismatch] = field(default_factory=list)
+    unmatched_provider: list[UnmatchedModel] = field(default_factory=list)
+    unmatched_db: list[UnmatchedModel] = field(default_factory=list)
+    matched_models: list[MatchedModel] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class PricingAuditReport:
+    """Full audit report across all gateways."""
+
+    timestamp: str = ""
+    duration_seconds: float = 0.0
+    threshold_percent: float = DEFAULT_THRESHOLD_PERCENT
+    total_models_audited: int = 0
+    total_mismatches: int = 0
+    total_missing_in_db: int = 0
+    total_missing_in_provider: int = 0
+    total_missing_pricing: int = 0
+    gateways: dict[str, GatewayAuditResult] = field(default_factory=dict)
+    summary: dict[str, Any] = field(default_factory=dict)
+
+
+# ── ID normalization ────────────────────────────────────────────────────────
+
+
+def _normalize_id(model_id: str) -> str:
+    """Normalize a model ID for matching.
+
+    Applies the same transformations that clean_model_name does during sync:
+    - Strip whitespace
+    - Remove colons (company prefix stripping)
+    - Remove parenthetical info like (FP8), (7B), (free)
+    - Collapse whitespace
+    - Lowercase
+    """
+    if not model_id:
+        return ""
+
+    s = model_id.strip()
+
+    # Remove known variant suffixes after colon (e.g., :free, :extended, :thinking)
+    # But DON'T strip the prefix before colon (that would turn "org/model:free" into "free")
+    s = re.sub(r":(free|extended|thinking|beta|online|floor)$", "", s, flags=re.IGNORECASE)
+
+    # For colon-prefixed IDs like "nousresearch:hermes-3", strip the prefix
+    # Only if the part before colon looks like a short org prefix (no slash)
+    if ":" in s and "/" not in s.split(":")[0]:
+        parts = s.split(":", 1)
+        if parts[1].strip():
+            s = parts[1].strip()
+
+    # Remove parenthetical info at end: (FP8), (7B), (free), etc.
+    s = re.sub(r"\s*\([^)]*\)\s*", " ", s)
+
+    # Collapse whitespace and lowercase
+    s = " ".join(s.split()).lower()
+
+    return s
+
+
+def _make_slug(model_id: str) -> str:
+    """Create a slug from a model ID for fuzzy matching.
+
+    Strips everything non-alphanumeric except forward slashes (to keep org/model),
+    lowercases, collapses separators.  Also strips known suffixes like :free, :extended.
+    """
+    if not model_id:
+        return ""
+
+    s = model_id.lower()
+    # Strip known variant suffixes (OpenRouter uses :free, :extended, :thinking etc.)
+    s = re.sub(r":(free|extended|thinking|beta|online|floor)\b", "", s)
+    # Keep alphanumeric, forward slash, dots, and dashes
+    s = re.sub(r"[^a-z0-9/.\-]", "", s)
+    return s
+
+
+def _match_models(
+    provider_models: list[dict],
+    db_models: list[dict],
+) -> tuple[
+    list[tuple[dict, dict, str]],  # matched: (provider_model, db_model, method)
+    list[dict],  # unmatched provider models
+    list[dict],  # unmatched DB models
+]:
+    """Multi-pass matching of provider models to DB models.
+
+    Pass 1: Exact match on raw ID
+    Pass 2: Normalized match (lowercase, strip colons/parens, collapse whitespace)
+    Pass 3: Slug match (alphanumeric-only comparison)
+
+    Returns (matched_pairs, unmatched_provider, unmatched_db).
+    """
+    matched: list[tuple[dict, dict, str]] = []
+    remaining_provider: dict[str, dict] = {}
+    remaining_db: dict[str, dict] = {}
+
+    # Index all models
+    for m in provider_models:
+        mid = m.get("id", "")
+        if mid:
+            remaining_provider[mid] = m
+
+    for m in db_models:
+        mid = m.get("id", "")
+        if mid:
+            remaining_db[mid] = m
+
+    # Pass 1: Exact match
+    exact_matches = set(remaining_provider.keys()) & set(remaining_db.keys())
+    for mid in exact_matches:
+        matched.append((remaining_provider.pop(mid), remaining_db.pop(mid), "exact"))
+
+    # Pass 2: Normalized match
+    if remaining_provider and remaining_db:
+        prov_norm: dict[str, list[str]] = {}
+        for pid in remaining_provider:
+            norm = _normalize_id(pid)
+            prov_norm.setdefault(norm, []).append(pid)
+
+        db_norm: dict[str, list[str]] = {}
+        for did in remaining_db:
+            norm = _normalize_id(did)
+            db_norm.setdefault(norm, []).append(did)
+
+        norm_matches = set(prov_norm.keys()) & set(db_norm.keys())
+        for norm_key in norm_matches:
+            # Take first match from each side
+            pid = prov_norm[norm_key][0]
+            did = db_norm[norm_key][0]
+            if pid in remaining_provider and did in remaining_db:
+                matched.append((remaining_provider.pop(pid), remaining_db.pop(did), "normalized"))
+
+    # Pass 3: Slug match (most aggressive)
+    if remaining_provider and remaining_db:
+        prov_slug: dict[str, list[str]] = {}
+        for pid in remaining_provider:
+            slug = _make_slug(pid)
+            prov_slug.setdefault(slug, []).append(pid)
+
+        db_slug: dict[str, list[str]] = {}
+        for did in remaining_db:
+            slug = _make_slug(did)
+            db_slug.setdefault(slug, []).append(did)
+
+        slug_matches = set(prov_slug.keys()) & set(db_slug.keys())
+        for slug_key in slug_matches:
+            pid = prov_slug[slug_key][0]
+            did = db_slug[slug_key][0]
+            if pid in remaining_provider and did in remaining_db:
+                matched.append((remaining_provider.pop(pid), remaining_db.pop(did), "cleaned"))
+
+    # Pass 4: Strip gateway prefix match
+    # Handles cases like DB="groq/allam-2-7b" vs API="allam-2-7b"
+    # or DB="groq/meta-llama/llama-4-scout" vs API="meta-llama/llama-4-scout"
+    # or DB="groq/groq/compound-mini" vs API="groq/compound-mini"
+    if remaining_provider and remaining_db:
+        # Collect all gateway slugs that appear as prefixes in DB IDs
+        db_prefixes: set[str] = set()
+        for did in remaining_db:
+            if "/" in did:
+                prefix = did.split("/", 1)[0].lower()
+                db_prefixes.add(prefix)
+
+        def _strip_all_prefixes(model_id: str, prefixes: set[str]) -> list[str]:
+            """Generate candidate IDs by stripping gateway prefixes.
+
+            Returns multiple candidates to handle:
+            - groq/model → model
+            - groq/groq/model → groq/model, model
+            - model → groq/model (add prefix)
+            """
+            candidates = [model_id.lower()]
+            parts = model_id.split("/", 1)
+            if len(parts) == 2 and parts[0].lower() in prefixes:
+                stripped = parts[1]
+                candidates.append(stripped.lower())
+                # Double prefix: groq/groq/x → x
+                inner_parts = stripped.split("/", 1)
+                if len(inner_parts) == 2 and inner_parts[0].lower() == parts[0].lower():
+                    candidates.append(inner_parts[1].lower())
+            else:
+                # Try adding each prefix: model → groq/model
+                for prefix in prefixes:
+                    candidates.append(f"{prefix}/{model_id}".lower())
+            return candidates
+
+        # Build lookup indices for both sides
+        prov_by_lower: dict[str, str] = {}  # lowered_id → original_id
+        for pid in remaining_provider:
+            for cand in _strip_all_prefixes(pid, db_prefixes):
+                if cand not in prov_by_lower:
+                    prov_by_lower[cand] = pid
+
+        db_by_lower: dict[str, str] = {}
+        for did in remaining_db:
+            for cand in _strip_all_prefixes(did, db_prefixes):
+                if cand not in db_by_lower:
+                    db_by_lower[cand] = did
+
+        # Match: for each provider candidate, check if any DB candidate matches
+        matched_prov_ids: set[str] = set()
+        matched_db_ids: set[str] = set()
+        for cand, pid in prov_by_lower.items():
+            if pid in matched_prov_ids:
+                continue
+            if cand in db_by_lower:
+                did = db_by_lower[cand]
+                if did in matched_db_ids:
+                    continue
+                if pid in remaining_provider and did in remaining_db:
+                    matched.append((remaining_provider.pop(pid), remaining_db.pop(did), "strip_prefix"))
+                    matched_prov_ids.add(pid)
+                    matched_db_ids.add(did)
+
+    return (
+        matched,
+        list(remaining_provider.values()),
+        list(remaining_db.values()),
+    )
+
+
+# ── Pricing helpers ─────────────────────────────────────────────────────────
+
+
+def _to_decimal(value: Any) -> Decimal | None:
+    """Safely convert a pricing value to Decimal."""
+    if value is None or value == "" or value == "0" or value == 0:
+        return Decimal("0")
+    try:
+        d = Decimal(str(value))
+        return d if d >= 0 else None
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+
+
+def _per_million(per_token: Decimal) -> str:
+    """Convert per-token price to per-million-token string for readability."""
+    return str((per_token * Decimal("1000000")).quantize(Decimal("0.0001")))
+
+
+def _calc_diff_percent(provider_val: Decimal, db_val: Decimal) -> float:
+    """Calculate percentage difference between two prices."""
+    if provider_val == 0 and db_val == 0:
+        return 0.0
+    if provider_val == 0:
+        return 100.0
+    diff = abs(provider_val - db_val)
+    return float((diff / provider_val) * 100)
+
+
+def _extract_pricing(model: dict) -> dict[str, Decimal | None]:
+    """Extract prompt and completion pricing from a model dict."""
+    pricing = model.get("pricing") or {}
+    return {
+        "prompt": _to_decimal(pricing.get("prompt")),
+        "completion": _to_decimal(pricing.get("completion")),
+    }
+
+
+def _pricing_summary(model: dict) -> dict[str, str] | None:
+    """Get a readable pricing summary for reporting unmatched models."""
+    pricing = model.get("pricing") or {}
+    prompt = pricing.get("prompt")
+    completion = pricing.get("completion")
+    if prompt is None and completion is None:
+        return None
+    result = {}
+    if prompt is not None:
+        p = _to_decimal(prompt)
+        result["prompt_per_million"] = _per_million(p) if p else "0"
+    if completion is not None:
+        c = _to_decimal(completion)
+        result["completion_per_million"] = _per_million(c) if c else "0"
+    return result
+
+
+def _guess_unmatched_reason(model_id: str, source: str, other_ids: set[str]) -> str:
+    """Guess why a model wasn't matched."""
+    norm = _normalize_id(model_id)
+    slug = _make_slug(model_id)
+
+    # Check if there's a near-match in the other side
+    for other_id in other_ids:
+        other_norm = _normalize_id(other_id)
+        other_slug = _make_slug(other_id)
+
+        # Very close slug match (off by small diff)
+        if slug and other_slug and (slug in other_slug or other_slug in slug):
+            if source == "provider":
+                return f"Likely matches DB model '{other_id}' but IDs differ slightly"
+            else:
+                return f"Likely matches provider model '{other_id}' but IDs differ slightly"
+
+    if source == "provider":
+        if ":" in model_id:
+            return "Contains colon in ID (stripped by DB clean_model_name during sync) — may exist under cleaned name"
+        if "(" in model_id:
+            return "Contains parenthetical info (stripped by DB clean_model_name) — may exist under cleaned name"
+        return "Model exists in provider API but not found in database — may not have been synced yet"
+    else:
+        return "Model exists in database but provider no longer lists it — may have been removed or renamed"
+
+
+# ── Data fetchers ───────────────────────────────────────────────────────────
+
+
+def _get_all_gateways() -> dict[str, str]:
+    """Get all auditable gateway slugs and display names."""
+    from src.routes.catalog import GATEWAY_REGISTRY
+    from src.services.model_catalog_sync import PROVIDER_FETCH_FUNCTIONS
+
+    return {
+        slug: info["name"]
+        for slug, info in GATEWAY_REGISTRY.items()
+        if slug in PROVIDER_FETCH_FUNCTIONS
+    }
+
+
+def _fetch_provider_models(gateway: str) -> list[dict]:
+    """Fetch live models directly from the provider's API.
+
+    Uses lightweight raw HTTP calls to avoid the enrich_model_with_pricing()
+    circular dependency that exists in the normal PROVIDER_FETCH_FUNCTIONS.
+    """
+    try:
+        return _raw_fetch_provider(gateway)
+    except Exception as e:
+        logger.error(f"Failed to fetch live provider models for {gateway}: {e}")
+        return []
+
+
+# ── Raw provider API fetchers ──────────────────────────────────────────────
+# These bypass the normal fetch_models_from_* functions to avoid the circular
+# dependency: fetch → enrich_model_with_pricing → _build_openrouter_pricing_index
+# → get_cached_models → transform_db_models_batch → _build_openrouter_pricing_index → ...
+
+
+def _raw_fetch_provider(gateway: str) -> list[dict]:
+    """Dispatch to the appropriate raw provider fetcher."""
+    import httpx
+
+    from src.config.config import Config
+    from src.services.pricing_normalization import (
+        PricingFormat,
+        get_provider_format,
+        normalize_to_per_token,
+    )
+
+    provider_format = get_provider_format(gateway)
+
+    # ── Provider API configs ──────────────────────────────────────────────
+    # Each entry: (url, headers, response_parser, pricing_extractor)
+
+    PROVIDER_CONFIGS: dict[str, dict] = {
+        "openrouter": {
+            "url": "https://openrouter.ai/api/v1/models",
+            "headers": {},  # No auth needed for model list
+        },
+        "deepinfra": {
+            "url": "https://api.deepinfra.com/models/list",
+            "key_attr": "DEEPINFRA_API_KEY",
+        },
+        "together": {
+            "url": "https://api.together.xyz/v1/models",
+            "key_attr": "TOGETHER_API_KEY",
+        },
+        "groq": {
+            "url": "https://api.groq.com/openai/v1/models",
+            "key_attr": "GROQ_API_KEY",
+        },
+        "fireworks": {
+            "url": "https://api.fireworks.ai/inference/v1/models",
+            "key_attr": "FIREWORKS_API_KEY",
+        },
+        "featherless": {
+            "url": "https://api.featherless.ai/v1/models",
+            "key_attr": "FEATHERLESS_API_KEY",
+        },
+        "cerebras": {
+            "url": "https://api.cerebras.ai/v1/models",
+            "key_attr": "CEREBRAS_API_KEY",
+        },
+        "xai": {
+            "url": "https://api.x.ai/v1/models",
+            "key_attr": "XAI_API_KEY",
+        },
+        "novita": {
+            "url": "https://api.novita.ai/v3/openai/models",
+            "key_attr": "NOVITA_API_KEY",
+        },
+        "nebius": {
+            "url": "https://api.studio.nebius.ai/v1/models",
+            "key_attr": "NEBIUS_API_KEY",
+        },
+        "cohere": {
+            "url": "https://api.cohere.com/v2/models",
+            "key_attr": "COHERE_API_KEY",
+            "auth_header": "Authorization",
+            "auth_prefix": "Bearer ",
+        },
+    }
+
+    config = PROVIDER_CONFIGS.get(gateway)
+    if not config:
+        logger.info(f"No raw fetch config for '{gateway}', skipping")
+        return []
+
+    url = config["url"]
+    key_attr = config.get("key_attr")
+    headers = config.get("headers", {})
+
+    if key_attr:
+        api_key = getattr(Config, key_attr, None)
+        if not api_key:
+            logger.warning(f"API key {key_attr} not configured for {gateway}")
+            return []
+        auth_header = config.get("auth_header", "Authorization")
+        auth_prefix = config.get("auth_prefix", "Bearer ")
+        headers[auth_header] = f"{auth_prefix}{api_key}"
+
+    headers.setdefault("Content-Type", "application/json")
+
+    try:
+        response = httpx.get(url, headers=headers, timeout=30.0)
+        response.raise_for_status()
+    except Exception as e:
+        logger.error(f"HTTP error fetching {gateway} models: {e}")
+        return []
+
+    payload = response.json()
+
+    # Parse response — most return {"data": [...]} or direct array
+    if isinstance(payload, list):
+        raw_models = payload
+    elif isinstance(payload, dict):
+        raw_models = payload.get("data", payload.get("models", []))
+    else:
+        return []
+
+    # Extract model ID and pricing
+    models: list[dict] = []
+    for raw in raw_models:
+        if not isinstance(raw, dict):
+            continue
+
+        # Different providers use different ID fields
+        model_id = raw.get("id") or raw.get("model_name") or ""
+        if not model_id:
+            continue
+
+        pricing = _extract_raw_pricing(raw, gateway, provider_format, normalize_to_per_token)
+
+        models.append({
+            "id": model_id,
+            "pricing": pricing,
+        })
+
+    logger.info(f"Raw fetched {len(models)} models from {gateway} API")
+    return models
+
+
+def _extract_raw_pricing(
+    raw: dict,
+    gateway: str,
+    provider_format: str,
+    normalize_fn,
+) -> dict[str, str | None]:
+    """Extract and normalize pricing from a raw provider API response model."""
+    from src.services.pricing_normalization import PricingFormat
+
+    pricing: dict[str, str | None] = {"prompt": None, "completion": None}
+
+    raw_pricing = raw.get("pricing") or {}
+
+    if gateway == "openrouter":
+        # OpenRouter: pricing.prompt / pricing.completion — already per-token
+        prompt = raw_pricing.get("prompt")
+        completion = raw_pricing.get("completion")
+        if prompt is not None and str(prompt) not in ("-1", ""):
+            pricing["prompt"] = str(prompt)
+        if completion is not None and str(completion) not in ("-1", ""):
+            pricing["completion"] = str(completion)
+        return pricing
+
+    if gateway == "deepinfra":
+        # DeepInfra: pricing.cents_per_input_token / cents_per_output_token
+        # These are in CENTS, so divide by 100 to get $/token
+        # But the system expects per-token, and DeepInfra format is PER_1M
+        # Actually DeepInfra raw data: cents_per_input_token means
+        # cost in cents for one token. So $/token = cents / 100.
+        # But wait — let's check what the DB stores and normalize consistently.
+        cents_in = raw_pricing.get("cents_per_input_token")
+        cents_out = raw_pricing.get("cents_per_output_token")
+        if cents_in is not None:
+            try:
+                # cents_per_token → $/token
+                pricing["prompt"] = str(Decimal(str(cents_in)) / Decimal("100"))
+            except (InvalidOperation, ValueError):
+                pass
+        if cents_out is not None:
+            try:
+                pricing["completion"] = str(Decimal(str(cents_out)) / Decimal("100"))
+            except (InvalidOperation, ValueError):
+                pass
+        return pricing
+
+    # Generic pattern: pricing.input/output or pricing.prompt/completion
+    # For most providers: values are per-1M tokens, need normalization to per-token
+    prompt_val = raw_pricing.get("prompt") or raw_pricing.get("input")
+    completion_val = raw_pricing.get("completion") or raw_pricing.get("output")
+
+    # Some providers use cents_per_input_token format (groq, fireworks)
+    if prompt_val is None:
+        cents_in = raw_pricing.get("cents_per_input_token")
+        if cents_in is not None:
+            try:
+                prompt_val = float(cents_in) / 100  # cents → dollars per 1M
+            except (ValueError, TypeError):
+                pass
+
+    if completion_val is None:
+        cents_out = raw_pricing.get("cents_per_output_token")
+        if cents_out is not None:
+            try:
+                completion_val = float(cents_out) / 100  # cents → dollars per 1M
+            except (ValueError, TypeError):
+                pass
+
+    # Normalize to per-token
+    if prompt_val is not None:
+        normalized = normalize_fn(prompt_val, provider_format)
+        if normalized is not None:
+            pricing["prompt"] = str(normalized)
+
+    if completion_val is not None:
+        normalized = normalize_fn(completion_val, provider_format)
+        if normalized is not None:
+            pricing["completion"] = str(normalized)
+
+    return pricing
+
+
+def _fetch_db_models_by_gateway() -> dict[str, list[dict]]:
+    """Fetch all models from the database, grouped by provider slug."""
+    from src.db.models_catalog_db import get_all_models_for_catalog
+
+    db_models_raw = get_all_models_for_catalog(include_inactive=False)
+    grouped: dict[str, list[dict]] = {}
+
+    for raw_model in db_models_raw:
+        try:
+            provider = raw_model.get("providers") or {}
+            slug = provider.get("slug", "unknown")
+
+            from src.services.pricing_normalization import get_provider_format, normalize_to_per_token, auto_detect_format
+
+            metadata = raw_model.get("metadata") or {}
+            pricing_raw = metadata.get("pricing_raw") if isinstance(metadata, dict) else None
+            is_migrated = raw_model.get("pricing_format_migrated", False)
+            provider_fmt = get_provider_format(slug)
+            pricing: dict[str, str | None] = {}
+
+            if pricing_raw and isinstance(pricing_raw, dict):
+                for field_name in ("prompt", "completion"):
+                    val = pricing_raw.get(field_name)
+                    if val is not None:
+                        if is_migrated:
+                            # Already per-token format
+                            pricing[field_name] = str(val)
+                        else:
+                            # Stored in provider's native format — normalize
+                            norm = normalize_to_per_token(val, provider_fmt)
+                            pricing[field_name] = str(norm) if norm is not None else None
+
+            # Fallback: use pricing_original_* columns if pricing_raw is empty
+            # These columns store values in the PROVIDER's native format
+            if not pricing.get("prompt") and raw_model.get("pricing_original_prompt") is not None:
+                norm = normalize_to_per_token(raw_model["pricing_original_prompt"], provider_fmt)
+                pricing["prompt"] = str(norm) if norm is not None else None
+            if not pricing.get("completion") and raw_model.get("pricing_original_completion") is not None:
+                norm = normalize_to_per_token(raw_model["pricing_original_completion"], provider_fmt)
+                pricing["completion"] = str(norm) if norm is not None else None
+
+            model_entry = {
+                "id": raw_model.get("provider_model_id", raw_model.get("model_name", "")),
+                "model_name": raw_model.get("model_name", ""),
+                "provider_slug": slug,
+                "pricing": pricing if pricing else None,
+            }
+
+            grouped.setdefault(slug, []).append(model_entry)
+        except Exception as e:
+            logger.warning(f"Failed to process DB model: {e}")
+
+    return grouped
+
+
+# ── Gateway audit ───────────────────────────────────────────────────────────
+
+
+def _audit_gateway(
+    gateway: str,
+    display_name: str,
+    provider_models: list[dict],
+    db_models: list[dict],
+    threshold: float,
+) -> GatewayAuditResult:
+    """Compare provider models against DB models for a single gateway."""
+    result = GatewayAuditResult(
+        gateway=gateway,
+        gateway_display_name=display_name,
+        provider_model_count=len(provider_models),
+        db_model_count=len(db_models),
+    )
+
+    # Multi-pass matching
+    matched_pairs, unmatched_prov, unmatched_db = _match_models(provider_models, db_models)
+
+    result.total_models = len(matched_pairs) + len(unmatched_prov) + len(unmatched_db)
+    result.models_only_in_provider = len(unmatched_prov)
+    result.models_only_in_db = len(unmatched_db)
+
+    # Build ID sets for reason guessing
+    all_prov_ids = {m.get("id", "") for m in provider_models}
+    all_db_ids = {m.get("id", "") for m in db_models}
+
+    # Process unmatched provider models
+    for m in sorted(unmatched_prov, key=lambda x: x.get("id", "")):
+        mid = m.get("id", "")
+        result.unmatched_provider.append(UnmatchedModel(
+            model_id=mid,
+            source="provider",
+            reason=_guess_unmatched_reason(mid, "provider", all_db_ids),
+            pricing=_pricing_summary(m),
+        ))
+
+    # Process unmatched DB models
+    for m in sorted(unmatched_db, key=lambda x: x.get("id", "")):
+        mid = m.get("id", "")
+        result.unmatched_db.append(UnmatchedModel(
+            model_id=mid,
+            source="database",
+            reason=_guess_unmatched_reason(mid, "database", all_prov_ids),
+            pricing=_pricing_summary(m),
+        ))
+
+    # Compare pricing for matched models
+    for prov_model, db_model, match_method in matched_pairs:
+        prov_pricing = _extract_pricing(prov_model)
+        db_pricing = _extract_pricing(db_model)
+
+        prov_id = prov_model.get("id", "")
+        db_id = db_model.get("id", "")
+
+        # Skip models where provider has no pricing data
+        if prov_pricing["prompt"] is None and prov_pricing["completion"] is None:
+            result.models_without_pricing += 1
+            result.matched_models.append(MatchedModel(
+                provider_id=prov_id,
+                db_id=db_id,
+                match_method=match_method,
+                pricing_status="no_provider_pricing",
+            ))
+            continue
+
+        result.models_with_pricing += 1
+        has_mismatch = False
+
+        for price_field in ("prompt", "completion"):
+            prov_val = prov_pricing.get(price_field)
+            db_val = db_pricing.get(price_field)
+
+            if prov_val is None:
+                continue
+
+            if db_val is None:
+                if prov_val > 0:
+                    has_mismatch = True
+                    result.mismatches.append(PricingMismatch(
+                        model_id=prov_id,
+                        db_model_id=db_id,
+                        gateway=gateway,
+                        field=price_field,
+                        provider_price=str(prov_val),
+                        db_price="MISSING",
+                        difference_percent=100.0,
+                        provider_price_per_million=_per_million(prov_val),
+                        db_price_per_million="MISSING",
+                    ))
+                continue
+
+            diff_pct = _calc_diff_percent(prov_val, db_val)
+
+            if diff_pct > threshold:
+                has_mismatch = True
+                result.mismatches.append(PricingMismatch(
+                    model_id=prov_id,
+                    db_model_id=db_id,
+                    gateway=gateway,
+                    field=price_field,
+                    provider_price=str(prov_val),
+                    db_price=str(db_val),
+                    difference_percent=round(diff_pct, 2),
+                    provider_price_per_million=_per_million(prov_val),
+                    db_price_per_million=_per_million(db_val),
+                ))
+
+        if has_mismatch:
+            result.models_mismatched += 1
+            result.matched_models.append(MatchedModel(
+                provider_id=prov_id,
+                db_id=db_id,
+                match_method=match_method,
+                pricing_status="mismatch",
+            ))
+        else:
+            result.models_matched += 1
+            result.matched_models.append(MatchedModel(
+                provider_id=prov_id,
+                db_id=db_id,
+                match_method=match_method,
+                pricing_status="match",
+            ))
+
+    return result
+
+
+# ── Main entry point ────────────────────────────────────────────────────────
+
+
+def run_pricing_audit(
+    gateways: list[str] | None = None,
+    threshold_percent: float = DEFAULT_THRESHOLD_PERCENT,
+) -> dict[str, Any]:
+    """
+    Run a full pricing audit comparing provider catalogs against database pricing.
+
+    Args:
+        gateways: Specific gateways to audit (None = all gateways).
+        threshold_percent: Minimum percentage difference to flag as mismatch.
+
+    Returns:
+        Audit report as a serializable dictionary, grouped by gateway.
+    """
+    from datetime import UTC, datetime
+
+    start_time = time.monotonic()
+    report = PricingAuditReport(
+        timestamp=datetime.now(UTC).isoformat(),
+        threshold_percent=threshold_percent,
+    )
+
+    all_gateways = _get_all_gateways()
+    if gateways:
+        target_gateways = {
+            g: all_gateways.get(g, g) for g in gateways if g in all_gateways
+        }
+    else:
+        target_gateways = all_gateways
+
+    logger.info(f"Starting pricing audit for {len(target_gateways)} gateways")
+
+    # Step 1: Fetch all DB models grouped by provider
+    logger.info("Fetching all models from database...")
+    db_models_by_gateway = _fetch_db_models_by_gateway()
+    logger.info(
+        f"Fetched {sum(len(v) for v in db_models_by_gateway.values())} models "
+        f"from {len(db_models_by_gateway)} providers in database"
+    )
+
+    # Step 2: Fetch provider models in parallel
+    logger.info("Fetching provider catalogs in parallel...")
+    provider_models_by_gateway: dict[str, list[dict]] = {}
+
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        futures = {
+            executor.submit(_fetch_provider_models, gw): gw
+            for gw in target_gateways
+        }
+        for future in as_completed(futures, timeout=180):
+            gw = futures[future]
+            try:
+                models = future.result(timeout=30)
+                provider_models_by_gateway[gw] = models
+                logger.info(f"Fetched {len(models)} models from provider API: {gw}")
+            except Exception as e:
+                provider_models_by_gateway[gw] = []
+                logger.warning(f"Failed to fetch provider models for {gw}: {e}")
+
+    # Step 3: Audit each gateway
+    for gw, display_name in sorted(target_gateways.items()):
+        provider_models = provider_models_by_gateway.get(gw, [])
+        db_models = db_models_by_gateway.get(gw, [])
+
+        # Check aliases (e.g., "hug" -> "huggingface")
+        if not db_models:
+            from src.routes.catalog import GATEWAY_REGISTRY
+
+            registry_entry = GATEWAY_REGISTRY.get(gw, {})
+            for alias in registry_entry.get("aliases", []):
+                db_models = db_models_by_gateway.get(alias, [])
+                if db_models:
+                    break
+
+        gateway_result = _audit_gateway(
+            gateway=gw,
+            display_name=display_name,
+            provider_models=provider_models,
+            db_models=db_models,
+            threshold=threshold_percent,
+        )
+
+        report.gateways[gw] = gateway_result
+        report.total_models_audited += gateway_result.total_models
+        report.total_mismatches += gateway_result.models_mismatched
+        report.total_missing_in_db += gateway_result.models_only_in_provider
+        report.total_missing_in_provider += gateway_result.models_only_in_db
+        report.total_missing_pricing += gateway_result.models_without_pricing
+
+    report.duration_seconds = round(time.monotonic() - start_time, 2)
+
+    report.summary = {
+        "gateways_audited": len(report.gateways),
+        "total_models_audited": report.total_models_audited,
+        "total_models_with_mismatches": report.total_mismatches,
+        "total_models_missing_in_db": report.total_missing_in_db,
+        "total_models_only_in_db": report.total_missing_in_provider,
+        "total_models_missing_pricing": report.total_missing_pricing,
+        "threshold_percent": report.threshold_percent,
+        "duration_seconds": report.duration_seconds,
+    }
+
+    return _serialize_report(report)
+
+
+# ── Serialization ───────────────────────────────────────────────────────────
+
+
+def _serialize_report(report: PricingAuditReport) -> dict[str, Any]:
+    """Convert the dataclass report to a JSON-serializable dictionary."""
+    result: dict[str, Any] = {
+        "timestamp": report.timestamp,
+        "duration_seconds": report.duration_seconds,
+        "threshold_percent": report.threshold_percent,
+        "summary": report.summary,
+        "gateways": {},
+    }
+
+    for gw, gw_result in report.gateways.items():
+        mismatches_list = []
+        for m in gw_result.mismatches:
+            mismatches_list.append({
+                "model_id": m.model_id,
+                "db_model_id": m.db_model_id,
+                "field": m.field,
+                "provider_price_per_token": m.provider_price,
+                "db_price_per_token": m.db_price,
+                "provider_price_per_million": m.provider_price_per_million,
+                "db_price_per_million": m.db_price_per_million,
+                "difference_percent": m.difference_percent,
+            })
+
+        unmatched_provider_list = []
+        for u in gw_result.unmatched_provider:
+            unmatched_provider_list.append({
+                "model_id": u.model_id,
+                "reason": u.reason,
+                "pricing": u.pricing,
+            })
+
+        unmatched_db_list = []
+        for u in gw_result.unmatched_db:
+            unmatched_db_list.append({
+                "model_id": u.model_id,
+                "reason": u.reason,
+                "pricing": u.pricing,
+            })
+
+        matched_list = []
+        for m in gw_result.matched_models:
+            matched_list.append({
+                "provider_id": m.provider_id,
+                "db_id": m.db_id,
+                "match_method": m.match_method,
+                "pricing_status": m.pricing_status,
+            })
+
+        result["gateways"][gw] = {
+            "display_name": gw_result.gateway_display_name,
+            "provider_model_count": gw_result.provider_model_count,
+            "db_model_count": gw_result.db_model_count,
+            "total_models": gw_result.total_models,
+            "models_with_pricing": gw_result.models_with_pricing,
+            "models_without_pricing": gw_result.models_without_pricing,
+            "models_matched": gw_result.models_matched,
+            "models_mismatched": gw_result.models_mismatched,
+            "models_only_in_provider": gw_result.models_only_in_provider,
+            "models_only_in_db": gw_result.models_only_in_db,
+            "mismatches": mismatches_list,
+            "unmatched_provider": unmatched_provider_list,
+            "unmatched_db": unmatched_db_list,
+            "matched_models": matched_list,
+            "errors": gw_result.errors,
+        }
+
+    return result

--- a/src/services/pricing_audit.py
+++ b/src/services/pricing_audit.py
@@ -361,12 +361,10 @@ def _pricing_summary(model: dict) -> dict[str, str] | None:
 
 def _guess_unmatched_reason(model_id: str, source: str, other_ids: set[str]) -> str:
     """Guess why a model wasn't matched."""
-    norm = _normalize_id(model_id)
     slug = _make_slug(model_id)
 
     # Check if there's a near-match in the other side
     for other_id in other_ids:
-        other_norm = _normalize_id(other_id)
         other_slug = _make_slug(other_id)
 
         # Very close slug match (off by small diff)
@@ -401,17 +399,19 @@ def _get_all_gateways() -> dict[str, str]:
     }
 
 
-def _fetch_provider_models(gateway: str) -> list[dict]:
+def _fetch_provider_models(gateway: str) -> list[dict] | None:
     """Fetch live models directly from the provider's API.
 
     Uses lightweight raw HTTP calls to avoid the enrich_model_with_pricing()
     circular dependency that exists in the normal PROVIDER_FETCH_FUNCTIONS.
+
+    Returns None on error (distinguishes from an empty catalog).
     """
     try:
         return _raw_fetch_provider(gateway)
     except Exception as e:
         logger.error(f"Failed to fetch live provider models for {gateway}: {e}")
-        return []
+        return None
 
 
 # ── Raw provider API fetchers ──────────────────────────────────────────────
@@ -426,7 +426,6 @@ def _raw_fetch_provider(gateway: str) -> list[dict]:
 
     from src.config.config import Config
     from src.services.pricing_normalization import (
-        PricingFormat,
         get_provider_format,
         normalize_to_per_token,
     )
@@ -551,8 +550,6 @@ def _extract_raw_pricing(
     normalize_fn,
 ) -> dict[str, str | None]:
     """Extract and normalize pricing from a raw provider API response model."""
-    from src.services.pricing_normalization import PricingFormat
-
     pricing: dict[str, str | None] = {"prompt": None, "completion": None}
 
     raw_pricing = raw.get("pricing") or {}
@@ -568,31 +565,33 @@ def _extract_raw_pricing(
         return pricing
 
     if gateway == "deepinfra":
-        # DeepInfra: pricing.cents_per_input_token / cents_per_output_token
-        # These are in CENTS, so divide by 100 to get $/token
-        # But the system expects per-token, and DeepInfra format is PER_1M
-        # Actually DeepInfra raw data: cents_per_input_token means
-        # cost in cents for one token. So $/token = cents / 100.
-        # But wait — let's check what the DB stores and normalize consistently.
+        # DeepInfra API: cents_per_input_token / cents_per_output_token
+        # Values are in cents per 1M tokens. Convert cents→dollars (/100),
+        # then normalize from per-1M to per-token via normalize_fn.
         cents_in = raw_pricing.get("cents_per_input_token")
         cents_out = raw_pricing.get("cents_per_output_token")
         if cents_in is not None:
             try:
-                # cents_per_token → $/token
-                pricing["prompt"] = str(Decimal(str(cents_in)) / Decimal("100"))
+                dollars_per_1m = float(Decimal(str(cents_in)) / Decimal("100"))
+                normalized = normalize_fn(dollars_per_1m, provider_format)
+                if normalized is not None:
+                    pricing["prompt"] = str(normalized)
             except (InvalidOperation, ValueError):
                 pass
         if cents_out is not None:
             try:
-                pricing["completion"] = str(Decimal(str(cents_out)) / Decimal("100"))
+                dollars_per_1m = float(Decimal(str(cents_out)) / Decimal("100"))
+                normalized = normalize_fn(dollars_per_1m, provider_format)
+                if normalized is not None:
+                    pricing["completion"] = str(normalized)
             except (InvalidOperation, ValueError):
                 pass
         return pricing
 
     # Generic pattern: pricing.input/output or pricing.prompt/completion
     # For most providers: values are per-1M tokens, need normalization to per-token
-    prompt_val = raw_pricing.get("prompt") or raw_pricing.get("input")
-    completion_val = raw_pricing.get("completion") or raw_pricing.get("output")
+    prompt_val = raw_pricing.get("prompt") if raw_pricing.get("prompt") is not None else raw_pricing.get("input")
+    completion_val = raw_pricing.get("completion") if raw_pricing.get("completion") is not None else raw_pricing.get("output")
 
     # Some providers use cents_per_input_token format (groq, fireworks)
     if prompt_val is None:
@@ -637,7 +636,7 @@ def _fetch_db_models_by_gateway() -> dict[str, list[dict]]:
             provider = raw_model.get("providers") or {}
             slug = provider.get("slug", "unknown")
 
-            from src.services.pricing_normalization import get_provider_format, normalize_to_per_token, auto_detect_format
+            from src.services.pricing_normalization import get_provider_format, normalize_to_per_token
 
             metadata = raw_model.get("metadata") or {}
             pricing_raw = metadata.get("pricing_raw") if isinstance(metadata, dict) else None
@@ -856,21 +855,34 @@ def run_pricing_audit(
     # Step 2: Fetch provider models in parallel
     logger.info("Fetching provider catalogs in parallel...")
     provider_models_by_gateway: dict[str, list[dict]] = {}
+    fetch_errors: dict[str, str] = {}
 
     with ThreadPoolExecutor(max_workers=10) as executor:
         futures = {
             executor.submit(_fetch_provider_models, gw): gw
             for gw in target_gateways
         }
-        for future in as_completed(futures, timeout=180):
-            gw = futures[future]
-            try:
-                models = future.result(timeout=30)
-                provider_models_by_gateway[gw] = models
-                logger.info(f"Fetched {len(models)} models from provider API: {gw}")
-            except Exception as e:
-                provider_models_by_gateway[gw] = []
-                logger.warning(f"Failed to fetch provider models for {gw}: {e}")
+        try:
+            for future in as_completed(futures, timeout=180):
+                gw = futures[future]
+                try:
+                    models = future.result(timeout=30)
+                    if models is None:
+                        provider_models_by_gateway[gw] = []
+                        fetch_errors[gw] = f"Failed to fetch models from {gw} API"
+                    else:
+                        provider_models_by_gateway[gw] = models
+                        logger.info(f"Fetched {len(models)} models from provider API: {gw}")
+                except Exception as e:
+                    provider_models_by_gateway[gw] = []
+                    fetch_errors[gw] = f"Provider fetch exception: {e}"
+                    logger.warning(f"Failed to fetch provider models for {gw}: {e}")
+        except TimeoutError:
+            logger.warning("Provider fetch timed out after 180s; proceeding with partial results")
+            for gw in target_gateways:
+                if gw not in provider_models_by_gateway:
+                    provider_models_by_gateway[gw] = []
+                    fetch_errors[gw] = "Provider fetch timed out"
 
     # Step 3: Audit each gateway
     for gw, display_name in sorted(target_gateways.items()):
@@ -894,6 +906,10 @@ def run_pricing_audit(
             db_models=db_models,
             threshold=threshold_percent,
         )
+
+        # Surface any fetch errors into the gateway result
+        if gw in fetch_errors:
+            gateway_result.errors.append(fetch_errors[gw])
 
         report.gateways[gw] = gateway_result
         report.total_models_audited += gateway_result.total_models

--- a/src/services/rate_limiting.py
+++ b/src/services/rate_limiting.py
@@ -15,9 +15,8 @@ from typing import Any
 
 import redis
 
-from src.services.pyroscope_config import tag_wrapper
-
 from src.db.rate_limits import get_rate_limit_config, update_rate_limit_config
+from src.services.pyroscope_config import tag_wrapper
 from src.services.rate_limiting_fallback import get_fallback_rate_limit_manager
 
 logger = logging.getLogger(__name__)

--- a/supabase/migrations/20260311000000_add_stale_model_tracking.sql
+++ b/supabase/migrations/20260311000000_add_stale_model_tracking.sql
@@ -1,0 +1,17 @@
+-- Add columns for tracking stale models during provider sync.
+-- When a provider API no longer lists a model, we increment consecutive_missing_count.
+-- After 3 consecutive misses, the model is soft-deactivated (is_active = false).
+
+ALTER TABLE models
+  ADD COLUMN IF NOT EXISTS last_seen_in_provider_at TIMESTAMPTZ DEFAULT now(),
+  ADD COLUMN IF NOT EXISTS consecutive_missing_count INTEGER DEFAULT 0 NOT NULL;
+
+-- Backfill: set last_seen_in_provider_at to updated_at for existing active models
+UPDATE models
+SET last_seen_in_provider_at = updated_at
+WHERE last_seen_in_provider_at IS NULL;
+
+-- Index for efficient stale-model queries (find models with high miss count per provider)
+CREATE INDEX IF NOT EXISTS idx_models_stale_tracking
+  ON models (provider_id, is_active, consecutive_missing_count)
+  WHERE is_active = true;


### PR DESCRIPTION
## Summary
- **Pricing Audit Service**: Raw API fetchers for 11+ providers with multi-pass ID matching (exact → normalized → slug → prefix-stripped) and per-token pricing normalization. Exposes `/admin/pricing-audit` endpoint comparing live API vs DB pricing across all gateways.
- **Stale Model Tracking**: Models missing from provider API for 3 consecutive sync cycles (~1.5 hours) are soft-deactivated (`is_active = false`). Safety guard prevents mass-deactivation when fetched count < 50% of existing active models.
- **DB Migration**: Adds `last_seen_in_provider_at` and `consecutive_missing_count` columns to `models` table with partial index for efficient stale queries.

## Files Changed
- `src/services/pricing_audit.py` — new pricing audit service (991 LOC)
- `src/routes/admin.py` — `/admin/pricing-audit` endpoint
- `src/db/models_catalog_db.py` — `process_stale_models()` function
- `src/services/model_catalog_sync.py` — stale tracking integration into sync pipeline
- `supabase/migrations/20260311000000_add_stale_model_tracking.sql` — schema migration

## Test plan
- [ ] Run pricing audit endpoint and verify match rates per gateway
- [ ] Verify safety guard skips stale detection on partial API responses
- [ ] Confirm models are only deactivated after 3 consecutive misses
- [ ] Verify `last_seen_in_provider_at` resets for models still in API
- [ ] Check admin panel pricing audit page loads and displays results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pricing audit tool to compare live provider catalogs with DB pricing and produce detailed reports; new admin endpoint to run audits on demand.
  * Implemented stale-model tracking with automatic soft-deactivation after consecutive missing syncs, plus reporting of reset/incremented/deactivated counts.
* **Chores**
  * DB migration to add columns and index to support stale-model tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a **pricing audit system** and **stale model auto-deactivation** to the gatewayz-backend. The pricing audit adds raw API fetchers for 11 providers, multi-pass ID matching, and an admin endpoint (`/admin/pricing-audit`) that compares live API pricing against DB values. The stale tracking increments a `consecutive_missing_count` for models absent from provider APIs and soft-deactivates them after 3 consecutive misses with a 50% safety guard.

**Key findings:**

- **Critical logic bug** (`pricing_audit.py` L865): `as_completed(futures, timeout=180)` raises `concurrent.futures.TimeoutError` outside the inner `try/except` block. A single slow provider will crash the entire audit and return a 500 error with no partial results.
- **Incorrect pricing calculation for DeepInfra** (`pricing_audit.py` L570–590): The DeepInfra-specific pricing handler has an unresolved `"But wait"` comment about units and exits early without calling `normalize_fn`. If `cents_per_input_token` is per-million (as suggested by `get_provider_format("deepinfra") = PER_1M`), prices will be 1,000,000× too large, flooding the audit with false mismatches. The generic handler below already handles `cents_per_input_token` correctly.
- **Minor**: Deactivated models in `process_stale_models` have their `consecutive_missing_count` set to `deactivation_threshold` (3) rather than their actual computed `new_count`, causing slight inaccuracy for models that exceed the threshold by more than one step.
- **Style**: `auto_detect_format` is imported but never used inside `_fetch_db_models_by_gateway`'s loop body.
- The DB migration is clean and safe (`IF NOT EXISTS`, proper backfill, partial index). The stale tracking integration in `model_catalog_sync.py` is well-guarded.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge — the pricing audit endpoint can crash on any slow provider, and the DeepInfra pricing handler likely produces wildly incorrect comparison results.
- Two concrete bugs in the new 991-LOC pricing_audit.py: an unhandled TimeoutError that turns any slow provider fetch into a 500 error for the whole audit, and a DeepInfra-specific pricing branch that bypasses normalization with an explicitly unresolved unit comment, producing 1M× inflated prices. These are in new code paths and would make the primary feature (pricing comparison) unreliable in production.
- src/services/pricing_audit.py — both the parallel-fetch timeout handling (L860–873) and the DeepInfra pricing extractor (L570–590) need fixes before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/services/pricing_audit.py | New 991-LOC pricing audit service with raw provider fetchers, multi-pass ID matching (exact/normalized/slug/prefix-strip), and pricing comparison logic. Contains two bugs: (1) unhandled `concurrent.futures.TimeoutError` from `as_completed(timeout=180)` that crashes the entire audit on slow providers; (2) DeepInfra pricing branch has an unresolved unit ambiguity ("But wait") and bypasses `normalize_fn`, potentially producing 1,000,000× incorrect prices for all DeepInfra models. Also has an unused `auto_detect_format` import inside a hot loop. |
| src/db/models_catalog_db.py | Adds `process_stale_models()` with paginated DB reads, safety-guard-aware reset/increment/deactivate logic. Solid overall; minor issue: deactivated models have their `consecutive_missing_count` capped to `deactivation_threshold` rather than their actual computed `new_count`. |
| src/services/model_catalog_sync.py | Integrates stale tracking into the sync pipeline with a 50% safety guard before calling `process_stale_models()`. Logic is correct and well-guarded; note it makes two separate DB queries for the active count (once for the guard, once inside `process_stale_models`). |
| src/routes/admin.py | Adds `/admin/pricing-audit` endpoint behind `require_admin` with gateway filtering and threshold query params. Delegates to `run_pricing_audit` via `asyncio.to_thread`; no server-side timeout means the HTTP connection stays open up to the full 180s+ audit duration. |
| supabase/migrations/20260311000000_add_stale_model_tracking.sql | Adds `last_seen_in_provider_at` (nullable TIMESTAMPTZ DEFAULT now()) and `consecutive_missing_count` (INTEGER NOT NULL DEFAULT 0) to the models table, backfills existing rows, and creates a partial index on `(provider_id, is_active, consecutive_missing_count) WHERE is_active = true`. Migration is safe and idempotent via `IF NOT EXISTS`. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Admin as Admin Client
    participant API as /admin/pricing-audit
    participant AuditSvc as pricing_audit.py
    participant ProviderAPIs as Provider APIs (11+)
    participant DB as Database

    Admin->>API: GET /admin/pricing-audit?gateway=...&threshold=...
    API->>AuditSvc: run_pricing_audit(gateways, threshold_percent)

    AuditSvc->>DB: get_all_models_for_catalog()
    DB-->>AuditSvc: raw models grouped by provider slug

    par Parallel fetch (ThreadPoolExecutor, max_workers=10, timeout=180s)
        AuditSvc->>ProviderAPIs: httpx.get(openrouter_url)
        AuditSvc->>ProviderAPIs: httpx.get(deepinfra_url)
        AuditSvc->>ProviderAPIs: httpx.get(groq_url)
        AuditSvc->>ProviderAPIs: httpx.get(... 8 more)
    end

    AuditSvc->>AuditSvc: _match_models() — 4-pass ID matching
    AuditSvc->>AuditSvc: _audit_gateway() per provider

    AuditSvc-->>API: PricingAuditReport dict
    API-->>Admin: JSON report

    Note over API,AuditSvc: Sync path also runs stale tracking after each provider sync
    participant SyncSvc as model_catalog_sync.py
    SyncSvc->>DB: COUNT active models (safety guard)
    SyncSvc->>DB: process_stale_models(provider_id, seen_ids)
    DB-->>SyncSvc: {reset, incremented, deactivated}
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/services/pricing_audit.py
Line: 865-873

Comment:
**Unhandled `TimeoutError` from `as_completed` crashes the entire audit**

`as_completed(futures, timeout=180)` raises `concurrent.futures.TimeoutError` if not all futures resolve within 180 seconds. This exception is thrown by the iterator itself — outside the inner `try/except` block — so it propagates all the way up through `run_pricing_audit` and the endpoint handler, returning a 500 error to the caller with no partial results.

With 10+ provider API calls in parallel, a single slow/hanging provider can reliably trigger this. The fix is to wrap the iteration in an outer try/except:

```python
        try:
            for future in as_completed(futures, timeout=180):
                gw = futures[future]
                try:
                    models = future.result(timeout=30)
                    provider_models_by_gateway[gw] = models
                    logger.info(f"Fetched {len(models)} models from provider API: {gw}")
                except Exception as e:
                    provider_models_by_gateway[gw] = []
                    logger.warning(f"Failed to fetch provider models for {gw}: {e}")
        except TimeoutError:
            logger.warning("Provider fetch timed out after 180s; proceeding with partial results")
            for gw in target_gateways:
                provider_models_by_gateway.setdefault(gw, [])
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/services/pricing_audit.py
Line: 570-590

Comment:
**DeepInfra pricing unit ambiguity — `normalize_fn` is bypassed, potentially producing 1,000,000× wrong prices**

The comment on line 573 reads `"DeepInfra format is PER_1M"` and then immediately contradicts itself with `"Actually... cost in cents for one token"`, ending with an unresolved `"But wait — let's check..."`. This uncertainty was never resolved before the code was merged.

If `get_provider_format("deepinfra")` returns `PER_1M` (meaning cents here are per-million tokens), then dividing by 100 converts cents → dollars per million, **not** dollars per token. The result is then returned early without being passed through `normalize_fn`, so the pricing will be 1,000,000× too large compared to the DB's per-token values. This would generate massive false positives for every DeepInfra model in the audit report.

The generic path below (used for groq, fireworks) correctly handles the same `cents_per_input_token` field: it converts cents → $/1M via `/ 100`, then calls `normalize_fn(prompt_val, provider_format)` to convert $/1M → $/token.

The DeepInfra-specific branch should either:
1. Follow the same path as the generic handler (convert then normalize), or  
2. Be removed entirely to fall through to the generic handler, which already handles `cents_per_input_token`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/services/pricing_audit.py
Line: 640

Comment:
**Unused import inside hot loop**

`auto_detect_format` is imported here but never referenced anywhere in `_fetch_db_models_by_gateway`. Additionally, this import is inside a `for` loop body — while Python caches module imports, placing imports inside loops is unconventional and clutters the control flow. Consider moving all imports to the top of the function (or the module).

```suggestion
            from src.services.pricing_normalization import get_provider_format, normalize_to_per_token
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/db/models_catalog_db.py
Line: 458-464

Comment:
**`consecutive_missing_count` capped at `deactivation_threshold` instead of `new_count`**

When deactivating a model, the count is set to `deactivation_threshold` (3) rather than the actual `new_count` that triggered deactivation. Because the loop places models into `ids_to_deactivate` based on their individual `new_count` (e.g., a model with an existing count of 5 would compute `new_count = 6`), but the update blanket-sets all deactivated models to 3. This means the stored count is inaccurate for any model whose `consecutive_missing_count` was already above the threshold before deactivation (e.g., if the threshold was lowered, or if a previously deactivated model was manually re-activated with a dirty counter).

Consider using `new_count` per model, consistent with the `ids_to_increment` approach. This would require grouping by `new_count` the same way the increment block does, or issuing individual updates for deactivations.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: b9cfc45</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->