### PR TITLE
Fix/fix pricing

### DIFF
--- a/check_counts.py
+++ b/check_counts.py
@@ -1,0 +1,20 @@
+
+import asyncio
+import os
+import sys
+
+# Add src to path
+sys.path.append(os.path.abspath('.'))
+
+from src.db.models_catalog_db import get_models_stats
+
+async def main():
+    try:
+        stats = get_models_stats()
+        print(f"Total models in DB: {stats.get('total_models', 0)}")
+        print(f"Active models in DB: {stats.get('active_models', 0)}")
+    except Exception as e:
+        print(f"Error checking stats: {e}")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/supabase/migrations/20260314000001_fix_analytics_pricing_unit_conversion.sql
+++ b/supabase/migrations/20260314000001_fix_analytics_pricing_unit_conversion.sql
@@ -1,0 +1,174 @@
+-- ============================================================================
+-- Fix Model Usage Analytics View: Correct pricing_raw Unit Conversion
+-- ============================================================================
+-- Migration: 20260314000001
+-- Description: Fixes cost inflation ($156B averages) caused by treating
+--              metadata.pricing_raw values as per-token when they are actually
+--              per-1M-token. Divides pricing_raw fallback by 1,000,000.
+--
+-- Root cause: metadata->'pricing_raw'->>'prompt' stores per-1M-token pricing
+-- (e.g. 0.15 = $0.15 per 1M tokens), but the previous view used these values
+-- directly as per-token prices, inflating costs by 1,000,000x.
+--
+-- Fix: Divide metadata.pricing_raw values by 1,000,000 to convert to per-token.
+-- model_pricing.price_per_input_token is already per-token, so no change needed.
+-- ============================================================================
+
+-- Drop and recreate the view
+DROP VIEW IF EXISTS "public"."model_usage_analytics";
+
+CREATE VIEW "public"."model_usage_analytics" AS
+SELECT
+    -- Model identification
+    m.id as model_id,
+    m.model_name,
+    m.provider_model_id,
+    p.name as provider_name,
+    p.slug as provider_slug,
+
+    -- Request counts
+    COUNT(ccr.id) as successful_requests,
+
+    -- Token usage breakdown
+    COALESCE(SUM(ccr.input_tokens), 0) as total_input_tokens,
+    COALESCE(SUM(ccr.output_tokens), 0) as total_output_tokens,
+    COALESCE(SUM(ccr.input_tokens + ccr.output_tokens), 0) as total_tokens,
+
+    -- Average token usage per request
+    ROUND(AVG(ccr.input_tokens), 2) as avg_input_tokens_per_request,
+    ROUND(AVG(ccr.output_tokens), 2) as avg_output_tokens_per_request,
+
+    -- Pricing (per 1M tokens for display)
+    -- model_pricing stores per-token → multiply by 1M for display
+    -- metadata.pricing_raw stores per-1M-token → use directly for display
+    COALESCE(
+        mp.price_per_input_token * 1000000,
+        CAST(m.metadata->'pricing_raw'->>'prompt' AS NUMERIC),
+        0
+    ) as input_token_price_per_1m,
+    COALESCE(
+        mp.price_per_output_token * 1000000,
+        CAST(m.metadata->'pricing_raw'->>'completion' AS NUMERIC),
+        0
+    ) as output_token_price_per_1m,
+
+    -- Per-token pricing (raw, for cost calculations)
+    -- model_pricing is already per-token
+    -- metadata.pricing_raw is per-1M-token → divide by 1,000,000
+    COALESCE(
+        mp.price_per_input_token,
+        CAST(m.metadata->'pricing_raw'->>'prompt' AS NUMERIC) / 1000000,
+        0
+    ) as input_token_price,
+    COALESCE(
+        mp.price_per_output_token,
+        CAST(m.metadata->'pricing_raw'->>'completion' AS NUMERIC) / 1000000,
+        0
+    ) as output_token_price,
+
+    -- Cost calculations (in USD)
+    -- Uses per-token price × token count
+    ROUND(
+        CAST(
+            (COALESCE(SUM(ccr.input_tokens), 0) * COALESCE(
+                mp.price_per_input_token,
+                CAST(m.metadata->'pricing_raw'->>'prompt' AS NUMERIC) / 1000000,
+                0
+            )) +
+            (COALESCE(SUM(ccr.output_tokens), 0) * COALESCE(
+                mp.price_per_output_token,
+                CAST(m.metadata->'pricing_raw'->>'completion' AS NUMERIC) / 1000000,
+                0
+            ))
+            AS NUMERIC
+        ),
+        6
+    ) as total_cost_usd,
+
+    -- Cost breakdown
+    ROUND(
+        CAST(COALESCE(SUM(ccr.input_tokens), 0) * COALESCE(
+            mp.price_per_input_token,
+            CAST(m.metadata->'pricing_raw'->>'prompt' AS NUMERIC) / 1000000,
+            0
+        ) AS NUMERIC),
+        6
+    ) as input_cost_usd,
+    ROUND(
+        CAST(COALESCE(SUM(ccr.output_tokens), 0) * COALESCE(
+            mp.price_per_output_token,
+            CAST(m.metadata->'pricing_raw'->>'completion' AS NUMERIC) / 1000000,
+            0
+        ) AS NUMERIC),
+        6
+    ) as output_cost_usd,
+
+    -- Average cost per request
+    ROUND(
+        CAST(
+            (COALESCE(SUM(ccr.input_tokens), 0) * COALESCE(
+                mp.price_per_input_token,
+                CAST(m.metadata->'pricing_raw'->>'prompt' AS NUMERIC) / 1000000,
+                0
+            )) +
+            (COALESCE(SUM(ccr.output_tokens), 0) * COALESCE(
+                mp.price_per_output_token,
+                CAST(m.metadata->'pricing_raw'->>'completion' AS NUMERIC) / 1000000,
+                0
+            ))
+            AS NUMERIC
+        ) / NULLIF(COUNT(ccr.id), 0),
+        6
+    ) as avg_cost_per_request_usd,
+
+    -- Performance metrics
+    ROUND(AVG(ccr.processing_time_ms), 2) as avg_processing_time_ms,
+
+    -- Model metadata
+    m.context_length,
+    m.modality,
+    m.health_status,
+    m.is_active,
+
+    -- Pricing metadata
+    mp.pricing_type,
+    mp.pricing_source,
+
+    -- Time tracking
+    MIN(ccr.created_at) as first_request_at,
+    MAX(ccr.created_at) as last_request_at
+
+FROM "public"."models" m
+INNER JOIN "public"."providers" p ON m.provider_id = p.id
+INNER JOIN "public"."chat_completion_requests" ccr ON m.id = ccr.model_id
+LEFT JOIN "public"."model_pricing" mp ON m.id = mp.model_id
+WHERE ccr.status = 'completed'
+GROUP BY
+    m.id,
+    m.model_name,
+    m.provider_model_id,
+    m.metadata,
+    m.context_length,
+    m.modality,
+    m.health_status,
+    m.is_active,
+    p.name,
+    p.slug,
+    mp.price_per_input_token,
+    mp.price_per_output_token,
+    mp.pricing_type,
+    mp.pricing_source
+HAVING COUNT(ccr.id) > 0
+ORDER BY successful_requests DESC, total_cost_usd DESC;
+
+-- Add comment
+COMMENT ON VIEW "public"."model_usage_analytics" IS
+    'Model usage analytics with corrected pricing. '
+    'metadata.pricing_raw is per-1M-token; divided by 1,000,000 for per-token cost calculations. '
+    'model_pricing.price_per_input/output_token is already per-token. '
+    'Updated 2026-03-14 to fix 1M× cost inflation.';
+
+-- Grant permissions
+GRANT SELECT ON "public"."model_usage_analytics" TO authenticated;
+GRANT SELECT ON "public"."model_usage_analytics" TO anon;
+GRANT SELECT ON "public"."model_usage_analytics" TO service_role;

--- a/trigger_sync_test.py
+++ b/trigger_sync_test.py
@@ -1,0 +1,36 @@
+
+import asyncio
+import os
+import sys
+
+# Add src to path
+sys.path.append(os.path.abspath('.'))
+
+from src.services.provider_model_sync_service import trigger_full_sync
+
+async def main():
+    try:
+        print("Triggering full sync (this may take a while)...")
+        result = await trigger_full_sync()
+        print(f"Sync Result: {result.get('success', False)}")
+        
+        # Check providers synced
+        providers = result.get('providers', {})
+        print(f"Providers Synced: {providers.get('synced_count', 0)}")
+        
+        # Check models synced
+        models = result.get('models', {})
+        print(f"Models Synced: {models.get('total_models_synced', 0)} from {models.get('providers_processed', 0)} providers")
+        
+        if models.get('errors'):
+            print(f"Errors: {len(models.get('errors'))}")
+            for err in models.get('errors')[:5]:
+                print(f" - {err}")
+                
+    except Exception as e:
+        print(f"Error triggering sync: {e}")
+        import traceback
+        traceback.print_exc()
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Backend (gatewayz-backend — fix/fix-pricing):

New SQL migration divides pricing_raw values by 1,000,000 in the model_usage_analytics view, fixing the $156B cost inflation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected inflated cost calculations in usage analytics by fixing pricing unit conversion. The system now properly converts per-1M-token pricing to per-token for accurate cost reporting and metrics.

* **Chores**
  * Added utility scripts for collecting model statistics and triggering full provider/model synchronization operations to support system monitoring and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a 1,000,000x cost inflation bug in the `model_usage_analytics` SQL view by correctly dividing `metadata.pricing_raw` fallback values by 1,000,000 to convert from per-1M-token to per-token pricing. The core SQL fix is correct and well-documented.

- **SQL migration**: Correctly applies `/ 1000000` to all six `pricing_raw` fallback paths (display pricing, per-token pricing, cost calculations, cost breakdown, and average cost). The `model_pricing` table path remains unchanged since it already stores per-token values.
- **Debug scripts committed**: Two root-level utility scripts (`check_counts.py`, `trigger_sync_test.py`) appear to be leftover development/debugging tools. They should be moved to `scripts/` or removed.
- **Bug in `check_counts.py`**: Accesses non-existent dictionary keys (`total_models`, `active_models`), so it will always print `0` regardless of actual data.

<h3>Confidence Score: 3/5</h3>

- The SQL migration fix is correct and safe; the debug scripts are low-risk but should not be shipped to production.
- The core fix (SQL migration) is well-reasoned and correctly addresses the 1Mx cost inflation. However, two debug scripts are included that don't belong at the repo root, and one has a logic bug (wrong dict keys). These lower the overall score from what would otherwise be a clean fix.
- `check_counts.py` has a logic bug (wrong dictionary keys). Both `check_counts.py` and `trigger_sync_test.py` should be relocated or removed before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| supabase/migrations/20260314000001_fix_analytics_pricing_unit_conversion.sql | Correctly fixes 1,000,000x cost inflation by dividing metadata.pricing_raw values by 1M in cost calculations while keeping display pricing intact. Well-commented and consistent with the data model. |
| check_counts.py | Debug utility with wrong dictionary keys (uses 'total_models'/'active_models' instead of 'total'/'active'), so output will always be 0. Should be moved to scripts/ or removed. |
| trigger_sync_test.py | Debug utility for triggering full sync, committed to repo root. Should be moved to scripts/ or removed. Running it accidentally against production could be disruptive. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[model_usage_analytics view] --> B{Pricing source?}
    B -->|model_pricing table exists| C[price_per_input/output_token<br/>Already per-token]
    B -->|Fallback to metadata| D[metadata.pricing_raw<br/>Per-1M-token values]
    C --> E[Display: multiply by 1M]
    C --> F[Cost calc: use directly]
    D --> G[Display: use directly]
    D --> H[Cost calc: divide by 1M<br/>**THIS FIX**]
    E --> I[input/output_token_price_per_1m]
    G --> I
    F --> J[total_cost_usd<br/>input/output_cost_usd<br/>avg_cost_per_request_usd]
    H --> J
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: check_counts.py
Line: 14-15

Comment:
**Wrong dictionary keys — output will always be 0**

`get_models_stats()` returns keys `"total"` and `"active"` (see `src/db/models_catalog_db.py:452-454`), but this script accesses `"total_models"` and `"active_models"`, which don't exist. Both `print` statements will always output `0` (the default).

```suggestion
        print(f"Total models in DB: {stats.get('total', 0)}")
        print(f"Active models in DB: {stats.get('active', 0)}")
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: check_counts.py
Line: 1-20

Comment:
**Debug script committed to repo root**

This appears to be a one-off debugging utility that was committed to the repository root. The project already has a well-organized `scripts/` directory with similar diagnostic tools (e.g., `scripts/check_provider_model_counts.py`, `scripts/verify_models_in_db.py`). Consider either moving this to `scripts/` or removing it entirely if it was only needed for development.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: trigger_sync_test.py
Line: 1-36

Comment:
**Debug script committed to repo root**

Same as `check_counts.py` — this is a one-off test/debug utility that should either live in `scripts/` (alongside similar scripts like `scripts/manual_sync_now.py`, `scripts/sync_missing_providers.py`) or be removed if no longer needed. Running `trigger_full_sync()` against production without safeguards could be disruptive if executed accidentally.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: f9ed156</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->