### PR TITLE
fix: normalize pricing 

### DIFF
--- a/src/db/models_catalog_db.py
+++ b/src/db/models_catalog_db.py
@@ -930,6 +930,18 @@ def _sync_pricing_to_model_pricing(supabase, upserted_models: list[dict[str, Any
         except (ValueError, TypeError, InvalidOperation):
             continue
 
+        # Guard: if price looks too large for per-token format (> 0.001),
+        # auto-detect the format and normalize to per-token.
+        # Per-token prices should be < 0.001 (even GPT-4 is ~$0.00003/token).
+        from src.services.pricing_normalization import auto_detect_format, normalize_to_per_token
+
+        if input_price > Decimal("0.001"):
+            detected = auto_detect_format(float(input_price))
+            input_price = normalize_to_per_token(input_price, detected) or Decimal("0")
+        if output_price > Decimal("0.001"):
+            detected = auto_detect_format(float(output_price))
+            output_price = normalize_to_per_token(output_price, detected) or Decimal("0")
+
         row = {
             "model_id": model_id,
             "price_per_input_token": str(input_price),

--- a/src/services/model_catalog_sync.py
+++ b/src/services/model_catalog_sync.py
@@ -309,8 +309,25 @@ def transform_normalized_model_to_db_schema(
             # Store relevant architecture info
             architecture_str = architecture.get("tokenizer") or architecture.get("instruct_type")
 
-        # Extract pricing
+        # Extract pricing and normalize to per-token format
         pricing = extract_pricing(normalized_model)
+
+        # Normalize pricing to per-token if the provider uses a different format
+        # (e.g., per-1M for NEAR, DeepInfra, etc.)
+        # This prevents storing inflated values in metadata.pricing_raw
+        from src.services.pricing_normalization import (
+            get_provider_format,
+            normalize_to_per_token,
+            PricingFormat,
+        )
+
+        source_gateway = normalized_model.get("source_gateway", provider_slug)
+        provider_format = get_provider_format(source_gateway)
+        if provider_format != PricingFormat.PER_TOKEN:
+            for field in ("prompt", "completion", "image", "request"):
+                if pricing[field] is not None and pricing[field] != Decimal("0"):
+                    normalized_val = normalize_to_per_token(pricing[field], provider_format)
+                    pricing[field] = normalized_val if normalized_val is not None else Decimal("0")
 
         # Extract capabilities
         capabilities = extract_capabilities(normalized_model)

--- a/supabase/migrations/20260315000000_fix_model_pricing_unit_normalization.sql
+++ b/supabase/migrations/20260315000000_fix_model_pricing_unit_normalization.sql
@@ -1,0 +1,135 @@
+-- ============================================================================
+-- Fix Model Pricing Unit Normalization
+-- ============================================================================
+-- Migration: 20260315000000
+-- Description: Fixes pricing data that was stored in per-1M-token format
+--              instead of per-token format in both the model_pricing table
+--              and models.metadata.pricing_raw.
+--
+-- Root cause: model_catalog_sync.py did not normalize pricing from providers
+-- that return per-1M-token prices (NEAR, DeepInfra, Fireworks, etc.) before
+-- storing in metadata.pricing_raw. The model_usage_analytics view then
+-- multiplied these already-large values by 1,000,000 for display, resulting
+-- in $100B+ prices shown on the Model Analytics page.
+--
+-- Fix: Divide prices > 0.001 by 1,000,000 (per-1M → per-token conversion).
+-- Per-token prices should be < 0.001 (even expensive models are ~$0.00006/token).
+-- ============================================================================
+
+-- Step 1: Diagnostic — count affected rows (logged via RAISE NOTICE)
+DO $$
+DECLARE
+    affected_model_pricing INTEGER;
+    affected_metadata INTEGER;
+BEGIN
+    SELECT COUNT(*) INTO affected_model_pricing
+    FROM model_pricing
+    WHERE price_per_input_token > 0.001 OR price_per_output_token > 0.001;
+
+    SELECT COUNT(*) INTO affected_metadata
+    FROM models
+    WHERE metadata->'pricing_raw' IS NOT NULL
+      AND (
+        COALESCE((metadata->'pricing_raw'->>'prompt')::NUMERIC, 0) > 0.001
+        OR COALESCE((metadata->'pricing_raw'->>'completion')::NUMERIC, 0) > 0.001
+      );
+
+    RAISE NOTICE '';
+    RAISE NOTICE '==========================================';
+    RAISE NOTICE 'Pricing unit normalization — pre-fix report';
+    RAISE NOTICE '==========================================';
+    RAISE NOTICE '  model_pricing rows with inflated prices: %', affected_model_pricing;
+    RAISE NOTICE '  models rows with inflated pricing_raw:   %', affected_metadata;
+    RAISE NOTICE '';
+END $$;
+
+-- Step 2: Fix model_pricing table
+-- Divide inflated per-1M values by 1,000,000 to get per-token
+UPDATE model_pricing
+SET
+    price_per_input_token = CASE
+        WHEN price_per_input_token > 0.001
+        THEN price_per_input_token / 1000000
+        ELSE price_per_input_token
+    END,
+    price_per_output_token = CASE
+        WHEN price_per_output_token > 0.001
+        THEN price_per_output_token / 1000000
+        ELSE price_per_output_token
+    END,
+    last_updated = NOW()
+WHERE price_per_input_token > 0.001 OR price_per_output_token > 0.001;
+
+-- Step 3: Fix models.metadata.pricing_raw (JSONB)
+-- Only update rows where pricing_raw values are inflated
+UPDATE models
+SET metadata = jsonb_set(
+    jsonb_set(
+        metadata,
+        '{pricing_raw,prompt}',
+        to_jsonb(
+            CASE
+                WHEN COALESCE((metadata->'pricing_raw'->>'prompt')::NUMERIC, 0) > 0.001
+                THEN (metadata->'pricing_raw'->>'prompt')::NUMERIC / 1000000
+                ELSE COALESCE((metadata->'pricing_raw'->>'prompt')::NUMERIC, 0)
+            END
+        )::TEXT::JSONB
+    ),
+    '{pricing_raw,completion}',
+    to_jsonb(
+        CASE
+            WHEN COALESCE((metadata->'pricing_raw'->>'completion')::NUMERIC, 0) > 0.001
+            THEN (metadata->'pricing_raw'->>'completion')::NUMERIC / 1000000
+            ELSE COALESCE((metadata->'pricing_raw'->>'completion')::NUMERIC, 0)
+        END
+    )::TEXT::JSONB
+)
+WHERE metadata->'pricing_raw' IS NOT NULL
+  AND (
+    COALESCE((metadata->'pricing_raw'->>'prompt')::NUMERIC, 0) > 0.001
+    OR COALESCE((metadata->'pricing_raw'->>'completion')::NUMERIC, 0) > 0.001
+  );
+
+-- Step 4: Post-fix verification
+DO $$
+DECLARE
+    remaining_model_pricing INTEGER;
+    remaining_metadata INTEGER;
+    sample_model TEXT;
+    sample_input NUMERIC;
+    sample_output NUMERIC;
+BEGIN
+    SELECT COUNT(*) INTO remaining_model_pricing
+    FROM model_pricing
+    WHERE price_per_input_token > 0.001 OR price_per_output_token > 0.001;
+
+    SELECT COUNT(*) INTO remaining_metadata
+    FROM models
+    WHERE metadata->'pricing_raw' IS NOT NULL
+      AND (
+        COALESCE((metadata->'pricing_raw'->>'prompt')::NUMERIC, 0) > 0.001
+        OR COALESCE((metadata->'pricing_raw'->>'completion')::NUMERIC, 0) > 0.001
+      );
+
+    -- Show a sample of fixed data
+    SELECT m.model_name, mp.price_per_input_token, mp.price_per_output_token
+    INTO sample_model, sample_input, sample_output
+    FROM model_pricing mp
+    JOIN models m ON m.id = mp.model_id
+    WHERE mp.price_per_input_token > 0
+    ORDER BY mp.price_per_input_token DESC
+    LIMIT 1;
+
+    RAISE NOTICE '';
+    RAISE NOTICE '==========================================';
+    RAISE NOTICE 'Pricing unit normalization — post-fix report';
+    RAISE NOTICE '==========================================';
+    RAISE NOTICE '  Remaining inflated model_pricing rows: %', remaining_model_pricing;
+    RAISE NOTICE '  Remaining inflated metadata rows:      %', remaining_metadata;
+    RAISE NOTICE '  Highest priced model: % (input: %, output: %)', sample_model, sample_input, sample_output;
+    RAISE NOTICE '';
+
+    IF remaining_model_pricing > 0 THEN
+        RAISE WARNING 'Some model_pricing rows still have inflated prices — manual review needed';
+    END IF;
+END $$;


### PR DESCRIPTION
During model sync and add migration to fix existing data

- Add pricing normalization in model_catalog_sync.py using existing pricing_normalization utilities
- Add validation guard in models_catalog_db.py to auto-detect and normalize inflated prices
- Add SQL migration to fix existing model_pricing and metadata.pricing_raw values stored in per-1M format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed pricing format inconsistencies by implementing automatic detection and normalization of pricing data to per-token units across all providers, resolving issues with inflated pricing values.
  * Database migration automatically corrects existing pricing records to the proper per-token format, ensuring accurate cost calculations throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds pricing normalization during model sync and a SQL migration to fix existing inflated pricing data stored in per-1M-token format instead of per-token format. The sync-time fix in `model_catalog_sync.py` correctly normalizes all four pricing fields. However, the runtime guard in `models_catalog_db.py` and the SQL migration both only fix input/output (prompt/completion) prices, leaving `image` and `request` pricing un-normalized — an incomplete fix that could allow the same inflation bug to persist for those fields.

- `model_catalog_sync.py`: Correctly normalizes all pricing fields (`prompt`, `completion`, `image`, `request`) at sync time using provider format lookup
- `models_catalog_db.py`: Normalization guard in `_sync_pricing_to_model_pricing` only covers `input_price`/`output_price`, missing `image` and `request` prices
- SQL migration: Well-structured with diagnostics, but only fixes `price_per_input_token`/`price_per_output_token` and `pricing_raw.prompt`/`pricing_raw.completion` — does not address `price_per_image_token`, `price_per_request`, or corresponding `pricing_raw` keys
- Both Python files place imports inside loop/function bodies instead of at module top-level

<h3>Confidence Score: 2/5</h3>

- This PR partially fixes the pricing normalization bug but has gaps that leave image/request pricing un-normalized in both runtime code and the migration.
- Score of 2 reflects that the core fix in model_catalog_sync.py is correct, but models_catalog_db.py and the SQL migration both have incomplete coverage — they only normalize prompt/completion (input/output) prices while leaving image/request prices inflated. This means the same class of bug can persist for image and request pricing fields.
- Pay close attention to `src/db/models_catalog_db.py` (lines 933-965) where image/request prices bypass normalization, and the SQL migration which should also fix `price_per_image_token`, `price_per_request`, and `pricing_raw.image`/`pricing_raw.request`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/db/models_catalog_db.py | Adds a per-token normalization guard in `_sync_pricing_to_model_pricing`, but only normalizes input/output prices — `image` and `request` prices are left raw, creating an inconsistency. Import is also placed inside the loop. |
| src/services/model_catalog_sync.py | Correctly normalizes all four pricing fields (prompt, completion, image, request) using provider format lookup before storing to `pricing_raw`. Minor style issue with import placement inside function body. |
| supabase/migrations/20260315000000_fix_model_pricing_unit_normalization.sql | Well-structured migration with diagnostic logging and verification, but only fixes `price_per_input_token`/`price_per_output_token` and `pricing_raw.prompt`/`pricing_raw.completion` — does not fix `price_per_image_token`, `price_per_request`, or `pricing_raw.image`/`pricing_raw.request`. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Provider as Provider API
    participant Sync as model_catalog_sync.py
    participant DB as models_catalog_db.py
    participant MP as model_pricing table
    participant Models as models.metadata.pricing_raw

    Provider->>Sync: Raw pricing (per-1M, per-1K, per-token)
    Sync->>Sync: extract_pricing() → Decimal values
    Sync->>Sync: get_provider_format() → detect format
    Sync->>Sync: normalize_to_per_token() for all 4 fields ✅
    Sync->>Models: Store normalized pricing_raw in metadata
    Models->>DB: _sync_pricing_to_model_pricing()
    DB->>DB: Read pricing_raw from metadata
    DB->>DB: auto_detect + normalize input/output ✅
    Note over DB: ⚠️ image/request NOT normalized
    DB->>MP: Upsert to model_pricing table
    Note over MP: Migration fixes input/output ✅
    Note over MP: ⚠️ image/request NOT fixed
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/db/models_catalog_db.py
Line: 936

Comment:
**Import inside loop body**

This `from src.services.pricing_normalization import ...` statement is inside the `for model in upserted_models` loop, so it executes on every iteration. While Python caches module lookups after the first import, the repeated `import` machinery still has overhead and is unconventional. Move this import to the top of the file or at least outside the loop body.

```suggestion
    from src.services.pricing_normalization import auto_detect_format, normalize_to_per_token
```

Should be placed before the `for model in upserted_models:` loop (around line 908) or at the module top-level.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/db/models_catalog_db.py
Line: 933-943

Comment:
**`image` and `request` prices are not normalized**

The normalization guard here only applies to `input_price` and `output_price`, but `image` (line 956) and `request` (line 963) prices are written raw to the `model_pricing` row without the same guard. This is inconsistent with `model_catalog_sync.py` (lines 327–330) which normalizes all four fields (`prompt`, `completion`, `image`, `request`).

If a provider returns inflated `image` or `request` pricing (e.g., per-1M format), those values will be stored un-normalized in `price_per_image_token` and `price_per_request`, causing the same bug this PR is trying to fix.

Consider adding the same auto-detect + normalize guard for the `image` and `request` Decimal values after they are parsed (around lines 953–965).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: supabase/migrations/20260315000000_fix_model_pricing_unit_normalization.sql
Line: 54-68

Comment:
**Migration does not fix `image` / `request` pricing columns**

This UPDATE only normalizes `price_per_input_token` and `price_per_output_token` in `model_pricing`, but `price_per_image_token` and `price_per_request` could also contain inflated per-1M values. The same applies to Step 3's `pricing_raw` fix which only corrects `prompt` and `completion` but not `image` or `request`.

If any models have inflated image/request pricing stored in the database, they will remain broken after this migration. Consider adding the same `CASE WHEN > 0.001 THEN / 1000000` logic for `price_per_image_token`, `price_per_request`, and the corresponding `pricing_raw` keys.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/services/model_catalog_sync.py
Line: 318-322

Comment:
**Import inside function body**

Same as `models_catalog_db.py` — this import is inside `transform_normalized_model_to_db_schema()` which is called per-model. Move to the module top-level to follow the existing import convention used in the rest of this file (lines 1–50).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: cd3da0a</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->