### PR TITLE
fix: include model name

### DIFF
--- a/src/routes/health.py
+++ b/src/routes/health.py
@@ -656,12 +656,16 @@ async def get_catalog_models(
             model_id = model.get("id", "unknown")
             health_data = health_lookup.get(model_id, {})
 
-            # Use health data if available, otherwise default to None/unknown
+            # Use health data if available; catalog-only models are "available"
             transformed = {
                 "model_id": model_id,
+                "name": model.get("name") or model.get("display_name") or model_id,
                 "provider": model.get("source_gateway", "unknown"),
+                "provider_slug": model.get("provider_slug", model.get("source_gateway", "unknown")),
                 "gateway": model.get("source_gateway", "unknown"),
-                "status": health_data.get("status", "unknown"),
+                "status": health_data.get("status", "available"),
+                "context_length": model.get("context_length"),
+                "modality": model.get("modality"),
                 "response_time_ms": health_data.get("response_time_ms"),
                 "avg_response_time_ms": health_data.get("avg_response_time_ms"),
                 "uptime_percentage": health_data.get("uptime_percentage"),


### PR DESCRIPTION
fix: include model name in catalog health response and set status to "available."

- Add name, provider_slug, context_length, modality to /health/catalog/models response
- Change default status from "unknown" to "available" for catalog-only models
- Models with health data retain their actual health status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Catalog models now include enriched metadata: name, provider slug, context length, and modality.
  * Improved default health status to "available" for models without health data, reducing ambiguity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enriches the `/health/catalog/models` endpoint response with additional model metadata (`name`, `provider_slug`, `context_length`, `modality`) sourced from the normalized catalog data, and changes the default status for catalog-only models (those without health monitoring data) from `"unknown"` to `"available"`.

- **New fields**: `name` (with fallback chain: name → display_name → model_id), `provider_slug`, `context_length`, `modality` — all drawn from the existing normalized model schema
- **Status default change**: Models without health data now report `"available"` instead of `"unknown"`, which better reflects that catalog presence implies availability
- **Minor issue**: A comment at line 678 claims the response schema matches `/health/models` exactly, but the catalog endpoint now returns a superset of that schema

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds read-only fields to an existing response and changes a sensible default value.
- The changes are additive (new response fields) and the status default change from "unknown" to "available" is a reasonable semantic improvement. All source fields exist in the normalized model schema. The only flag is a stale comment, which is cosmetic.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/routes/health.py | Adds `name`, `provider_slug`, `context_length`, and `modality` fields to the `/health/catalog/models` response and changes the default status from "unknown" to "available" for catalog-only models. One stale comment noted. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant CatalogEndpoint as /health/catalog/models
    participant ModelService as get_all_models_parallel()
    participant HealthCache as simple_health_cache

    Client->>CatalogEndpoint: GET /health/catalog/models
    CatalogEndpoint->>ModelService: Fetch all catalog models
    ModelService-->>CatalogEndpoint: Models (id, name, provider_slug, context_length, modality, ...)
    CatalogEndpoint->>HealthCache: get_models_health()
    HealthCache-->>CatalogEndpoint: Health records (status, response_time_ms, ...)
    CatalogEndpoint->>CatalogEndpoint: Merge catalog fields + health data
    Note over CatalogEndpoint: Default status = "available"<br/>if no health data exists
    CatalogEndpoint-->>Client: { model_id, name, provider_slug,<br/>context_length, modality, status, ... }
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/routes/health.py`, line 678 ([link](https://github.com/alpaca-network/gatewayz-backend/blob/5328d0206cc8e5219012c2593bafc437d6713f20/src/routes/health.py#L678)) 

   **Stale comment: schemas no longer match**

   This comment says "Match /health/models schema exactly", but with the addition of `name`, `provider_slug`, `context_length`, and `modality`, the catalog endpoint's per-model schema now has fields that `/health/models` does not return. Consider updating the comment to reflect the intentional divergence (e.g., "Return catalog-enriched superset of /health/models schema").

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/routes/health.py
Line: 678

Comment:
**Stale comment: schemas no longer match**

This comment says "Match /health/models schema exactly", but with the addition of `name`, `provider_slug`, `context_length`, and `modality`, the catalog endpoint's per-model schema now has fields that `/health/models` does not return. Consider updating the comment to reflect the intentional divergence (e.g., "Return catalog-enriched superset of /health/models schema").

```suggestion
        # Superset of /health/models schema (adds catalog fields: name, provider_slug, context_length, modality)
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 5328d02</sub>

<!-- /greptile_comment -->