### PR TITLE
fix: resolve isort failures on main for model_catalog_sync.py

### DIFF
--- a/src/services/model_catalog_sync.py
+++ b/src/services/model_catalog_sync.py
@@ -23,7 +23,9 @@ from src.services.canopywave_client import fetch_models_from_canopywave
 from src.services.cerebras_client import fetch_models_from_cerebras
 from src.services.chutes_client import fetch_models_from_chutes
 from src.services.clarifai_client import fetch_models_from_clarifai
-from src.services.cloudflare_workers_ai_client import fetch_models_from_cloudflare_workers_ai
+from src.services.cloudflare_workers_ai_client import (
+    fetch_models_from_cloudflare_workers_ai,
+)
 from src.services.cohere_client import fetch_models_from_cohere
 from src.services.deepinfra_client import fetch_models_from_deepinfra
 from src.services.fal_image_client import fetch_models_from_fal
@@ -41,6 +43,11 @@ from src.services.novita_client import fetch_models_from_novita
 from src.services.onerouter_client import fetch_models_from_onerouter
 from src.services.openai_client import fetch_models_from_openai
 from src.services.openrouter_client import fetch_models_from_openrouter
+from src.services.pricing_normalization import (
+    PricingFormat,
+    get_provider_format,
+    normalize_to_per_token,
+)
 from src.services.simplismart_client import fetch_models_from_simplismart
 from src.services.sybil_client import fetch_models_from_sybil
 from src.services.together_client import fetch_models_from_together
@@ -315,12 +322,6 @@ def transform_normalized_model_to_db_schema(
         # Normalize pricing to per-token if the provider uses a different format
         # (e.g., per-1M for NEAR, DeepInfra, etc.)
         # This prevents storing inflated values in metadata.pricing_raw
-        from src.services.pricing_normalization import (
-            get_provider_format,
-            normalize_to_per_token,
-            PricingFormat,
-        )
-
         source_gateway = normalized_model.get("source_gateway", provider_slug)
         provider_format = get_provider_format(source_gateway)
         if provider_format != PricingFormat.PER_TOKEN:


### PR DESCRIPTION
Move pricing_normalization import from local (function-level) to top-level in correct alphabetical order, and wrap long cloudflare import line per isort/black profile.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes isort linting failures in `model_catalog_sync.py` by hoisting the `pricing_normalization` import from a local (function-level) position to the top-level import block in correct alphabetical order, and wrapping the long `cloudflare_workers_ai_client` import line to comply with isort/black formatting rules. No functional or behavioral changes — strictly a lint compliance fix.

- Moved `PricingFormat`, `get_provider_format`, and `normalize_to_per_token` imports to top-level
- Wrapped long cloudflare import in parentheses for line-length compliance
- Removed redundant local import inside `transform_normalized_model_to_db_schema`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only reorganizes import statements with no functional changes.
- The changes are purely cosmetic (import ordering and line wrapping) with zero behavioral impact. No circular import risk was found, and all three imported symbols are still used in the same file.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/services/model_catalog_sync.py | Moves pricing_normalization import from function-level to top-level in correct alphabetical order, and wraps a long cloudflare import line per isort/black formatting. No behavioral changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[model_catalog_sync.py] -->|top-level import| B[pricing_normalization.py]
    B -->|PricingFormat| A
    B -->|get_provider_format| A
    B -->|normalize_to_per_token| A
    A -->|top-level import wrapped| C[cloudflare_workers_ai_client.py]
    C -->|fetch_models_from_cloudflare_workers_ai| A

    style A fill:#e8f5e9,stroke:#4caf50
    style B fill:#e3f2fd,stroke:#2196f3
    style C fill:#e3f2fd,stroke:#2196f3
```

<sub>Last reviewed commit: ae0eaa9</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal code structure for improved maintainability.

**Note:** This release contains no user-facing changes and focuses on internal code improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->