### PR TITLE
ci: add Conceptual Model test workflow (186 tests on every PR)

### DIFF
--- a/.github/workflows/conceptual-model-tests.yml
+++ b/.github/workflows/conceptual-model-tests.yml
@@ -18,6 +18,10 @@ concurrency:
   group: cm-tests-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   PYTHON_VERSION: "3.12"
 


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs all 186 Conceptual Model tests on every PR.

## What it does

- Runs `tests/conceptual_model/test_cm01` through `test_cm18` (186 tests)
- Posts a **sticky comment** on the PR with pass/fail counts and per-section breakdown
- Uploads JUnit XML + full output as artifacts
- Triggers on PRs touching `src/**` or `tests/conceptual_model/**`
- Uses `pytest-xdist` for parallel execution, 30s timeout per test

## Test plan

- [ ] Workflow runs successfully on this PR
- [ ] Sticky comment appears with results table
- [ ] Artifacts uploaded

Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new GitHub Actions workflow (`.github/workflows/conceptual-model-tests.yml`) that runs all 18 conceptual model test modules (186 tests) on every PR, posts a sticky Markdown comment with pass/fail counts and a per-section breakdown, and uploads JUnit XML + raw output as artifacts. The workflow pattern (wheelhouse caching, Blacksmith runner, `actions/setup-python@v5`) aligns well with the existing `ci.yml` convention.

**Key issues found:**

- **[Critical — Logic]** The "Run Conceptual Model tests" step will silently never generate `cm-summary.md` (and therefore never post the PR comment) when tests fail. GitHub Actions uses `bash -eo pipefail` by default; when pytest exits non-zero, the pipe `pytest ... | tee cm-test-output.txt` propagates that exit code, and `-e` aborts the script before any summary generation code runs. The sticky comment is only posted on a green run — the opposite of what's useful. The fix is to capture pytest's exit code with `set +e` / `PYTEST_EXIT=$?` (matching the pattern already used in `ci.yml`), then exit with it after the summary is written.
- **[Style]** No explicit `permissions: pull-requests: write` block is declared. Repositories/orgs using a restrictive default `GITHUB_TOKEN` permission policy may silently block the sticky comment step.
- **[Style]** When `tests/conceptual_model/**` is touched, both this workflow and `ci.yml` (which triggers on `tests/**`) run the same CM tests, doubling compute usage on that path.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is — the PR comment (the primary deliverable of this workflow) is never generated when tests fail due to a `set -eo pipefail` script abort, defeating the workflow's main purpose.
- Score of 2 reflects one critical logic bug (summary/comment silently skipped on all failing runs), one missing permission declaration that can cause intermittent failures, and a duplicate-run inefficiency with `ci.yml`. The structural approach (caching, runner choice, sticky comment, artifacts) is sound, but the core reporting behavior is broken in the most important case.
- `.github/workflows/conceptual-model-tests.yml` — specifically the `run:` block of the "Run Conceptual Model tests" step (lines 73–119) needs the `set +e` / exit-code capture pattern before the summary can work correctly on failures.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/conceptual-model-tests.yml | New CI workflow running 186 conceptual model tests on every PR — has a critical logic bug where the pytest pipe exits early under `set -eo pipefail`, preventing `cm-summary.md` from ever being created on test failures, which means the sticky PR comment is never posted when it is most needed. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PR as Pull Request
    participant GHA as GitHub Actions
    participant Pytest as pytest (xdist)
    participant Tee as tee (cm-test-output.txt)
    participant Script as Summary Script
    participant Sticky as sticky-comment action

    PR->>GHA: Push / PR event
    GHA->>Pytest: Run CM tests (-n auto --timeout=30)
    Pytest->>Tee: Stream output
    Tee-->>GHA: Write cm-test-output.txt

    alt Tests PASS (exit 0)
        Pytest-->>GHA: exit 0
        GHA->>Script: Continue script
        Script->>Script: grep counts, build cm-summary.md
        Script-->>GHA: cm-summary.md created
        GHA->>Sticky: Post/update PR comment
        Sticky-->>PR: ✅ Comment posted
    else Tests FAIL (exit ≠ 0) — BUG
        Pytest-->>GHA: exit 1
        Note over GHA,Script: set -eo pipefail aborts script HERE
        Note over Script: Summary script never runs
        Note over Script: cm-summary.md never created
        GHA->>Sticky: Try to read cm-summary.md
        Sticky-->>PR: ❌ No comment posted (file missing)
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/conceptual-model-tests.yml
Line: 74-119

Comment:
**Summary is never generated when tests fail**

GitHub Actions defaults to `bash --noprofile --norc -eo pipefail` for `run:` steps. With `-eo pipefail` in effect, the pipe on line 80:

```bash
pytest ... 2>&1 | tee cm-test-output.txt
```

will exit with pytest's non-zero code when any test fails. The `-e` flag then causes the entire script to immediately abort — meaning everything from line 83 onward (`cm-summary.md` creation, the `grep` counts, the per-section loop) never executes. The file `cm-summary.md` is never created, and the sticky-comment step either fails or posts nothing.

This is the opposite of the desired behavior: the PR comment is only generated for a fully-green run, but is silently skipped on any failure — which is exactly when reviewers need it most.

The existing `ci.yml` handles this correctly by explicitly using `set +e` and capturing the exit code. The same pattern should be applied here:

```bash
set +e
pytest tests/conceptual_model/ \
  -v \
  --tb=short \
  -n auto \
  --timeout=30 \
  --junitxml=cm-test-results.xml \
  2>&1 | tee cm-test-output.txt
PYTEST_EXIT=$?
set -e

# Extract summary for PR comment
echo "## Conceptual Model Test Results" > cm-summary.md
# ... rest of summary generation unchanged ...

exit $PYTEST_EXIT
```

This ensures the summary is always written and the step still fails (causing the check to turn red) when tests are broken.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/conceptual-model-tests.yml
Line: 131-136

Comment:
**Missing `permissions` block for PR comments**

The `marocchino/sticky-pull-request-comment@v2` action requires write access to pull-request comments. Without an explicit `permissions:` declaration, this workflow relies entirely on the repository's default `GITHUB_TOKEN` permission level. If the organization or repository is configured with a restrictive default (e.g., `read-all`), comment posting will fail silently.

Adding a job-level `permissions` block is a best practice for clarity and reliability:

```yaml
jobs:
  conceptual-model-tests:
    name: CM Tests
    runs-on: blacksmith-4vcpu-ubuntu-2404
    permissions:
      pull-requests: write
      contents: read
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/conceptual-model-tests.yml
Line: 6-9

Comment:
**Conceptual model tests run twice when `tests/conceptual_model/` changes**

The existing `ci.yml` workflow is triggered by `tests/**` paths, which already includes `tests/conceptual_model/**`. When a PR modifies files under `tests/conceptual_model/`, both workflows fire: `ci.yml` runs all tests across 4 shards (which includes the CM tests), and this new workflow also runs the CM tests in full. This doubles compute usage on every change to the test suite itself.

Consider either:
- Narrowing `ci.yml`'s `tests/**` path filter to exclude `tests/conceptual_model/**` (so this dedicated workflow owns that directory), or
- Using a `workflow_call` pattern where `ci.yml` delegates to this workflow rather than re-running those tests inline.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: c7b374b</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->