### PR TITLE
ci: auto-add new issues and PRs to Gatewayz API project

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -3,7 +3,7 @@ name: Add to Gatewayz API Project
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 permissions:
@@ -14,7 +14,7 @@ jobs:
     name: Add to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      - uses: actions/add-to-project@31b3f3ccdc584546fc445612dec3f38ff3b00d44 # v1.0.2
         with:
           project-url: https://github.com/orgs/Alpaca-Network/projects/6
           github-token: ${{ secrets.WIKI_PAT }}


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically adds every new issue and PR to the **Gatewayz API** project board (#6).

## Setup Required

This workflow needs a `PROJECT_TOKEN` repository secret:

1. Go to GitHub Settings > Developer Settings > Personal Access Tokens
2. Create a token with `project` scope (for org project access)
3. Add it as a repository secret: Settings > Secrets > Actions > `PROJECT_TOKEN`

Without the secret, the workflow will fail silently on new issues/PRs.

## What it does

- Triggers on every new issue (`issues: opened`) and new PR (`pull_request: opened`)
- Adds the item to https://github.com/orgs/Alpaca-Network/projects/6
- Uses the official `actions/add-to-project@v1.0.2` action

## Also done this session

Manually added all 11 issues from this session (#2057-#2066, #2076) to the project.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow that automatically adds newly opened issues and pull requests to the project's board, streamlining project board organization and reducing manual triage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a single GitHub Actions workflow (`.github/workflows/add-to-project.yml`) that automatically adds every newly opened issue and PR to the **Gatewayz API** project board (#6) using the `actions/add-to-project` action. The intent is straightforward and the overall structure is correct, but there are two functional issues that will cause the workflow to fail in practice, plus a security hardening gap.

- **Fork PRs lose secret access**: The `pull_request` event does not expose repository secrets when the PR originates from a forked repository. `secrets.PROJECT_TOKEN` will be empty for external contributor PRs, causing the action to fail. The event should be changed to `pull_request_target`, which is safe here because no code is checked out.
- **Insufficient PAT scope documented**: The setup instructions only mention the `project` scope. For private repositories, `actions/add-to-project` also needs the `repo` scope to resolve issue/PR node IDs via the GitHub GraphQL API — without it the workflow will `404` or `403` at runtime.
- **Action not pinned to a commit SHA**: `actions/add-to-project@v1.0.2` references a mutable tag. Pinning to the corresponding full commit SHA follows GitHub's security hardening guide and prevents supply-chain risk from a compromised or replaced tag.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is — the workflow will silently fail for fork PRs and may fail for private-repo issues/PRs due to missing PAT scope.
- Two logic issues will cause real runtime failures: the `pull_request` event drops secrets for fork-originated PRs, and the documented PAT scope (`project` only) is insufficient for private repositories. These need to be resolved before the workflow reliably does what it's intended to do. The SHA-pinning concern is a best-practice gap rather than a blocking issue.
- .github/workflows/add-to-project.yml requires attention for the event trigger type, PAT scope, and action SHA pinning.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/add-to-project.yml | New workflow to auto-add issues/PRs to the Gatewayz API project board. Has two functional issues: (1) `pull_request` event hides secrets from fork PRs — should be `pull_request_target`; (2) the PAT may need `repo` scope in addition to `project` for private repos. Also missing commit-SHA pinning for the third-party action. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub
    participant Runner as Actions Runner
    participant Action as actions/add-to-project
    participant ProjectAPI as GitHub Projects API

    GH->>Runner: issues:opened / pull_request:opened
    Note over Runner: Loads secrets.PROJECT_TOKEN<br/>(unavailable for fork PRs with pull_request event)
    Runner->>Action: Run with project-url + github-token
    Action->>ProjectAPI: GraphQL: resolve issue/PR node ID<br/>(needs repo scope for private repos)
    ProjectAPI-->>Action: Node ID
    Action->>ProjectAPI: GraphQL: addProjectV2ItemById
    ProjectAPI-->>Action: Item added to project board
    Action-->>Runner: Success
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/add-to-project.yml
Line: 6-7

Comment:
**Secrets unavailable for fork-originated PRs**

The `pull_request` event from forked repositories does **not** expose repository secrets to the workflow runner. This means `secrets.PROJECT_TOKEN` will be empty for any PR submitted by an external contributor from a fork, causing the `add-to-project` step to fail with an authentication error.

Since this workflow does not check out any code (so there's no risk of executing untrusted code from the fork), switching to `pull_request_target` is the safe and correct fix — it runs in the context of the base repo and always has access to secrets:

```suggestion
  pull_request_target:
    types: [opened]
```

See [GitHub docs on `pull_request_target`](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target) for details. If this repo only receives PRs from team members (no forks), this is lower risk, but it's still the correct event to use for secret-dependent project-board automation.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/add-to-project.yml
Line: 17

Comment:
**Action not pinned to a commit SHA**

Referencing `actions/add-to-project@v1.0.2` by a mutable tag means a compromised or force-pushed tag could silently swap in malicious code. GitHub's security hardening guide recommends pinning third-party actions to an immutable full-length commit SHA.

```suggestion
      - uses: actions/add-to-project@ab9f4b3e8e442878f48604dbc6b6a30e9c768052
```

(`ab9f4b3e8e442878f48604dbc6b6a30e9c768052` is the SHA for the `v1.0.2` release — verify it against the [actions/add-to-project releases page](https://github.com/actions/add-to-project/releases) before merging.)

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/add-to-project.yml
Line: 19-20

Comment:
**PAT may need `repo` scope in addition to `project`**

The PR description instructs setting up a token with only the `project` scope. However, `actions/add-to-project` needs to resolve the node ID of the newly created issue or PR in order to call the GraphQL Projects API. For **private** repositories, that lookup requires the `repo` scope on the PAT as well; `project` alone is insufficient.

If the repository is private and the PAT only has `project` scope, the action will fail with a `404` or `403` when trying to read the issue/PR. The setup instructions in the PR description (or in a `README`/`CONTRIBUTING` file) should specify:

> Create a classic PAT with **`project`** and **`repo`** scopes (or `public_repo` for public repos).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 6e150bf</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->