### PR TITLE
feat: add live model test endpoint for admin dashboard

### DIFF
--- a/scripts/test_all_models.py
+++ b/scripts/test_all_models.py
@@ -1,0 +1,463 @@
+#!/usr/bin/env python3
+"""
+Live Model Inference Test — verify every displayed model can generate a response.
+
+Fetches the full catalog from the Gatewayz API, sends a minimal chat completion
+to each model, and reports pass / fail / skip per model with timing.
+
+Usage:
+    # Test against production
+    python scripts/test_all_models.py --base-url https://api.gatewayz.ai --api-key $KEY
+
+    # Test against local dev server
+    python scripts/test_all_models.py --api-key $KEY
+
+    # Filter by gateway or provider
+    python scripts/test_all_models.py --api-key $KEY --gateway openrouter
+    python scripts/test_all_models.py --api-key $KEY --provider fireworks
+
+    # Limit concurrency and number of models (useful for quick checks)
+    python scripts/test_all_models.py --api-key $KEY --limit 20 --concurrency 3
+
+    # Export results to JSON
+    python scripts/test_all_models.py --api-key $KEY --output results.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+try:
+    import httpx
+except ImportError:
+    print("ERROR: httpx is required. Install with: pip install httpx")
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ModelResult:
+    model_id: str
+    gateway: str
+    provider: str
+    status: str  # "pass", "fail", "skip", "timeout", "error"
+    status_code: int | None = None
+    latency_ms: float = 0.0
+    error: str | None = None
+    response_preview: str | None = None
+
+
+@dataclass
+class TestReport:
+    timestamp: str = ""
+    base_url: str = ""
+    total_models: int = 0
+    tested: int = 0
+    passed: int = 0
+    failed: int = 0
+    skipped: int = 0
+    timed_out: int = 0
+    errored: int = 0
+    duration_s: float = 0.0
+    results: list[dict] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Catalog fetcher
+# ---------------------------------------------------------------------------
+
+SKIP_MODALITIES = {"image", "audio", "embedding", "tts", "stt"}
+
+# Models known to be non-chat (image gen, embeddings, etc.)
+SKIP_MODEL_PREFIXES = (
+    "dall-e",
+    "stable-diffusion",
+    "sdxl",
+    "flux",
+    "midjourney",
+    "text-embedding",
+    "whisper",
+    "tts-",
+    "jina-embeddings",
+    "nomic-embed",
+    "bge-",
+)
+
+
+async def fetch_catalog(
+    client: httpx.AsyncClient,
+    base_url: str,
+    gateway: str | None,
+    provider: str | None,
+) -> list[dict]:
+    """Fetch models from the catalog endpoint."""
+    params: dict = {"limit": 10000}
+    if gateway:
+        params["gateway"] = gateway
+
+    resp = await client.get(f"{base_url}/models", params=params, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+
+    # The endpoint returns {"data": [...]} or a list directly
+    models = data.get("data", data) if isinstance(data, dict) else data
+
+    # Filter by provider if specified
+    if provider:
+        provider_lower = provider.lower()
+        models = [
+            m
+            for m in models
+            if m.get("provider_slug", "").lower() == provider_lower
+            or m.get("source_gateway", "").lower() == provider_lower
+        ]
+
+    return models
+
+
+def should_skip(model: dict) -> str | None:
+    """Return a skip reason if this model shouldn't be inference-tested, else None."""
+    model_id = model.get("id", "").lower()
+
+    # Skip non-chat modalities
+    modality = model.get("modality", "").lower()
+    if modality and modality in SKIP_MODALITIES:
+        return f"non-chat modality: {modality}"
+
+    # Skip known non-chat model prefixes
+    for prefix in SKIP_MODEL_PREFIXES:
+        if model_id.startswith(prefix) or f"/{prefix}" in model_id:
+            return f"non-chat model prefix: {prefix}"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Inference tester
+# ---------------------------------------------------------------------------
+
+TEST_PAYLOAD = {
+    "messages": [{"role": "user", "content": "Say OK"}],
+    "max_tokens": 5,
+    "temperature": 0,
+}
+
+
+async def test_model(
+    client: httpx.AsyncClient,
+    base_url: str,
+    model: dict,
+    timeout_s: float,
+    semaphore: asyncio.Semaphore,
+) -> ModelResult:
+    """Send a minimal chat completion and check the response."""
+    model_id = model.get("id", "unknown")
+    gateway = model.get("source_gateway", model.get("provider_slug", "unknown"))
+    provider = model.get("provider_slug", gateway)
+
+    # Check if we should skip
+    skip_reason = should_skip(model)
+    if skip_reason:
+        return ModelResult(
+            model_id=model_id,
+            gateway=gateway,
+            provider=provider,
+            status="skip",
+            error=skip_reason,
+        )
+
+    payload = {**TEST_PAYLOAD, "model": model_id}
+
+    async with semaphore:
+        start = time.monotonic()
+        try:
+            resp = await client.post(
+                f"{base_url}/v1/chat/completions",
+                json=payload,
+                timeout=timeout_s,
+            )
+            latency = (time.monotonic() - start) * 1000
+
+            if resp.status_code == 200:
+                body = resp.json()
+                content = (
+                    body.get("choices", [{}])[0]
+                    .get("message", {})
+                    .get("content", "")
+                )
+                return ModelResult(
+                    model_id=model_id,
+                    gateway=gateway,
+                    provider=provider,
+                    status="pass",
+                    status_code=200,
+                    latency_ms=round(latency, 1),
+                    response_preview=content[:80] if content else "(empty)",
+                )
+            else:
+                error_detail = ""
+                try:
+                    err_body = resp.json()
+                    error_detail = err_body.get("error", {}).get(
+                        "message", err_body.get("detail", "")
+                    )
+                except Exception:
+                    error_detail = resp.text[:200]
+
+                return ModelResult(
+                    model_id=model_id,
+                    gateway=gateway,
+                    provider=provider,
+                    status="fail",
+                    status_code=resp.status_code,
+                    latency_ms=round(latency, 1),
+                    error=f"HTTP {resp.status_code}: {error_detail[:150]}",
+                )
+
+        except httpx.TimeoutException:
+            latency = (time.monotonic() - start) * 1000
+            return ModelResult(
+                model_id=model_id,
+                gateway=gateway,
+                provider=provider,
+                status="timeout",
+                latency_ms=round(latency, 1),
+                error=f"Timed out after {timeout_s}s",
+            )
+        except Exception as exc:
+            latency = (time.monotonic() - start) * 1000
+            return ModelResult(
+                model_id=model_id,
+                gateway=gateway,
+                provider=provider,
+                status="error",
+                latency_ms=round(latency, 1),
+                error=str(exc)[:200],
+            )
+
+
+# ---------------------------------------------------------------------------
+# Report printer
+# ---------------------------------------------------------------------------
+
+STATUS_ICONS = {
+    "pass": "\033[32m PASS\033[0m",
+    "fail": "\033[31m FAIL\033[0m",
+    "skip": "\033[90m SKIP\033[0m",
+    "timeout": "\033[33m TIME\033[0m",
+    "error": "\033[31m ERR \033[0m",
+}
+
+
+def print_result(idx: int, total: int, r: ModelResult) -> None:
+    icon = STATUS_ICONS.get(r.status, " ??? ")
+    latency = f"{r.latency_ms:7.0f}ms" if r.latency_ms else "       -"
+    code = f"{r.status_code}" if r.status_code else "   "
+    detail = ""
+    if r.status == "pass":
+        detail = r.response_preview or ""
+    elif r.error:
+        detail = r.error[:80]
+
+    print(f"  [{idx:4d}/{total}] {icon}  {code}  {latency}  {r.model_id[:55]:<55}  {detail}")
+
+
+def print_summary(report: TestReport) -> None:
+    print()
+    print("=" * 100)
+    print("RESULTS SUMMARY")
+    print("=" * 100)
+    print(f"  Catalog models:  {report.total_models}")
+    print(f"  Tested:          {report.tested}")
+    print(f"  Passed:          \033[32m{report.passed}\033[0m")
+    print(f"  Failed:          \033[31m{report.failed}\033[0m")
+    print(f"  Timed out:       \033[33m{report.timed_out}\033[0m")
+    print(f"  Errors:          \033[31m{report.errored}\033[0m")
+    print(f"  Skipped:         {report.skipped}")
+    print(f"  Duration:        {report.duration_s:.1f}s")
+
+    if report.tested > 0:
+        pass_rate = report.passed / report.tested * 100
+        color = "\033[32m" if pass_rate >= 90 else "\033[33m" if pass_rate >= 70 else "\033[31m"
+        print(f"  Pass rate:       {color}{pass_rate:.1f}%\033[0m")
+    print("=" * 100)
+
+    # Breakdown by gateway
+    gateway_stats: dict[str, dict] = {}
+    for r in report.results:
+        gw = r.get("gateway", "unknown")
+        if gw not in gateway_stats:
+            gateway_stats[gw] = {"pass": 0, "fail": 0, "timeout": 0, "error": 0, "skip": 0}
+        gateway_stats[gw][r["status"]] = gateway_stats[gw].get(r["status"], 0) + 1
+
+    if gateway_stats:
+        print("\nPer-gateway breakdown:")
+        print(f"  {'Gateway':<25} {'Pass':>6} {'Fail':>6} {'Time':>6} {'Err':>6} {'Skip':>6}")
+        print(f"  {'-' * 25} {'-' * 6} {'-' * 6} {'-' * 6} {'-' * 6} {'-' * 6}")
+        for gw, stats in sorted(gateway_stats.items()):
+            print(
+                f"  {gw:<25} {stats.get('pass', 0):>6} {stats.get('fail', 0):>6} "
+                f"{stats.get('timeout', 0):>6} {stats.get('error', 0):>6} {stats.get('skip', 0):>6}"
+            )
+
+    # Show failures
+    failures = [r for r in report.results if r["status"] in ("fail", "timeout", "error")]
+    if failures:
+        print(f"\nFailed models ({len(failures)}):")
+        for r in failures[:50]:
+            print(f"  \033[31m{r['status'].upper():>7}\033[0m  {r['model_id']:<55}  {(r.get('error') or '')[:60]}")
+        if len(failures) > 50:
+            print(f"  ... and {len(failures) - 50} more")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+async def run(args: argparse.Namespace) -> TestReport:
+    base_url = args.base_url.rstrip("/")
+    api_key = args.api_key
+
+    headers = {"Authorization": f"Bearer {api_key}"}
+    semaphore = asyncio.Semaphore(args.concurrency)
+
+    report = TestReport(
+        timestamp=datetime.now(UTC).isoformat(),
+        base_url=base_url,
+    )
+
+    async with httpx.AsyncClient(headers=headers) as client:
+        # 1. Fetch catalog
+        print(f"Fetching model catalog from {base_url}/models ...")
+        models = await fetch_catalog(client, base_url, args.gateway, args.provider)
+        report.total_models = len(models)
+        print(f"Found {len(models)} models in catalog")
+
+        if not models:
+            print("No models found. Check --base-url and --api-key.")
+            return report
+
+        # Apply limit
+        if args.limit and args.limit < len(models):
+            models = models[: args.limit]
+            print(f"Limited to first {args.limit} models")
+
+        # 2. Test all models concurrently
+        print(f"\nTesting {len(models)} models (concurrency={args.concurrency}, timeout={args.timeout}s)...")
+        print("-" * 100)
+
+        start_time = time.monotonic()
+
+        tasks = [test_model(client, base_url, m, args.timeout, semaphore) for m in models]
+        results: list[ModelResult] = await asyncio.gather(*tasks)
+
+        report.duration_s = round(time.monotonic() - start_time, 1)
+
+        # 3. Print results as they complete
+        for idx, r in enumerate(results, 1):
+            print_result(idx, len(results), r)
+            report.results.append(asdict(r))
+            if r.status == "pass":
+                report.passed += 1
+                report.tested += 1
+            elif r.status == "fail":
+                report.failed += 1
+                report.tested += 1
+            elif r.status == "timeout":
+                report.timed_out += 1
+                report.tested += 1
+            elif r.status == "error":
+                report.errored += 1
+                report.tested += 1
+            elif r.status == "skip":
+                report.skipped += 1
+
+    print_summary(report)
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Test all displayed models by sending a minimal chat completion to each."
+    )
+    parser.add_argument(
+        "--base-url",
+        default=os.getenv("BASE_URL", "http://localhost:8000"),
+        help="API base URL (default: $BASE_URL or http://localhost:8000)",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.getenv("TEST_API_KEY"),
+        help="API key for authentication (default: $TEST_API_KEY)",
+    )
+    parser.add_argument(
+        "--gateway",
+        default=None,
+        help="Filter models by gateway (e.g., openrouter, fireworks)",
+    )
+    parser.add_argument(
+        "--provider",
+        default=None,
+        help="Filter models by provider slug",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Max number of models to test",
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=5,
+        help="Max concurrent requests (default: 5)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Per-request timeout in seconds (default: 30)",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        default=None,
+        help="Export results to JSON file",
+    )
+
+    args = parser.parse_args()
+
+    if not args.api_key:
+        print("ERROR: --api-key or $TEST_API_KEY is required")
+        sys.exit(1)
+
+    report = asyncio.run(run(args))
+
+    # Export JSON if requested
+    if args.output:
+        output_path = Path(args.output)
+        with open(output_path, "w") as f:
+            json.dump(asdict(report), f, indent=2, default=str)
+        print(f"\nResults exported to {output_path}")
+
+    # Exit with failure if pass rate < 70%
+    if report.tested > 0 and (report.passed / report.tested) < 0.7:
+        sys.exit(1)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/main.py
+++ b/src/main.py
@@ -515,6 +515,7 @@ def create_app() -> FastAPI:
         ("users", "User Management"),
         ("api_keys", "API Key Management"),
         ("admin", "Admin Operations"),
+        ("live_model_test", "Live Model Test"),  # Admin live inference sweep
         # ("admin_pricing_analytics", "Admin Pricing Analytics"),  # REMOVED - Phase 2 deprecation
         ("api_key_monitoring", "API Key Tracking Monitoring"),  # API key tracking quality metrics
         ("credits", "Credits Management"),  # Credit operations (add, adjust, bulk-add, refund)

--- a/src/routes/live_model_test.py
+++ b/src/routes/live_model_test.py
@@ -1,0 +1,383 @@
+"""
+Live Model Test endpoint — admin-only inference sweep across all catalog models.
+
+Sends a minimal chat completion to each model (or a filtered subset),
+bypassing billing, and returns per-provider/per-model pass/fail stats.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from src.security.deps import require_admin
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/admin/live-test", tags=["admin", "live-test"])
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+SKIP_MODEL_PREFIXES = (
+    "dall-e",
+    "stable-diffusion",
+    "sdxl",
+    "flux",
+    "midjourney",
+    "text-embedding",
+    "whisper",
+    "tts-",
+    "jina-embeddings",
+    "nomic-embed",
+    "bge-",
+    "text-moderation",
+)
+
+SKIP_MODALITIES = {"image", "audio", "embedding", "tts", "stt", "moderation"}
+
+TEST_MESSAGES = [{"role": "user", "content": "Say OK"}]
+TEST_MAX_TOKENS = 5
+
+
+class ModelTestResult(BaseModel):
+    model_id: str
+    gateway: str
+    provider: str
+    status: str = Field(description="pass, fail, skip, timeout, error")
+    status_code: int | None = None
+    latency_ms: float = 0.0
+    error: str | None = None
+    response_preview: str | None = None
+
+
+class ProviderSummary(BaseModel):
+    provider: str
+    total: int = 0
+    passed: int = 0
+    failed: int = 0
+    timed_out: int = 0
+    errored: int = 0
+    skipped: int = 0
+    avg_latency_ms: float = 0.0
+
+
+class LiveTestReport(BaseModel):
+    timestamp: str
+    duration_s: float = 0.0
+    total_models: int = 0
+    tested: int = 0
+    passed: int = 0
+    failed: int = 0
+    timed_out: int = 0
+    errored: int = 0
+    skipped: int = 0
+    pass_rate: float = 0.0
+    by_provider: list[ProviderSummary] = []
+    failures: list[ModelTestResult] = []
+    results: list[ModelTestResult] = []
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _should_skip(model: dict) -> str | None:
+    model_id = model.get("id", "").lower()
+    modality = model.get("modality", "").lower()
+    if modality and modality in SKIP_MODALITIES:
+        return f"non-chat modality: {modality}"
+    for prefix in SKIP_MODEL_PREFIXES:
+        if model_id.startswith(prefix) or f"/{prefix}" in model_id:
+            return f"non-chat prefix: {prefix}"
+    return None
+
+
+async def _fetch_catalog(
+    gateway: str | None,
+    provider: str | None,
+) -> list[dict]:
+    """Fetch models from the internal catalog service."""
+    from src.services.models import get_cached_models
+
+    try:
+        gw = gateway or "all"
+        models = (
+            await get_cached_models(gw)
+            if asyncio.iscoroutinefunction(get_cached_models)
+            else get_cached_models(gw)
+        )
+        if not models:
+            models = []
+    except Exception as exc:
+        logger.warning("Failed to fetch catalog via get_cached_models: %s", exc)
+        models = []
+
+    # Fallback: try DB catalog
+    if not models:
+        try:
+            from src.db.models_catalog_db import get_all_catalog_models
+
+            result = await get_all_catalog_models(limit=10000)
+            models = result if isinstance(result, list) else result.get("data", [])
+        except Exception as exc:
+            logger.warning("Failed to fetch catalog from DB: %s", exc)
+            models = []
+
+    if provider:
+        p = provider.lower()
+        models = [
+            m
+            for m in models
+            if m.get("provider_slug", "").lower() == p or m.get("source_gateway", "").lower() == p
+        ]
+
+    return models
+
+
+async def _test_single_model(
+    client: httpx.AsyncClient,
+    model: dict,
+    timeout_s: float,
+    semaphore: asyncio.Semaphore,
+) -> ModelTestResult:
+    """Send a minimal chat completion to one model via the gateway."""
+    model_id = model.get("id", "unknown")
+    gateway = model.get("source_gateway", model.get("provider_slug", "unknown"))
+    provider = model.get("provider_slug", gateway)
+
+    skip_reason = _should_skip(model)
+    if skip_reason:
+        return ModelTestResult(
+            model_id=model_id,
+            gateway=gateway,
+            provider=provider,
+            status="skip",
+            error=skip_reason,
+        )
+
+    payload = {
+        "model": model_id,
+        "messages": TEST_MESSAGES,
+        "max_tokens": TEST_MAX_TOKENS,
+        "temperature": 0,
+    }
+
+    async with semaphore:
+        start = time.monotonic()
+        try:
+            resp = await client.post(
+                "/v1/chat/completions",
+                json=payload,
+                timeout=timeout_s,
+            )
+            latency = (time.monotonic() - start) * 1000
+
+            if resp.status_code == 200:
+                body = resp.json()
+                content = body.get("choices", [{}])[0].get("message", {}).get("content", "")
+                return ModelTestResult(
+                    model_id=model_id,
+                    gateway=gateway,
+                    provider=provider,
+                    status="pass",
+                    status_code=200,
+                    latency_ms=round(latency, 1),
+                    response_preview=content[:80] if content else "(empty)",
+                )
+            else:
+                err = ""
+                try:
+                    eb = resp.json()
+                    err = eb.get("error", {}).get("message", eb.get("detail", ""))
+                except Exception:
+                    err = resp.text[:200]
+                return ModelTestResult(
+                    model_id=model_id,
+                    gateway=gateway,
+                    provider=provider,
+                    status="fail",
+                    status_code=resp.status_code,
+                    latency_ms=round(latency, 1),
+                    error=f"HTTP {resp.status_code}: {err[:150]}",
+                )
+
+        except httpx.TimeoutException:
+            latency = (time.monotonic() - start) * 1000
+            return ModelTestResult(
+                model_id=model_id,
+                gateway=gateway,
+                provider=provider,
+                status="timeout",
+                latency_ms=round(latency, 1),
+                error=f"Timed out after {timeout_s}s",
+            )
+        except Exception as exc:
+            latency = (time.monotonic() - start) * 1000
+            return ModelTestResult(
+                model_id=model_id,
+                gateway=gateway,
+                provider=provider,
+                status="error",
+                latency_ms=round(latency, 1),
+                error=str(exc)[:200],
+            )
+
+
+def _build_provider_summaries(results: list[ModelTestResult]) -> list[ProviderSummary]:
+    stats: dict[str, dict[str, Any]] = {}
+    for r in results:
+        p = r.provider
+        if p not in stats:
+            stats[p] = {
+                "provider": p,
+                "total": 0,
+                "passed": 0,
+                "failed": 0,
+                "timed_out": 0,
+                "errored": 0,
+                "skipped": 0,
+                "latencies": [],
+            }
+        s = stats[p]
+        s["total"] += 1
+        if r.status == "pass":
+            s["passed"] += 1
+            s["latencies"].append(r.latency_ms)
+        elif r.status == "fail":
+            s["failed"] += 1
+        elif r.status == "timeout":
+            s["timed_out"] += 1
+        elif r.status == "error":
+            s["errored"] += 1
+        elif r.status == "skip":
+            s["skipped"] += 1
+
+    summaries = []
+    for s in sorted(stats.values(), key=lambda x: x["passed"], reverse=True):
+        lats = s.pop("latencies")
+        s["avg_latency_ms"] = round(sum(lats) / len(lats), 1) if lats else 0.0
+        summaries.append(ProviderSummary(**s))
+    return summaries
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.post("/run", response_model=LiveTestReport)
+async def run_live_model_test(
+    gateway: str | None = Query(None, description="Filter by gateway"),
+    provider: str | None = Query(None, description="Filter by provider slug"),
+    limit: int = Query(0, ge=0, description="Max models to test (0 = all)"),
+    concurrency: int = Query(5, ge=1, le=20, description="Parallel requests"),
+    timeout: float = Query(30.0, ge=5, le=120, description="Per-model timeout (s)"),
+    admin_user: dict = Depends(require_admin),
+) -> LiveTestReport:
+    """
+    Run a live inference test against all (or filtered) catalog models.
+
+    Sends a minimal 5-token chat completion to each model through the gateway,
+    using the admin user's API key. Returns per-provider stats and failure details.
+
+    **Warning**: This makes real inference calls. With 1000+ models at concurrency=5,
+    expect ~10-30 minutes and a small credit cost (~$0.01-0.05).
+    """
+    from src.config.config import Config
+
+    # Use the admin's own API key (already authenticated)
+    admin_api_key = admin_user.get("api_key", "")
+    if not admin_api_key:
+        raise HTTPException(status_code=400, detail="Admin user has no API key")
+
+    base_url = Config.BASE_URL if hasattr(Config, "BASE_URL") else "http://localhost:8000"
+    # For self-calls, prefer localhost to avoid NAT hairpin
+    if "gatewayz.ai" not in base_url:
+        base_url = "http://localhost:8000"
+
+    logger.info(
+        "Admin %s triggered live model test (gateway=%s, provider=%s, limit=%s)",
+        admin_user.get("email", "?"),
+        gateway,
+        provider,
+        limit,
+    )
+
+    # 1. Fetch catalog
+    models = await _fetch_catalog(gateway, provider)
+    if limit and limit > 0:
+        models = models[:limit]
+
+    if not models:
+        return LiveTestReport(
+            timestamp=datetime.now(UTC).isoformat(),
+            total_models=0,
+        )
+
+    # 2. Run tests
+    semaphore = asyncio.Semaphore(concurrency)
+    headers = {"Authorization": f"Bearer {admin_api_key}"}
+
+    start_time = time.monotonic()
+
+    async with httpx.AsyncClient(base_url=base_url, headers=headers) as client:
+        tasks = [_test_single_model(client, m, timeout, semaphore) for m in models]
+        results = await asyncio.gather(*tasks)
+
+    duration = round(time.monotonic() - start_time, 1)
+
+    # 3. Build report
+    passed = sum(1 for r in results if r.status == "pass")
+    failed = sum(1 for r in results if r.status == "fail")
+    timed_out = sum(1 for r in results if r.status == "timeout")
+    errored = sum(1 for r in results if r.status == "error")
+    skipped = sum(1 for r in results if r.status == "skip")
+    tested = passed + failed + timed_out + errored
+
+    report = LiveTestReport(
+        timestamp=datetime.now(UTC).isoformat(),
+        duration_s=duration,
+        total_models=len(models),
+        tested=tested,
+        passed=passed,
+        failed=failed,
+        timed_out=timed_out,
+        errored=errored,
+        skipped=skipped,
+        pass_rate=round(passed / tested * 100, 1) if tested else 0.0,
+        by_provider=_build_provider_summaries(results),
+        failures=[r for r in results if r.status in ("fail", "timeout", "error")],
+        results=list(results),
+    )
+
+    logger.info(
+        "Live test complete: %d/%d passed (%.1f%%) in %.1fs",
+        passed,
+        tested,
+        report.pass_rate,
+        duration,
+    )
+
+    return report
+
+
+@router.get("/status")
+async def get_live_test_status(
+    admin_user: dict = Depends(require_admin),
+) -> dict:
+    """Check if the live test endpoint is available."""
+    return {
+        "status": "available",
+        "message": "POST /admin/live-test/run to start a test sweep",
+        "timestamp": datetime.now(UTC).isoformat(),
+    }


### PR DESCRIPTION
## Summary

- **`POST /admin/live-test/run`** — Admin-only endpoint that sends a minimal 5-token chat completion to every catalog model and returns per-provider pass/fail stats
- **`GET /admin/live-test/status`** — Availability check
- **`scripts/test_all_models.py`** — Standalone CLI script for the same sweep (async, configurable concurrency/timeout/filters)
- Auto-skips non-chat models (embeddings, image gen, TTS, etc.)
- Configurable: gateway, provider, limit, concurrency (1-20), timeout (5-120s)

Frontend page already pushed to admin-panel repo (Alpaca-Network/gatewayz-admin@91b8dd2).

## Test plan

- [ ] Deploy and hit `POST /admin/live-test/run?limit=5` with an admin API key
- [ ] Verify response contains `by_provider` stats and `failures` list
- [ ] Test with `?gateway=openrouter&limit=10` filter
- [ ] Run `scripts/test_all_models.py --api-key $KEY --limit 10` locally
- [ ] Verify non-chat models (dall-e, embeddings) are skipped
- [ ] Confirm admin auth is enforced (403 for non-admin keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `POST /admin/live-test/run` endpoint and a companion CLI script (`scripts/test_all_models.py`) that sweep every catalog model with a minimal 5-token chat completion and report per-provider pass/fail stats. The feature is well-scoped for admin use and the CLI script is clean, but the route implementation has two P1 correctness bugs that need fixing before this is production-reliable.

**Key changes:**
- `src/routes/live_model_test.py` — new admin router with `POST /run` and `GET /status`; fetches models from internal catalog, fans out concurrent `httpx` self-calls, and returns a `LiveTestReport`
- `src/main.py` — one-line router tag registration
- `scripts/test_all_models.py` — standalone async CLI equivalent for local/CI use

**Issues found:**
- **P1** — `admin_user.get("api_key", "")` reads from the legacy `users.api_key` column, not from the key the admin authenticated with. For accounts on the new `api_keys_new` system this field can be empty or stale, causing either a 400 error or silent self-calls with the wrong key. The fix is to inject `get_api_key` as a separate dependency.
- **P1** — `Config.BASE_URL` does not exist on the `Config` class, so `hasattr(Config, "BASE_URL")` is always `False` and the hostname-based fallback is dead code. The endpoint always resolves to `localhost:8000`, which incidentally works but is misleading and fragile.
- **P2** — No server-side overall timeout on the sweep. A full-catalog run can take tens of minutes; most reverse proxies will drop the HTTP connection before completion, leaving the async task orphaned on the server. An async job pattern (fire-and-poll) would be more robust.
- **P2** — `SKIP_MODEL_PREFIXES` in the route includes `"text-moderation"` but the CLI script does not; the two lists will drift further apart over time.

<h3>Confidence Score: 4/5</h3>

Not safe to merge as-is — two P1 bugs (wrong API key extraction and dead Config.BASE_URL reference) will cause the endpoint to malfunction for new-style admin accounts.

Two P1 issues exist: the API key used for self-calls is read from the wrong source and can be empty or stale, and the Config.BASE_URL dead-code path means the base URL resolution silently always falls back to localhost. Both are straightforward fixes. The CLI script and router registration are clean. All other findings are P2.

src/routes/live_model_test.py — specifically the API key extraction (line 292) and base URL resolution (lines 294-301).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/live_model_test.py | New admin endpoint for live model sweep; has two P1 bugs: wrong API key extraction from user dict, and dead Config.BASE_URL reference that silently always resolves to localhost. Also lacks an overall request timeout, risking hung connections on large sweeps. |
| src/main.py | Single-line router registration for the new live_model_test tag — correct and consistent with existing patterns. |
| scripts/test_all_models.py | Well-structured standalone CLI script; async, concurrent, handles skip/fail/timeout correctly, and has appropriate validation. Minor: lacks concurrency bounds validation and diverges from the route's SKIP_MODEL_PREFIXES. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Admin Client
    participant E as live-test endpoint
    participant A as Auth Middleware
    participant M as Model Catalog
    participant G as Gateway Chat

    C->>E: POST /admin/live-test/run
    E->>A: require_admin dependency check
    A-->>E: Validated admin profile
    E->>M: fetch catalog with gateway and provider filters
    M-->>E: Filtered model list
    E->>E: Apply limit, create semaphore
    loop Concurrent batches up to N=20
        E->>G: POST /v1/chat/completions with model id
        G-->>E: pass or fail or timeout result
    end
    E->>E: Build per-provider summaries
    E-->>C: LiveTestReport with stats and failures
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/routes/live_model_test.py
Line: 292-301

Comment:
**`admin_user` dict does not contain the authenticated API key**

`admin_user.get("api_key", "")` reads from the `users` table's legacy `api_key` column, **not** from the key the admin just authenticated with. For accounts created via the new `api_keys_new` system, `users.api_key` can be empty or stale, causing the 400 error `"Admin user has no API key"` — or worse, silently making self-test calls with a wrong/inactive key.

The authenticated API key is available through the `get_api_key` dependency but is not threaded through `require_admin`. The fix is to also depend on `get_api_key` directly:

```python
from src.security.deps import require_admin, get_api_key

@router.post("/run", response_model=LiveTestReport)
async def run_live_model_test(
    ...,
    admin_api_key: str = Depends(get_api_key),
    admin_user: dict = Depends(require_admin),
) -> LiveTestReport:
    if not admin_api_key:
        raise HTTPException(status_code=400, detail="Admin user has no API key")
    ...
    headers = {"Authorization": f"Bearer {admin_api_key}"}
```

This ensures the key used for self-calls is the exact same key that just passed authentication.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/routes/live_model_test.py
Line: 294-301

Comment:
**`Config.BASE_URL` does not exist — base URL always falls back to `localhost:8000`**

`Config` has no `BASE_URL` attribute (the config only defines provider-specific URLs like `CANOPYWAVE_BASE_URL`, `NOSANA_BASE_URL`, etc.), so `hasattr(Config, "BASE_URL")` is always `False`. The first branch of the ternary is never reached; `base_url` is set to `"http://localhost:8000"` unconditionally.

This happens to work when the service is self-hosted on that port, but:
- The "prefer localhost to avoid NAT hairpin" comment makes the dead-code intent ambiguous
- A port change or deployment behind an internal proxy will break silently
- The `"gatewayz.ai"` hostname check (lines 300-301) is therefore also dead code

If localhost is the correct target for self-calls, drop the dead Config lookup and make the intent explicit:

```python
# Self-call: always use localhost to avoid NAT hairpin
base_url = "http://localhost:8000"
```

If you do need environment-specific URLs, add `BASE_URL = os.environ.get("BASE_URL", "http://localhost:8000")` to `Config`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/routes/live_model_test.py
Line: 316-320

Comment:
**Endpoint can block for tens of minutes with no server-side overall timeout**

With `concurrency=5`, `timeout=120s`, and the full model catalog (1000+ models), worst-case wall time is `ceil(1000/5) × 120 s ≈ 24 000 s`. Even typical usage (200 models, 30 s timeout) can exceed 20 minutes.

- Most HTTP clients and reverse proxies (Nginx default is 60s) will drop the connection long before the sweep completes, leaving the async task still running on the server with no way to retrieve its results.
- Consider capping the effective concurrency or, better, turning this into a background job: return a `job_id` immediately and expose a `GET /admin/live-test/results/{job_id}` polling endpoint.

At minimum, document the expected wall-time prominently in the docstring and add a hard cap on `limit` (e.g., `le=500`) or a server-side `asyncio.wait_for` guard.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/routes/live_model_test.py
Line: 30-46

Comment:
**`SKIP_MODEL_PREFIXES` diverges between route and CLI script**

`live_model_test.py` has `"text-moderation"` in `SKIP_MODEL_PREFIXES` (line 45) but `scripts/test_all_models.py` does not. New entries added in one place won't automatically be reflected in the other, leading to inconsistent skip behaviour between the API endpoint and the local CLI tool.

Consider extracting the shared constants into a utility module (e.g., `src/utils/model_skip_list.py`) and importing from there in both files.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add live model test endpoint and C..."](https://github.com/alpaca-network/gatewayz-backend/commit/213611005dbb75156e1e05a0db7f4a15883c6118) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26621726)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->