### PR TITLE
fix(health): prevent 5XX cascade on system-health page

### DIFF
--- a/src/routes/health.py
+++ b/src/routes/health.py
@@ -596,7 +596,6 @@ async def get_catalog_models(
     provider: str | None = Query(None, description="Filter by specific provider"),
     limit: int = Query(100, ge=1, le=1000, description="Maximum number of models to return"),
     offset: int = Query(0, ge=0, description="Number of models to skip for pagination"),
-    api_key: str = Depends(get_api_key),
 ):
     """
     Get ALL models from the model catalog (not just health-tracked ones)
@@ -713,7 +712,6 @@ async def get_catalog_models(
 @router.get("/health/catalog/providers", tags=["health", "catalog"])
 async def get_catalog_providers(
     priority: str | None = Query(None, description="Filter by priority ('fast' or 'slow')"),
-    api_key: str = Depends(get_api_key),
 ):
     """
     Get ALL providers/gateways from the gateway registry (not just health-tracked ones)

--- a/src/routes/system.py
+++ b/src/routes/system.py
@@ -1658,9 +1658,26 @@ async def check_all_gateways():
 
     except Exception as e:
         logger.error(f"Failed to retrieve gateway health from cache: {e}", exc_info=True)
-        raise HTTPException(
-            status_code=500, detail=f"Failed to retrieve gateway health: {str(e)}"
-        ) from e
+        # Return graceful empty response instead of 500
+        # (matches /health/models pattern — never crash the admin dashboard)
+        return {
+            "success": False,
+            "data": {},
+            "summary": {
+                "total_gateways": 0,
+                "healthy": 0,
+                "degraded": 0,
+                "unhealthy": 0,
+                "unconfigured": 0,
+                "overall_health_percentage": 0,
+            },
+            "timestamp": datetime.now(UTC).isoformat(),
+            "metadata": {
+                "cache_age_seconds": None,
+                "data_source": "error-fallback",
+                "error": str(e),
+            },
+        }
 
 
 @router.get("/health/gateways/dashboard", response_class=HTMLResponse, tags=["health"])


### PR DESCRIPTION
- /health/gateways: return graceful empty response instead of HTTP 500 when Redis cache read fails (matches /health/models pattern)
- /health/catalog/providers: remove auth requirement — endpoint only reads from in-memory GATEWAY_REGISTRY, no Supabase needed
- /health/catalog/models: remove auth requirement — endpoint reads from in-memory gateway caches, not Supabase

When Supabase is slow/down, the auth dependency (get_api_key) returns HTTP 500 for all authenticated endpoints. Removing auth from catalog endpoints breaks the cascading failure chain so the admin proxy fallbacks actually work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Health check catalog endpoints are now accessible without API key authentication.
  * System gateway check now returns a structured fallback response on cache errors, improving error handling and visibility instead of returning server errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes three targeted changes to prevent HTTP 5XX cascades on the system-health admin page when Supabase or Redis is degraded: (1) `/health/gateways` now returns a structured 200 with `success: false` instead of raising HTTP 500 on Redis read failure, (2) auth is removed from `/health/catalog/models`, and (3) auth is removed from `/health/catalog/providers`.

**Key changes:**
- `system.py`: New `except` block for `/health/gateways` returns a typed empty-data envelope (`success: false`, `data_source: \"error-fallback\"`) instead of `raise HTTPException(500)`. This is a solid fix and consistent with the rest of the file's empty-cache path.
- `health.py`: `Depends(get_api_key)` removed from both catalog endpoints. These endpoints read exclusively from in-memory structures (`GATEWAY_REGISTRY`, gateway caches) and avoid any Supabase call, which is the correct motivation. However, both endpoints now expose a superset of the data available from the still-authenticated `/health/models` and `/health/providers` — including `has_api_key` booleans for every configured gateway. The existing `get_optional_api_key` dependency in `deps.py` would achieve the same cascade-prevention goal while keeping authenticated requests working normally.
- The new `system.py` error fallback does not call `capture_error`, unlike every analogous fallback in `health.py`, so Redis failures on `/health/gateways` will not fire an error-tracking event.

<h3>Confidence Score: 4/5</h3>

Safe to merge after confirming fully-public access to catalog endpoints is intentional; the system.py change is unambiguously correct.

The system.py change is clean and low-risk. The health.py auth removal is a deliberate trade-off between availability and access control, but it leaves two read-heavy endpoints fully public while their authenticated counterparts exist alongside them — the P1 comment should be resolved or explicitly acknowledged before merge.

src/routes/health.py — auth removal deserves a second look; src/routes/system.py — missing capture_error telemetry in new error fallback.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/routes/system.py | Adds graceful error fallback to /health/gateways — returns structured 200 with success:false instead of HTTP 500 on Redis read failure. Change is straightforward and safe; minor gap is missing capture_error telemetry in the new except block (all analogous handlers in health.py include it). |
| src/routes/health.py | Removes Depends(get_api_key) from /health/catalog/models and /health/catalog/providers, making them fully unauthenticated. The endpoints return the full model/provider catalog (superset of the authenticated /health/models and /health/providers data) and expose has_api_key booleans for all gateways. The optional-auth pattern already in deps.py would achieve the same cascade-prevention goal with less exposure. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Admin Dashboard
    participant GW as /health/gateways
    participant Cat as /health/catalog/*
    participant Redis
    participant Supabase
    participant Auth as get_api_key

    Note over GW: system.py change
    Client->>GW: GET /health/gateways
    GW->>Redis: get_gateways_health()
    Redis--xGW: Exception (Redis down)
    GW-->>Client: 200 {success:false, data:{}, data_source:"error-fallback"}

    Note over Cat: health.py change (before)
    Client->>Auth: Bearer token
    Auth->>Supabase: validate key
    Supabase--xAuth: 500 (Supabase down)
    Auth-->>Client: 500 Internal Error

    Note over Cat: health.py change (after)
    Client->>Cat: GET /health/catalog/models
    Cat->>Cat: get_all_models_parallel() [in-memory]
    Cat-->>Client: 200 {data:[...9000+ models]}
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/routes/health.py`, line 593-599 ([link](https://github.com/alpaca-network/gatewayz-backend/blob/e3e4729b9b9129e1df3945edb64df225001a7e3c/src/routes/health.py#L593-L599)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Catalog endpoints now fully public while their authenticated counterparts are not**

   After this PR, `/health/catalog/models` and `/health/catalog/providers` are completely unauthenticated, yet they return a *superset* of the data available from the authenticated `/health/models` (line 507) and `/health/providers` (line 419) endpoints:

   - `/health/catalog/models` returns the **full model catalog (9,000+ models)** across all gateways.
   - `/health/catalog/providers` returns the full provider list enriched with `has_api_key` (line 749) — a boolean that reveals which gateways have API keys configured, which is operational intelligence about the system's configuration.

   The PR's stated motivation (break the Supabase cascade) is valid, but there's a subtler approach already available in the codebase: `get_optional_api_key` / `get_optional_user` (defined in `src/security/deps.py`) perform auth when credentials are present and silently skip it when they aren't. This would keep the endpoints accessible during a Supabase outage (no auth attempt = no cascade) while still accepting authenticated requests in normal operation.

   If fully public access is genuinely intentional, please add a comment to both function signatures explaining the decision, so future reviewers don't inadvertently re-add auth.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/routes/health.py
   Line: 593-599

   Comment:
   **Catalog endpoints now fully public while their authenticated counterparts are not**

   After this PR, `/health/catalog/models` and `/health/catalog/providers` are completely unauthenticated, yet they return a *superset* of the data available from the authenticated `/health/models` (line 507) and `/health/providers` (line 419) endpoints:

   - `/health/catalog/models` returns the **full model catalog (9,000+ models)** across all gateways.
   - `/health/catalog/providers` returns the full provider list enriched with `has_api_key` (line 749) — a boolean that reveals which gateways have API keys configured, which is operational intelligence about the system's configuration.

   The PR's stated motivation (break the Supabase cascade) is valid, but there's a subtler approach already available in the codebase: `get_optional_api_key` / `get_optional_user` (defined in `src/security/deps.py`) perform auth when credentials are present and silently skip it when they aren't. This would keep the endpoints accessible during a Supabase outage (no auth attempt = no cascade) while still accepting authenticated requests in normal operation.

   If fully public access is genuinely intentional, please add a comment to both function signatures explaining the decision, so future reviewers don't inadvertently re-add auth.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/routes/system.py
Line: 1659-1680

Comment:
**Missing `capture_error` telemetry in error fallback**

The error handler logs via `logger.error` but, unlike every equivalent fallback in `health.py` (lines 575–580, 692–696, 789–796), does not call `capture_error`. This means Redis-read failures on `/health/gateways` will be silently swallowed by error-tracking (e.g. Sentry) — the endpoint now returns HTTP 200, so there's no other signal that something is wrong.

`capture_error` is not currently imported in `system.py`, so it would need to be added. Example pattern from `health.py`:

```python
except Exception as e:
    logger.error(f"Failed to retrieve gateway health from cache: {e}", exc_info=True)
    capture_error(
        e,
        context_type="health_endpoint",
        context_data={"endpoint": "/health/gateways", "operation": "check_all_gateways"},
        tags={"endpoint": "gateway_health", "error_type": type(e).__name__},
    )
    # Return graceful empty response instead of 500
    ...
```

Without this, the only way to detect recurring Redis failures is to watch for `"data_source": "error-fallback"` in the response body — there will be no error-tracking event fired.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/routes/health.py
Line: 593-599

Comment:
**Catalog endpoints now fully public while their authenticated counterparts are not**

After this PR, `/health/catalog/models` and `/health/catalog/providers` are completely unauthenticated, yet they return a *superset* of the data available from the authenticated `/health/models` (line 507) and `/health/providers` (line 419) endpoints:

- `/health/catalog/models` returns the **full model catalog (9,000+ models)** across all gateways.
- `/health/catalog/providers` returns the full provider list enriched with `has_api_key` (line 749) — a boolean that reveals which gateways have API keys configured, which is operational intelligence about the system's configuration.

The PR's stated motivation (break the Supabase cascade) is valid, but there's a subtler approach already available in the codebase: `get_optional_api_key` / `get_optional_user` (defined in `src/security/deps.py`) perform auth when credentials are present and silently skip it when they aren't. This would keep the endpoints accessible during a Supabase outage (no auth attempt = no cascade) while still accepting authenticated requests in normal operation.

If fully public access is genuinely intentional, please add a comment to both function signatures explaining the decision, so future reviewers don't inadvertently re-add auth.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(health): prevent 5XX cascade on syst..."](https://github.com/alpaca-network/gatewayz-backend/commit/e3e4729b9b9129e1df3945edb64df225001a7e3c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26671577)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->