### PR TITLE
Fixed defects that was preventing Live-Testing to execute

### DIFF
--- a/src/db/users.py
+++ b/src/db/users.py
@@ -352,6 +352,7 @@ def _get_user_uncached(api_key: str) -> dict[str, Any] | None:
                     user["environment_tag"] = key_data.get("environment_tag", "live")
                     user["scope_permissions"] = key_data.get("scope_permissions")
                     user["is_primary"] = key_data.get("is_primary", False)
+                    user["api_key"] = api_key  # ensure api_key is always in user dict
                     return user
             except (DatabaseResultError, KeyError) as e:
                 logger.warning(

--- a/src/handlers/chat_handler.py
+++ b/src/handlers/chat_handler.py
@@ -743,7 +743,14 @@ class ChatInferenceHandler:
             else:
                 raise ValueError("Provider response missing choices")
 
-            # Token estimation fallback if provider didn't provide usage
+            # Token estimation fallback if provider didn't return usage data
+            if prompt_tokens == 0 and completion_tokens == 0:
+                completion_tokens = max(1, len(content or "") // 4)
+                prompt_chars = sum(
+                    len(m.get("content", "")) if isinstance(m.get("content"), str) else 0
+                    for m in messages
+                )
+                prompt_tokens = max(1, prompt_chars // 4)
                 logger.info(
                     f"[ChatHandler] No usage data from provider {provider_used}, estimated "
                     f"{prompt_tokens} prompt + {completion_tokens} completion tokens"

--- a/src/middleware/security_middleware.py
+++ b/src/middleware/security_middleware.py
@@ -12,6 +12,7 @@ import asyncio
 import hashlib
 import logging
 import os
+import secrets
 import time
 from collections import Counter, deque
 
@@ -785,15 +786,29 @@ class SecurityMiddleware(BaseHTTPMiddleware):
         if self._is_streaming_request(request):
             return await call_next(request)
 
+        # Detect internal live-test self-calls so their failures don't pollute the
+        # velocity-mode window.  Requires BOTH the marker header AND a Bearer token
+        # that matches ADMIN_API_KEY — external clients cannot forge this without the key.
+        _admin_key_env = os.environ.get("ADMIN_API_KEY", "")
+        _incoming_key = request.headers.get("Authorization", "").replace("Bearer ", "").strip()
+        _is_internal_live_test = bool(
+            _admin_key_env
+            and _incoming_key
+            and request.headers.get("X-Internal-Source") == "live-test"
+            and secrets.compare_digest(_incoming_key, _admin_key_env)
+        )
+
         # Proceed to next middleware/app logic
         start_time = time.time()
         response = await call_next(request)
         request_duration = time.time() - start_time
 
         # Track response for Global Velocity Mode
-        # Record outcome and check if we should activate velocity mode
-        self._record_request_outcome(response.status_code, request_duration)
-        self._check_and_activate_velocity_mode()
+        # Skip for internal live-test calls — their provider failures should not
+        # inflate the system error rate and risk triggering velocity mode for other users.
+        if not _is_internal_live_test:
+            self._record_request_outcome(response.status_code, request_duration)
+            self._check_and_activate_velocity_mode()
 
         # Check if velocity mode should be deactivated and logged
         self._check_velocity_mode_deactivation()

--- a/src/routes/live_model_test.py
+++ b/src/routes/live_model_test.py
@@ -332,6 +332,11 @@ async def run_live_model_test(
 
     start_time = time.monotonic()
 
+    # Tag self-calls so the security middleware skips velocity-mode recording for them.
+    # The header is validated in the middleware by comparing the Bearer token against
+    # ADMIN_API_KEY, so it cannot be forged by external clients.
+    headers["X-Internal-Source"] = "live-test"
+
     async with httpx.AsyncClient(base_url=base_url, headers=headers) as client:
         tasks = [_test_single_model(client, m, timeout, semaphore) for m in models]
         results = await asyncio.gather(*tasks)


### PR DESCRIPTION
Fix 1 — src/db/users.py:355                               
  Added user["api_key"] = api_key so the user dict always includes the API key regardless of       
  whether auth went through the new api_keys_new table or the legacy users table. This removes the 
  400 "Admin user has no API key" error that was blocking the live test entirely.                  
                                                                                                   
  Fix 2 — src/handlers/chat_handler.py:746-757                                                     
  Removed the dead logger that was silently trapped inside the else: block after raise 
  ValueError(...) (Python ignores comment indentation, so it was unreachable). Replaced it with an 
  actual token estimation block at the correct indentation level, matching the streaming path — so
  non-streaming requests no longer silently show $0 cost when providers omit usage data.           
                                                            
  Fix 3 — src/routes/live_model_test.py:338
  Added X-Internal-Source: live-test header to all httpx self-calls made during a live test sweep.
                                                                                                   
  Fix 4 — src/middleware/security_middleware.py:789-811
  Added a detection block that recognizes the live test header + validates the Bearer token matches
   ADMIN_API_KEY. If both match, the request's outcome is excluded from the velocity mode window — 
  so 50+ concurrent model test failures won't accidentally throttle real users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured API keys are properly included in user resolution
  * Improved token usage estimation fallback logic for accurate chat response token counting

* **Security**
  * Added internal live-test call detection and isolation in request processing to prevent test traffic from affecting normal operation metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes four interconnected defects that were preventing the Live-Testing sweep from executing end-to-end. The changes span authentication (ensuring `api_key` is always present on admin user dicts coming from the `api_keys_new` table), cost accounting (adding the missing token estimation block to the non-streaming path in `ChatHandler`), request tagging (injecting `X-Internal-Source: live-test` on httpx self-calls), and middleware (skipping velocity-mode error recording for those tagged requests so 50+ concurrent model test failures don't throttle real users).

Key points:
- **Fix 1** (`src/db/users.py`): Correctly targets only the `api_keys_new` path — the legacy users path already has `api_key` as a column in the `SELECT *` result, so no change is needed there.
- **Fix 2** (`src/handlers/chat_handler.py`): The token estimation block was previously dead code at the wrong indentation level. The new `if prompt_tokens == 0 and completion_tokens == 0` guard covers the no-usage case; however, if a provider returns a partial usage object (one field non-zero, the other zero), the zero field is left unestimated and cost would be undercounted — see inline comment.
- **Fix 3 & 4** (`src/routes/live_model_test.py` + `src/middleware/security_middleware.py`): The bypass correctly uses `secrets.compare_digest` for timing-safe comparison and requires both the marker header and a matching `ADMIN_API_KEY` token, so it cannot be forged by external callers without knowing the key.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — all remaining findings are P2 style/improvement suggestions with no blocking correctness issues.
- All four fixes are targeted and logically sound. The one logic comment in `chat_handler.py` (partial usage object leaving a zero field unestimated) is an edge case that only causes a minor undercount for an unusual provider behaviour — it does not break the primary path. The middleware bypass uses `secrets.compare_digest` correctly and fails closed when `ADMIN_API_KEY` is unset. No P0 or P1 issues found.
- src/handlers/chat_handler.py — token estimation condition (lines 747–753) could silently skip estimating a partially-zero usage object.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/db/users.py | Adds `user["api_key"] = api_key` to the new api_keys_new path so the admin user dict always carries the API key — fixes the 400 blocking live tests. The legacy path already returns api_key via the SELECT * query, so no change needed there. |
| src/handlers/chat_handler.py | Adds the previously-missing token estimation block for non-streaming requests when the provider omits usage data. The `and` condition means a partially-zero usage object (one field non-zero) skips estimation, potentially leaving the other field at 0 and undercounting cost. |
| src/middleware/security_middleware.py | Adds timing-safe detection of internal live-test requests (header + ADMIN_API_KEY token match) to skip velocity-mode recording for them. Uses `secrets.compare_digest` correctly; minor style nit on `str.replace` vs `str.removeprefix`. |
| src/routes/live_model_test.py | Injects the `X-Internal-Source: live-test` header into the httpx client before running model sweep tasks — pairs correctly with the new middleware detection logic. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Admin as Admin Client
    participant LMT as live_model_test.py
    participant SM as SecurityMiddleware
    participant CH as ChatHandler
    participant DB as DB (users / api_keys_new)

    Admin->>LMT: POST /live-test (Bearer ADMIN_API_KEY)
    LMT->>DB: Authenticate admin (require_admin)
    DB-->>LMT: user dict (now includes api_key via Fix 1)
    LMT->>LMT: Build headers with Authorization + X-Internal-Source: live-test
    loop Per model (concurrent)
        LMT->>SM: POST /chat (Bearer ADMIN_API_KEY, X-Internal-Source: live-test)
        SM->>SM: Detect internal live-test (header + secrets.compare_digest)
        SM->>CH: Forward request
        CH->>CH: Call provider
        CH->>CH: Extract usage (Fix 2: estimate if both tokens == 0)
        CH-->>SM: Response
        SM->>SM: Skip _record_request_outcome (is_internal_live_test=True)
        SM->>SM: _check_velocity_mode_deactivation (always runs)
        SM-->>LMT: Response
    end
    LMT-->>Admin: LiveTestReport
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/middleware/security_middleware.py
Line: 813-814

Comment:
**Velocity-mode deactivation still runs for internal live-test calls**

`_check_velocity_mode_deactivation()` is invoked unconditionally even when `_is_internal_live_test` is `True`. This is likely intentional (live-test call completions shouldn't prevent the system from recovering from velocity mode), but the asymmetry is worth a brief comment to make the intent clear — especially since the lines directly above explicitly skip the recording/activation step for these same requests.

Consider a short inline note:

```suggestion
        # Deactivation is always checked, even for internal live-test requests,
        # so the system can recover from velocity mode as normal traffic succeeds.
        self._check_velocity_mode_deactivation()
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/handlers/chat_handler.py
Line: 747-753

Comment:
**Estimation skipped when only one token count is zero**

The guard `prompt_tokens == 0 and completion_tokens == 0` only fires when the provider omits usage entirely (both fields default to `0` at lines 730–731). If a provider returns a partial usage object where one field is genuinely `0` and the other is non-zero, neither field gets estimated — the zero value is charged as-is. Given that `max(1, …)` is used inside the block, an asymmetric zero would silently undercount cost.

Consider checking each field independently:

```
if prompt_tokens == 0:
    prompt_chars = sum(
        len(m.get("content", "")) if isinstance(m.get("content"), str) else 0
        for m in messages
    )
    prompt_tokens = max(1, prompt_chars // 4)
if completion_tokens == 0:
    completion_tokens = max(1, len(content or "") // 4)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/middleware/security_middleware.py
Line: 793

Comment:
**`str.replace` without count strips all occurrences**

`str.replace(old, new)` replaces every matching substring in the string. Consider using `str.removeprefix("Bearer ")` (Python 3.9+) instead — it only strips the leading prefix and is a no-op if the prefix is not present, which more precisely matches the intended behavior here.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Added user\[api\_key\] so that user diction..."](https://github.com/alpaca-network/gatewayz-backend/commit/c194c068a0afeeb350084f55c5c05440f97b2aa9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26808362)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->