### PR TITLE
fix: correct xAI model routing and add authenticated streaming failover

### DIFF
--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -3028,9 +3028,7 @@ async def chat_completions(
                 logger.error(f"[Unified Handler] Error: {type(exc).__name__}: {exc}", exc_info=True)
                 if isinstance(exc, HTTPException):
                     raise
-                # Map provider-specific errors
-                from src.services.provider_failover import map_provider_error
-
+                # Map provider-specific errors (map_provider_error imported at module level)
                 http_exc = map_provider_error(error_provider, error_model, exc)
                 raise http_exc
         else:

--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -2665,11 +2665,7 @@ async def chat_completions(
                             return  # Stream completed successfully
 
                         except HTTPException as _http_exc:
-                            if (
-                                not _content_started
-                                and not _is_last
-                                and should_failover(_http_exc)
-                            ):
+                            if not _content_started and not _is_last and should_failover(_http_exc):
                                 logger.warning(
                                     f"[Unified Handler] Provider '{_attempt_provider}' failed "
                                     f"(HTTP {_http_exc.status_code}) for model {original_model}, "

--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -2629,73 +2629,102 @@ async def chat_completions(
             # Streaming path
             # Use unified handler for authenticated streaming requests
             if not is_anonymous:
-                try:
-                    logger.info(
-                        f"[Unified Handler] Processing authenticated streaming request for model {original_model}"
-                    )
+                # Authenticated streaming with provider failover.
+                # We wrap consumption inside an async generator so that errors during
+                # iteration (not just setup) can be caught and the next provider tried,
+                # but only before the first content chunk has been sent to the client.
+                async def _auth_stream_with_failover():
+                    _adapter = OpenAIChatAdapter()
+                    last_exc = None
 
-                    # Convert external OpenAI format to internal format
-                    adapter = OpenAIChatAdapter()
-                    internal_request = adapter.to_internal_request(
-                        {"messages": messages, "model": original_model, "stream": True, **optional}
-                    )
-                    # Pass the detected provider so the handler doesn't have to re-detect
-                    internal_request.provider = provider
+                    for _idx, _attempt_provider in enumerate(provider_chain):
+                        _is_last = _idx == len(provider_chain) - 1
+                        _content_started = False
+                        try:
+                            _internal_req = _adapter.to_internal_request(
+                                {
+                                    "messages": messages,
+                                    "model": original_model,
+                                    "stream": True,
+                                    **optional,
+                                }
+                            )
+                            # Set the provider for this attempt
+                            _internal_req.provider = _attempt_provider
 
-                    # Create unified handler with user context (pass request for disconnect detection)
-                    handler = ChatInferenceHandler(api_key, background_tasks, request=request)
+                            _handler = ChatInferenceHandler(
+                                api_key, background_tasks, request=request
+                            )
+                            _internal_stream = _handler.process_stream(_internal_req)
+                            _sse_stream = _adapter.from_internal_stream(_internal_stream)
 
-                    # Process stream through unified pipeline
-                    internal_stream = handler.process_stream(internal_request)
+                            async for _chunk in _sse_stream:
+                                _content_started = True
+                                yield _chunk
 
-                    # Convert internal stream to SSE format
-                    sse_stream = adapter.from_internal_stream(internal_stream)
+                            return  # Stream completed successfully
 
-                    # Prepare response headers
-                    stream_headers = {}
-                    if rl_pre is not None:
-                        stream_headers.update(get_rate_limit_headers(rl_pre))
+                        except HTTPException as _http_exc:
+                            if (
+                                not _content_started
+                                and not _is_last
+                                and should_failover(_http_exc)
+                            ):
+                                logger.warning(
+                                    f"[Unified Handler] Provider '{_attempt_provider}' failed "
+                                    f"(HTTP {_http_exc.status_code}) for model {original_model}, "
+                                    f"failing over ({_idx + 1}/{len(provider_chain)})"
+                                )
+                                last_exc = _http_exc
+                                continue
+                            raise
 
-                    # PERF: Add timing headers
-                    if tracker:
-                        prep_time_ms = tracker.get_total_duration() * 1000
-                        stream_headers["X-Prep-Time-Ms"] = f"{prep_time_ms:.1f}"
-                    stream_headers["X-Provider"] = "unified"
-                    stream_headers["X-Model"] = original_model
-                    stream_headers["X-Requested-Model"] = original_model
+                        except Exception as _exc:
+                            if not _content_started and not _is_last:
+                                logger.warning(
+                                    f"[Unified Handler] Provider '{_attempt_provider}' error "
+                                    f"({type(_exc).__name__}: {_exc}) for model {original_model}, "
+                                    f"failing over ({_idx + 1}/{len(provider_chain)})"
+                                )
+                                last_exc = map_provider_error(
+                                    _attempt_provider, original_model, _exc
+                                )
+                                continue
+                            if isinstance(_exc, HTTPException):
+                                raise
+                            raise map_provider_error(
+                                _attempt_provider, original_model, _exc
+                            ) from _exc
 
-                    # SSE streaming headers to prevent buffering by proxies/nginx
-                    stream_headers["X-Accel-Buffering"] = "no"
-                    stream_headers["Cache-Control"] = "no-cache, no-transform"
-                    stream_headers["Connection"] = "keep-alive"
+                    # All providers exhausted
+                    if last_exc:
+                        raise last_exc
 
-                    logger.info(
-                        f"[Unified Handler] Returning SSE streaming response for model {original_model}"
-                    )
+                # Prepare response headers
+                stream_headers = {}
+                if rl_pre is not None:
+                    stream_headers.update(get_rate_limit_headers(rl_pre))
+                if tracker:
+                    prep_time_ms = tracker.get_total_duration() * 1000
+                    stream_headers["X-Prep-Time-Ms"] = f"{prep_time_ms:.1f}"
+                stream_headers["X-Provider"] = "unified"
+                stream_headers["X-Model"] = original_model
+                stream_headers["X-Requested-Model"] = original_model
+                # SSE streaming headers to prevent buffering by proxies/nginx
+                stream_headers["X-Accel-Buffering"] = "no"
+                stream_headers["Cache-Control"] = "no-cache, no-transform"
+                stream_headers["Connection"] = "keep-alive"
 
-                    return StreamingResponse(
-                        sse_stream,
-                        media_type="text/event-stream",
-                        headers=stream_headers,
-                    )
+                logger.info(
+                    f"[Unified Handler] Returning SSE streaming response for model {original_model} "
+                    f"(provider_chain={provider_chain})"
+                )
 
-                except Exception as exc:
-                    # Map any errors to HTTPException
-                    logger.error(
-                        f"[Unified Handler] Streaming error: {type(exc).__name__}: {exc}",
-                        exc_info=True,
-                    )
-                    if isinstance(exc, HTTPException):
-                        raise
-                    # Map provider-specific errors
-                    from src.services.provider_failover import map_provider_error
-
-                    http_exc = map_provider_error(
-                        "onerouter",  # Default provider for error mapping
-                        original_model,
-                        exc,
-                    )
-                    raise http_exc
+                return StreamingResponse(
+                    _auth_stream_with_failover(),
+                    media_type="text/event-stream",
+                    headers=stream_headers,
+                )
             else:
                 # Anonymous users: keep existing provider routing logic
                 last_http_exc = None

--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -424,6 +424,13 @@ def transform_model_id(model_id: str, provider: str, use_multi_provider: bool = 
         logger.debug(f"Stripped provider prefix for {provider_lower}: '{model_id}' -> '{stripped}'")
         return stripped
 
+    # xAI models use "x-ai/" prefix in the catalog but the xAI API expects bare model names
+    # (e.g., "x-ai/grok-2-1212" -> "grok-2-1212")
+    if provider_lower == "xai" and model_id.startswith("x-ai/"):
+        stripped = model_id[5:]  # len("x-ai/") == 5
+        logger.debug(f"Stripped x-ai/ prefix for xai: '{model_id}' -> '{stripped}'")
+        return stripped
+
     # If already in full Fireworks path format, return as-is (already lowercase)
     if model_id.startswith("accounts/fireworks/models/"):
         logger.debug(f"Model ID already in Fireworks format: {model_id}")
@@ -1684,8 +1691,8 @@ def detect_provider_from_model_id(
         ]:
             return "fal"
 
-        # XAI models (e.g., "xai/grok-2")
-        if org == "xai":
+        # XAI models (e.g., "xai/grok-2" or "x-ai/grok-2-1212")
+        if org in ("xai", "x-ai"):
             return "xai"
 
         # Groq models (e.g., "groq/llama-3.3-70b-versatile", "groq/mixtral-8x7b-32768")

--- a/src/services/provider_failover.py
+++ b/src/services/provider_failover.py
@@ -69,6 +69,8 @@ _NATIVE_PROVIDER_PREFIXES = {
         "anthropic",
         "openrouter",
     ),  # Anthropic models: try anthropic first, then openrouter
+    "x-ai/": ("xai",),  # xAI models: xai only (no cross-provider support)
+    "xai/": ("xai",),  # also handle xai/ prefix variant
 }
 
 


### PR DESCRIPTION
- model_transformations.py: detect_provider_from_model_id now recognises org "x-ai" (with hyphen) in addition to "xai", fixing routing for all x-ai/grok-* models (grok-3, grok-4, grok-2-1212, etc.) that were falling through to openrouter and triggering the entire failover chain
- model_transformations.py: transform_model_id now strips the "x-ai/" prefix for the xai provider so grok model IDs reach the xAI API in their expected bare form (e.g. "grok-2-1212" not "x-ai/grok-2-1212")
- provider_failover.py: add "x-ai/" and "xai/" to _NATIVE_PROVIDER_PREFIXES as a safety net so enforce_model_failover_rules restricts the chain to ["xai"] even if detection is bypassed
- chat.py: replace the single-attempt authenticated streaming block with _auth_stream_with_failover(), an async generator that iterates over the full provider_chain and retries on failover-eligible status codes as long as no content has been sent to the client yet, matching the behaviour already present in the anonymous path
- chat.py: use the actual provider variable (not hardcoded "onerouter") when calling map_provider_error in the authenticated error handler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider failover added for authenticated streaming requests: streaming now transparently attempts alternate providers if earlier attempts fail, and success logs include the attempted provider chain.
  * xAI model support: recognized and normalized xAI model names (both xai/ and x-ai/), with routing constrained to the xAI provider.

* **Bug Fixes**
  * Improved streaming error handling to catch failures during content iteration, allowing failover only before content is sent and surfacing final HTTP errors if all providers fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related xAI (`grok-*`) routing bugs and aligns authenticated streaming failover behaviour with the anonymous path.

**What changed and why:**
- `detect_provider_from_model_id` now recognises the `"x-ai"` org prefix (with hyphen) in addition to `"xai"`, so all `x-ai/grok-*` catalogue IDs are routed to the `xai` provider instead of falling through to OpenRouter.
- `transform_model_id` strips the `"x-ai/"` prefix when the resolved provider is `xai`, ensuring the API call uses bare model names (e.g. `grok-2-1212`) as the xAI API expects.
- `_NATIVE_PROVIDER_PREFIXES` in `provider_failover.py` gains `"x-ai/"` and `"xai/"` entries as a defence-in-depth guard inside `enforce_model_failover_rules`.
- The authenticated streaming block in `chat.py` is rewritten as `_auth_stream_with_failover()`, an async generator closure that iterates the full `provider_chain` and retries on failover-eligible status codes — matching the behaviour already present in the anonymous path. A separate bug where the error mapper received a hardcoded `"onerouter"` instead of the actual provider is also fixed.

**Key observations:**
- The `_content_started` flag (set to `True` immediately before `yield _chunk`) correctly prevents failover once any SSE data chunk has been produced; the approach mirrors the anonymous path and is safe.
- One minor style issue: the `isinstance(_exc, HTTPException)` guard inside the `except Exception` block is unreachable dead code (see inline comment).
- Both `should_failover` and `map_provider_error` are top-level imports in `chat.py`, so the closure captures them correctly without lazy imports.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — all remaining feedback is a minor style cleanup with no impact on correctness or runtime behaviour.
- The xAI routing fixes are correct and well-scoped. The authenticated streaming failover rewrite mirrors the already-proven anonymous path. The only finding is a dead-code guard in `except Exception` that has no runtime consequence.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/chat.py | Replaces single-attempt authenticated streaming with `_auth_stream_with_failover()`, a closure that iterates `provider_chain` and retries on failover-eligible errors before any content has been sent; also fixes hardcoded `"onerouter"` in the error-mapping call. One dead-code guard (`isinstance(_exc, HTTPException)` inside `except Exception`) can be removed. |
| src/services/model_transformations.py | Adds `"x-ai"` org recognition in `detect_provider_from_model_id` so `x-ai/grok-*` models route to `"xai"` instead of falling through; adds a dedicated `"x-ai/"` prefix-stripping step in `transform_model_id` for the xai provider. Both changes are correct and interact safely with the existing lowercase-normalisation pass. |
| src/services/provider_failover.py | Adds `"x-ai/"` and `"xai/"` entries to `_NATIVE_PROVIDER_PREFIXES` mapping both to `("xai",)`, acting as a safety net in `enforce_model_failover_rules` to prevent xAI models from leaking to unrelated providers even if detection is bypassed. Change is minimal and correct. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Chat as chat_completions()
    participant Failover as provider_failover.py
    participant Transforms as model_transformations.py
    participant Handler as ChatInferenceHandler

    Client->>Chat: POST /v1/chat/completions stream=true model=x-ai/grok-2-1212

    Chat->>Transforms: detect_provider_from_model_id("x-ai/grok-2-1212")
    Note over Transforms: org="x-ai" now matches xai or x-ai
    Transforms-->>Chat: provider="xai"

    Chat->>Failover: build_provider_failover_chain("xai")
    Note over Failover: xai not in FALLBACK_ELIGIBLE so returns ["xai"]
    Failover-->>Chat: provider_chain=["xai"]

    Chat->>Failover: enforce_model_failover_rules("x-ai/grok-2-1212", ["xai"])
    Note over Failover: x-ai/ prefix maps to allowed=(xai,)
    Failover-->>Chat: ["xai"]

    Chat->>Client: StreamingResponse headers committed

    loop _auth_stream_with_failover for each provider
        Chat->>Transforms: transform_model_id("x-ai/grok-2-1212", "xai")
        Note over Transforms: strips x-ai/ prefix returns grok-2-1212
        Transforms-->>Handler: internal_req model=grok-2-1212 provider=xai

        Handler->>Handler: process_stream(internal_req)

        alt Stream succeeds
            Handler-->>Client: SSE chunks yielded _content_started=True
        else HTTPException no content yet not last provider
            Handler-->>Chat: HTTPException 502 503 504
            Note over Chat: should_failover=True continue to next provider
        else Error after content started or last provider
            Chat-->>Client: raise stream terminated
        end
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/routes/chat.py
Line: 2693-2694

Comment:
**Dead code: `isinstance(_exc, HTTPException)` check is unreachable**

The `except HTTPException` clause on line 2667 precedes this `except Exception` clause. Because `HTTPException` is a subclass of `Exception`, any `HTTPException` is caught by the first handler and will never reach this block. The `isinstance` guard and its `raise` are therefore unreachable — any `_exc` that arrives here is guaranteed to be a non-`HTTPException`.

```suggestion
                        except Exception as _exc:
                            if not _content_started and not _is_last:
                                logger.warning(
                                    f"[Unified Handler] Provider '{_attempt_provider}' error "
                                    f"({type(_exc).__name__}: {_exc}) for model {original_model}, "
                                    f"failing over ({_idx + 1}/{len(provider_chain)})"
                                )
                                last_exc = map_provider_error(
                                    _attempt_provider, original_model, _exc
                                )
                                continue
                            raise map_provider_error(
                                _attempt_provider, original_model, _exc
                            ) from _exc
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remove inline map\_provider\_error im..."](https://github.com/alpaca-network/gatewayz-backend/commit/206cda6237df522b43d6bf58c6e17e1b45947ad9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26814568)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->