### PR TITLE
Fix/fix request defect

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,97 @@ Proprietary - All rights reserved
 
 ---
 
+## 🔄 Model Routing Hotfixes & Rollback Guide
+
+Documents four model routing fixes in commit `c09165c4`. Each section explains what changed and how to revert it individually. Silent redirects (aliases to newer model IDs) are intentional — deprecated upstream models are mapped to their current equivalents so existing integrations keep working without client changes.
+
+### Quick Rollback (revert all four at once)
+
+```bash
+git revert c09165c4 --no-edit
+```
+
+---
+
+### Fix 1 — Cerebras qwen-3: disable reasoning tokens by default
+
+**Problem**: `cerebras-cloud-sdk >=1.64.x` enables hybrid thinking for qwen-3 models by default. The gateway doesn't handle reasoning tokens in the stream, so Cerebras returned a 400 — which the error handler translated to the misleading _"Invalid value for parameter 'request'"_ message.
+
+**Change**: `src/services/cerebras_client.py` — added `_apply_cerebras_reasoning_defaults()` which injects `disable_reasoning=True` for any model whose name contains `qwen-3` or `qwen3`, unless the caller already set `disable_reasoning` or `reasoning_effort`.
+
+**Manual rollback**:
+1. Remove the constant and helper (lines ~111–126):
+   ```python
+   _CEREBRAS_REASONING_MODELS = ("qwen-3", "qwen3")
+
+   def _apply_cerebras_reasoning_defaults(model: str, kwargs: dict) -> dict: ...
+   ```
+2. Remove the two call sites in `make_cerebras_request_openai()` and `make_cerebras_request_openai_stream()`:
+   ```python
+   kwargs = _apply_cerebras_reasoning_defaults(model, kwargs)  # remove this line
+   ```
+
+---
+
+### Fix 2 — DeepSeek: pin to stable versioned model ID
+
+**Problem**: The generic `deepseek/deepseek-chat` alias on OpenRouter pointed to overloaded capacity, causing Bad Gateway (502) after 3 retries.
+
+**Change**: `src/services/model_transformations.py` — `deepseek-chat`, `deepseek-chat-v3`, and `deepseek-chat-v3.1` entries in the OpenRouter model mapping table now resolve to `deepseek/deepseek-chat-v3-0324` (stable versioned endpoint).
+
+**Manual rollback**: In `model_transformations.py`, find the OpenRouter model mapping dict and revert the deepseek-chat entries:
+```python
+# Revert to generic alias:
+"deepseek/deepseek-chat": "deepseek/deepseek-chat",
+"deepseek-chat": "deepseek/deepseek-chat",
+"deepseek/deepseek-chat-v3": "deepseek/deepseek-chat",
+"deepseek/deepseek-chat-v3.1": "deepseek/deepseek-chat",
+```
+
+---
+
+### Fix 3 — Mistral: explicit OpenRouter routing for mistralai org prefix
+
+**Problem**: `detect_provider_from_model_id()` had no case for the `mistralai` org prefix. It fell through to the default (`onerouter` / Infron AI), which accepted the request but returned an empty stream.
+
+**Change**: `src/services/model_transformations.py` — added an explicit `if org == "mistralai": return "openrouter"` check inside `detect_provider_from_model_id()`.
+
+**Manual rollback**: Remove the block added to `detect_provider_from_model_id()`:
+```python
+# Remove this block:
+if org == "mistralai":
+    logger.info(f"Routing '{model_id}' to openrouter (mistralai org prefix)")
+    return "openrouter"
+```
+
+---
+
+### Fix 4 — xAI grok-2 / grok-2-1212: redirect deprecated models to grok-3
+
+**Problem**: xAI deprecated `grok-2-1212`. The 404 response body wasn't parseable by the error handler's model extractor, so it surfaced as _"Model 'unknown' not found"_ with no actionable detail.
+
+**Change**: `src/services/model_transformations.py` — added `grok-2`, `grok-2-1212`, and their prefixed variants to both `MODEL_ID_ALIASES` (→ `x-ai/grok-3`) and the xai provider mapping table (→ `grok-3`).
+
+**Manual rollback**:
+1. Remove from `MODEL_ID_ALIASES`:
+   ```python
+   "grok-2": "x-ai/grok-3",
+   "grok-2-1212": "x-ai/grok-3",
+   "xai/grok-2": "x-ai/grok-3",
+   "xai/grok-2-1212": "x-ai/grok-3",
+   "x-ai/grok-2": "x-ai/grok-3",
+   "x-ai/grok-2-1212": "x-ai/grok-3",
+   ```
+2. Remove from the xai provider mapping table:
+   ```python
+   "grok-2": "grok-3",
+   "grok-2-1212": "grok-3",
+   "xai/grok-2": "grok-3",
+   "xai/grok-2-1212": "grok-3",
+   ```
+
+---
+
 ## 🙏 Acknowledgments
 
 Built with:

--- a/src/services/cerebras_client.py
+++ b/src/services/cerebras_client.py
@@ -108,6 +108,24 @@ def get_cerebras_client():
         raise
 
 
+_CEREBRAS_REASONING_MODELS = ("qwen-3", "qwen3")
+
+
+def _apply_cerebras_reasoning_defaults(model: str, kwargs: dict) -> dict:
+    """Disable reasoning by default for Cerebras models that support it.
+
+    qwen-3 models have hybrid thinking enabled by default in cerebras-cloud-sdk
+    >=1.64.x. Without explicitly disabling it the API returns a 400 because the
+    gateway doesn't handle reasoning tokens in the stream. Pass
+    disable_reasoning=True unless the caller already set it.
+    """
+    model_lower = model.lower()
+    if any(tag in model_lower for tag in _CEREBRAS_REASONING_MODELS):
+        if "disable_reasoning" not in kwargs and "reasoning_effort" not in kwargs:
+            kwargs = {**kwargs, "disable_reasoning": True}
+    return kwargs
+
+
 def make_cerebras_request_openai(messages, model, **kwargs):
     """Make request to Cerebras using official SDK or OpenAI-compatible client
 
@@ -123,6 +141,7 @@ def make_cerebras_request_openai(messages, model, **kwargs):
         from src.utils.provider_timing import ProviderTimingContext
 
         client = get_cerebras_client()
+        kwargs = _apply_cerebras_reasoning_defaults(model, kwargs)
 
         # Log request for debugging
         logger.debug(f"Cerebras request - model: {model}, messages: {len(messages)}")
@@ -151,6 +170,7 @@ def make_cerebras_request_openai_stream(messages, model, **kwargs):
         from src.utils.provider_timing import ProviderTimingContext
 
         client = get_cerebras_client()
+        kwargs = _apply_cerebras_reasoning_defaults(model, kwargs)
 
         # Log request for debugging
         logger.debug(f"Cerebras streaming request - model: {model}, messages: {len(messages)}")

--- a/src/services/model_transformations.py
+++ b/src/services/model_transformations.py
@@ -230,12 +230,18 @@ MODEL_ID_ALIASES = {
     "grok-4.1-fast": "x-ai/grok-4.1-fast",
     # XAI Grok specialized models
     "grok-code-fast-1": "x-ai/grok-code-fast-1",
-    # XAI Grok deprecated models (grok-beta was deprecated 2025-09-15, use grok-3)
-    # Note: Map directly to canonical x-ai/ prefix (apply_model_alias now resolves one chain level)
+    # XAI Grok deprecated models — redirect to grok-3 (current equivalent)
+    # grok-beta deprecated 2025-09-15; grok-2/grok-2-1212 deprecated, use grok-3
     "grok-beta": "x-ai/grok-3",
     "xai/grok-beta": "x-ai/grok-3",
     "grok-vision-beta": "x-ai/grok-3",
     "xai/grok-vision-beta": "x-ai/grok-3",
+    "grok-2": "x-ai/grok-3",
+    "grok-2-1212": "x-ai/grok-3",
+    "xai/grok-2": "x-ai/grok-3",
+    "xai/grok-2-1212": "x-ai/grok-3",
+    "x-ai/grok-2": "x-ai/grok-3",
+    "x-ai/grok-2-1212": "x-ai/grok-3",
     # Zhipu AI GLM models - z-ai/ prefix aliases (OpenRouter format)
     # GLM-4.7 doesn't exist, map to closest available version GLM-4-flash
     "z-ai/glm-4.7": "z-ai/glm-4-flash",
@@ -665,20 +671,21 @@ _MODEL_ID_MAPPINGS: dict[str, dict[str, str]] = {
         "deepseek/deepseek-coder": "deepseek/deepseek-coder",
         "deepseek-ai/deepseek-coder": "deepseek/deepseek-coder",
         "deepseek-coder": "deepseek/deepseek-coder",
-        # DeepSeek Chat (default chat model)
-        "deepseek/deepseek-chat": "deepseek/deepseek-chat",
-        "deepseek-ai/deepseek-chat": "deepseek/deepseek-chat",
-        "deepseek-chat": "deepseek/deepseek-chat",
-        # DeepSeek Chat V3 variants - map to the canonical deepseek/deepseek-chat on OpenRouter
-        "deepseek/deepseek-chat-v3": "deepseek/deepseek-chat",
-        "deepseek/deepseek-chat-v3.1": "deepseek/deepseek-chat",
-        "deepseek/deepseek-chat-v3-0324": "deepseek/deepseek-chat",
-        "deepseek-ai/deepseek-chat-v3": "deepseek/deepseek-chat",
-        "deepseek-ai/deepseek-chat-v3.1": "deepseek/deepseek-chat",
-        "deepseek-ai/deepseek-chat-v3-0324": "deepseek/deepseek-chat",
-        "deepseek-chat-v3": "deepseek/deepseek-chat",
-        "deepseek-chat-v3.1": "deepseek/deepseek-chat",
-        "deepseek-chat-v3-0324": "deepseek/deepseek-chat",
+        # DeepSeek Chat (default chat model) — use stable versioned ID to avoid
+        # OpenRouter alias routing instability with the generic deepseek/deepseek-chat slug
+        "deepseek/deepseek-chat": "deepseek/deepseek-chat-v3-0324",
+        "deepseek-ai/deepseek-chat": "deepseek/deepseek-chat-v3-0324",
+        "deepseek-chat": "deepseek/deepseek-chat-v3-0324",
+        # DeepSeek Chat V3 variants - map to the stable versioned ID on OpenRouter
+        "deepseek/deepseek-chat-v3": "deepseek/deepseek-chat-v3-0324",
+        "deepseek/deepseek-chat-v3.1": "deepseek/deepseek-chat-v3-0324",
+        "deepseek/deepseek-chat-v3-0324": "deepseek/deepseek-chat-v3-0324",
+        "deepseek-ai/deepseek-chat-v3": "deepseek/deepseek-chat-v3-0324",
+        "deepseek-ai/deepseek-chat-v3.1": "deepseek/deepseek-chat-v3-0324",
+        "deepseek-ai/deepseek-chat-v3-0324": "deepseek/deepseek-chat-v3-0324",
+        "deepseek-chat-v3": "deepseek/deepseek-chat-v3-0324",
+        "deepseek-chat-v3.1": "deepseek/deepseek-chat-v3-0324",
+        "deepseek-chat-v3-0324": "deepseek/deepseek-chat-v3-0324",
         # Cerebras models explicitly routed through OpenRouter
         # (for users who request provider="openrouter" explicitly or failover scenarios)
         "cerebras/llama-3.3-70b": "meta-llama/llama-3.3-70b-instruct",
@@ -1049,20 +1056,18 @@ _MODEL_ID_MAPPINGS: dict[str, dict[str, str]] = {
         "mixtral-8x7b": "mistralai/completion/models/mixtral-8x7b-instruct",
     },
     "xai": {
-        # XAI Grok models - pass-through format
-        # Models are referenced by their simple names (e.g., "grok-2", "grok-3")
-        # Can also use xai/grok-* format
-        # Note: grok-beta was deprecated on 2025-09-15, now redirected to grok-3
+        # XAI Grok models — bare model names expected by the xAI API
+        # grok-beta, grok-2, grok-2-1212 are deprecated; redirect to grok-3
         "grok-beta": "grok-3",
-        "grok-2": "grok-2",
-        "grok-2-1212": "grok-2-1212",
+        "grok-vision-beta": "grok-3",
+        "grok-2": "grok-3",
+        "grok-2-1212": "grok-3",
         "grok-3": "grok-3",
-        "grok-vision-beta": "grok-3",  # grok-vision-beta also deprecated
         "xai/grok-beta": "grok-3",
-        "xai/grok-2": "grok-2",
-        "xai/grok-2-1212": "grok-2-1212",
-        "xai/grok-3": "grok-3",
         "xai/grok-vision-beta": "grok-3",
+        "xai/grok-2": "grok-3",
+        "xai/grok-2-1212": "grok-3",
+        "xai/grok-3": "grok-3",
     },
     "cerebras": {
         # Cerebras API expects model IDs without the "cerebras/" prefix
@@ -1664,6 +1669,11 @@ def detect_provider_from_model_id(
                 )
                 return "cerebras"
             return "alibaba-cloud"
+
+        # Mistral models — route to OpenRouter which carries the full mistralai catalog
+        if org == "mistralai":
+            logger.info(f"Routing '{model_id}' to openrouter (mistralai org prefix)")
+            return "openrouter"
 
         # DeepSeek models are primarily on Fireworks in this system
         # Support both "deepseek-ai/" and "deepseek/" org prefixes


### PR DESCRIPTION
5/5 agent checks passed — all routing is verified clean:                            
  - cerebras/qwen-3-32b → cerebras, disable_reasoning=True injected ✅
  - deepseek/deepseek-chat → openrouter as deepseek-chat-v3-0324 ✅                   
  - mistralai/mistral-large-2411 → openrouter via org-prefix ✅    
  - x-ai/grok-2-1212 → aliased to grok-3 via xai provider ✅                          
  - Error handlers and provider_failover.py unchanged / no bypasses ✅                
                                                                                      
  Pushed 2 commits to fix/fix-request-defect:                                         
  - c09165c4 — the 4 routing fixes                                                    
  - ddc0def0 — rollback guide added to README.md under a new "Model Routing Hotfixes &
   Rollback Guide" section with per-fix instructions and a git revert c09165c4        
  --no-edit one-liner                                                                 
                             

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model routing for Grok (deprecated versions now correctly route to grok-3), DeepSeek Chat (updated to stable versioned model), and Mistral provider detection.
  * Enhanced Cerebras qwen-3 model handling with automatic reasoning parameter defaults.

* **Documentation**
  * Added model routing hotfixes and rollback guide with revert instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR resolves four independent model-routing defects by patching `src/services/cerebras_client.py` and `src/services/model_transformations.py`, and adds an operator rollback guide to `README.md`.

**Changes by fix:**
- **Fix 1 (Cerebras qwen-3):** Adds `_apply_cerebras_reasoning_defaults()` which injects `disable_reasoning=True` for any qwen-3 model before the API call, curing a 400 caused by the `cerebras-cloud-sdk ≥1.64.x` hybrid-thinking default that the gateway's stream handler can't process.
- **Fix 2 (DeepSeek chat stability):** Remaps all `deepseek-chat` / `deepseek-chat-v3*` OpenRouter entries from the generic (overloaded) `deepseek/deepseek-chat` slug to the stable versioned endpoint `deepseek/deepseek-chat-v3-0324`, curing intermittent 502s.
- **Fix 3 (Mistral routing):** Adds an explicit `if org == "mistralai": return "openrouter"` branch in `detect_provider_from_model_id`, so models like `mistralai/mistral-large-2411` reach OpenRouter instead of falling through to the `onerouter` default which returned empty streams.
- **Fix 4 (grok-2 deprecated):** Adds `grok-2` / `grok-2-1212` (and their `xai/` / `x-ai/` prefixed variants) to `MODEL_ID_ALIASES` pointing to `x-ai/grok-3`; the existing `x-ai/` prefix-stripping in `transform_model_id` then reduces this to the bare `grok-3` expected by the xAI API. The xai provider mapping table entries added for the same keys are unreachable dead code.
- **README:** Documents all four fixes with per-fix manual rollback steps and a single `git revert c09165c4 --no-edit` one-liner.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all four fixes are targeted and correct; the only findings are P2 style concerns about dead code and a minor documentation gap.

All remaining findings are P2 or lower. The dead xai mapping entries are harmless (unreachable but non-breaking). The disable_reasoning SDK-path note is a documentation suggestion, not a runtime defect. All four routing fixes correctly address their stated bugs and do not regress existing paths.

No files require special attention — model_transformations.py has the dead xai mapping entries but they cause no runtime impact.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/services/cerebras_client.py | Adds `_apply_cerebras_reasoning_defaults()` to inject `disable_reasoning=True` for qwen-3 models on both sync and streaming paths, correctly guarding against caller-supplied `disable_reasoning` or `reasoning_effort`. |
| src/services/model_transformations.py | Three routing fixes: DeepSeek chat mapped to stable versioned ID on OpenRouter, mistralai org-prefix added to detect_provider_from_model_id, and grok-2/grok-2-1212 aliases redirected to grok-3. The xai provider mapping table gains grok-2 entries that are dead code due to MODEL_ID_ALIASES + x-ai/ prefix stripping running first. |
| README.md | Adds a "Model Routing Hotfixes & Rollback Guide" section documenting all four fixes with per-fix manual rollback instructions and a single `git revert c09165c4 --no-edit` one-liner. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Gateway
    participant Alias as apply_model_alias
    participant Detect as detect_provider
    participant Transform as transform_model_id

    Note over Client,Transform: Fix 1 — Cerebras qwen-3 (disable_reasoning)
    Client->>Gateway: model=cerebras/qwen-3-32b
    Gateway->>Transform: transform("cerebras/qwen-3-32b", "cerebras")
    Transform-->>Gateway: "qwen-3-32b"
    Gateway->>Gateway: _apply_cerebras_reasoning_defaults() injects disable_reasoning=True
    Gateway-->>Client: Cerebras API (no 400)

    Note over Client,Transform: Fix 2 — DeepSeek chat → stable versioned ID
    Client->>Gateway: model=deepseek/deepseek-chat
    Gateway->>Detect: detect_provider("deepseek/deepseek-chat")
    Detect-->>Gateway: "openrouter" (via MODEL_PROVIDER_OVERRIDES)
    Gateway->>Transform: transform("deepseek/deepseek-chat", "openrouter")
    Transform-->>Gateway: "deepseek/deepseek-chat-v3-0324"
    Gateway-->>Client: OpenRouter (stable endpoint, no 502)

    Note over Client,Transform: Fix 3 — mistralai/ prefix → OpenRouter
    Client->>Gateway: model=mistralai/mistral-large-2411
    Gateway->>Detect: detect_provider("mistralai/mistral-large-2411")
    Detect->>Detect: org=="mistralai" → return "openrouter"
    Detect-->>Gateway: "openrouter"
    Gateway-->>Client: OpenRouter (no empty stream)

    Note over Client,Transform: Fix 4 — grok-2 alias → grok-3
    Client->>Gateway: model=grok-2-1212
    Gateway->>Alias: apply_model_alias("grok-2-1212")
    Alias-->>Gateway: "x-ai/grok-3" (MODEL_ID_ALIASES)
    Gateway->>Detect: detect_provider("x-ai/grok-3")
    Detect-->>Gateway: "xai"
    Gateway->>Transform: transform("x-ai/grok-3", "xai")
    Transform->>Transform: strip "x-ai/" prefix
    Transform-->>Gateway: "grok-3"
    Gateway-->>Client: xAI API (no 404)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/services/model_transformations.py
Line: 1063-1070

Comment:
**Dead entries in xai provider mapping table**

The four grok-2 entries added here (`"grok-2": "grok-3"`, `"grok-2-1212": "grok-3"`, `"xai/grok-2": "grok-3"`, `"xai/grok-2-1212": "grok-3"`) are unreachable dead code.

Here's why: `transform_model_id` calls `apply_model_alias` unconditionally at the very top (line ~356), which resolves all four of these keys → `"x-ai/grok-3"`. The function then hits the early-return `x-ai/` prefix-strip block at lines 435–438 (`if provider_lower == "xai" and model_id.startswith("x-ai/")`) and returns `"grok-3"` **before** the mapping table is ever consulted at line ~503.

The actual fix is entirely in `MODEL_ID_ALIASES`; these four xai mapping entries do nothing. They're harmless, but they misrepresent where the real routing logic lives — future maintainers editing the xai mapping block may not realise that the aliases dictionary is the source of truth for these deprecated IDs.

Consider removing them or, if you want belt-and-suspenders redundancy, add a comment explaining that they are never reached via the normal call path.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/services/cerebras_client.py
Line: 114-126

Comment:
**`disable_reasoning` behaviour on the OpenAI SDK fallback path**

When `cerebras.cloud.sdk` is not installed, `get_cerebras_client()` returns an `openai.OpenAI` pointed at `https://api.cerebras.ai/v1`. On that path, `_apply_cerebras_reasoning_defaults` still injects `disable_reasoning=True`, which the OpenAI SDK passes straight through as an extra JSON body field.

The hybrid-thinking behaviour that caused the 400 is a feature of the Cerebras Cloud SDK (≥1.64.x), not the underlying REST endpoint. If the REST endpoint also honours `disable_reasoning` the parameter is fine; if it doesn't, the OpenAI-SDK fallback path now sends an unknown field to the API. Worth explicitly documenting that the REST endpoint accepts this parameter — or guard the injection:

```python
# Only apply if we are actually using the official Cerebras SDK
# (the OpenAI-compatible REST endpoint may not accept disable_reasoning)
```

Not a blocker — the OpenAI SDK passes unknown kwargs as extra JSON body params and the API likely accepts the field — but the docstring currently implies the issue is SDK-level, so a short note clarifying the REST-endpoint behaviour would prevent future confusion.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add model routing hotfixes and rol..."](https://github.com/alpaca-network/gatewayz-backend/commit/ddc0def096ccce521a8b93de291810675178d54e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26859875)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->