### PR TITLE
fix: close Phase 2A/2B/2C remaining gaps — bugs + DB-first upgrades

### DIFF
--- a/scripts/database/seed_providers.py
+++ b/scripts/database/seed_providers.py
@@ -22,9 +22,6 @@ project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
 from src.config.supabase_config import get_supabase_client
-from src.services.gateway_registry import get_gateway_registry
-
-GATEWAY_REGISTRY = get_gateway_registry()
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
@@ -97,6 +94,9 @@ def seed_providers(dry_run: bool = False) -> dict:
         Dictionary with sync results
     """
     try:
+        from src.services.gateway_registry import get_gateway_registry
+
+        GATEWAY_REGISTRY = get_gateway_registry()
         client = get_supabase_client()
 
         logger.info(f"🔄 Syncing {len(GATEWAY_REGISTRY)} providers from GATEWAY_REGISTRY")

--- a/scripts/database/seed_providers.py
+++ b/scripts/database/seed_providers.py
@@ -22,11 +22,12 @@ project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
 from src.config.supabase_config import get_supabase_client
-from src.routes.catalog import GATEWAY_REGISTRY
+from src.services.gateway_registry import get_gateway_registry
+
+GATEWAY_REGISTRY = get_gateway_registry()
 
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
 
@@ -70,7 +71,9 @@ def transform_gateway_to_provider(gateway_id: str, gateway_config: dict) -> dict
         "name": gateway_config["name"],
         "slug": gateway_id,
         "description": f"{gateway_config['name']} - {gateway_config.get('priority', 'standard')} priority gateway",
-        "api_key_env_var": PROVIDER_ENV_VAR_MAP.get(gateway_id, f"{gateway_id.upper().replace('-', '_')}_API_KEY"),
+        "api_key_env_var": PROVIDER_ENV_VAR_MAP.get(
+            gateway_id, f"{gateway_id.upper().replace('-', '_')}_API_KEY"
+        ),
         "supports_streaming": True,  # Most providers support streaming
         "is_active": True,
         "site_url": gateway_config.get("site_url"),
@@ -79,7 +82,7 @@ def transform_gateway_to_provider(gateway_id: str, gateway_config: dict) -> dict
             "priority": gateway_config.get("priority", "slow"),
             "icon": gateway_config.get("icon"),
             "aliases": gateway_config.get("aliases", []),
-        }
+        },
     }
 
 
@@ -112,14 +115,15 @@ def seed_providers(dry_run: bool = False) -> dict:
                 "success": True,
                 "dry_run": True,
                 "providers_synced": len(providers_to_upsert),
-                "providers": [p["slug"] for p in providers_to_upsert]
+                "providers": [p["slug"] for p in providers_to_upsert],
             }
 
         # Upsert all providers (insert or update on conflict)
-        result = client.table("providers").upsert(
-            providers_to_upsert,
-            on_conflict="slug"  # Update if slug already exists
-        ).execute()
+        result = (
+            client.table("providers")
+            .upsert(providers_to_upsert, on_conflict="slug")  # Update if slug already exists
+            .execute()
+        )
 
         synced_count = len(result.data) if result.data else 0
 
@@ -132,16 +136,12 @@ def seed_providers(dry_run: bool = False) -> dict:
         return {
             "success": True,
             "providers_synced": synced_count,
-            "providers": [p["slug"] for p in providers_to_upsert]
+            "providers": [p["slug"] for p in providers_to_upsert],
         }
 
     except Exception as e:
         logger.error(f"❌ Failed to seed providers: {e}", exc_info=True)
-        return {
-            "success": False,
-            "error": str(e),
-            "providers_synced": 0
-        }
+        return {"success": False, "error": str(e), "providers_synced": 0}
 
 
 def main():
@@ -149,7 +149,9 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser(description="Seed providers from GATEWAY_REGISTRY")
-    parser.add_argument("--dry-run", action="store_true", help="Show what would be done without making changes")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Show what would be done without making changes"
+    )
     args = parser.parse_args()
 
     logger.info("=" * 80)

--- a/src/routes/api_models.py
+++ b/src/routes/api_models.py
@@ -125,27 +125,10 @@ async def get_model_detail(
             provider_groups.append(enhanced_openrouter)
 
         # Add providers from other gateways based on detected gateway
-        if detected_gateway in [
-            "featherless",
-            "deepinfra",
-            "chutes",
-            "groq",
-            "fireworks",
-            "together",
-            "cerebras",
-            "nebius",
-            "xai",
-            "novita",
-            "hug",
-            "aimo",
-            "near",
-            "fal",
-            "anannas",
-            "aihubmix",
-            "vercel-ai-gateway",
-            "onerouter",
-            "helicone",
-        ]:
+        from src.db.providers_db import get_active_provider_slugs
+
+        active_slugs = get_active_provider_slugs()
+        if detected_gateway in active_slugs:
             # Get models from the detected gateway to derive providers
             # Get models from the detected gateway to derive providers
             gateway_models = await asyncio.to_thread(get_cached_models, detected_gateway)

--- a/src/routes/api_models.py
+++ b/src/routes/api_models.py
@@ -127,7 +127,7 @@ async def get_model_detail(
         # Add providers from other gateways based on detected gateway
         from src.db.providers_db import get_active_provider_slugs
 
-        active_slugs = get_active_provider_slugs()
+        active_slugs = await asyncio.to_thread(get_active_provider_slugs)
         if detected_gateway in active_slugs:
             # Get models from the detected gateway to derive providers
             # Get models from the detected gateway to derive providers

--- a/src/routes/api_models.py
+++ b/src/routes/api_models.py
@@ -130,7 +130,6 @@ async def get_model_detail(
         active_slugs = await asyncio.to_thread(get_active_provider_slugs)
         if detected_gateway in active_slugs:
             # Get models from the detected gateway to derive providers
-            # Get models from the detected gateway to derive providers
             gateway_models = await asyncio.to_thread(get_cached_models, detected_gateway)
             if gateway_models:
                 derived_providers = derive_providers_from_models(gateway_models, detected_gateway)

--- a/src/services/gateway_registry.py
+++ b/src/services/gateway_registry.py
@@ -470,6 +470,9 @@ def _load_registry_from_db() -> dict[str, dict]:
                 "timeout": meta.get("timeout", _DEFAULT_FETCH_TIMEOUT),
                 "has_fetch_function": meta.get("has_fetch_function", True),
                 "fetch_slug_override": meta.get("fetch_slug_override"),
+                "latency_tier": meta.get("latency_tier"),
+                "pricing_format": meta.get("pricing_format"),
+                "failover_priority": meta.get("failover_priority"),
             }
 
         _registry_cache = new_registry

--- a/src/services/pricing.py
+++ b/src/services/pricing.py
@@ -44,8 +44,8 @@ def _build_reverse_transform_lookup() -> dict[str, str]:
     """
     Build a reverse lookup from provider-native model IDs back to canonical IDs.
 
-    Uses _MODEL_ID_MAPPINGS from model_transformations.py.  For each provider
-    mapping (canonical -> native), we store native -> canonical so that when a
+    Uses the DB-backed model mappings cache.  For each provider mapping
+    (canonical -> native), we store native -> canonical so that when a
     pricing lookup receives a transformed ID we can recover the original.
 
     Priority rules when multiple canonical IDs map to the same native ID:
@@ -55,14 +55,16 @@ def _build_reverse_transform_lookup() -> dict[str, str]:
       - Among entries with the same prefix status, the first one wins (stable).
     """
     try:
-        from src.services.model_transformations import _MODEL_ID_MAPPINGS
-    except ImportError:
-        logger.warning("Could not import _MODEL_ID_MAPPINGS for reverse transform lookup")
+        from src.services.model_mappings_cache import get_all_provider_mappings
+
+        all_mappings = get_all_provider_mappings()
+    except Exception:
+        logger.warning("Could not load model mappings cache for reverse transform lookup")
         return {}
 
     reverse: dict[str, str] = {}
 
-    for _provider, mapping in _MODEL_ID_MAPPINGS.items():
+    for _provider, mapping in all_mappings.items():
         for canonical, native in mapping.items():
             native_lower = native.lower()
             # Skip identity mappings (canonical == native) -- they don't help
@@ -82,7 +84,7 @@ def _build_reverse_transform_lookup() -> dict[str, str]:
     logger.info(
         "[PRICING] Built reverse-transform lookup with %d entries from %d providers",
         len(reverse),
-        len(_MODEL_ID_MAPPINGS),
+        len(all_mappings),
     )
     return reverse
 

--- a/src/services/pricing.py
+++ b/src/services/pricing.py
@@ -25,7 +25,7 @@ _pricing_cache_lock = threading.RLock()  # Reentrant lock to prevent race condit
 # Reverse-transform lookup: maps provider-specific (transformed) model IDs
 # back to their canonical/base form so pricing lookups succeed.
 #
-# Built lazily from model_transformations._MODEL_ID_MAPPINGS on first call.
+# Built lazily from the DB-backed model mappings cache on first call.
 # Key = transformed (native) model ID (lowercased)
 # Value = canonical model ID that the user originally supplied (the mapping *key*
 #         with an org/ prefix, i.e. the one most likely stored in the pricing DB).
@@ -58,8 +58,8 @@ def _build_reverse_transform_lookup() -> dict[str, str]:
         from src.services.model_mappings_cache import get_all_provider_mappings
 
         all_mappings = get_all_provider_mappings()
-    except Exception:
-        logger.warning("Could not load model mappings cache for reverse transform lookup")
+    except Exception as exc:
+        logger.warning("Could not load model mappings cache for reverse transform lookup: %s", exc)
         return {}
 
     reverse: dict[str, str] = {}

--- a/src/services/pricing_normalization.py
+++ b/src/services/pricing_normalization.py
@@ -163,9 +163,25 @@ def get_provider_format(provider_slug: str) -> str:
         >>> get_provider_format('aihubmix')
         'per_1k'
     """
+    # DB-first: check providers metadata for pricing_format
+    try:
+        from src.services.gateway_registry import get_gateway_registry
+
+        registry = get_gateway_registry()
+        entry = registry.get(provider_slug.lower())
+        if entry and entry.get("pricing_format"):
+            fmt = entry["pricing_format"]
+            if fmt == "per_token":
+                return PricingFormat.PER_TOKEN
+            elif fmt == "per_1k":
+                return PricingFormat.PER_1K_TOKENS
+            elif fmt == "per_1m":
+                return PricingFormat.PER_1M_TOKENS
+    except Exception:
+        pass
     return PROVIDER_PRICING_FORMATS.get(
         provider_slug.lower(),
-        PricingFormat.PER_1M_TOKENS,  # Default assumption for unknown providers
+        PricingFormat.PER_1M_TOKENS,
     )
 
 

--- a/src/services/pricing_normalization.py
+++ b/src/services/pricing_normalization.py
@@ -136,7 +136,7 @@ PROVIDER_PRICING_FORMATS = {
     "google-vertex": PricingFormat.PER_1M_TOKENS,
     "novita": PricingFormat.PER_1M_TOKENS,
     "nebius": PricingFormat.PER_1M_TOKENS,
-    "alibaba-cloud": PricingFormat.PER_1M_TOKENS,
+    "alibaba": PricingFormat.PER_1M_TOKENS,
     "morpheus": PricingFormat.PER_1M_TOKENS,
     "helicone": PricingFormat.PER_1M_TOKENS,  # Helicone API returns per-1M pricing
     "vercel-ai-gateway": PricingFormat.PER_1M_TOKENS,  # Vercel API returns per-token, but we convert to per-1M in client
@@ -177,8 +177,8 @@ def get_provider_format(provider_slug: str) -> str:
                 return PricingFormat.PER_1K_TOKENS
             elif fmt == "per_1m":
                 return PricingFormat.PER_1M_TOKENS
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("Failed to load pricing format from DB for %s: %s", provider_slug, exc)
     return PROVIDER_PRICING_FORMATS.get(
         provider_slug.lower(),
         PricingFormat.PER_1M_TOKENS,

--- a/src/services/provider_failover.py
+++ b/src/services/provider_failover.py
@@ -57,6 +57,27 @@ FALLBACK_PROVIDER_PRIORITY: tuple[str, ...] = (
     "fireworks",
     "together",
 )
+
+
+def _get_failover_priority() -> tuple[str, ...]:
+    """Get failover priority from DB, falling back to hardcoded tuple."""
+    try:
+        from src.services.gateway_registry import get_gateway_registry
+
+        registry = get_gateway_registry()
+        prioritized = [
+            (entry["failover_priority"], slug)
+            for slug, entry in registry.items()
+            if entry.get("failover_priority") is not None
+        ]
+        if prioritized:
+            prioritized.sort()
+            return tuple(slug for _, slug in prioritized)
+    except Exception:
+        pass
+    return FALLBACK_PROVIDER_PRIORITY
+
+
 FALLBACK_ELIGIBLE_PROVIDERS = set(FALLBACK_PROVIDER_PRIORITY)
 # Include 402 (Payment Required) to allow failover when provider credits are exhausted
 FAILOVER_STATUS_CODES = {401, 402, 403, 404, 502, 503, 504}
@@ -91,7 +112,7 @@ def build_provider_failover_chain(initial_provider: str | None) -> list[str]:
     if provider:
         chain.append(provider)
 
-    for candidate in FALLBACK_PROVIDER_PRIORITY:
+    for candidate in _get_failover_priority():
         if candidate not in chain:
             chain.append(candidate)
 

--- a/src/services/provider_failover.py
+++ b/src/services/provider_failover.py
@@ -105,7 +105,8 @@ def build_provider_failover_chain(initial_provider: str | None) -> list[str]:
     """
     provider = (initial_provider or "").lower()
 
-    if provider not in FALLBACK_ELIGIBLE_PROVIDERS:
+    eligible = set(_get_failover_priority())
+    if provider not in eligible:
         return [provider] if provider else ["onerouter"]
 
     chain: list[str] = []

--- a/src/services/provider_failover.py
+++ b/src/services/provider_failover.py
@@ -53,7 +53,7 @@ FALLBACK_PROVIDER_PRIORITY: tuple[str, ...] = (
     "vercel-ai-gateway",
     "aihubmix",
     "anannas",
-    "alibaba-cloud",
+    "alibaba",
     "fireworks",
     "together",
 )
@@ -73,11 +73,13 @@ def _get_failover_priority() -> tuple[str, ...]:
         if prioritized:
             prioritized.sort()
             return tuple(slug for _, slug in prioritized)
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("Failed to load failover priority from DB: %s", exc)
     return FALLBACK_PROVIDER_PRIORITY
 
 
+# DEPRECATED: production code now uses _get_failover_priority() for eligibility.
+# Kept for backward-compat with existing tests; will be removed in a follow-up.
 FALLBACK_ELIGIBLE_PROVIDERS = set(FALLBACK_PROVIDER_PRIORITY)
 # Include 402 (Payment Required) to allow failover when provider credits are exhausted
 FAILOVER_STATUS_CODES = {401, 402, 403, 404, 502, 503, 504}
@@ -105,7 +107,8 @@ def build_provider_failover_chain(initial_provider: str | None) -> list[str]:
     """
     provider = (initial_provider or "").lower()
 
-    eligible = set(_get_failover_priority())
+    priority = _get_failover_priority()
+    eligible = set(priority)
     if provider not in eligible:
         return [provider] if provider else ["onerouter"]
 
@@ -113,7 +116,7 @@ def build_provider_failover_chain(initial_provider: str | None) -> list[str]:
     if provider:
         chain.append(provider)
 
-    for candidate in _get_failover_priority():
+    for candidate in priority:
         if candidate not in chain:
             chain.append(candidate)
 

--- a/src/services/providers.py
+++ b/src/services/providers.py
@@ -131,7 +131,18 @@ def fetch_providers_from_openrouter():
 def get_provider_logo_from_services(provider_id: str, site_url: str = None) -> str:
     """Get provider logo using third-party services and manual mapping"""
     try:
-        # Try manual mapping first
+        # Try DB first (logo_url column on providers table)
+        try:
+            from src.services.gateway_registry import get_gateway_registry
+
+            registry = get_gateway_registry()
+            entry = registry.get(provider_id)
+            if entry and entry.get("logo_url"):
+                return entry["logo_url"]
+        except Exception:
+            pass  # Fall through to manual mapping
+
+        # Try manual mapping as fallback
         if provider_id in MANUAL_LOGO_DB:
             logger.info(f"Found manual logo for {provider_id}")
             return MANUAL_LOGO_DB[provider_id]

--- a/src/services/providers.py
+++ b/src/services/providers.py
@@ -136,7 +136,7 @@ def get_provider_logo_from_services(provider_id: str, site_url: str = None) -> s
             from src.services.gateway_registry import get_gateway_registry
 
             registry = get_gateway_registry()
-            entry = registry.get(provider_id)
+            entry = registry.get(provider_id.lower())
             if entry and entry.get("logo_url"):
                 return entry["logo_url"]
         except Exception:

--- a/src/services/request_prioritization.py
+++ b/src/services/request_prioritization.py
@@ -75,6 +75,20 @@ PROVIDER_LATENCY_TIERS: dict[str, int] = {
 DEFAULT_PROVIDER_TIER = 3
 
 
+def _get_provider_latency_tier(provider_slug: str) -> int:
+    """Get latency tier for a provider, checking DB first then hardcoded fallback."""
+    try:
+        from src.services.gateway_registry import get_gateway_registry
+
+        registry = get_gateway_registry()
+        entry = registry.get(provider_slug.lower())
+        if entry and entry.get("latency_tier") is not None:
+            return entry["latency_tier"]
+    except Exception:
+        pass
+    return PROVIDER_LATENCY_TIERS.get(provider_slug.lower(), DEFAULT_PROVIDER_TIER)
+
+
 class RequestPriority(IntEnum):
     """Priority levels for requests (lower number = higher priority)"""
 
@@ -310,7 +324,7 @@ def get_preferred_providers_for_priority(
 
     # Sort providers by their latency tier
     def get_tier(provider: str) -> int:
-        return PROVIDER_LATENCY_TIERS.get(provider.lower(), DEFAULT_PROVIDER_TIER)
+        return _get_provider_latency_tier(provider)
 
     # Group providers by tier
     tier_1 = [p for p in available_providers if get_tier(p) == 1]  # Ultra-fast
@@ -385,7 +399,7 @@ def get_provider_latency_tier(provider: str) -> int:
     Returns:
         Tier number (1=fastest, 4=variable)
     """
-    return PROVIDER_LATENCY_TIERS.get(provider.lower(), DEFAULT_PROVIDER_TIER)
+    return _get_provider_latency_tier(provider)
 
 
 def get_low_latency_models() -> list[str]:
@@ -423,8 +437,20 @@ def get_fastest_providers() -> list[str]:
     Returns:
         List of provider names sorted by speed
     """
-    sorted_providers = sorted(PROVIDER_LATENCY_TIERS.items(), key=lambda x: x[1])
-    return [provider for provider, _ in sorted_providers]
+    try:
+        from src.services.gateway_registry import get_gateway_registry
+
+        registry = get_gateway_registry()
+        db_tiers = {
+            slug: entry["latency_tier"]
+            for slug, entry in registry.items()
+            if entry.get("latency_tier") is not None
+        }
+        if db_tiers:
+            return [p for p, _ in sorted(db_tiers.items(), key=lambda x: x[1])]
+    except Exception:
+        pass
+    return [p for p, _ in sorted(PROVIDER_LATENCY_TIERS.items(), key=lambda x: x[1])]
 
 
 def suggest_low_latency_alternative(model_id: str) -> str | None:

--- a/src/services/request_prioritization.py
+++ b/src/services/request_prioritization.py
@@ -68,7 +68,7 @@ PROVIDER_LATENCY_TIERS: dict[str, int] = {
     "huggingface": 4,
     "featherless": 4,
     "near": 4,
-    "alibaba-cloud": 4,
+    "alibaba": 4,
 }
 
 # Default tier for unknown providers
@@ -84,8 +84,8 @@ def _get_provider_latency_tier(provider_slug: str) -> int:
         entry = registry.get(provider_slug.lower())
         if entry and entry.get("latency_tier") is not None:
             return entry["latency_tier"]
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("Failed to load latency tier from DB for %s: %s", provider_slug, exc)
     return PROVIDER_LATENCY_TIERS.get(provider_slug.lower(), DEFAULT_PROVIDER_TIER)
 
 
@@ -425,8 +425,8 @@ def get_ultra_low_latency_models() -> list[str]:
         result = get_models_by_latency_tier(1)
         if result:
             return sorted(result)
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("Failed to load ultra-low-latency models from DB: %s", exc)
     return sorted(ULTRA_LOW_LATENCY_MODELS)
 
 
@@ -448,8 +448,8 @@ def get_fastest_providers() -> list[str]:
         }
         if db_tiers:
             return [p for p, _ in sorted(db_tiers.items(), key=lambda x: x[1])]
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("Failed to load fastest providers from DB: %s", exc)
     return [p for p, _ in sorted(PROVIDER_LATENCY_TIERS.items(), key=lambda x: x[1])]
 
 

--- a/supabase/migrations/20260402000001_add_provider_metadata_fields.sql
+++ b/supabase/migrations/20260402000001_add_provider_metadata_fields.sql
@@ -1,0 +1,36 @@
+-- Add latency_tier, pricing_format, and failover_priority to providers metadata JSONB
+-- These fields enable DB-first lookups in request_prioritization, pricing_normalization,
+-- and provider_failover (replacing hardcoded dicts).
+
+-- ── latency_tier (from PROVIDER_LATENCY_TIERS in request_prioritization.py) ──
+-- Tier 1: <100ms (specialized inference HW), Tier 2: 100-500ms, Tier 3: 500ms+, Tier 4: variable
+UPDATE "public"."providers" SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"latency_tier": 1}'::jsonb WHERE slug IN ('groq', 'cerebras');
+UPDATE "public"."providers" SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"latency_tier": 2}'::jsonb WHERE slug IN ('fireworks', 'together', 'cloudflare-workers-ai');
+UPDATE "public"."providers" SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"latency_tier": 3}'::jsonb WHERE slug IN ('openrouter', 'deepinfra', 'google-vertex');
+UPDATE "public"."providers" SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"latency_tier": 4}'::jsonb WHERE slug IN ('huggingface', 'featherless', 'near', 'alibaba');
+
+-- ── pricing_format (from PROVIDER_PRICING_FORMATS in pricing_normalization.py) ──
+-- Values: "per_token", "per_1k", "per_1m"
+UPDATE "public"."providers" SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"pricing_format": "per_token"}'::jsonb WHERE slug = 'openrouter';
+UPDATE "public"."providers" SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"pricing_format": "per_1k"}'::jsonb WHERE slug = 'aihubmix';
+UPDATE "public"."providers" SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"pricing_format": "per_1m"}'::jsonb
+    WHERE slug IN ('anthropic', 'deepinfra', 'featherless', 'together', 'fireworks', 'near',
+                   'groq', 'cerebras', 'xai', 'aimo', 'google-vertex', 'novita', 'nebius',
+                   'alibaba', 'morpheus', 'helicone', 'vercel-ai-gateway', 'chutes');
+
+-- ── failover_priority (from FALLBACK_PROVIDER_PRIORITY in provider_failover.py) ──
+-- Lower number = tried first during failover
+UPDATE "public"."providers" SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"failover_priority": 1}'::jsonb WHERE slug = 'onerouter';
+UPDATE "public"."providers" SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"failover_priority": 2}'::jsonb WHERE slug = 'openai';
+UPDATE "public"."providers" SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"failover_priority": 3}'::jsonb WHERE slug = 'anthropic';
+UPDATE "public"."providers" SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"failover_priority": 4}'::jsonb WHERE slug = 'google-vertex';
+UPDATE "public"."providers" SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"failover_priority": 5}'::jsonb WHERE slug = 'openrouter';
+UPDATE "public"."providers" SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"failover_priority": 6}'::jsonb WHERE slug = 'cerebras';
+UPDATE "public"."providers" SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"failover_priority": 7}'::jsonb WHERE slug = 'huggingface';
+UPDATE "public"."providers" SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"failover_priority": 8}'::jsonb WHERE slug = 'featherless';
+UPDATE "public"."providers" SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"failover_priority": 9}'::jsonb WHERE slug = 'vercel-ai-gateway';
+UPDATE "public"."providers" SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"failover_priority": 10}'::jsonb WHERE slug = 'aihubmix';
+UPDATE "public"."providers" SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"failover_priority": 11}'::jsonb WHERE slug = 'anannas';
+UPDATE "public"."providers" SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"failover_priority": 12}'::jsonb WHERE slug = 'alibaba';
+UPDATE "public"."providers" SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"failover_priority": 13}'::jsonb WHERE slug = 'fireworks';
+UPDATE "public"."providers" SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"failover_priority": 14}'::jsonb WHERE slug = 'together';

--- a/tests/conceptual_model/test_cm05_provider_failover.py
+++ b/tests/conceptual_model/test_cm05_provider_failover.py
@@ -84,7 +84,7 @@ class TestFailoverChain:
             "vercel-ai-gateway",
             "aihubmix",
             "anannas",
-            "alibaba-cloud",
+            "alibaba",
             "fireworks",
             "together",
         )


### PR DESCRIPTION
## Summary

- **Fix pricing.py broken reverse-transform** — `_MODEL_ID_MAPPINGS` was deleted in Phase 2B but `pricing.py` still imported it, causing silent billing errors for all transformed model IDs (Fireworks, Featherless, etc.). Now uses `get_all_provider_mappings()` from DB cache.
- **Fix seed_providers.py broken import** — `GATEWAY_REGISTRY` was removed from `catalog.py` in Phase 2A. Now uses `get_gateway_registry()` service (lazy, inside function body).
- **Replace 5 hardcoded provider dicts with DB-first lookups** — latency tiers, pricing formats, failover priority, logo URLs, and gateway slug list now read from providers metadata JSONB with hardcoded fallbacks preserved.
- **New migration** seeds `latency_tier`, `pricing_format`, `failover_priority` into providers metadata.
- **Code review fixes** — async safety (`asyncio.to_thread` for sync DB call in async handler), failover eligibility mismatch, case-insensitive logo lookup.

Closes remaining gaps in #2094, #2095, #2096.

## Test plan

- [ ] CI passes (all test categories)
- [ ] `black --check --line-length 100` passes on all modified files
- [ ] Verify no remaining imports of deleted `_MODEL_ID_MAPPINGS` or `GATEWAY_REGISTRY` from catalog
- [ ] Pricing reverse-transform returns populated dict (not `{}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Providers and their metadata (latency tiers, pricing formats, failover priority, logos) are now loaded from the database and used at runtime.
* **Behavior/Improvements**
  * Failover ordering, provider selection, and priority/latency decisions now follow DB-configured values with safer fallbacks on errors.
* **Tests**
  * Updated provider failover test expectations to match renamed provider keys.
* **Chores**
  * Added a DB migration to populate new provider metadata fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes Phase 2A/2B/2C gaps by fixing two broken imports (`_MODEL_ID_MAPPINGS` → `get_all_provider_mappings()`, `GATEWAY_REGISTRY` → `get_gateway_registry()`), replacing five hardcoded provider dicts with DB-first lookups via the gateway registry, and adding a migration to seed the new metadata fields.

- **P1 — alibaba slug mismatch in migration**: The migration sets `failover_priority`, `latency_tier`, and `pricing_format` for `slug = 'alibaba'`, but every Python fallback dict (`FALLBACK_PROVIDER_PRIORITY`, `PROVIDER_LATENCY_TIERS`, `PROVIDER_PRICING_FORMATS`) and the model-mappings table all use `"alibaba-cloud"`. Once the migration runs, DB-on and DB-off modes diverge: Alibaba failover and routing will stop matching under the DB path.
- **P2 — `FALLBACK_ELIGIBLE_PROVIDERS` is now dead code** in the production path but still imported by tests, meaning failover eligibility tests no longer exercise the live logic.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the alibaba slug mismatch in the migration; all other changes are well-structured with correct fallbacks.

One P1 finding: the migration seeds metadata for slug 'alibaba' while the entire Python codebase and model-mappings table use 'alibaba-cloud', which will cause Alibaba failover/latency-tier/pricing-format lookups to silently diverge once the migration is applied. All other changes are correct and well-implemented.

supabase/migrations/20260402000001_add_provider_metadata_fields.sql — alibaba slug needs to match the rest of the codebase ('alibaba-cloud').

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| supabase/migrations/20260402000001_add_provider_metadata_fields.sql | Seeds latency_tier, pricing_format, and failover_priority into provider metadata JSONB, but uses slug='alibaba' while all Python fallback dicts and model-mapping tables use 'alibaba-cloud', causing a behavioural split between DB-on and DB-off modes. |
| src/services/pricing.py | Fixes broken reverse-transform lookup by replacing deleted _MODEL_ID_MAPPINGS with get_all_provider_mappings() from the DB-backed model_mappings_cache — correct fix with appropriate exception broadening. |
| scripts/database/seed_providers.py | Fixes broken GATEWAY_REGISTRY import by lazily importing get_gateway_registry() inside the function body; purely cosmetic formatting changes otherwise. |
| src/services/provider_failover.py | Adds _get_failover_priority() for DB-first failover ordering, but calls it twice per request and leaves FALLBACK_ELIGIBLE_PROVIDERS as dead code still referenced by tests, decoupling test coverage from live behaviour. |
| src/services/request_prioritization.py | Adds _get_provider_latency_tier() for DB-first latency tier lookups and updates get_fastest_providers() accordingly; logic is correct and registry is cached so per-call overhead is minimal. |
| src/services/pricing_normalization.py | Adds DB-first path for pricing format via gateway_registry with correct string-to-PricingFormat mapping and clean fallback to hardcoded PROVIDER_PRICING_FORMATS. |
| src/services/providers.py | Adds DB-first logo_url lookup via gateway_registry using provider_id.lower() for case-insensitive matching, with clean fallback to existing MANUAL_LOGO_DB chain. |
| src/routes/api_models.py | Replaces hardcoded 18-entry gateway slug list with asyncio.to_thread(get_active_provider_slugs) DB lookup, correctly wrapping the sync function for the async handler. |
| src/services/gateway_registry.py | Extends the registry entry schema to include latency_tier, pricing_format, and failover_priority from provider metadata JSONB, enabling the new DB-first lookups. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request arrives] --> B{build_provider_failover_chain}
    B --> C[_get_failover_priority]
    C --> D{DB available?}
    D -- Yes --> E[gateway_registry DB query\nreturns 'alibaba' slug]
    D -- No --> F[FALLBACK_PROVIDER_PRIORITY\nreturns 'alibaba-cloud' slug]
    E --> G{provider in eligible set?}
    F --> G
    G -- Yes --> H[Build failover chain]
    G -- No --> I[Return single-provider or onerouter]

    B2[get_provider_format] --> C2{DB available?}
    C2 -- Yes --> E2[registry 'alibaba' pricing_format]
    C2 -- No --> F2[PROVIDER_PRICING_FORMATS 'alibaba-cloud' key]

    B3[_get_provider_latency_tier] --> C3{DB available?}
    C3 -- Yes --> E3[registry 'alibaba' latency_tier]
    C3 -- No --> F3[PROVIDER_LATENCY_TIERS 'alibaba-cloud' key]

    style E fill:#f96,stroke:#c00
    style F fill:#9cf,stroke:#06c
    style E2 fill:#f96,stroke:#c00
    style F2 fill:#9cf,stroke:#06c
    style E3 fill:#f96,stroke:#c00
    style F3 fill:#9cf,stroke:#06c
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/services/provider_failover.py`, line 105-120 ([link](https://github.com/alpaca-network/gatewayz-backend/blob/3ce6e5943be6f9987ab284ebd0e6bfb0a9831fe9/src/services/provider_failover.py#L105-L120)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`_get_failover_priority()` called twice per invocation**

   `_get_failover_priority()` is called once to build `eligible` and again inside the `for` loop. Even though the registry is cached, calling it twice per request is unnecessary. Assign to a local variable once:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/services/provider_failover.py
   Line: 105-120

   Comment:
   **`_get_failover_priority()` called twice per invocation**

   `_get_failover_priority()` is called once to build `eligible` and again inside the `for` loop. Even though the registry is cached, calling it twice per request is unnecessary. Assign to a local variable once:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: supabase/migrations/20260402000001_add_provider_metadata_fields.sql
Line: 29-34

Comment:
**Alibaba slug mismatch between migration and hardcoded fallbacks**

The migration targets `slug = 'alibaba'`, but every hardcoded dict in the Python code (`FALLBACK_PROVIDER_PRIORITY` in `provider_failover.py`, `PROVIDER_LATENCY_TIERS` in `request_prioritization.py`, and `PROVIDER_PRICING_FORMATS` in `pricing_normalization.py`) uses `"alibaba-cloud"`. The model-provider-mappings table also uses `"alibaba-cloud"` as the provider slug.

When this migration runs and the DB is reachable, `_get_failover_priority()` / `_get_provider_latency_tier()` / `get_provider_format()` will resolve the provider as `"alibaba"`. Requests that arrive with `"alibaba-cloud"` will miss the DB-sourced eligible-provider set and fall through silently, effectively disabling Alibaba failover. When the DB is unavailable the hardcoded fallbacks kick in with `"alibaba-cloud"`, creating a split behaviour between DB-on and DB-off modes.

The fix is to align the migration to use the slug that the rest of the codebase already uses (`'alibaba-cloud'`), or to update the three hardcoded dicts to use `'alibaba'`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/services/provider_failover.py
Line: 105-120

Comment:
**`_get_failover_priority()` called twice per invocation**

`_get_failover_priority()` is called once to build `eligible` and again inside the `for` loop. Even though the registry is cached, calling it twice per request is unnecessary. Assign to a local variable once:

```suggestion
    priority = _get_failover_priority()
    eligible = set(priority)
    if provider not in eligible:
        return [provider] if provider else ["onerouter"]

    chain: list[str] = []
    if provider:
        chain.append(provider)

    for candidate in priority:
        if candidate not in chain:
            chain.append(candidate)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/services/provider_failover.py
Line: 81

Comment:
**`FALLBACK_ELIGIBLE_PROVIDERS` is now dead code in production logic**

`build_provider_failover_chain` was updated to derive eligibility dynamically via `_get_failover_priority()`, so this module-level set is no longer used by any production code path. It is still imported and asserted against in `tests/services/test_provider_failover.py`, which means the tests are now validating the static fallback set rather than the live dynamic behaviour. This should either be removed and the test updated to mock the DB path, or given a deprecation comment so it isn't mistakenly relied on.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: address code review — async safety,..."](https://github.com/alpaca-network/gatewayz-backend/commit/3ce6e5943be6f9987ab284ebd0e6bfb0a9831fe9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27208639)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->