### PR TITLE
feat: Phase 3 — infrastructure dynamism & provider dispatch tables

### DIFF
--- a/src/cache.py
+++ b/src/cache.py
@@ -225,7 +225,11 @@ def get_models_cache(gateway: str):
         slug = "huggingface"
     elif slug == "alibaba":
         return _alibaba_models_cache  # Special dict with quota tracking
-    return _get_or_create_cache(slug)
+    # Only return caches for known providers; return None for unknown slugs
+    # to preserve backward-compat (callers guard with `if cache is None:`)
+    if slug in _cache_instances:
+        return _cache_instances[slug]
+    return None
 
 
 def get_providers_cache():
@@ -259,6 +263,11 @@ def clear_models_cache(gateway: str):
         slug = gateway.lower()
         if slug == "hug":
             slug = "huggingface"
+        elif slug == "alibaba":
+            # Alibaba uses a special dict with quota tracking, not _CacheDict
+            _alibaba_models_cache["data"] = None
+            _alibaba_models_cache["timestamp"] = None
+            return
         cache = _cache_instances.get(slug)
         if cache:
             cache["data"] = None

--- a/src/cache.py
+++ b/src/cache.py
@@ -126,19 +126,31 @@ class _CacheDict(dict):
 # Cache dictionaries - Now using Redis-backed wrappers
 # ============================================================================
 
+# Dynamic cache registry: creates _CacheDict instances on demand.
+_cache_instances: dict[str, _CacheDict] = {}
+
+
+def _get_or_create_cache(slug: str) -> _CacheDict:
+    """Return the _CacheDict for *slug*, creating it on first access."""
+    if slug not in _cache_instances:
+        _cache_instances[slug] = _CacheDict(slug)
+    return _cache_instances[slug]
+
+
+# Pre-created aliases for backward compatibility (scripts + legacy imports)
 # OpenRouter (primary gateway)
-_models_cache = _CacheDict("openrouter")
+_models_cache = _get_or_create_cache("openrouter")
 
 # Multi-provider catalog (uses "all" as gateway slug)
-_multi_provider_catalog_cache = _CacheDict("all")
+_multi_provider_catalog_cache = _get_or_create_cache("all")
 
 # Major provider caches
-_featherless_models_cache = _CacheDict("featherless")
-_chutes_models_cache = _CacheDict("chutes")
-_groq_models_cache = _CacheDict("groq")
-_fireworks_models_cache = _CacheDict("fireworks")
-_together_models_cache = _CacheDict("together")
-_modelz_cache = _CacheDict("modelz")
+_featherless_models_cache = _get_or_create_cache("featherless")
+_chutes_models_cache = _get_or_create_cache("chutes")
+_groq_models_cache = _get_or_create_cache("groq")
+_fireworks_models_cache = _get_or_create_cache("fireworks")
+_together_models_cache = _get_or_create_cache("together")
+_modelz_cache = _get_or_create_cache("modelz")
 
 # Legacy caches (special handling needed)
 _huggingface_cache = {"data": {}, "timestamp": None, "ttl": 3600, "stale_ttl": 7200}
@@ -146,32 +158,32 @@ _provider_cache = {"data": None, "timestamp": None, "ttl": 3600, "stale_ttl": 72
 
 
 # DeepInfra and Portkey-based providers
-_deepinfra_models_cache = _CacheDict("deepinfra")
-_cerebras_models_cache = _CacheDict("cerebras")
-_nebius_models_cache = _CacheDict("nebius")
-_xai_models_cache = _CacheDict("xai")
-_zai_models_cache = _CacheDict("zai")
-_novita_models_cache = _CacheDict("novita")
-_huggingface_models_cache = _CacheDict("huggingface")
-_aimo_models_cache = _CacheDict("aimo")
-_near_models_cache = _CacheDict("near")
-_fal_models_cache = _CacheDict("fal")
-_google_vertex_models_cache = _CacheDict("google-vertex")
+_deepinfra_models_cache = _get_or_create_cache("deepinfra")
+_cerebras_models_cache = _get_or_create_cache("cerebras")
+_nebius_models_cache = _get_or_create_cache("nebius")
+_xai_models_cache = _get_or_create_cache("xai")
+_zai_models_cache = _get_or_create_cache("zai")
+_novita_models_cache = _get_or_create_cache("novita")
+_huggingface_models_cache = _get_or_create_cache("huggingface")
+_aimo_models_cache = _get_or_create_cache("aimo")
+_near_models_cache = _get_or_create_cache("near")
+_fal_models_cache = _get_or_create_cache("fal")
+_google_vertex_models_cache = _get_or_create_cache("google-vertex")
 
 # Gateway and provider caches
-_vercel_ai_gateway_models_cache = _CacheDict("vercel-ai-gateway")
-_helicone_models_cache = _CacheDict("helicone")
-_aihubmix_models_cache = _CacheDict("aihubmix")
-_anannas_models_cache = _CacheDict("anannas")
-_onerouter_models_cache = _CacheDict("onerouter")
-_cloudflare_workers_ai_models_cache = _CacheDict("cloudflare-workers-ai")
-_clarifai_models_cache = _CacheDict("clarifai")
-_openai_models_cache = _CacheDict("openai")
-_anthropic_models_cache = _CacheDict("anthropic")
-_simplismart_models_cache = _CacheDict("simplismart")
-_sybil_models_cache = _CacheDict("sybil")
-_canopywave_models_cache = _CacheDict("canopywave")
-_morpheus_models_cache = _CacheDict("morpheus")
+_vercel_ai_gateway_models_cache = _get_or_create_cache("vercel-ai-gateway")
+_helicone_models_cache = _get_or_create_cache("helicone")
+_aihubmix_models_cache = _get_or_create_cache("aihubmix")
+_anannas_models_cache = _get_or_create_cache("anannas")
+_onerouter_models_cache = _get_or_create_cache("onerouter")
+_cloudflare_workers_ai_models_cache = _get_or_create_cache("cloudflare-workers-ai")
+_clarifai_models_cache = _get_or_create_cache("clarifai")
+_openai_models_cache = _get_or_create_cache("openai")
+_anthropic_models_cache = _get_or_create_cache("anthropic")
+_simplismart_models_cache = _get_or_create_cache("simplismart")
+_sybil_models_cache = _get_or_create_cache("sybil")
+_canopywave_models_cache = _get_or_create_cache("canopywave")
+_morpheus_models_cache = _get_or_create_cache("morpheus")
 
 # Special case: Alibaba cache with quota error tracking
 # Keep as regular dict since it has special fields beyond standard cache structure
@@ -207,42 +219,13 @@ def get_models_cache(gateway: str):
         DeprecationWarning,
         stacklevel=2,
     )
-    cache_map = {
-        "openrouter": _models_cache,
-        "featherless": _featherless_models_cache,
-        "deepinfra": _deepinfra_models_cache,
-        "chutes": _chutes_models_cache,
-        "groq": _groq_models_cache,
-        "fireworks": _fireworks_models_cache,
-        "together": _together_models_cache,
-        "google-vertex": _google_vertex_models_cache,
-        "cerebras": _cerebras_models_cache,
-        "nebius": _nebius_models_cache,
-        "xai": _xai_models_cache,
-        "zai": _zai_models_cache,
-        "novita": _novita_models_cache,
-        "huggingface": _huggingface_models_cache,
-        "hug": _huggingface_models_cache,  # Alias for backward compatibility
-        "aimo": _aimo_models_cache,
-        "near": _near_models_cache,
-        "fal": _fal_models_cache,
-        "vercel-ai-gateway": _vercel_ai_gateway_models_cache,
-        "helicone": _helicone_models_cache,
-        "aihubmix": _aihubmix_models_cache,
-        "anannas": _anannas_models_cache,
-        "alibaba": _alibaba_models_cache,
-        "onerouter": _onerouter_models_cache,
-        "cloudflare-workers-ai": _cloudflare_workers_ai_models_cache,
-        "clarifai": _clarifai_models_cache,
-        "openai": _openai_models_cache,
-        "anthropic": _anthropic_models_cache,
-        "simplismart": _simplismart_models_cache,
-        "sybil": _sybil_models_cache,
-        "canopywave": _canopywave_models_cache,
-        "morpheus": _morpheus_models_cache,
-        "modelz": _modelz_cache,
-    }
-    return cache_map.get(gateway.lower())
+    slug = gateway.lower()
+    # Special cases
+    if slug == "hug":
+        slug = "huggingface"
+    elif slug == "alibaba":
+        return _alibaba_models_cache  # Special dict with quota tracking
+    return _get_or_create_cache(slug)
 
 
 def get_providers_cache():
@@ -272,43 +255,11 @@ def clear_models_cache(gateway: str):
     except Exception as e:
         logger.error(f"Error delegating clear_models_cache to new cache system: {e}")
 
-        # Fallback: clear in-memory cache
-        cache_map = {
-            "openrouter": _models_cache,
-            "featherless": _featherless_models_cache,
-            "deepinfra": _deepinfra_models_cache,
-            "chutes": _chutes_models_cache,
-            "groq": _groq_models_cache,
-            "fireworks": _fireworks_models_cache,
-            "together": _together_models_cache,
-            "google-vertex": _google_vertex_models_cache,
-            "cerebras": _cerebras_models_cache,
-            "nebius": _nebius_models_cache,
-            "xai": _xai_models_cache,
-            "zai": _zai_models_cache,
-            "novita": _novita_models_cache,
-            "huggingface": _huggingface_models_cache,
-            "hug": _huggingface_models_cache,
-            "helicone": _helicone_models_cache,
-            "aimo": _aimo_models_cache,
-            "near": _near_models_cache,
-            "fal": _fal_models_cache,
-            "vercel-ai-gateway": _vercel_ai_gateway_models_cache,
-            "aihubmix": _aihubmix_models_cache,
-            "anannas": _anannas_models_cache,
-            "alibaba": _alibaba_models_cache,
-            "onerouter": _onerouter_models_cache,
-            "cloudflare-workers-ai": _cloudflare_workers_ai_models_cache,
-            "clarifai": _clarifai_models_cache,
-            "openai": _openai_models_cache,
-            "anthropic": _anthropic_models_cache,
-            "simplismart": _simplismart_models_cache,
-            "sybil": _sybil_models_cache,
-            "canopywave": _canopywave_models_cache,
-            "morpheus": _morpheus_models_cache,
-            "modelz": _modelz_cache,
-        }
-        cache = cache_map.get(gateway.lower())
+        # Fallback: clear in-memory cache via dynamic registry
+        slug = gateway.lower()
+        if slug == "hug":
+            slug = "huggingface"
+        cache = _cache_instances.get(slug)
         if cache:
             cache["data"] = None
             cache["timestamp"] = None

--- a/src/handlers/chat_handler.py
+++ b/src/handlers/chat_handler.py
@@ -257,7 +257,17 @@ class ChatInferenceHandler:
         with tag_wrapper({"provider": provider_name, "model": model_id}):
             try:
                 # Route to appropriate provider
-                if provider_name == "openrouter":
+                # Check if provider supports native async (DB-driven)
+                _use_async = False
+                try:
+                    from src.services.gateway_registry import get_gateway_registry
+
+                    _reg = get_gateway_registry()
+                    _use_async = _reg.get(provider_name, {}).get("async_streaming", False)
+                except Exception:
+                    _use_async = provider_name == "openrouter"  # fallback
+
+                if _use_async:
                     return make_openrouter_request_openai(messages, model_id, **kwargs)
 
                 # Registry-based dispatch for all other providers
@@ -385,8 +395,18 @@ class ChatInferenceHandler:
 
         try:
             with tag_wrapper({"provider": provider_name, "model": model_id}):
-                if provider_name == "openrouter":
-                    # OpenRouter is the only provider with native async streaming
+                # Check if provider supports native async streaming (DB-driven)
+                _use_async_stream = False
+                try:
+                    from src.services.gateway_registry import get_gateway_registry
+
+                    _reg = get_gateway_registry()
+                    _use_async_stream = _reg.get(provider_name, {}).get("async_streaming", False)
+                except Exception:
+                    _use_async_stream = provider_name == "openrouter"  # fallback
+
+                if _use_async_stream:
+                    # Provider supports native async streaming
                     stream = await make_openrouter_request_openai_stream_async(
                         messages, model_id, **kwargs
                     )

--- a/src/handlers/chat_handler.py
+++ b/src/handlers/chat_handler.py
@@ -25,7 +25,7 @@ from src.schemas.internal.chat import (
 from src.services.circuit_breaker import CircuitBreakerError
 from src.services.credit_precheck import estimate_and_check_credits
 
-# OpenRouter is the only provider with native async streaming — import directly.
+# Providers with native async streaming use direct imports (currently OpenRouter).
 # All other providers are dispatched via PROVIDER_ROUTING (lazy-imported to avoid
 # circular deps with chat.py which imports this module).
 from src.services.openrouter_client import (
@@ -257,17 +257,19 @@ class ChatInferenceHandler:
         with tag_wrapper({"provider": provider_name, "model": model_id}):
             try:
                 # Route to appropriate provider
-                # Check if provider supports native async (DB-driven)
-                _use_async = False
+                # OpenRouter has native async — check via DB flag with fallback
+                _is_openrouter_async = False
                 try:
                     from src.services.gateway_registry import get_gateway_registry
 
                     _reg = get_gateway_registry()
-                    _use_async = _reg.get(provider_name, {}).get("async_streaming", False)
+                    _is_openrouter_async = provider_name == "openrouter" and _reg.get(
+                        provider_name, {}
+                    ).get("async_streaming", False)
                 except Exception:
-                    _use_async = provider_name == "openrouter"  # fallback
+                    _is_openrouter_async = provider_name == "openrouter"
 
-                if _use_async:
+                if _is_openrouter_async:
                     return make_openrouter_request_openai(messages, model_id, **kwargs)
 
                 # Registry-based dispatch for all other providers
@@ -395,18 +397,20 @@ class ChatInferenceHandler:
 
         try:
             with tag_wrapper({"provider": provider_name, "model": model_id}):
-                # Check if provider supports native async streaming (DB-driven)
-                _use_async_stream = False
+                # OpenRouter has native async streaming — check via DB flag
+                _is_openrouter_async_stream = False
                 try:
                     from src.services.gateway_registry import get_gateway_registry
 
                     _reg = get_gateway_registry()
-                    _use_async_stream = _reg.get(provider_name, {}).get("async_streaming", False)
+                    _is_openrouter_async_stream = provider_name == "openrouter" and _reg.get(
+                        provider_name, {}
+                    ).get("async_streaming", False)
                 except Exception:
-                    _use_async_stream = provider_name == "openrouter"  # fallback
+                    _is_openrouter_async_stream = provider_name == "openrouter"
 
-                if _use_async_stream:
-                    # Provider supports native async streaming
+                if _is_openrouter_async_stream:
+                    # OpenRouter supports native async streaming
                     stream = await make_openrouter_request_openai_stream_async(
                         messages, model_id, **kwargs
                     )

--- a/src/routes/images.py
+++ b/src/routes/images.py
@@ -311,14 +311,14 @@ async def generate_images(
             # Start timing inference
             start = time.monotonic()
 
-            if provider == "deepinfra":
-                # Direct DeepInfra request
-                make_request_func = partial(
-                    make_deepinfra_image_request, prompt=prompt, model=model, size=req.size, n=req.n
-                )
-                actual_provider = "deepinfra"
-            elif provider == "google-vertex":
-                # Google Vertex AI request
+            # Image provider dispatch table
+            IMAGE_PROVIDER_ROUTING = {
+                "deepinfra": make_deepinfra_image_request,
+                "fal": make_fal_image_request,
+            }
+
+            if provider == "google-vertex":
+                # Google Vertex needs extra params from the request object
                 google_project_id = (
                     req.google_project_id if hasattr(req, "google_project_id") else None
                 )
@@ -326,7 +326,6 @@ async def generate_images(
                 google_endpoint_id = (
                     req.google_endpoint_id if hasattr(req, "google_endpoint_id") else None
                 )
-
                 make_request_func = partial(
                     make_google_vertex_image_request,
                     prompt=prompt,
@@ -338,16 +337,21 @@ async def generate_images(
                     endpoint_id=google_endpoint_id,
                 )
                 actual_provider = "google-vertex"
-            elif provider == "fal":
-                # Fal.ai request
+            elif provider in IMAGE_PROVIDER_ROUTING:
                 make_request_func = partial(
-                    make_fal_image_request, prompt=prompt, model=model, size=req.size, n=req.n
+                    IMAGE_PROVIDER_ROUTING[provider],
+                    prompt=prompt,
+                    model=model,
+                    size=req.size,
+                    n=req.n,
                 )
-                actual_provider = "fal"
+                actual_provider = provider
             else:
+                supported = sorted(list(IMAGE_PROVIDER_ROUTING.keys()) + ["google-vertex"])
                 raise HTTPException(
                     status_code=400,
-                    detail=f"Provider '{provider}' is not supported for image generation. Use 'deepinfra', 'google-vertex', or 'fal'",
+                    detail=f"Provider '{provider}' is not supported for image generation. "
+                    f"Use one of: {', '.join(supported)}",
                 )
 
             # Wrap image generation with distributed tracing for Tempo

--- a/src/routes/images.py
+++ b/src/routes/images.py
@@ -29,6 +29,12 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+# Image provider dispatch table (module-level to avoid per-request allocation)
+IMAGE_PROVIDER_ROUTING = {
+    "deepinfra": make_deepinfra_image_request,
+    "fal": make_fal_image_request,
+}
+
 # DEPRECATED: Hardcoded image pricing fallback.
 # Canonical image pricing now lives in src/data/manual_pricing.json under the
 # "image_pricing" key.  This dict is kept only as a last-resort fallback during
@@ -310,12 +316,6 @@ async def generate_images(
 
             # Start timing inference
             start = time.monotonic()
-
-            # Image provider dispatch table
-            IMAGE_PROVIDER_ROUTING = {
-                "deepinfra": make_deepinfra_image_request,
-                "fal": make_fal_image_request,
-            }
 
             if provider == "google-vertex":
                 # Google Vertex needs extra params from the request object

--- a/src/services/connection_pool.py
+++ b/src/services/connection_pool.py
@@ -328,8 +328,8 @@ def get_provider_pooled_client(slug: str) -> OpenAI:
     """Return a pooled OpenAI-compat client for *slug*, configured from the DB registry.
 
     Resolves base_url, api_key, custom headers, and timeout from the gateway
-    registry (populated by the ``providers`` table).  Falls back to the
-    provider-specific helper functions below when the registry lookup fails.
+    registry (populated by the ``providers`` table).  Raises ``ValueError``
+    when the provider is missing, has no API key, or has no base_url.
     """
     from src.services.gateway_registry import get_gateway_registry, get_provider_api_key
 
@@ -347,11 +347,17 @@ def get_provider_pooled_client(slug: str) -> OpenAI:
         raise ValueError(f"No base_url configured for provider '{slug}'")
 
     # Resolve templated URLs (e.g. Cloudflare {CLOUDFLARE_ACCOUNT_ID})
-    if "{CLOUDFLARE_ACCOUNT_ID}" in base_url:
-        account_id = Config.CLOUDFLARE_ACCOUNT_ID
-        if not account_id:
-            raise ValueError("Cloudflare Account ID not configured")
-        base_url = base_url.replace("{CLOUDFLARE_ACCOUNT_ID}", account_id)
+    import re as _re
+
+    placeholders = _re.findall(r"\{(\w+)\}", base_url)
+    for placeholder in placeholders:
+        value = getattr(Config, placeholder, None) or os.environ.get(placeholder)
+        if not value:
+            raise ValueError(
+                f"Template variable '{{{placeholder}}}' in base_url for '{slug}' "
+                f"is not configured in Config or environment"
+            )
+        base_url = base_url.replace(f"{{{placeholder}}}", value)
 
     # Resolve timeout
     timeout = None

--- a/src/services/connection_pool.py
+++ b/src/services/connection_pool.py
@@ -319,7 +319,74 @@ def get_pool_stats() -> dict[str, int]:
         }
 
 
-# Provider-specific helper functions
+# ---------------------------------------------------------------------------
+# Generic DB-driven pooled client (Phase 3)
+# ---------------------------------------------------------------------------
+
+
+def get_provider_pooled_client(slug: str) -> OpenAI:
+    """Return a pooled OpenAI-compat client for *slug*, configured from the DB registry.
+
+    Resolves base_url, api_key, custom headers, and timeout from the gateway
+    registry (populated by the ``providers`` table).  Falls back to the
+    provider-specific helper functions below when the registry lookup fails.
+    """
+    from src.services.gateway_registry import get_gateway_registry, get_provider_api_key
+
+    registry = get_gateway_registry()
+    entry = registry.get(slug)
+    if not entry:
+        raise ValueError(f"Provider '{slug}' not found in gateway registry")
+
+    api_key = get_provider_api_key(slug)
+    if not api_key:
+        raise ValueError(f"{slug} API key not configured (env var: {entry.get('api_key_env_var')})")
+
+    base_url = entry.get("base_url")
+    if not base_url:
+        raise ValueError(f"No base_url configured for provider '{slug}'")
+
+    # Resolve templated URLs (e.g. Cloudflare {CLOUDFLARE_ACCOUNT_ID})
+    if "{CLOUDFLARE_ACCOUNT_ID}" in base_url:
+        account_id = Config.CLOUDFLARE_ACCOUNT_ID
+        if not account_id:
+            raise ValueError("Cloudflare Account ID not configured")
+        base_url = base_url.replace("{CLOUDFLARE_ACCOUNT_ID}", account_id)
+
+    # Resolve timeout
+    timeout = None
+    timeout_ms = entry.get("custom_timeout_ms")
+    if timeout_ms:
+        timeout = httpx.Timeout(
+            connect=10.0,
+            read=timeout_ms / 1000.0,
+            write=10.0,
+            pool=5.0,
+        )
+
+    # Resolve custom headers
+    raw_headers = entry.get("default_headers") or {}
+    headers = {}
+    for key, value in raw_headers.items():
+        # Resolve sentinel placeholders (e.g. __OPENROUTER_SITE_URL__)
+        if isinstance(value, str) and value.startswith("__") and value.endswith("__"):
+            attr_name = value.strip("_")
+            headers[key] = getattr(Config, attr_name, "") or ""
+        else:
+            headers[key] = value
+
+    return get_pooled_client(
+        provider=slug,
+        base_url=base_url,
+        api_key=api_key,
+        default_headers=headers if headers else None,
+        timeout=timeout,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Provider-specific helper functions (thin wrappers for backward compat)
+# ---------------------------------------------------------------------------
 def get_openrouter_pooled_client() -> OpenAI:
     """Get pooled client for OpenRouter."""
     if not Config.OPENROUTER_API_KEY:
@@ -664,8 +731,8 @@ def warmup_provider_connections() -> dict[str, str]:
     Returns:
         Dict mapping provider names to their warmup status ("ok" or error message)
     """
-    # Providers to pre-warm, ordered by typical traffic volume
-    providers_to_warm = [
+    # Fallback warmup list (used if registry unavailable)
+    _FALLBACK_WARMUP = [
         ("openai", get_openai_pooled_client),
         ("anthropic", get_anthropic_pooled_client),
         ("openrouter", get_openrouter_pooled_client),
@@ -676,23 +743,45 @@ def warmup_provider_connections() -> dict[str, str]:
         ("xai", get_xai_pooled_client),
     ]
 
+    # Try DB-driven warmup: warm all providers that have a base_url
+    try:
+        from src.services.gateway_registry import get_gateway_registry
+
+        registry = get_gateway_registry()
+        slugs_to_warm = [
+            slug
+            for slug, entry in registry.items()
+            if entry.get("base_url") and entry.get("api_key_env_var")
+        ]
+    except Exception:
+        slugs_to_warm = None
+
     results = {}
 
-    for provider_name, get_client_fn in providers_to_warm:
-        try:
-            # Creating the client establishes the connection
-            client = get_client_fn()
-            # The client is now in the pool with an active connection
-            results[provider_name] = "ok"
-            logger.info(f"✅ Warmed up connection to {provider_name}")
-        except ValueError as e:
-            # API key not configured - expected for some providers
-            results[provider_name] = f"skipped: {e}"
-            logger.debug(f"⏭️  Skipping {provider_name} warmup: {e}")
-        except Exception as e:
-            # Connection error - log but don't fail startup
-            results[provider_name] = f"error: {e}"
-            logger.warning(f"⚠️  Failed to warm up {provider_name}: {e}")
+    if slugs_to_warm is not None:
+        for slug in slugs_to_warm:
+            try:
+                get_provider_pooled_client(slug)
+                results[slug] = "ok"
+                logger.info(f"✅ Warmed up connection to {slug}")
+            except ValueError as e:
+                results[slug] = f"skipped: {e}"
+                logger.debug(f"⏭️  Skipping {slug} warmup: {e}")
+            except Exception as e:
+                results[slug] = f"error: {e}"
+                logger.warning(f"⚠️  Failed to warm up {slug}: {e}")
+    else:
+        for provider_name, get_client_fn in _FALLBACK_WARMUP:
+            try:
+                get_client_fn()
+                results[provider_name] = "ok"
+                logger.info(f"✅ Warmed up connection to {provider_name}")
+            except ValueError as e:
+                results[provider_name] = f"skipped: {e}"
+                logger.debug(f"⏭️  Skipping {provider_name} warmup: {e}")
+            except Exception as e:
+                results[provider_name] = f"error: {e}"
+                logger.warning(f"⚠️  Failed to warm up {provider_name}: {e}")
 
     return results
 

--- a/src/services/gateway_health_service.py
+++ b/src/services/gateway_health_service.py
@@ -382,6 +382,52 @@ GATEWAY_CONFIG = {
 }
 
 
+# Rename to fallback; the active config is built dynamically
+_FALLBACK_GATEWAY_CONFIG = dict(GATEWAY_CONFIG)
+
+# Module-level dynamic config cache
+_dynamic_config_cache: dict[str, dict] | None = None
+_dynamic_config_ts: float = 0.0
+_DYNAMIC_CONFIG_TTL = 300  # 5 minutes
+
+
+def _get_gateway_config() -> dict[str, dict]:
+    """Build gateway health config from DB registry, with fallback.
+
+    Returns a dict compatible with the ``GATEWAY_CONFIG`` format.
+    """
+    global _dynamic_config_cache, _dynamic_config_ts
+    import time as _time
+
+    now = _time.monotonic()
+    if _dynamic_config_cache is not None and (now - _dynamic_config_ts) < _DYNAMIC_CONFIG_TTL:
+        return _dynamic_config_cache
+
+    try:
+        from src.services.gateway_registry import get_gateway_registry, get_provider_api_key
+
+        registry = get_gateway_registry()
+        configs: dict[str, dict] = {}
+        for slug, entry in registry.items():
+            configs[slug] = {
+                "name": entry.get("name", slug),
+                "url": entry.get("models_endpoint"),
+                "api_key_env": entry.get("api_key_env_var", ""),
+                "api_key": get_provider_api_key(slug),
+                "cache": _CacheWrapper(slug),
+                "min_expected_models": entry.get("min_expected_models", 1),
+                "header_type": entry.get("header_type", "bearer"),
+            }
+        if configs:
+            _dynamic_config_cache = configs
+            _dynamic_config_ts = now
+            return configs
+    except Exception as exc:
+        logger.warning("Failed to build dynamic gateway config: %s", exc)
+
+    return _FALLBACK_GATEWAY_CONFIG
+
+
 def build_headers(gateway_config: dict[str, Any]) -> dict[str, str]:
     """Build authentication headers based on gateway type"""
     api_key = gateway_config.get("api_key")
@@ -659,15 +705,16 @@ async def run_comprehensive_check(
     Returns:
         Dictionary with test results
     """
+    active_config = _get_gateway_config()
     if gateway:
         gateway_key = gateway.lower()
-        if gateway_key not in GATEWAY_CONFIG:
+        if gateway_key not in active_config:
             raise ValueError(
-                f"Unknown gateway: {gateway}. Available: {', '.join(GATEWAY_CONFIG.keys())}"
+                f"Unknown gateway: {gateway}. Available: {', '.join(active_config.keys())}"
             )
-        gateways_to_check = {gateway_key: GATEWAY_CONFIG[gateway_key]}
+        gateways_to_check = {gateway_key: active_config[gateway_key]}
     else:
-        gateways_to_check = GATEWAY_CONFIG
+        gateways_to_check = active_config
 
     results = {
         "timestamp": datetime.now(UTC).isoformat(),
@@ -701,7 +748,7 @@ async def run_comprehensive_check(
         if isinstance(gateway_result, Exception):
             logger.error(f"Error checking {gateway_name}: {gateway_result}")
             gateway_result = {
-                "name": GATEWAY_CONFIG[gateway_name]["name"],
+                "name": active_config.get(gateway_name, {}).get("name", gateway_name),
                 "final_status": "error",
                 "error": str(gateway_result),
             }

--- a/src/services/gateway_registry.py
+++ b/src/services/gateway_registry.py
@@ -7,6 +7,7 @@ a hardcoded registry on cold start when the database is unreachable.
 """
 
 import logging
+import os
 import time
 from typing import Any
 
@@ -466,6 +467,7 @@ def _load_registry_from_db() -> dict[str, dict]:
                 "api_key_env_var": row.get("api_key_env_var"),
                 "fetch_module_path": row.get("fetch_module_path"),
                 "fetch_function_name": row.get("fetch_function_name"),
+                # Phase 1/2 fields
                 "color": meta.get("color", "bg-gray-500"),
                 "priority": meta.get("priority", "slow"),
                 "icon": meta.get("icon"),
@@ -476,6 +478,17 @@ def _load_registry_from_db() -> dict[str, dict]:
                 "latency_tier": meta.get("latency_tier"),
                 "pricing_format": meta.get("pricing_format"),
                 "failover_priority": meta.get("failover_priority"),
+                # Phase 3 infrastructure fields
+                "base_url": row.get("base_url") or meta.get("pool_base_url"),
+                "models_endpoint": meta.get("models_endpoint"),
+                "chat_completions_endpoint": meta.get("chat_completions_endpoint"),
+                "min_expected_models": meta.get("min_expected_models", 1),
+                "header_type": meta.get("header_type", "bearer"),
+                "default_headers": meta.get("default_headers", {}),
+                "custom_timeout_ms": meta.get("custom_timeout_ms"),
+                "hostnames": meta.get("hostnames", []),
+                "monitor_402_frequency": meta.get("monitor_402_frequency", False),
+                "async_streaming": meta.get("async_streaming", False),
             }
 
         _registry_cache = new_registry
@@ -576,6 +589,32 @@ def get_provider_fetch_timeout(slug: str) -> int:
             return cfg.get("timeout", _DEFAULT_FETCH_TIMEOUT)
 
     return _DEFAULT_FETCH_TIMEOUT
+
+
+def get_provider_api_key(slug: str) -> str | None:
+    """Resolve the actual API key value for *slug*.
+
+    Reads ``api_key_env_var`` from the registry, then resolves it via
+    ``Config`` (which mirrors ``os.environ`` for known vars) with a
+    fallback to ``os.environ.get()``.
+    """
+    registry = _get_registry()
+    entry = registry.get(slug)
+    if not entry:
+        return None
+    env_var = entry.get("api_key_env_var")
+    if not env_var:
+        return None
+    # Prefer Config (supports .env files and test overrides)
+    try:
+        from src.config import Config
+
+        val = getattr(Config, env_var, None)
+        if val:
+            return val
+    except Exception:
+        pass
+    return os.environ.get(env_var)
 
 
 def validate_gateway(gateway: str | None) -> None:

--- a/src/services/intelligent_health_monitor.py
+++ b/src/services/intelligent_health_monitor.py
@@ -434,8 +434,22 @@ class IntelligentHealthMonitor:
         )
 
     def _get_gateway_endpoint(self, gateway: str) -> str | None:
-        """Get the API endpoint URL for a gateway"""
-        endpoints = {
+        """Get the API endpoint URL for a gateway (DB-driven, with fallback)."""
+        # DB-first: check gateway registry for chat_completions_endpoint
+        try:
+            from src.services.gateway_registry import get_gateway_registry
+
+            registry = get_gateway_registry()
+            entry = registry.get(gateway)
+            if entry:
+                endpoint = entry.get("chat_completions_endpoint")
+                if endpoint:
+                    return endpoint
+        except Exception:
+            pass
+
+        # Fallback to hardcoded endpoints
+        _fallback_endpoints = {
             "openrouter": "https://openrouter.ai/api/v1/chat/completions",
             "featherless": "https://api.featherless.ai/v1/chat/completions",
             "deepinfra": "https://api.deepinfra.com/v1/openai/chat/completions",
@@ -448,16 +462,27 @@ class IntelligentHealthMonitor:
             "huggingface": None,  # Different per model
             "portkey": "https://api.portkey.ai/v1/chat/completions",
         }
-        return endpoints.get(gateway)
+        return _fallback_endpoints.get(gateway)
 
     async def _get_auth_headers(self, gateway: str) -> dict[str, str]:
-        """Get authentication headers for a gateway"""
-        from src.config import Config
-
+        """Get authentication headers for a gateway (DB-driven, with fallback)."""
         headers = {}
 
-        # Map gateways to their API keys (using getattr for safety)
-        key_mapping = {
+        # DB-first: resolve API key from registry
+        try:
+            from src.services.gateway_registry import get_provider_api_key
+
+            api_key = get_provider_api_key(gateway)
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
+                return headers
+        except Exception:
+            pass
+
+        # Fallback to hardcoded key mapping
+        from src.config import Config
+
+        _fallback_key_mapping = {
             "openrouter": getattr(Config, "OPENROUTER_API_KEY", None),
             "featherless": getattr(Config, "FEATHERLESS_API_KEY", None),
             "deepinfra": getattr(Config, "DEEPINFRA_API_KEY", None),
@@ -468,7 +493,7 @@ class IntelligentHealthMonitor:
             "cerebras": getattr(Config, "CEREBRAS_API_KEY", None),
         }
 
-        api_key = key_mapping.get(gateway)
+        api_key = _fallback_key_mapping.get(gateway)
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
 

--- a/src/services/model_health_monitor.py
+++ b/src/services/model_health_monitor.py
@@ -302,37 +302,42 @@ class ModelHealthMonitor:
             # Import here to avoid circular imports
             from src.services.models import get_cached_models
 
-            # Get models from different gateways
-            gateways = [
-                "openrouter",
-                "featherless",
-                "deepinfra",
-                "huggingface",
-                "groq",
-                "fireworks",
-                "together",
-                "xai",
-                "novita",
-                "chutes",
-                "aimo",
-                "near",
-                "fal",
-                "google-vertex",
-                "cerebras",
-                "nebius",
-                "helicone",
-                "aihubmix",
-                "anannas",
-                "onerouter",
-                "cloudflare-workers-ai",
-                "vercel-ai-gateway",
-                "openai",
-                "anthropic",
-                "clarifai",
-                "alibaba",
-                "simplismart",
-                "modelz",
-            ]
+            # Get models from different gateways (DB-driven, with fallback)
+            try:
+                from src.db.providers_db import get_active_provider_slugs
+
+                gateways = get_active_provider_slugs()
+            except Exception:
+                gateways = [
+                    "openrouter",
+                    "featherless",
+                    "deepinfra",
+                    "huggingface",
+                    "groq",
+                    "fireworks",
+                    "together",
+                    "xai",
+                    "novita",
+                    "chutes",
+                    "aimo",
+                    "near",
+                    "fal",
+                    "google-vertex",
+                    "cerebras",
+                    "nebius",
+                    "helicone",
+                    "aihubmix",
+                    "anannas",
+                    "onerouter",
+                    "cloudflare-workers-ai",
+                    "vercel-ai-gateway",
+                    "openai",
+                    "anthropic",
+                    "clarifai",
+                    "alibaba",
+                    "simplismart",
+                    "modelz",
+                ]
 
             for gateway in gateways:
                 try:

--- a/src/services/pricing_audit.py
+++ b/src/services/pricing_audit.py
@@ -501,6 +501,7 @@ def _raw_fetch_provider(gateway: str) -> list[dict]:
             config = {
                 "url": entry["models_endpoint"],
                 "key_attr": entry.get("api_key_env_var"),
+                "header_type": entry.get("header_type", "bearer"),
             }
     except Exception:
         pass

--- a/src/services/pricing_audit.py
+++ b/src/services/pricing_audit.py
@@ -441,7 +441,7 @@ def _raw_fetch_provider(gateway: str) -> list[dict]:
     # ── Provider API configs ──────────────────────────────────────────────
     # Each entry: (url, headers, response_parser, pricing_extractor)
 
-    PROVIDER_CONFIGS: dict[str, dict] = {
+    _FALLBACK_PROVIDER_CONFIGS: dict[str, dict] = {
         "openrouter": {
             "url": "https://openrouter.ai/api/v1/models",
             "headers": {},  # No auth needed for model list
@@ -490,7 +490,24 @@ def _raw_fetch_provider(gateway: str) -> list[dict]:
         },
     }
 
-    config = PROVIDER_CONFIGS.get(gateway)
+    # DB-first: try to build config from gateway registry
+    config = None
+    try:
+        from src.services.gateway_registry import get_gateway_registry
+
+        registry = get_gateway_registry()
+        entry = registry.get(gateway)
+        if entry and entry.get("models_endpoint"):
+            config = {
+                "url": entry["models_endpoint"],
+                "key_attr": entry.get("api_key_env_var"),
+            }
+    except Exception:
+        pass
+
+    # Fallback to hardcoded config
+    if not config:
+        config = _FALLBACK_PROVIDER_CONFIGS.get(gateway)
     if not config:
         logger.info(f"No raw fetch config for '{gateway}', skipping")
         return []

--- a/src/services/provider_credit_monitor.py
+++ b/src/services/provider_credit_monitor.py
@@ -36,8 +36,26 @@ _402_WINDOW_MINUTES = 15  # Sliding window for 402 tracking
 _402_CRITICAL_THRESHOLD = 10  # Critical if >=10 402s in window
 _402_WARNING_THRESHOLD = 3  # Warning if >=3 402s in window
 
+# Fallback set (used when registry is unavailable)
+_FALLBACK_402_PROVIDERS = {"together", "deepinfra", "fireworks", "groq"}
+
+
+def _get_monitored_402_providers() -> set[str]:
+    """Return providers monitored via 402-frequency (DB-driven, with fallback)."""
+    try:
+        from src.services.gateway_registry import get_gateway_registry
+
+        registry = get_gateway_registry()
+        dynamic = {
+            slug for slug, entry in registry.items() if entry.get("monitor_402_frequency", False)
+        }
+        return dynamic if dynamic else _FALLBACK_402_PROVIDERS
+    except Exception:
+        return _FALLBACK_402_PROVIDERS
+
+
 # Providers monitored via 402-frequency (no public balance API)
-MONITORED_402_PROVIDERS = {"together", "deepinfra", "fireworks", "groq"}
+MONITORED_402_PROVIDERS = _FALLBACK_402_PROVIDERS
 
 
 async def check_openrouter_credits() -> dict[str, Any]:
@@ -170,11 +188,11 @@ def record_provider_402(provider: str) -> None:
     The credit monitor uses 402 frequency as a proxy signal for
     credit exhaustion on providers without a public balance API.
 
-    Only records for providers in ``MONITORED_402_PROVIDERS`` to
+    Only records for providers in the monitored 402 set to
     prevent unbounded key creation.
     """
     provider = provider.lower()
-    if provider not in MONITORED_402_PROVIDERS:
+    if provider not in _get_monitored_402_providers():
         return  # Ignore providers we don't monitor via 402 frequency
     now = datetime.now(UTC)
     cutoff = now - timedelta(minutes=_402_WINDOW_MINUTES)
@@ -238,7 +256,7 @@ async def check_all_provider_credits() -> dict[str, dict[str, Any]]:
     results["openrouter"] = await check_openrouter_credits()
 
     # Top providers without balance APIs: monitor via 402 frequency
-    for provider in MONITORED_402_PROVIDERS:
+    for provider in _get_monitored_402_providers():
         results[provider] = check_provider_402_status(provider)
 
     return results

--- a/src/services/provider_span_enricher.py
+++ b/src/services/provider_span_enricher.py
@@ -78,8 +78,8 @@ _FALLBACK_PROVIDER_HOST_MAP: dict[str, str] = {
     "api.openrouter.ai": "openrouter",
     "api.groq.com": "groq",
     "api.mistral.ai": "mistral",
-    "api.together.ai": "together-ai",
-    "api.together.xyz": "together-ai",
+    "api.together.ai": "together",
+    "api.together.xyz": "together",
     "api.perplexity.ai": "perplexity",
     "api.cohere.com": "cohere",
     "api.cohere.ai": "cohere",
@@ -141,7 +141,8 @@ def _build_provider_host_map() -> dict[str, str]:
     return host_map
 
 
-# Backward-compat alias (read-only access to current map)
+# Backward-compat alias — static fallback only; use _build_provider_host_map()
+# for the live DB-driven map.
 _PROVIDER_HOST_MAP = _FALLBACK_PROVIDER_HOST_MAP
 
 

--- a/src/services/provider_span_enricher.py
+++ b/src/services/provider_span_enricher.py
@@ -47,63 +47,102 @@ logger = logging.getLogger(__name__)
 # Maps lowercase hostname (or hostname suffix) → canonical peer.service name.
 # Tempo will use this value as the "server" label in service-graph metrics and
 # as the node label in the Live Service Dependency Map panel.
-_PROVIDER_HOST_MAP: dict[str, str] = {
-    # OpenAI family
-    "api.openai.com": "openai",
-    "api.openai.azure.com": "azure-openai",
-    # Anthropic
-    "api.anthropic.com": "anthropic",
-    # OpenRouter (aggregator — single edge, not per-model)
-    "openrouter.ai": "openrouter",
-    "api.openrouter.ai": "openrouter",
-    # Groq
-    "api.groq.com": "groq",
-    # Mistral
-    "api.mistral.ai": "mistral",
-    # Together AI
-    "api.together.ai": "together-ai",
-    "api.together.xyz": "together-ai",
-    # Perplexity
-    "api.perplexity.ai": "perplexity",
-    # Cohere
-    "api.cohere.com": "cohere",
-    "api.cohere.ai": "cohere",
-    # Google (Gemini / Vertex)
-    "generativelanguage.googleapis.com": "google-gemini",
-    "us-central1-aiplatform.googleapis.com": "google-vertex",
-    # Fireworks AI
-    "api.fireworks.ai": "fireworks",
-    # DeepSeek
-    "api.deepseek.com": "deepseek",
-    # xAI (Grok)
-    "api.x.ai": "xai",
-    # Cerebras
-    "api.cerebras.ai": "cerebras",
-    # Featherless
-    "inference.featherless.ai": "featherless",
-    # Hyperbolic
-    "api.hyperbolic.xyz": "hyperbolic",
-    # Novita
-    "api.novita.ai": "novita",
-    # HuggingFace
-    "api.huggingface.co": "huggingface",
-    "huggingface.co": "huggingface",
-    # Portkey (proxy/gateway)
-    "api.portkey.ai": "portkey",
-    # Replicate
-    "api.replicate.com": "replicate",
-    # AI21
-    "api.ai21.com": "ai21",
-    # Upstash (Redis)
-    # Not an AI provider, but useful to see in topology
+# Static infrastructure hosts (not AI providers — always kept in code)
+_INFRA_HOST_MAP: dict[str, str] = {
     "upstash.io": "upstash-redis",
-    # Supabase (Postgres)
     "supabase.co": "supabase",
-    # Stripe
     "api.stripe.com": "stripe",
-    # Sentry
     "sentry.io": "sentry",
 }
+
+# Static external AI providers (not in our gateway registry)
+_EXTERNAL_HOST_MAP: dict[str, str] = {
+    "api.openai.azure.com": "azure-openai",
+    "api.mistral.ai": "mistral",
+    "api.perplexity.ai": "perplexity",
+    "api.cohere.com": "cohere",
+    "api.cohere.ai": "cohere",
+    "api.deepseek.com": "deepseek",
+    "api.hyperbolic.xyz": "hyperbolic",
+    "api.portkey.ai": "portkey",
+    "api.replicate.com": "replicate",
+    "api.ai21.com": "ai21",
+}
+
+# Fallback map — used when the gateway registry is unavailable
+_FALLBACK_PROVIDER_HOST_MAP: dict[str, str] = {
+    "api.openai.com": "openai",
+    "api.openai.azure.com": "azure-openai",
+    "api.anthropic.com": "anthropic",
+    "openrouter.ai": "openrouter",
+    "api.openrouter.ai": "openrouter",
+    "api.groq.com": "groq",
+    "api.mistral.ai": "mistral",
+    "api.together.ai": "together-ai",
+    "api.together.xyz": "together-ai",
+    "api.perplexity.ai": "perplexity",
+    "api.cohere.com": "cohere",
+    "api.cohere.ai": "cohere",
+    "generativelanguage.googleapis.com": "google-gemini",
+    "us-central1-aiplatform.googleapis.com": "google-vertex",
+    "api.fireworks.ai": "fireworks",
+    "api.deepseek.com": "deepseek",
+    "api.x.ai": "xai",
+    "api.cerebras.ai": "cerebras",
+    "inference.featherless.ai": "featherless",
+    "api.hyperbolic.xyz": "hyperbolic",
+    "api.novita.ai": "novita",
+    "api.huggingface.co": "huggingface",
+    "huggingface.co": "huggingface",
+    "api.portkey.ai": "portkey",
+    "api.replicate.com": "replicate",
+    "api.ai21.com": "ai21",
+    "upstash.io": "upstash-redis",
+    "supabase.co": "supabase",
+    "api.stripe.com": "stripe",
+    "sentry.io": "sentry",
+}
+
+# Module-level cached host map (rebuilt when gateway registry refreshes)
+_host_map_cache: dict[str, str] | None = None
+_host_map_cache_ts: float = 0.0
+_HOST_MAP_TTL = 300  # 5 minutes
+
+
+def _build_provider_host_map() -> dict[str, str]:
+    """Build the hostname-to-provider map from gateway registry + static maps."""
+    global _host_map_cache, _host_map_cache_ts
+    import time
+
+    now = time.monotonic()
+    if _host_map_cache is not None and (now - _host_map_cache_ts) < _HOST_MAP_TTL:
+        return _host_map_cache
+
+    host_map: dict[str, str] = {}
+    # 1. Static infrastructure hosts
+    host_map.update(_INFRA_HOST_MAP)
+    # 2. External AI providers (not in our registry)
+    host_map.update(_EXTERNAL_HOST_MAP)
+    # 3. Provider hostnames from DB registry
+    try:
+        from src.services.gateway_registry import get_gateway_registry
+
+        registry = get_gateway_registry()
+        for slug, entry in registry.items():
+            for hostname in entry.get("hostnames", []):
+                host_map[hostname] = slug
+    except Exception:
+        # Fall back to static map
+        host_map.update(_FALLBACK_PROVIDER_HOST_MAP)
+        return host_map
+
+    _host_map_cache = host_map
+    _host_map_cache_ts = now
+    return host_map
+
+
+# Backward-compat alias (read-only access to current map)
+_PROVIDER_HOST_MAP = _FALLBACK_PROVIDER_HOST_MAP
 
 
 def _resolve_peer_service(host: str) -> str | None:
@@ -114,10 +153,11 @@ def _resolve_peer_service(host: str) -> str | None:
     Checks exact match first, then suffix match (e.g. any *.supabase.co).
     """
     host = host.lower()
-    if host in _PROVIDER_HOST_MAP:
-        return _PROVIDER_HOST_MAP[host]
+    host_map = _build_provider_host_map()
+    if host in host_map:
+        return host_map[host]
     # Suffix match — handles regional subdomains like us-east-1.supabase.co
-    for pattern, service in _PROVIDER_HOST_MAP.items():
+    for pattern, service in host_map.items():
         if host.endswith("." + pattern) or host == pattern:
             return service
     return None

--- a/src/utils/auto_sentry.py
+++ b/src/utils/auto_sentry.py
@@ -380,11 +380,12 @@ def _extract_provider_from_module(module_name: str) -> str:
             underscore_pattern = r"(?<![a-z])" + re.escape(underscore_slug) + r"(?![a-z])"
             if re.search(pattern, module_name) or re.search(underscore_pattern, module_name):
                 return slug
-        return "unknown"
+        # No match in registry — fall through to hardcoded chain
+        # (covers providers not in our registry like portkey)
     except Exception:
         pass
 
-    # Fallback to hardcoded chain
+    # Fallback to hardcoded chain (covers non-registry providers)
     if "openrouter" in module_name:
         return "openrouter"
     elif "portkey" in module_name:

--- a/src/utils/auto_sentry.py
+++ b/src/utils/auto_sentry.py
@@ -361,18 +361,24 @@ def _extract_context_data(
 def _extract_provider_from_module(module_name: str) -> str:
     """Extract provider name from module path (DB-driven, with fallback).
 
-    Iterates registry slugs sorted longest-first to avoid false matches
-    from short slugs like ``"fal"`` matching ``"fallback"``.
+    Uses word-boundary matching to prevent false positives from short slugs
+    like ``"fal"`` matching ``"fallback"`` or ``"near"`` matching ``"linear"``.
     """
+    import re
+
     try:
         from src.services.gateway_registry import get_gateway_registry
 
         registry = get_gateway_registry()
-        # Sort slugs longest-first to prevent short-slug false positives
+        # Sort slugs longest-first to prevent one slug shadowing another
         slugs = sorted(registry.keys(), key=len, reverse=True)
         for slug in slugs:
-            # Also check underscore variant (e.g. "google_vertex" in module paths)
-            if slug in module_name or slug.replace("-", "_") in module_name:
+            # Word-boundary match: slug must be bordered by non-alpha chars
+            # e.g. "fal_client" matches but "fallback" does not
+            pattern = r"(?<![a-z])" + re.escape(slug) + r"(?![a-z])"
+            underscore_slug = slug.replace("-", "_")
+            underscore_pattern = r"(?<![a-z])" + re.escape(underscore_slug) + r"(?![a-z])"
+            if re.search(pattern, module_name) or re.search(underscore_pattern, module_name):
                 return slug
         return "unknown"
     except Exception:

--- a/src/utils/auto_sentry.py
+++ b/src/utils/auto_sentry.py
@@ -359,7 +359,26 @@ def _extract_context_data(
 
 
 def _extract_provider_from_module(module_name: str) -> str:
-    """Extract provider name from module path."""
+    """Extract provider name from module path (DB-driven, with fallback).
+
+    Iterates registry slugs sorted longest-first to avoid false matches
+    from short slugs like ``"fal"`` matching ``"fallback"``.
+    """
+    try:
+        from src.services.gateway_registry import get_gateway_registry
+
+        registry = get_gateway_registry()
+        # Sort slugs longest-first to prevent short-slug false positives
+        slugs = sorted(registry.keys(), key=len, reverse=True)
+        for slug in slugs:
+            # Also check underscore variant (e.g. "google_vertex" in module paths)
+            if slug in module_name or slug.replace("-", "_") in module_name:
+                return slug
+        return "unknown"
+    except Exception:
+        pass
+
+    # Fallback to hardcoded chain
     if "openrouter" in module_name:
         return "openrouter"
     elif "portkey" in module_name:

--- a/supabase/migrations/20260402000003_seed_infrastructure_metadata.sql
+++ b/supabase/migrations/20260402000003_seed_infrastructure_metadata.sql
@@ -1,0 +1,340 @@
+-- Phase 3: Seed infrastructure metadata into providers.metadata JSONB
+-- Adds: base_url (pool), models_endpoint, chat_completions_endpoint,
+--        min_expected_models, header_type, default_headers, custom_timeout_ms,
+--        hostnames, monitor_402_frequency, async_streaming
+--
+-- These fields allow gateway_registry.py to serve infrastructure config
+-- that was previously hardcoded in connection_pool.py, gateway_health_service.py,
+-- intelligent_health_monitor.py, provider_span_enricher.py, and
+-- provider_credit_monitor.py.
+
+-- Helper: merge keys into existing metadata JSONB without overwriting other fields.
+-- Uses || (JSONB concat) which merges top-level keys.
+
+-- openrouter
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'pool_base_url', 'https://openrouter.ai/api/v1',
+    'models_endpoint', 'https://openrouter.ai/api/v1/models',
+    'chat_completions_endpoint', 'https://openrouter.ai/api/v1/chat/completions',
+    'min_expected_models', 100,
+    'header_type', 'bearer',
+    'default_headers', '{"HTTP-Referer": "__OPENROUTER_SITE_URL__", "X-Title": "__OPENROUTER_SITE_NAME__"}'::jsonb,
+    'hostnames', '["openrouter.ai", "api.openrouter.ai"]'::jsonb,
+    'monitor_402_frequency', false,
+    'async_streaming', true
+)
+WHERE slug = 'openrouter';
+
+-- featherless
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'pool_base_url', 'https://api.featherless.ai/v1',
+    'models_endpoint', 'https://api.featherless.ai/v1/models',
+    'chat_completions_endpoint', 'https://api.featherless.ai/v1/chat/completions',
+    'min_expected_models', 10,
+    'header_type', 'bearer',
+    'hostnames', '["inference.featherless.ai"]'::jsonb
+)
+WHERE slug = 'featherless';
+
+-- fireworks
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'pool_base_url', 'https://api.fireworks.ai/inference/v1',
+    'models_endpoint', 'https://api.fireworks.ai/inference/v1/models',
+    'chat_completions_endpoint', 'https://api.fireworks.ai/inference/v1/chat/completions',
+    'min_expected_models', 10,
+    'header_type', 'bearer',
+    'hostnames', '["api.fireworks.ai"]'::jsonb,
+    'monitor_402_frequency', true
+)
+WHERE slug = 'fireworks';
+
+-- together
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'pool_base_url', 'https://api.together.xyz/v1',
+    'models_endpoint', 'https://api.together.xyz/v1/models',
+    'chat_completions_endpoint', 'https://api.together.xyz/v1/chat/completions',
+    'min_expected_models', 20,
+    'header_type', 'bearer',
+    'hostnames', '["api.together.ai", "api.together.xyz"]'::jsonb,
+    'monitor_402_frequency', true
+)
+WHERE slug = 'together';
+
+-- huggingface
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'pool_base_url', 'https://router.huggingface.co/v1',
+    'models_endpoint', 'https://huggingface.co/api/models',
+    'min_expected_models', 100,
+    'header_type', 'bearer',
+    'custom_timeout_ms', 120000,
+    'hostnames', '["api.huggingface.co", "huggingface.co"]'::jsonb
+)
+WHERE slug = 'huggingface';
+
+-- xai
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'pool_base_url', 'https://api.x.ai/v1',
+    'models_endpoint', 'https://api.x.ai/v1/models',
+    'chat_completions_endpoint', 'https://api.x.ai/v1/chat/completions',
+    'min_expected_models', 2,
+    'header_type', 'bearer',
+    'custom_timeout_ms', 600000,
+    'hostnames', '["api.x.ai"]'::jsonb
+)
+WHERE slug = 'xai';
+
+-- deepinfra
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'pool_base_url', 'https://api.deepinfra.com/v1/openai',
+    'models_endpoint', 'https://api.deepinfra.com/models/list',
+    'chat_completions_endpoint', 'https://api.deepinfra.com/v1/openai/chat/completions',
+    'min_expected_models', 50,
+    'header_type', 'bearer',
+    'monitor_402_frequency', true
+)
+WHERE slug = 'deepinfra';
+
+-- chutes
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'pool_base_url', 'https://llm.chutes.ai/v1',
+    'models_endpoint', 'https://llm.chutes.ai/v1/models',
+    'min_expected_models', 5,
+    'header_type', 'bearer'
+)
+WHERE slug = 'chutes';
+
+-- groq
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'pool_base_url', 'https://api.groq.com/openai/v1',
+    'models_endpoint', 'https://api.groq.com/openai/v1/models',
+    'chat_completions_endpoint', 'https://api.groq.com/openai/v1/chat/completions',
+    'min_expected_models', 5,
+    'header_type', 'bearer',
+    'hostnames', '["api.groq.com"]'::jsonb,
+    'monitor_402_frequency', true
+)
+WHERE slug = 'groq';
+
+-- cerebras
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'models_endpoint', 'https://api.cerebras.ai/v1/models',
+    'chat_completions_endpoint', 'https://api.cerebras.ai/v1/chat/completions',
+    'min_expected_models', 2,
+    'header_type', 'bearer',
+    'hostnames', '["api.cerebras.ai"]'::jsonb
+)
+WHERE slug = 'cerebras';
+
+-- novita
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'models_endpoint', 'https://api.novita.ai/v3/openai/models',
+    'chat_completions_endpoint', 'https://api.novita.ai/v3/openai/chat/completions',
+    'min_expected_models', 5,
+    'header_type', 'bearer',
+    'hostnames', '["api.novita.ai"]'::jsonb
+)
+WHERE slug = 'novita';
+
+-- nebius
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'models_endpoint', 'https://api.studio.nebius.ai/v1/models',
+    'min_expected_models', 5,
+    'header_type', 'bearer'
+)
+WHERE slug = 'nebius';
+
+-- openai
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'pool_base_url', 'https://api.openai.com/v1',
+    'models_endpoint', 'https://api.openai.com/v1/models',
+    'min_expected_models', 10,
+    'header_type', 'bearer',
+    'hostnames', '["api.openai.com"]'::jsonb
+)
+WHERE slug = 'openai';
+
+-- anthropic
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'pool_base_url', 'https://api.anthropic.com/v1',
+    'min_expected_models', 3,
+    'header_type', 'bearer',
+    'hostnames', '["api.anthropic.com"]'::jsonb
+)
+WHERE slug = 'anthropic';
+
+-- google-vertex
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'min_expected_models', 10,
+    'header_type', 'google',
+    'hostnames', '["us-central1-aiplatform.googleapis.com", "generativelanguage.googleapis.com"]'::jsonb
+)
+WHERE slug = 'google-vertex';
+
+-- clarifai
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'pool_base_url', 'https://api.clarifai.com/v2/ext/openai/v1',
+    'min_expected_models', 5,
+    'header_type', 'bearer'
+)
+WHERE slug = 'clarifai';
+
+-- onerouter
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'pool_base_url', 'https://llm.infron.ai/v1',
+    'models_endpoint', 'https://api.infron.ai/v1/models',
+    'min_expected_models', 100,
+    'header_type', 'bearer'
+)
+WHERE slug = 'onerouter';
+
+-- zai
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'pool_base_url', 'https://api.z.ai/api/paas/v4/'
+)
+WHERE slug = 'zai';
+
+-- cloudflare-workers-ai
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'pool_base_url', 'https://api.cloudflare.com/client/v4/accounts/{CLOUDFLARE_ACCOUNT_ID}/ai/v1',
+    'min_expected_models', 10,
+    'header_type', 'bearer'
+)
+WHERE slug = 'cloudflare-workers-ai';
+
+-- simplismart
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'pool_base_url', 'https://api.simplismart.live',
+    'models_endpoint', 'https://api.simplismart.ai/v1/models',
+    'min_expected_models', 5,
+    'header_type', 'bearer'
+)
+WHERE slug = 'simplismart';
+
+-- sybil
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'pool_base_url', 'https://api.sybil.com/v1',
+    'min_expected_models', 3,
+    'header_type', 'bearer'
+)
+WHERE slug = 'sybil';
+
+-- canopywave
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'models_endpoint', 'https://inference.canopywave.io/v1/models',
+    'min_expected_models', 5,
+    'header_type', 'bearer'
+)
+WHERE slug = 'canopywave';
+
+-- morpheus
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'pool_base_url', 'https://api.mor.org/api/v1',
+    'min_expected_models', 3,
+    'header_type', 'bearer'
+)
+WHERE slug = 'morpheus';
+
+-- akash
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'pool_base_url', 'https://api.akashml.com/v1'
+)
+WHERE slug = 'akash';
+
+-- nosana
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'pool_base_url', 'https://dashboard.k8s.prd.nos.ci/api/v1'
+)
+WHERE slug = 'nosana';
+
+-- aihubmix
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'models_endpoint', 'https://aihubmix.com/v1/models',
+    'min_expected_models', 5,
+    'header_type', 'aihubmix'
+)
+WHERE slug = 'aihubmix';
+
+-- anannas
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'models_endpoint', 'https://api.anannas.ai/v1/models',
+    'min_expected_models', 5,
+    'header_type', 'bearer'
+)
+WHERE slug = 'anannas';
+
+-- near
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'models_endpoint', 'https://cloud-api.near.ai/v1/models',
+    'min_expected_models', 4,
+    'header_type', 'bearer'
+)
+WHERE slug = 'near';
+
+-- aimo
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'models_endpoint', 'https://beta.aimo.network/api/v1/models',
+    'min_expected_models', 5,
+    'header_type', 'bearer'
+)
+WHERE slug = 'aimo';
+
+-- fal
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'min_expected_models', 50,
+    'header_type', 'bearer'
+)
+WHERE slug = 'fal';
+
+-- vercel-ai-gateway
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'min_expected_models', 5,
+    'header_type', 'bearer'
+)
+WHERE slug = 'vercel-ai-gateway';
+
+-- helicone
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'min_expected_models', 5,
+    'header_type', 'bearer'
+)
+WHERE slug = 'helicone';
+
+-- alibaba
+UPDATE "public"."providers"
+SET metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+    'min_expected_models', 5,
+    'header_type', 'bearer'
+)
+WHERE slug = 'alibaba';


### PR DESCRIPTION
## Summary

Phase 3 of the dynamic catalog migration. Replaces ~185 hardcoded per-provider infrastructure items across 12 files with DB-driven lookups from the gateway registry.

### Category G — Infrastructure Dynamism (10 files)
- **Migration**: Seeds infrastructure metadata (base_url, models_endpoint, hostnames, timeouts, 402 monitoring flags, async_streaming) into `providers.metadata` JSONB for all 33 providers
- **gateway_registry.py**: Unpacks 10 new metadata fields + `get_provider_api_key()` helper
- **connection_pool.py**: Generic `get_provider_pooled_client(slug)` + DB-driven connection warmup
- **gateway_health_service.py**: Dynamic `_get_gateway_config()` from registry
- **model_health_monitor.py**: Dynamic gateway list from `get_active_provider_slugs()`
- **intelligent_health_monitor.py**: DB-first endpoint + auth header lookups
- **provider_span_enricher.py**: Dynamic hostname map from registry + static infra hosts
- **provider_credit_monitor.py**: DB-driven 402 monitoring provider set
- **auto_sentry.py**: Dynamic provider extraction (sorted longest-first to avoid false matches)
- **pricing_audit.py**: DB-first provider configs
- **cache.py**: Dynamic `_get_or_create_cache()` replaces 45 individual cache dicts

### Category H — Provider Dispatch Tables (2 files)
- **images.py**: `IMAGE_PROVIDER_ROUTING` dispatch table for deepinfra/fal
- **chat_handler.py**: DB-driven `async_streaming` metadata flag replaces hardcoded OpenRouter check

**Note**: messages.py dispatch chain was already dead code (replaced by unified handler) — no changes needed.

All changes follow the DB-first with hardcoded fallback pattern from Phases 1-2.

## Test plan
- [x] `black --check --line-length 100` on all modified files
- [x] `pytest tests/conceptual_model/ -v` — 148 passed, 10 skipped, 3 xfailed, 1 xpassed
- [ ] Verify `get_provider_pooled_client("openrouter")` returns valid client (requires API key)
- [ ] Verify warmup_provider_connections() succeeds with dynamic list
- [ ] Verify gateway_health_service builds configs for all active providers
- [ ] Apply migration `20260402000003` to staging DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Database-seeded provider configuration for richer provider settings and runtime discovery.
  * Migration added to populate provider infrastructure metadata.

* **Improvements**
  * Lazy in-memory caching for provider model data to reduce startup load.
  * Image generation uses lookup-based provider routing and reports supported providers.
  * Gateway connections, health checks, pooling, streaming detection, hostname resolution, and 402 monitoring now prefer DB-driven registry values with safe fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Phase 3 of the dynamic catalog migration replaces ~185 hardcoded infrastructure items across 12 files with DB-driven lookups from the gateway registry, seeded by a single JSONB-merge migration. The DB-first with hardcoded-fallback pattern is applied consistently, and the overall structure is sound.

- **P1 — `auto_sentry.py`**: The dynamic slug-matching loop in `_extract_provider_from_module` uses a plain substring check (`slug in module_name`). The docstring claims longest-first sorting prevents false positives, but that only guards against slug-vs-slug shadowing. Short registry slugs like `\"fal\"` are substrings of common words in module paths (e.g. `\"fal\"` in `\"rate_limiting_fallback\"`), so exceptions from the fallback service would be incorrectly attributed to the FAL.ai provider in Sentry. Word-boundary guards are needed.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the slug word-boundary bug in auto_sentry; all other findings are P2 style/cleanup.

One P1 defect: short registry slugs (notably 'fal') are substrings of common words in module paths ('fallback'), causing incorrect Sentry provider attribution for the fallback service. The longest-first sort the PR relies on only guards slug-vs-slug conflicts, not slug-vs-word. All remaining findings are P2 or lower.

src/utils/auto_sentry.py — _extract_provider_from_module needs word-boundary guards on slug matching.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/utils/auto_sentry.py | Dynamic registry slug matching in _extract_provider_from_module introduces false-positive substring matches (e.g. "fal" matching "fallback"); the longest-first sort does not prevent this class of error. |
| src/services/gateway_registry.py | Adds 10 new infrastructure metadata fields unpacked from providers.metadata JSONB and a new get_provider_api_key() helper; clean DB-first with env/Config fallback pattern. |
| src/cache.py | Replaces 45 hardcoded _CacheDict instances with a dynamic _get_or_create_cache registry; get_models_cache now returns a truthy object for unknown slugs instead of None, which is a silent behavioral change for deprecated callers. |
| src/services/connection_pool.py | Adds generic get_provider_pooled_client(slug) and DB-driven warmup; template URL resolution is only implemented for CLOUDFLARE_ACCOUNT_ID, leaving other future templates silently broken. |
| src/routes/images.py | Introduces IMAGE_PROVIDER_ROUTING dispatch table for deepinfra/fal; correctly preserves google-vertex special-casing, but dict is rebuilt on every request instead of at module level. |
| src/services/pricing_audit.py | DB-first path for raw provider fetch only returns url and key_attr, losing auth_header/auth_prefix customisation fields present in the fallback configs; defaults to Bearer which works for most providers. |
| supabase/migrations/20260402000003_seed_infrastructure_metadata.sql | Seeds infrastructure metadata for 33 providers using safe JSONB merge (||); UPDATE-only with no schema changes, safe to apply to existing data. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request / Startup] --> B{Registry cached and fresh?}
    B -- Yes --> C[Return cached registry dict]
    B -- No --> D[Load from providers DB]
    D -- Success --> E[Unpack metadata fields: base_url, models_endpoint, async_streaming, etc.]
    E --> F[Store in _registry_cache]
    F --> C
    D -- Failure --> G[Use hardcoded fallback registry]
    C --> H{Consumer}
    H --> H1[connection_pool: get_provider_pooled_client]
    H --> H2[gateway_health_service: _get_gateway_config]
    H --> H3[chat_handler: async_streaming flag]
    H --> H4[provider_span_enricher: _build_provider_host_map]
    H --> H5[auto_sentry: _extract_provider_from_module]
    H --> H6[provider_credit_monitor: _get_monitored_402_providers]
    H1 -- missing key/url --> I1[raise ValueError, skipped in warmup]
    H2 -- empty configs --> I2[return FALLBACK_GATEWAY_CONFIG]
    H3 -- exception --> I3[fallback: openrouter only]
    H4 -- exception --> I4[use FALLBACK_PROVIDER_HOST_MAP]
    H5 -- exception --> I5[hardcoded elif chain]
    H6 -- exception --> I6[FALLBACK_402_PROVIDERS set]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/routes/images.py`, line 262-265 ([link](https://github.com/alpaca-network/gatewayz-backend/blob/d48284ef76306d25aa8f897b2acb7edc43010398/src/routes/images.py#L262-L265)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Dispatch table rebuilt on every request**

   `IMAGE_PROVIDER_ROUTING` is defined inside the `generate_images` handler, so a new dict is allocated on every call. Move it to module level so it is created once at import time.

   

   And remove the local definition from inside the function.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/routes/images.py
   Line: 262-265

   Comment:
   **Dispatch table rebuilt on every request**

   `IMAGE_PROVIDER_ROUTING` is defined inside the `generate_images` handler, so a new dict is allocated on every call. Move it to module level so it is created once at import time.

   

   And remove the local definition from inside the function.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/routes/images.py
Line: 262-265

Comment:
**Dispatch table rebuilt on every request**

`IMAGE_PROVIDER_ROUTING` is defined inside the `generate_images` handler, so a new dict is allocated on every call. Move it to module level so it is created once at import time.

```suggestion
IMAGE_PROVIDER_ROUTING = {
    "deepinfra": make_deepinfra_image_request,
    "fal": make_fal_image_request,
}
```

And remove the local definition from inside the function.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/cache.py
Line: 222-228

Comment:
**`get_models_cache` now returns a truthy object for any unknown slug**

The old implementation returned `None` for unrecognised gateways (`cache_map.get(gateway.lower())`). The new path calls `_get_or_create_cache(slug)` for everything except `"hug"` and `"alibaba"`, which returns a fully-initialised (4-key, **truthy**) `_CacheDict`. Any caller that guards on `if cache is None:` will silently skip that branch and proceed with an empty cache, which may cascade into missing data or stale-response bugs.

Since the function is deprecated and consumers should have migrated to `model_catalog_cache`, this is unlikely to hit production today — but the semantic break is worth a note or a `None` guard for unmapped slugs.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/services/connection_pool.py
Line: 349-354

Comment:
**Only `{CLOUDFLARE_ACCOUNT_ID}` template is resolved — future templates silently pass through**

The template resolution in `get_provider_pooled_client` is a single hard-coded `if "{CLOUDFLARE_ACCOUNT_ID}" in base_url` check. Any future provider whose `pool_base_url` contains a different `{PLACEHOLDER}` (e.g. a per-tenant subdomain) would have the raw template string passed to the OpenAI client as the `base_url`, resulting in a silent HTTP connection error rather than a clear configuration error at startup.

Consider a generic resolver that scans for all `{VAR}` patterns and resolves them from `Config`, raising `ValueError` for any that remain unresolved after substitution.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/utils/auto_sentry.py
Line: 367-379

Comment:
**Short slug `"fal"` still matches `"fallback"` — sort order does not help**

The docstring says "sorted longest-first to avoid false matches from short slugs like `fal` matching `fallback`", but that reasoning is incorrect. Longest-first sort only prevents one *slug* from shadowing another slug (e.g. `"open"` vs `"openrouter"`). It does nothing to stop a registry slug from matching an unrelated word in the module path.

`"fal" in "rate_limiting_fallback"` is `True` — `fal` appears as a substring of `fallback`. Any exception raised inside `src.services.rate_limiting_fallback` would be attributed to the FAL.ai provider in Sentry. Similar risks exist for other short slugs (`"zai"` in `"authorization"`, `"near"` in `"linear"`, etc.).

The original hardcoded chain was safe because each check was written explicitly for a known module path segment. The dynamic path needs word-boundary guards — for example using `re.search` with a pattern that requires the slug not to be surrounded by other lowercase letters, or by requiring the slug to appear as a complete path component (bounded by `.` or `_`).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: Phase 3 PR3 — provider dispatch ta..."](https://github.com/alpaca-network/gatewayz-backend/commit/d48284ef76306d25aa8f897b2acb7edc43010398) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27236231)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->