### PR TITLE
fix(live-test): fix httpx.Timeout TypeError crashing all providers + …

### DIFF
--- a/src/routes/live_model_test.py
+++ b/src/routes/live_model_test.py
@@ -174,17 +174,20 @@ async def _test_single_model(
         "temperature": 0,
     }
 
-    # Enforce a hard total timeout. httpx's default is per-phase (connect, read, write
-    # each get their own timeout), which allows a slow server to exceed the intended cap.
-    total_timeout = httpx.Timeout(total=timeout_s, connect=min(10.0, timeout_s))
+    # Cap connect phase independently; read/write/pool all get timeout_s.
+    # httpx.Timeout takes a positional default for all phases, then keyword overrides.
+    per_phase_timeout = httpx.Timeout(timeout_s, connect=min(10.0, timeout_s))
 
     async with semaphore:
         start = time.monotonic()
         try:
-            resp = await client.post(
-                "/v1/chat/completions",
-                json=payload,
-                timeout=total_timeout,
+            resp = await asyncio.wait_for(
+                client.post(
+                    "/v1/chat/completions",
+                    json=payload,
+                    timeout=per_phase_timeout,
+                ),
+                timeout=timeout_s,
             )
             latency = (time.monotonic() - start) * 1000
 
@@ -217,7 +220,7 @@ async def _test_single_model(
                     error=f"HTTP {resp.status_code}: {err[:150]}",
                 )
 
-        except httpx.TimeoutException:
+        except (httpx.TimeoutException, asyncio.TimeoutError):
             latency = (time.monotonic() - start) * 1000
             return ModelTestResult(
                 model_id=model_id,
@@ -287,7 +290,7 @@ async def run_live_model_test(
     provider: str | None = Query(None, description="Filter by provider slug"),
     limit: int = Query(50, ge=0, le=5000, description="Max models to test (default 50, max 5000)"),
     concurrency: int = Query(10, ge=1, le=20, description="Parallel requests"),
-    timeout: float = Query(15.0, ge=5, le=60, description="Per-model timeout (s)"),
+    timeout: float = Query(60.0, ge=5, le=120, description="Per-model timeout (s)"),
     skip_unhealthy: bool = Query(True, description="Skip models with health_status=down"),
     admin_user: dict = Depends(require_admin),
 ) -> LiveTestReport:

--- a/src/routes/live_model_test.py
+++ b/src/routes/live_model_test.py
@@ -220,7 +220,7 @@ async def _test_single_model(
                     error=f"HTTP {resp.status_code}: {err[:150]}",
                 )
 
-        except (httpx.TimeoutException, asyncio.TimeoutError):
+        except (httpx.TimeoutException, TimeoutError):
             latency = (time.monotonic() - start) * 1000
             return ModelTestResult(
                 model_id=model_id,


### PR DESCRIPTION
…default 60s

httpx.Timeout has no 'total' keyword — valid kwargs are connect/read/write/pool. Using total= raised TypeError on every _test_single_model call; asyncio.gather propagated the first exception and crashed /run with 500 for every provider.

Fix: use positional default + connect override, wrap with asyncio.wait_for for true wall-clock cap, catch asyncio.TimeoutError alongside httpx.TimeoutException.

Also: default timeout 15s → 60s, max 60 → 120 to reduce false timeouts on slow providers.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a `TypeError` crash in the live model test endpoint caused by passing `total=` to `httpx.Timeout`, which only accepts a positional default plus `connect`/`read`/`write`/`pool` keyword overrides. The fix switches to `httpx.Timeout(timeout_s, connect=…)`, wraps each request in `asyncio.wait_for` for a true wall-clock cap, catches `asyncio.TimeoutError` alongside `httpx.TimeoutException`, and raises per-model timeout limits (15 s → 60 s default, 60 → 120 s max).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the targeted bug is correctly fixed and all remaining findings are minor style suggestions.

The httpx.Timeout fix is valid (positional default + keyword override is the correct API). The dual-timeout strategy (asyncio.wait_for outer wall-clock cap + httpx.Timeout inner per-phase cap) is intentional and sound. Exception handling covers all common failure paths. The only actionable note — missing return_exceptions=True on asyncio.gather — is a defensive best-practice improvement, not a current defect under normal operation.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/routes/live_model_test.py | Fixes httpx.Timeout(total=…) TypeError by switching to valid positional+keyword form; adds asyncio.wait_for wall-clock cap and catches asyncio.TimeoutError; raises default timeout 15 s → 60 s, max 60 → 120 s. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Admin as Admin Client
    participant Route as /admin/live-test/run
    participant Catalog as _fetch_catalog()
    participant Gather as asyncio.gather
    participant Test as _test_single_model()
    participant GW as Gateway self-call

    Admin->>Route: POST /run (gateway, provider, limit, timeout)
    Route->>Catalog: fetch models from DB
    Catalog-->>Route: model list
    Route->>Gather: gather(*tasks) — Semaphore(concurrency)
    loop per model
        Gather->>Test: _test_single_model(client, model, timeout_s, semaphore)
        alt should skip
            Test-->>Gather: ModelTestResult(status=skip)
        else run inference
            Test->>GW: asyncio.wait_for(client.post(/v1/chat/completions), timeout=timeout_s)
            Note over Test,GW: httpx.Timeout(timeout_s, connect=min(10s, timeout_s))
            alt HTTP 200
                GW-->>Test: response body
                Test-->>Gather: ModelTestResult(status=pass)
            else HTTP 4xx/5xx
                GW-->>Test: error response
                Test-->>Gather: ModelTestResult(status=fail)
            else httpx.TimeoutException or asyncio.TimeoutError
                Test-->>Gather: ModelTestResult(status=timeout)
            else Exception
                Test-->>Gather: ModelTestResult(status=error)
            end
        end
    end
    Gather-->>Route: list[ModelTestResult]
    Route-->>Admin: LiveTestReport
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/routes/live_model_test.py`, line 353 ([link](https://github.com/alpaca-network/gatewayz-backend/blob/4399f93f268310ee9e26653d6b1255e56ee40183/src/routes/live_model_test.py#L353)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`asyncio.gather` without `return_exceptions=True`**

   `_test_single_model` catches all `Exception` types, but `asyncio.CancelledError` is a `BaseException` subclass in Python 3.10+ and will **not** be caught by `except Exception`. If any task is externally cancelled (e.g., the request itself times out at a higher level), the uncaught `CancelledError` propagates through `gather` and crashes the entire sweep — the same class of failure this PR fixes. Adding `return_exceptions=True` ensures every outcome becomes a value, not a raised exception.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/routes/live_model_test.py
   Line: 353

   Comment:
   **`asyncio.gather` without `return_exceptions=True`**

   `_test_single_model` catches all `Exception` types, but `asyncio.CancelledError` is a `BaseException` subclass in Python 3.10+ and will **not** be caught by `except Exception`. If any task is externally cancelled (e.g., the request itself times out at a higher level), the uncaught `CancelledError` propagates through `gather` and crashes the entire sweep — the same class of failure this PR fixes. Adding `return_exceptions=True` ensures every outcome becomes a value, not a raised exception.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/routes/live_model_test.py
Line: 353

Comment:
**`asyncio.gather` without `return_exceptions=True`**

`_test_single_model` catches all `Exception` types, but `asyncio.CancelledError` is a `BaseException` subclass in Python 3.10+ and will **not** be caught by `except Exception`. If any task is externally cancelled (e.g., the request itself times out at a higher level), the uncaught `CancelledError` propagates through `gather` and crashes the entire sweep — the same class of failure this PR fixes. Adding `return_exceptions=True` ensures every outcome becomes a value, not a raised exception.

```suggestion
        results = await asyncio.gather(*tasks, return_exceptions=True)
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): replace asyncio.TimeoutError wi..."](https://github.com/alpaca-network/gatewayz-backend/commit/4399f93f268310ee9e26653d6b1255e56ee40183) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27379829)</sub>

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->