### PR TITLE
fix(live-test): drop asyncio.wait_for, add return_exceptions=True to …

### DIFF
--- a/src/routes/live_model_test.py
+++ b/src/routes/live_model_test.py
@@ -181,13 +181,10 @@ async def _test_single_model(
     async with semaphore:
         start = time.monotonic()
         try:
-            resp = await asyncio.wait_for(
-                client.post(
-                    "/v1/chat/completions",
-                    json=payload,
-                    timeout=per_phase_timeout,
-                ),
-                timeout=timeout_s,
+            resp = await client.post(
+                "/v1/chat/completions",
+                json=payload,
+                timeout=per_phase_timeout,
             )
             latency = (time.monotonic() - start) * 1000
 
@@ -220,7 +217,7 @@ async def _test_single_model(
                     error=f"HTTP {resp.status_code}: {err[:150]}",
                 )
 
-        except (httpx.TimeoutException, asyncio.TimeoutError):
+        except httpx.TimeoutException:
             latency = (time.monotonic() - start) * 1000
             return ModelTestResult(
                 model_id=model_id,
@@ -350,7 +347,25 @@ async def run_live_model_test(
 
     async with httpx.AsyncClient(base_url=base_url, headers=headers) as client:
         tasks = [_test_single_model(client, m, timeout, semaphore, skip_unhealthy) for m in models]
-        results = await asyncio.gather(*tasks)
+        raw = await asyncio.gather(*tasks, return_exceptions=True)
+
+    # Convert any unexpected exceptions into error results so one bad model cannot
+    # crash the entire endpoint (return_exceptions=True prevents gather from propagating).
+    results: list[ModelTestResult] = []
+    for item in raw:
+        if isinstance(item, BaseException):
+            logger.error("Unexpected exception in _test_single_model: %s", item)
+            results.append(
+                ModelTestResult(
+                    model_id="unknown",
+                    gateway="unknown",
+                    provider="unknown",
+                    status="error",
+                    error=str(item)[:200],
+                )
+            )
+        else:
+            results.append(item)
 
     duration = round(time.monotonic() - start_time, 1)
 


### PR DESCRIPTION
…gather

asyncio.wait_for cancels the wrapped coroutine on timeout, which can propagate CancelledError (BaseException) past the except Exception handler and crash gather.

Simpler fix: httpx.Timeout(timeout_s, connect=min(10, timeout_s)) already caps each phase — no wait_for needed.

return_exceptions=True on asyncio.gather means any unexpected exception in a single model test is returned as a result object, never crashes the /run endpoint. Exceptions are logged and recorded as status=error.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a crash path in the `/admin/live-test/run` endpoint by removing `asyncio.wait_for` and replacing it with per-phase `httpx.Timeout`, and by adding `return_exceptions=True` to `asyncio.gather`.

- **`asyncio.wait_for` removal**: `wait_for` cancels the wrapped coroutine on timeout, raising `CancelledError` — a `BaseException` — which bypasses `_test_single_model`'s `except Exception` handler and would propagate into `gather`, crashing the endpoint. Using `httpx.Timeout(timeout_s, connect=min(10.0, timeout_s))` directly eliminates this risk while still capping every HTTP phase independently.
- **`return_exceptions=True`**: Any remaining `BaseException` that escapes a task is now captured as a result object rather than re-raised by `gather`. The post-gather loop converts these into `status=error` rows correctly using `isinstance(item, BaseException)` — the right predicate since `Exception` alone would miss `CancelledError` and `KeyboardInterrupt`.
- **Minor observability gap**: When a `BaseException` does escape `_test_single_model`, the synthesised error row uses `model_id=\"unknown\"`. Because `gather` preserves order, the model identity can be recovered by zipping `raw` with `models` — see inline comment.
- The `X-Internal-Source: live-test` self-call header is correctly validated in `security_middleware.py` via `secrets.compare_digest` against `ADMIN_API_KEY`, so that bypass path is secure and cannot be forged by external callers.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the core fix is correct and well-reasoned with no regressions.

Removing asyncio.wait_for is the right fix for the CancelledError propagation bug; return_exceptions=True with a BaseException isinstance guard is implemented correctly. The only gap is that error rows for escaped BaseExceptions lose the model_id, which is purely a debugging/observability concern and does not affect endpoint correctness or safety.

src/routes/live_model_test.py — specifically the exception-to-ModelTestResult conversion loop at lines 354–368

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/live_model_test.py | Drops asyncio.wait_for (CancelledError crash risk) in favour of httpx per-phase Timeout; adds return_exceptions=True with correct BaseException guard — one minor observability gap where escaped-exception rows lose model identity |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Admin
    participant RunEndpoint as /run Endpoint
    participant Gather as asyncio.gather
    participant TestFn as _test_single_model
    participant HTTP as httpx.AsyncClient

    Admin->>+RunEndpoint: POST /admin/live-test/run
    RunEndpoint->>+Gather: gather(*tasks, return_exceptions=True)
    loop For each model (bounded by asyncio.Semaphore)
        Gather->>+TestFn: await _test_single_model(...)
        TestFn->>+HTTP: POST /v1/chat/completions
        note over HTTP: Timeout(timeout_s,\nconnect=min(10s, timeout_s))
        HTTP-->>-TestFn: response / TimeoutException / Exception
        alt HTTP 200
            TestFn-->>Gather: ModelTestResult(status=pass)
        else HTTP 4xx/5xx
            TestFn-->>Gather: ModelTestResult(status=fail)
        else httpx.TimeoutException
            TestFn-->>Gather: ModelTestResult(status=timeout)
        else Exception
            TestFn-->>Gather: ModelTestResult(status=error)
        else BaseException e.g. CancelledError
            TestFn-->>-Gather: exception object
        end
    end
    Gather-->>-RunEndpoint: raw: list[ModelTestResult | BaseException]
    RunEndpoint->>RunEndpoint: zip(raw, models) — convert BaseException → ModelTestResult(status=error)
    RunEndpoint-->>-Admin: LiveTestReport
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/routes/live_model_test.py
Line: 354-368

Comment:
**Lost model identity on exception escape**

When a `BaseException` (e.g. `CancelledError`) escapes `_test_single_model`, the synthesised `ModelTestResult` carries `model_id="unknown"`, `gateway="unknown"`, `provider="unknown"`. Since `asyncio.gather(..., return_exceptions=True)` preserves order (one entry per input coroutine), the offending model can be recovered by zipping `raw` with `models`:

```python
for item, model in zip(raw, models):
    if isinstance(item, BaseException):
        logger.error(
            "Unexpected exception in _test_single_model (%s): %s",
            _get_model_id(model),
            item,
        )
        results.append(
            ModelTestResult(
                model_id=_get_model_id(model),
                gateway=model.get("source_gateway", model.get("provider_slug", "unknown")),
                provider=model.get("provider_slug", "unknown"),
                status="error",
                error=str(item)[:200],
            )
        )
    else:
        results.append(item)
```

This makes the error rows in the final report actionable — you can see exactly which model triggered the unexpected exception rather than having to cross-reference logs manually.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/live-test-r..."](https://github.com/alpaca-network/gatewayz-backend/commit/ffcbf5ed774fb62c64361eaeee46ca3189d29eb1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27380033)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->