### PR TITLE
security: close critical RLS leak (users/api_keys/payments)

### DIFF
--- a/scripts/security/rotate_exposed_api_keys.py
+++ b/scripts/security/rotate_exposed_api_keys.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Rotate all gw_live_* API keys on prod.
+
+Context: a Supabase RLS misconfiguration (fixed in migrations 20260527000000/1/2)
+exposed the entire `users` table — including plaintext api_key — to anyone
+with the publishable anon key from approximately project creation through
+2026-05-27. Every existing gw_live_* key must be considered compromised.
+
+This script:
+  1) Lists every active user with an existing api_key
+  2) Generates a new api_key for each
+  3) Writes the new key back into users.api_key
+  4) (optional) Updates the matching api_keys_new row
+  5) Outputs a CSV: user_id,email,old_key_prefix,new_key with secrets redacted
+
+NOT RUN AUTOMATICALLY. Run after deciding the customer notification plan.
+Service role key must be supplied via SUPABASE_SERVICE_KEY env var.
+"""
+
+import os
+import secrets
+import sys
+import time
+from typing import Any
+
+from supabase import create_client
+
+PROD_URL = "https://ynleroehyrmaafkgjgmr.supabase.co"
+KEY = os.environ.get("SUPABASE_SERVICE_KEY")
+if not KEY:
+    print("ERROR: set SUPABASE_SERVICE_KEY env var to the prod service_role key", file=sys.stderr)
+    sys.exit(1)
+DRY_RUN = os.environ.get("DRY_RUN", "true").lower() in {"1", "true", "yes"}
+
+client = create_client(PROD_URL, KEY)
+
+
+def gen_key() -> str:
+    """Match existing format: gw_live_<43 url-safe base64 chars>."""
+    return "gw_live_" + secrets.token_urlsafe(32)
+
+
+def main() -> None:
+    print(f"=== API key rotation (DRY_RUN={DRY_RUN}) ===")
+    print()
+
+    page = 0
+    page_size = 500
+    rotated = 0
+    skipped = 0
+    print("user_id,email,old_key_prefix,new_key_prefix,status")
+
+    while True:
+        res = (
+            client.table("users")
+            .select("id, email, api_key, is_active")
+            .order("id")
+            .range(page * page_size, page * page_size + page_size - 1)
+            .execute()
+        )
+        rows = res.data or []
+        if not rows:
+            break
+        for u in rows:
+            uid = u["id"]
+            email = u.get("email") or ""
+            old = u.get("api_key") or ""
+            if not old.startswith("gw_live_"):
+                skipped += 1
+                continue
+            new = gen_key()
+            old_pref = old[:15]
+            new_pref = new[:15]
+            status = "DRY_RUN"
+            if not DRY_RUN:
+                try:
+                    client.table("users").update({"api_key": new}).eq("id", uid).execute()
+                    # Best-effort: keep api_keys_new in sync if present
+                    try:
+                        client.table("api_keys_new").update({"api_key": new}).eq(
+                            "user_id", uid
+                        ).eq("api_key", old).execute()
+                    except Exception:
+                        pass
+                    status = "rotated"
+                    rotated += 1
+                except Exception as e:
+                    status = f"ERROR:{str(e)[:60]}"
+            print(f"{uid},{email},{old_pref},{new_pref},{status}")
+        if len(rows) < page_size:
+            break
+        page += 1
+        time.sleep(0.05)
+
+    print()
+    print(f"=== Done. rotated={rotated} skipped={skipped} ===")
+    if DRY_RUN:
+        print("DRY_RUN=true — no rows were written. Set DRY_RUN=false to apply.")
+
+
+if __name__ == "__main__":
+    main()

--- a/supabase/migrations/20260527000000_emergency_rls_lockdown.sql
+++ b/supabase/migrations/20260527000000_emergency_rls_lockdown.sql
@@ -1,0 +1,72 @@
+-- EMERGENCY: Critical RLS gaps surfaced by Supabase advisor 2026-05-27.
+--
+-- Verified externally with the public anon key:
+--   GET /rest/v1/users?limit=1   returned plaintext rows including api_key, email,
+--                                 stripe_customer_id, stripe_subscription_id.
+--   GET /rest/v1/payments        returned amounts + stripe_payment_intent_id.
+--   GET /rest/v1/rate_limit_usage returned plaintext api_key (second exposure).
+--   GET /rest/v1/chat_completion_requests returned per-request logs.
+--   GET /rest/v1/message_feedback returned user content/PII.
+--   GET /rest/v1/security_audit_log returned IPs + fingerprints.
+--
+-- Root cause: RLS was never enabled on these tables and the default Supabase
+-- grants give anon + authenticated SELECT on everything in `public`.
+--
+-- The backend uses the service_role key for all writes; service_role BYPASSES RLS
+-- so the application keeps working.  We:
+--   1) ENABLE RLS (any non-service_role reader now gets zero rows by default)
+--   2) REVOKE anon + authenticated grants (defense in depth, in case RLS is
+--      ever disabled again — and to remove these tables from the publicly
+--      exposed PostgREST schema entirely)
+--
+-- Tables in scope (this migration):
+--   users, payments, rate_limit_usage, chat_completion_requests,
+--   message_feedback, security_audit_log
+--
+-- A follow-up migration covers the remaining advisor findings (the operational
+-- leakage tables: model_pricing, model_aliases, subscription_products, etc).
+
+-- ============================================================================
+-- 1) USERS — leaks api_key + email + stripe IDs
+-- ============================================================================
+ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.users FROM anon, authenticated;
+
+-- ============================================================================
+-- 2) PAYMENTS — leaks Stripe payment_intent_id + amounts
+-- ============================================================================
+ALTER TABLE public.payments ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.payments FROM anon, authenticated;
+
+-- ============================================================================
+-- 3) RATE_LIMIT_USAGE — leaks plaintext api_key (second copy of the leak)
+-- ============================================================================
+ALTER TABLE public.rate_limit_usage ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.rate_limit_usage FROM anon, authenticated;
+
+-- ============================================================================
+-- 4) CHAT_COMPLETION_REQUESTS — leaks per-request logs
+-- ============================================================================
+ALTER TABLE public.chat_completion_requests ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.chat_completion_requests FROM anon, authenticated;
+
+-- ============================================================================
+-- 5) MESSAGE_FEEDBACK — leaks user/message content
+-- ============================================================================
+ALTER TABLE public.message_feedback ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.message_feedback FROM anon, authenticated;
+
+-- ============================================================================
+-- 6) SECURITY_AUDIT_LOG — leaks IPs + fingerprints (helps attackers learn detection)
+-- ============================================================================
+ALTER TABLE public.security_audit_log ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.security_audit_log FROM anon, authenticated;
+
+-- service_role retains full access (it bypasses RLS by default; explicit grants
+-- here are belt-and-suspenders).
+GRANT ALL ON public.users TO service_role;
+GRANT ALL ON public.payments TO service_role;
+GRANT ALL ON public.rate_limit_usage TO service_role;
+GRANT ALL ON public.chat_completion_requests TO service_role;
+GRANT ALL ON public.message_feedback TO service_role;
+GRANT ALL ON public.security_audit_log TO service_role;

--- a/supabase/migrations/20260527000001_full_security_hardening.sql
+++ b/supabase/migrations/20260527000001_full_security_hardening.sql
@@ -1,0 +1,130 @@
+-- Full security hardening based on Supabase advisor findings 2026-05-27.
+--
+-- Companion to 20260527000000_emergency_rls_lockdown.sql which already locked
+-- down the most critical leak (users, payments, rate_limit_usage,
+-- chat_completion_requests, message_feedback, security_audit_log).
+--
+-- This migration addresses:
+--   A) The remaining 11 RLS-disabled tables (operational + competitive data)
+--   B) 8 SECURITY DEFINER views that bypass underlying-table RLS
+--   C) 58 functions missing SET search_path (search_path injection risk)
+--
+-- All changes are safe for the FastAPI backend because it uses the
+-- service_role key which BYPASSES RLS. Frontend code that talks directly to
+-- PostgREST with the anon key will need to be reviewed (currently nothing
+-- shows it does — only the backend hits the DB).
+
+-- ============================================================================
+-- A) Lock down remaining tables (RLS + revoke anon/authenticated grants)
+-- ============================================================================
+DO $block$
+DECLARE
+    t text;
+    tables text[] := ARRAY[
+        'rate_limit_usage',                  -- already locked in prior migration but idempotent
+        'model_routing_rules',               -- reveals routing logic
+        'model_quality_scores',              -- internal quality data
+        'reconciliation_logs',               -- internal job results
+        'temporary_email_domains',           -- bot-detection list
+        'unique_models',                     -- catalog (less sensitive but private)
+        'unique_models_provider',
+        'chat_completion_daily_aggregates',  -- usage aggregates per user
+        'system_config',                     -- internal config
+        'model_pricing',                     -- pricing strategy
+        'subscription_products',             -- stripe product IDs + pricing tiers
+        'model_aliases',                     -- routing logic
+        'model_provider_mappings',           -- routing logic
+        'partner_trials',                    -- partner deal terms
+        'partner_trial_analytics'            -- partner usage metrics
+    ];
+BEGIN
+    FOREACH t IN ARRAY tables LOOP
+        EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', t);
+        EXECUTE format('REVOKE ALL ON public.%I FROM anon, authenticated', t);
+        EXECUTE format('GRANT ALL ON public.%I TO service_role', t);
+    END LOOP;
+END;
+$block$;
+
+-- ============================================================================
+-- B) Rebuild SECURITY DEFINER views without the SECURITY DEFINER property.
+--    The views remain readable by the backend via service_role; we just stop
+--    them from bypassing RLS on the underlying tables.
+--
+--    pg_views.definition gives us the SELECT body — we wrap it in a fresh
+--    CREATE OR REPLACE VIEW without security_invoker setting → defaults to
+--    SECURITY INVOKER (the safe default).
+-- ============================================================================
+DO $block$
+DECLARE
+    v text;
+    views text[] := ARRAY[
+        'butter_cache_analytics',
+        'unique_models_summary',
+        'model_usage_analytics',
+        'api_key_tracking_quality',
+        'ongoing_downtime_incidents',
+        'provider_health_current',
+        'model_status_current',
+        'unique_models_provider_count'
+    ];
+    view_def text;
+BEGIN
+    FOREACH v IN ARRAY views LOOP
+        SELECT pg_get_viewdef(format('public.%I', v)::regclass, true)
+          INTO view_def;
+        IF view_def IS NULL THEN
+            RAISE WARNING 'View public.% not found, skipping', v;
+            CONTINUE;
+        END IF;
+        -- Recreate as SECURITY INVOKER (default). Postgres 15+ supports
+        -- `security_invoker = true` explicitly but plain CREATE OR REPLACE
+        -- VIEW already strips SECURITY DEFINER unless explicitly set.
+        EXECUTE format(
+            'CREATE OR REPLACE VIEW public.%I WITH (security_invoker = true) AS %s',
+            v, view_def
+        );
+        -- Keep service_role grant; remove anon/authenticated grants.
+        EXECUTE format('REVOKE ALL ON public.%I FROM anon, authenticated', v);
+        EXECUTE format('GRANT SELECT ON public.%I TO service_role', v);
+    END LOOP;
+END;
+$block$;
+
+-- ============================================================================
+-- C) Set search_path on every function in `public` that lacks one. Iterates
+--    pg_proc dynamically so all 58 functions are covered (and any new ones).
+--    SET search_path = pg_catalog, public is the recommended hardening.
+-- ============================================================================
+DO $block$
+DECLARE
+    r record;
+    sig text;
+BEGIN
+    FOR r IN
+        SELECT n.nspname AS schema_name,
+               p.proname AS func_name,
+               pg_get_function_identity_arguments(p.oid) AS args,
+               p.proconfig
+          FROM pg_proc p
+          JOIN pg_namespace n ON n.oid = p.pronamespace
+         WHERE n.nspname = 'public'
+           AND p.prokind = 'f'
+           AND (p.proconfig IS NULL
+                OR NOT EXISTS (
+                    SELECT 1 FROM unnest(p.proconfig) cfg
+                     WHERE cfg LIKE 'search_path=%'
+                ))
+    LOOP
+        sig := format('%I.%I(%s)', r.schema_name, r.func_name, r.args);
+        BEGIN
+            EXECUTE format(
+                'ALTER FUNCTION %s SET search_path = pg_catalog, public',
+                sig
+            );
+        EXCEPTION WHEN OTHERS THEN
+            RAISE WARNING 'Could not set search_path on %: %', sig, SQLERRM;
+        END;
+    END LOOP;
+END;
+$block$;

--- a/supabase/migrations/20260527000002_final_security_hardening.sql
+++ b/supabase/migrations/20260527000002_final_security_hardening.sql
@@ -1,0 +1,121 @@
+-- Final security hardening pass after migrations 20260527000000 + 000001.
+--
+-- Remaining Supabase advisor findings:
+--   A) 18 SECURITY DEFINER functions are EXECUTE-grantable to anon and
+--      authenticated. SECURITY DEFINER functions run with the OWNER's
+--      privileges so they bypass RLS on whatever they touch. Anyone with the
+--      publishable anon key can call them via /rest/v1/rpc/<func>.
+--   B) 9 tables have RLS policies with `USING (true)` (rls_policy_always_true).
+--      These were redundant once we REVOKEd the table-level grants in
+--      migration 000000 (revoke fires before RLS), but they're still a
+--      footgun — if someone later re-grants SELECT on the table, the
+--      always-true policy makes everything readable again.
+--   C) provider_stats_24h matview is exposed via PostgREST API.
+--
+-- All changes are safe for the FastAPI backend (uses service_role; bypasses
+-- both EXECUTE grants and RLS policies).
+
+-- ============================================================================
+-- A) Revoke EXECUTE on internal SECURITY DEFINER functions from anon + authenticated
+-- ============================================================================
+DO $block$
+DECLARE
+    f text;
+    funcs text[] := ARRAY[
+        'cleanup_chat_completion_requests',
+        'cleanup_model_health_history',
+        'cleanup_rate_limit_alerts',
+        'get_admin_notification_unread_count',
+        'get_api_key_request_summary',
+        'get_available_coupons',
+        'get_chat_completion_summary_by_api_key',
+        'get_chat_completion_summary_by_filters',
+        'is_coupon_redeemable',
+        'mark_all_admin_notifications_read',
+        'mark_expired_trials',
+        'reconcile_paid_users_trial_status',
+        'record_trial_grant',
+        'rollup_chat_completion_requests',
+        'run_and_log_expired_trials',
+        'run_and_log_trial_reconciliation',
+        'run_and_log_ttl_cleanups',
+        'update_model_tier'
+    ];
+    proc_oid oid;
+BEGIN
+    FOREACH f IN ARRAY funcs LOOP
+        FOR proc_oid IN
+            SELECT p.oid FROM pg_proc p
+            JOIN pg_namespace n ON n.oid = p.pronamespace
+            WHERE n.nspname = 'public' AND p.proname = f
+        LOOP
+            EXECUTE format(
+                'REVOKE EXECUTE ON FUNCTION %s FROM anon, authenticated, PUBLIC',
+                proc_oid::regprocedure
+            );
+            EXECUTE format(
+                'GRANT EXECUTE ON FUNCTION %s TO service_role',
+                proc_oid::regprocedure
+            );
+        END LOOP;
+    END LOOP;
+END;
+$block$;
+
+-- ============================================================================
+-- B) Drop always-true RLS policies. The tables are already protected by
+--    REVOKEd table grants (migration 000000) and being absent from
+--    anon/authenticated. Dropping these policies removes a footgun: if
+--    SELECT is ever re-granted, the always-true policy would make the
+--    table publicly readable again.
+-- ============================================================================
+DO $block$
+DECLARE
+    r record;
+BEGIN
+    FOR r IN
+        SELECT schemaname, tablename, policyname
+          FROM pg_policies
+         WHERE schemaname = 'public'
+           AND tablename IN (
+               'activity_log',
+               'api_keys_new',
+               'coupon_redemptions',
+               'coupons',
+               'credit_transactions',
+               'payments',
+               'users',
+               'velocity_mode_events'
+           )
+           AND (
+               qual = 'true' OR qual IS NULL  -- USING (true) or no USING clause
+               OR with_check = 'true'
+           )
+    LOOP
+        BEGIN
+            EXECUTE format(
+                'DROP POLICY IF EXISTS %I ON public.%I',
+                r.policyname, r.tablename
+            );
+            RAISE NOTICE 'Dropped always-true policy %.%', r.tablename, r.policyname;
+        EXCEPTION WHEN OTHERS THEN
+            RAISE WARNING 'Could not drop policy %.%: %', r.tablename, r.policyname, SQLERRM;
+        END;
+    END LOOP;
+END;
+$block$;
+
+-- ============================================================================
+-- C) Remove materialized view from PostgREST API
+-- ============================================================================
+DO $block$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_matviews
+         WHERE schemaname = 'public' AND matviewname = 'provider_stats_24h'
+    ) THEN
+        EXECUTE 'REVOKE ALL ON public.provider_stats_24h FROM anon, authenticated';
+        EXECUTE 'GRANT SELECT ON public.provider_stats_24h TO service_role';
+    END IF;
+END;
+$block$;


### PR DESCRIPTION
## Summary

**Severity: CRITICAL** — the entire `users` table (including plaintext `gw_live_*` api_key, emails, Stripe IDs) was readable by anyone with the publishable anon key. Externally verified via PostgREST before fix.

Migrations were applied to prod **before** opening this PR to stop the active leak.

## What leaked (verified before fix)

| Table | Exposed data |
|---|---|
| `users` | api_key, email, stripe_customer_id, stripe_subscription_id, credits, privy_user_id |
| `payments` | amount, stripe_payment_intent_id, stripe_checkout_session_id |
| `rate_limit_usage` | api_key (second exposure) |
| `chat_completion_requests` | Full per-request logs |
| `message_feedback` | User content stored in metadata |
| `security_audit_log` | IPs, fingerprints, detection internals |

Plus 11 more tables leaking pricing strategy, partner deal terms, routing logic, etc.

## Three migrations

### `20260527000000_emergency_rls_lockdown.sql`
Enables RLS + REVOKEs anon/authenticated grants on the 6 sensitive tables. Stops the bleed at the door.

### `20260527000001_full_security_hardening.sql`
- 11 more RLS-disabled tables
- Rebuilds 8 SECURITY DEFINER views as SECURITY INVOKER
- Sets `search_path = pg_catalog, public` on 58 functions

### `20260527000002_final_security_hardening.sql`
- REVOKEs EXECUTE on 18 internal SECURITY DEFINER RPCs
- Drops 12 `USING(true)` RLS policies
- Removes provider_stats_24h matview from PostgREST

## Advisor before → after

- ERROR: **27 → 0**
- WARN: 105 → 1 (cosmetic pg_trgm-in-public)
- INFO: rls_enabled_no_policy is deny-by-default — desired state

## Post-fix verification

```
$ curl https://ynler...supabase.co/rest/v1/users?limit=1 -H "apikey: <ANON>"
HTTP 401  permission denied for table users
```
Service role (backend) unaffected — confirmed via probe.

## Operator action required

Run `scripts/security/rotate_exposed_api_keys.py` **after** notifying customers. Every `gw_live_*` key issued before 2026-05-27 should be considered compromised. Script defaults to DRY_RUN=true.

## Test plan

- [x] Migration applied to prod (stops the leak)
- [x] Anon probe confirms 401 / empty on all formerly-exposed tables
- [x] Service-role probe confirms backend keeps working
- [x] Supabase advisor: 0 ERRORs
- [ ] Run rotation script after deciding customer notification plan
- [ ] Customer-facing comms (operator action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented emergency security lockdown on database tables to restrict unauthorized access to sensitive user and payment data
  * Added automated API key rotation for exposed credentials
  * Enhanced database access controls and security policies to prevent unauthorized data exposure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Alpaca-Network/gatewayz-backend/pull/2120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->