### PR TITLE
Phase 3 credit-ledger shadow dual-write + Phase 1/3 migration & Phase 5 multi-region rollout docs

### DIFF
--- a/docs/superpowers/specs/2026-06-17-phase1-3-migration-review.md
+++ b/docs/superpowers/specs/2026-06-17-phase1-3-migration-review.md
@@ -1,0 +1,75 @@
+# Phase 1 & 3 Migration Review + Apply Guide (Gatewayz One)
+
+**Status:** staged on `main`, NOT applied. Review this before running. **You apply** — these touch the production DB; do not let an automated agent run them blind.
+
+**Files**
+- `supabase/migrations/20260617000000_gatewayz_one_phase1_registry.sql` (142 lines)
+- `supabase/migrations/20260617000001_gatewayz_one_phase3_credit_ledger.sql` (51 lines)
+
+---
+
+## TL;DR
+
+Both migrations are **purely additive and idempotent** — no `DROP`, no column retypes, no data rewrites, every statement guarded by `IF NOT EXISTS` / a constraint-existence check. **Risk: LOW.** No application code reads the new Phase 1 schema yet, and the Phase 3 ledger is only written by the new flag-gated shadow path (off by default). One thing to confirm before running: the `user_id bigint` typing vs `public.users.id` (FKs were deliberately left off to avoid a type-mismatch failure).
+
+---
+
+## What each migration does
+
+### Phase 1 — registry & projection schema (`…000000`)
+- `providers`: + `tier` (`'niche'` default, CHECK `core|aggregator|niche`), `region_affinity`, `async_streaming`, `auth_type`, `base_url`. Retires the `ENABLED_PROVIDERS` env var in favour of `is_active` + `tier`.
+- `models_catalog`: + `canonical_id`, `capabilities` (jsonb), `modality`, `context_length`, `deprecated_at`; partial index on `canonical_id WHERE deprecated_at IS NULL`.
+- **NEW** `model_provider_offers` — the (model × provider) join the smart router scores over (`upstream_cost`, `quality_prior`, `p50_ms`, `p95_ms`, `is_active`; UNIQUE `(canonical_id, provider_slug)`). RLS on, no policy.
+- **NEW** `routing_policies` — per-key / system-default policy + weights (CHECK `cost|latency|quality|balanced`). RLS on, no policy.
+- **NEW** `user_memory` — portable per-user memory (`kind`, `content`, `salience`). RLS on, no policy.
+- `chat_sessions`: + `conversation_id` (uuid), `rolling_summary`; partial index.
+
+### Phase 3 — append-only credit ledger (`…000001`)
+- **NEW** `credit_ledger` — one debit-or-credit line per row; `ref` (idempotency = request id), `account` (`user:subscription_allowance|user:purchased_credits|revenue`), `debit`/`credit` `numeric(14,10)` (CHECK ≥ 0, exactly one side non-zero), `state` (`reserved|settled|released`). Indexes on `ref` and `(user_id, created_at)`.
+- Immutability: `BEFORE UPDATE OR DELETE` trigger raises — append-only audit trail.
+- RLS on, no permissive policy → backend `service_role` only.
+
+## Safety assessment
+
+| Dimension | Finding |
+|-----------|---------|
+| Destructive ops | None — no DROP/TRUNCATE/retype/NOT NULL-on-existing |
+| Idempotency | Full — re-runnable; `IF NOT EXISTS` + constraint guards |
+| Locking | `ADD COLUMN` is metadata-only in PG11+ (defaults here are constant/non-volatile → no table rewrite). New columns with `NOT NULL DEFAULT` on `providers`/`models_catalog` are fast. Brief `ACCESS EXCLUSIVE` per ALTER; run off-peak on very large tables. |
+| Security | New tables RLS-enabled, no permissive policy → only `service_role` (which bypasses RLS) can access. Matches the 2026-05-27 hardening posture. |
+| App impact at apply time | Zero — no code reads Phase 1 columns; `credit_ledger` only written when `CREDIT_LEDGER_SHADOW_ENABLED=true` (default false). |
+
+## ⚠️ Confirm before applying
+1. **`user_id` type / FK.** Both migrations type `user_id` as `bigint` to match the integer user ids in the codebase, and **omit the FK** to `public.users(id)`. Confirm `public.users.id` is an integer/bigint; if so, add `REFERENCES public.users(id)` (and to `credit_ledger.user_id`). If `users.id` is uuid, change these columns to uuid first.
+2. **`numeric(14,10)`** gives 4 integer digits — max ~9999.9999999999 per line. Confirm no single charge/balance line exceeds that; widen precision if needed.
+
+## Apply steps (you run)
+```bash
+# from repo root, with the Supabase project linked (supabase link --project-ref <ref>)
+supabase migration list            # confirm both are pending
+supabase db push                   # applies all pending migrations
+# or apply one explicitly via the SQL editor / psql against the prod connection string
+```
+Recommended: apply to **staging first**, run the verification queries, then prod.
+
+## Verification (post-apply)
+```sql
+-- Phase 1
+SELECT column_name FROM information_schema.columns
+ WHERE table_name='providers' AND column_name IN ('tier','region_affinity','async_streaming','auth_type','base_url');
+SELECT to_regclass('public.model_provider_offers'), to_regclass('public.routing_policies'), to_regclass('public.user_memory');
+-- Phase 3
+SELECT to_regclass('public.credit_ledger');
+-- immutability trigger fires:
+-- UPDATE public.credit_ledger SET debit=0 WHERE id=<any>;  -- expect: ERROR append-only
+SELECT relrowsecurity FROM pg_class WHERE relname IN ('credit_ledger','model_provider_offers','routing_policies','user_memory');
+```
+
+## Rollback
+Additive, so rollback is dropping the new objects (only if nothing has written to them):
+```sql
+DROP TABLE IF EXISTS public.credit_ledger;            -- + function credit_ledger_block_mutations
+DROP TABLE IF EXISTS public.model_provider_offers, public.routing_policies, public.user_memory;
+-- columns: ALTER TABLE public.providers DROP COLUMN IF EXISTS tier, ... (etc.)
+```
+Once the shadow path has written ledger rows, prefer leaving the table (it's an audit trail) and just disabling `CREDIT_LEDGER_SHADOW_ENABLED`.

--- a/docs/superpowers/specs/2026-06-17-phase5-multi-region-deploy-plan.md
+++ b/docs/superpowers/specs/2026-06-17-phase5-multi-region-deploy-plan.md
@@ -1,0 +1,41 @@
+# Phase 5 — Multi-Region Deploy Plan (Gatewayz One)
+
+**Status:** plan only — no infra changes. The selection core (`src/services/region_router.py`) is built + tested; this is the rollout from single-region to active-active.
+
+## Current state
+- **Gateway (data plane):** stateless FastAPI app (Vercel `api/index.py` / Railway/Docker `start.sh`), single region.
+- **`region_router.py` (pure, built):** `Region` dataclass + `is_region_eligible(region)`, `select_regions(regions, *, home)` → ordered eligible regions, `primary_region(...)`. No I/O — the decision core; not yet wired or fed real region inventory.
+- **State today:** Supabase (single primary Postgres), Redis (rate limits / caches), Stripe/Resend external.
+
+## Target: active-active, latency-routed
+Two+ regions each running the full stateless gateway; users hit the nearest healthy region; control-plane config (registry, routing_policies — Phase 1 tables) is shared; the billing ledger (Phase 3) is the cross-region source of truth for money.
+
+```
+            ┌─ region A (gateway, Redis-A) ─┐
+client ─ GeoDNS/anycast ─┤                              ├─ Supabase (primary + read replicas)
+            └─ region B (gateway, Redis-B) ─┘            └─ providers (region_affinity from Phase 1)
+```
+
+## What gates multi-region (must resolve before active-active)
+| Concern | Issue | Resolution |
+|---------|-------|------------|
+| **Credit balances** | Concurrent debits in two regions can oversell a balance (last-writer-wins) | Cut billing over to the Phase 3 ledger with atomic reserve→settle (single source of truth); until then, route a user's billing-affecting writes to one **home** region (`select_regions(home=...)`). |
+| **Rate limits** | Per-region Redis = N× the intended limit | Global limit store (shared Redis / Upstash global) OR partition limits per region and divide budgets. |
+| **DB writes** | Single Postgres primary = cross-region write latency | Keep writes to primary; add read replicas per region for catalog/registry reads (mostly-read path). |
+| **Config drift** | Registry/policies must be identical everywhere | Already centralized in Supabase (Phase 1 tables) — regions read the same control plane. |
+| **Provider affinity** | Some providers are region-locked | Use `providers.region_affinity` (Phase 1) to bias `select_regions`/failover per region. |
+
+## Rollout phases (each independently reversible)
+1. **Inventory + wire (no traffic change).** Feed real `Region` inventory (from config/registry) into `region_router`; expose `primary_region`/`select_regions` behind a flag; log the selected region as a header. Single region still serves all traffic. Tests: selection eligibility/ordering (already covered) + wiring.
+2. **Passive second region.** Deploy the gateway to region B pointed at the same Supabase primary + its own Redis. Health-check only; no user traffic. Verify catalog/inference parity.
+3. **Read-routed.** GeoDNS/anycast sends nearest-region traffic for **read/inference** paths; billing-affecting writes pinned to the home region (`select_regions(home=user_home)`). Watch latency + error budgets.
+4. **Active-active billing.** Only after the Phase 3 ledger is the billing source of truth (atomic reserve/settle handles concurrent debits). Then drop the home-region pin; both regions accept billing writes.
+5. **Failover drills.** Kill region A; confirm region B absorbs traffic within DNS TTL; confirm no double-charge / no lost rate-limit enforcement.
+
+## Dependencies / sequencing
+- **Phase 1 migration applied** → `providers.region_affinity`, control-plane tables exist.
+- **Phase 3 ledger cut over** (see the shadow→reconcile→switch plan) → required before phase 4 (active-active billing). Until then, stay at rollout phase 3 with home-region write pinning.
+- Global/partitioned rate-limit store decision (infra).
+
+## Out of scope here (needs infra/owner)
+GeoDNS/anycast provider choice, Redis global vs per-region, Supabase read-replica provisioning, region list + capacity. This doc is the sequencing + invariants; the infra changes are a separate, owner-driven step.

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -123,6 +123,13 @@ class Config:
     # Abuse / Cost Controls
     # Anonymous (unauthenticated) inference is off by default. Set to "true" to allow.
     ANONYMOUS_ENABLED = os.environ.get("ANONYMOUS_ENABLED", "false").lower() in {"1", "true", "yes"}
+    # Phase 3 credit ledger (Gatewayz One §6.D), SHADOW dual-write. Off by default.
+    # When true, a settled double-entry is recorded in public.credit_ledger alongside
+    # the authoritative deduction (non-blocking) so the ledger can be reconciled before
+    # any cutover. Requires the credit_ledger migration to be applied first.
+    CREDIT_LEDGER_SHADOW_ENABLED = os.environ.get(
+        "CREDIT_LEDGER_SHADOW_ENABLED", "false"
+    ).lower() in {"1", "true", "yes"}
     # Reject inference requests for models without a row in model_pricing.
     REQUIRE_MODEL_PRICING = os.environ.get("REQUIRE_MODEL_PRICING", "true").lower() in {"1", "true", "yes"}
     # Subscription statuses that may NOT call the API (comma-separated).

--- a/src/services/billing/credit_handler.py
+++ b/src/services/billing/credit_handler.py
@@ -502,13 +502,29 @@ async def handle_credits_and_usage(
             )
 
         # Phase 3 (Gatewayz One §6.D) SHADOW dual-write: mirror this completed
-        # deduction as a settled double-entry in the credit ledger so the ledger can
-        # be reconciled against the live system before any cutover. Flag-gated (off by
-        # default) and fully non-blocking — a failure here must never affect billing.
+        # deduction as a settled double-entry in the credit ledger so it can be
+        # reconciled against the live system before any cutover. Flag-gated (off by
+        # default). The store call never raises and runs its Supabase I/O off-thread;
+        # on the non-streaming path it is awaited, so when enabled it adds the ledger
+        # write to request latency (acceptable for the shadow phase — streaming
+        # backgrounds it via the _with_fallback task).
+        #
+        # Skip exactly the cases deduct_credits itself bypasses (admin tier, and
+        # sub-$0.000001 amounts) — otherwise the shadow would record revenue for money
+        # that was never actually deducted, diverging from the live system.
+        # TODO(cutover): derive the allowance/purchased split from the amount
+        # deduct_credits actually spent (it re-reads fresh balances) instead of this
+        # request's in-memory snapshot, which can be stale under concurrency. The
+        # REVENUE total stays correct (= cost); only the debit split can drift.
         try:
             from src.config import Config
 
-            if Config.CREDIT_LEDGER_SHADOW_ENABLED and user:
+            if (
+                Config.CREDIT_LEDGER_SHADOW_ENABLED
+                and user
+                and float(cost or 0) >= 0.000001
+                and user.get("tier") != "admin"
+            ):
                 from src.services.billing.credit_ledger_store import record_shadow_settlement
 
                 await record_shadow_settlement(

--- a/src/services/billing/credit_handler.py
+++ b/src/services/billing/credit_handler.py
@@ -501,6 +501,26 @@ async def handle_credits_and_usage(
                 f"Failed to update rate limit usage after successful deduction for user {user.get('id')}: {e}"
             )
 
+        # Phase 3 (Gatewayz One §6.D) SHADOW dual-write: mirror this completed
+        # deduction as a settled double-entry in the credit ledger so the ledger can
+        # be reconciled against the live system before any cutover. Flag-gated (off by
+        # default) and fully non-blocking — a failure here must never affect billing.
+        try:
+            from src.config import Config
+
+            if Config.CREDIT_LEDGER_SHADOW_ENABLED and user:
+                from src.services.billing.credit_ledger_store import record_shadow_settlement
+
+                await record_shadow_settlement(
+                    ref=request_id,
+                    user_id=user.get("id"),
+                    cost=cost,
+                    allowance=user.get("subscription_allowance") or 0,
+                    purchased=user.get("purchased_credits") or 0,
+                )
+        except Exception as e:
+            logger.warning("credit_ledger shadow dual-write failed (non-fatal): %s", e)
+
     return cost
 
 

--- a/src/services/billing/credit_ledger_store.py
+++ b/src/services/billing/credit_ledger_store.py
@@ -1,0 +1,112 @@
+"""Persistence + shadow-recording for the Phase 3 credit ledger (Gatewayz One).
+
+Bridges the pure ledger math (:mod:`src.services.credit_ledger`) to the
+append-only ``public.credit_ledger`` table. Used in SHADOW mode: alongside the
+authoritative ``subscription_allowance``/``purchased_credits`` deduction it
+records a settled double-entry, so the ledger can be reconciled against the live
+system *before* any cutover to ledger-authoritative billing.
+
+Contract for the shadow path:
+  * **Non-blocking** — :func:`record_shadow_settlement` never raises; a failure
+    here must never affect billing or the request. It returns ``True`` on write,
+    ``False`` on any skip/failure (logged at WARNING).
+  * **Idempotent** — keyed on ``ref`` (the request id). If the ref already has
+    ledger rows, the write is skipped (client retries won't double-record).
+  * **Allowance-first** — mirrors how ``deduct_credits`` spends balances, via
+    :func:`src.services.credit_ledger.split_charge`.
+
+The table is created by ``supabase/migrations/20260617000001_gatewayz_one_phase3_credit_ledger.sql``;
+until that migration is applied (and ``CREDIT_LEDGER_SHADOW_ENABLED=true``) this
+module is dormant.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from decimal import Decimal
+
+from src.services.credit_ledger import (
+    ALLOWANCE,
+    PURCHASED,
+    REVENUE,
+    EntryState,
+    LedgerEntry,
+    split_charge,
+)
+
+logger = logging.getLogger(__name__)
+
+_ZERO = Decimal("0")
+
+
+def build_settled_entries(ref: str, cost, allowance, purchased) -> list[LedgerEntry]:
+    """Build a balanced, SETTLED double-entry for a completed charge.
+
+    Spends ``allowance`` before ``purchased`` (matching ``deduct_credits``) and
+    credits ``revenue`` for the total. Raises ``ValueError`` /
+    ``InsufficientBalance`` from :func:`split_charge` for a bad/oversized charge —
+    callers in the shadow path swallow those.
+    """
+    split = split_charge(cost, allowance, purchased)
+    entries: list[LedgerEntry] = []
+    if split.from_allowance > 0:
+        entries.append(LedgerEntry(ref, ALLOWANCE, split.from_allowance, _ZERO, EntryState.SETTLED))
+    if split.from_purchased > 0:
+        entries.append(LedgerEntry(ref, PURCHASED, split.from_purchased, _ZERO, EntryState.SETTLED))
+    if split.total > 0:
+        entries.append(LedgerEntry(ref, REVENUE, _ZERO, split.total, EntryState.SETTLED))
+    return entries
+
+
+def _entries_to_rows(entries: list[LedgerEntry], user_id) -> list[dict]:
+    """Serialize ledger entries to ``credit_ledger`` insert rows (Decimals as str)."""
+    return [
+        {
+            "ref": e.ref,
+            "user_id": user_id,
+            "account": e.account,
+            "debit": str(e.debit),
+            "credit": str(e.credit),
+            "state": e.state.value,
+        }
+        for e in entries
+    ]
+
+
+def _record_shadow_settlement_sync(ref, user_id, cost, allowance, purchased) -> bool:
+    """Synchronous core of :func:`record_shadow_settlement`. Never raises."""
+    try:
+        if not ref:
+            return False
+
+        from src.config.supabase_config import get_supabase_client
+
+        client = get_supabase_client()
+
+        # Idempotency: skip if this ref already has ledger rows (retry-safe).
+        existing = client.table("credit_ledger").select("id").eq("ref", ref).limit(1).execute()
+        if getattr(existing, "data", None):
+            return False
+
+        entries = build_settled_entries(ref, cost, allowance, purchased)
+        if not entries:
+            return False
+
+        client.table("credit_ledger").insert(_entries_to_rows(entries, user_id)).execute()
+        return True
+    except Exception as e:  # never let a shadow write affect billing
+        logger.warning("credit_ledger shadow write skipped (ref=%s): %s", ref, e)
+        return False
+
+
+async def record_shadow_settlement(ref, user_id, cost, allowance, purchased) -> bool:
+    """Record a SETTLED double-entry mirroring a completed deduction (shadow mode).
+
+    Idempotent by ``ref`` and fully non-blocking — returns ``True`` if rows were
+    written, ``False`` on any skip/failure. Runs the blocking Supabase I/O in a
+    thread so it doesn't stall the event loop.
+    """
+    return await asyncio.to_thread(
+        _record_shadow_settlement_sync, ref, user_id, cost, allowance, purchased
+    )

--- a/supabase/migrations/20260617000001_gatewayz_one_phase3_credit_ledger.sql
+++ b/supabase/migrations/20260617000001_gatewayz_one_phase3_credit_ledger.sql
@@ -27,8 +27,15 @@ CREATE TABLE IF NOT EXISTS public.credit_ledger (
     CONSTRAINT credit_ledger_one_sided CHECK ((debit = 0) OR (credit = 0))
 );
 
-CREATE INDEX IF NOT EXISTS idx_credit_ledger_ref
-    ON public.credit_ledger (ref);
+-- (ref, account, state) is UNIQUE: at most one line per account per lifecycle
+-- state for a given ref. This is the DB backstop for the application-level
+-- idempotency check in credit_ledger_store — concurrent same-ref writes (HTTP /
+-- streaming retries) that both pass the app-level SELECT will collide here, so a
+-- duplicate settlement is rejected at the DB. The leading `ref` column also serves
+-- ref lookups. `state` is included so the future reserve→settle→release flow can
+-- append one row per state for the same (ref, account) without a false collision.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_credit_ledger_ref_account_state
+    ON public.credit_ledger (ref, account, state);
 CREATE INDEX IF NOT EXISTS idx_credit_ledger_user_time
     ON public.credit_ledger (user_id, created_at);
 

--- a/tests/billing/test_credit_ledger_store.py
+++ b/tests/billing/test_credit_ledger_store.py
@@ -1,0 +1,106 @@
+"""Tests for the Phase 3 credit-ledger shadow dual-write store.
+
+Covers the pure entry-builder and the non-blocking, idempotent shadow recorder
+(Supabase client mocked). The shadow path must NEVER raise and must skip when a
+ref already has rows.
+"""
+
+import asyncio
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from src.services.credit_ledger import ALLOWANCE, PURCHASED, REVENUE, EntryState, is_balanced
+from src.services.billing.credit_ledger_store import (
+    build_settled_entries,
+    record_shadow_settlement,
+)
+
+
+# --------------------------------------------------------------------------- #
+# build_settled_entries — pure double-entry math
+# --------------------------------------------------------------------------- #
+def test_build_settled_entries_allowance_only():
+    entries = build_settled_entries("req-1", cost="0.50", allowance="2.00", purchased="0")
+    accounts = {e.account: e for e in entries}
+    assert accounts[ALLOWANCE].debit == Decimal("0.50")
+    assert PURCHASED not in accounts  # no purchased line when allowance covers it
+    assert accounts[REVENUE].credit == Decimal("0.50")
+    assert all(e.state is EntryState.SETTLED for e in entries)
+    assert is_balanced(entries)
+
+
+def test_build_settled_entries_spans_allowance_and_purchased():
+    entries = build_settled_entries("req-2", cost="3.00", allowance="2.00", purchased="5.00")
+    accounts = {e.account: e for e in entries}
+    assert accounts[ALLOWANCE].debit == Decimal("2.00")
+    assert accounts[PURCHASED].debit == Decimal("1.00")  # remainder from purchased
+    assert accounts[REVENUE].credit == Decimal("3.00")
+    assert is_balanced(entries)
+
+
+def test_build_settled_entries_zero_cost_is_empty():
+    assert build_settled_entries("req-3", cost="0", allowance="2.00", purchased="0") == []
+
+
+# --------------------------------------------------------------------------- #
+# record_shadow_settlement — non-blocking, idempotent persistence
+# --------------------------------------------------------------------------- #
+def _mock_client(existing_data=None, insert_raises=False):
+    client = MagicMock()
+    table = client.table.return_value
+    table.select.return_value.eq.return_value.limit.return_value.execute.return_value = MagicMock(
+        data=existing_data
+    )
+    if insert_raises:
+        table.insert.side_effect = RuntimeError("supabase down")
+    else:
+        table.insert.return_value.execute.return_value = MagicMock(data=[{"id": 1}])
+    return client
+
+
+def test_record_shadow_settlement_writes_rows():
+    client = _mock_client(existing_data=[])
+    with patch("src.config.supabase_config.get_supabase_client", return_value=client):
+        ok = asyncio.run(
+            record_shadow_settlement(
+                ref="req-10", user_id=7, cost="1.25", allowance="5.00", purchased="0"
+            )
+        )
+    assert ok is True
+    # one insert of the settled rows (allowance debit + revenue credit)
+    inserted = client.table.return_value.insert.call_args.args[0]
+    assert {r["account"] for r in inserted} == {ALLOWANCE, REVENUE}
+    assert all(r["state"] == "settled" and r["user_id"] == 7 and r["ref"] == "req-10" for r in inserted)
+
+
+def test_record_shadow_settlement_idempotent_skips_existing_ref():
+    client = _mock_client(existing_data=[{"id": 99}])  # ref already recorded
+    with patch("src.config.supabase_config.get_supabase_client", return_value=client):
+        ok = asyncio.run(
+            record_shadow_settlement(
+                ref="req-dup", user_id=7, cost="1.00", allowance="5.00", purchased="0"
+            )
+        )
+    assert ok is False
+    client.table.return_value.insert.assert_not_called()
+
+
+def test_record_shadow_settlement_non_blocking_on_error():
+    client = _mock_client(existing_data=[], insert_raises=True)
+    with patch("src.config.supabase_config.get_supabase_client", return_value=client):
+        # must NOT raise — billing path depends on this
+        ok = asyncio.run(
+            record_shadow_settlement(
+                ref="req-err", user_id=7, cost="1.00", allowance="5.00", purchased="0"
+            )
+        )
+    assert ok is False
+
+
+def test_record_shadow_settlement_empty_ref_is_noop():
+    with patch("src.config.supabase_config.get_supabase_client") as get_client:
+        ok = asyncio.run(
+            record_shadow_settlement(ref="", user_id=7, cost="1.00", allowance="5.00", purchased="0")
+        )
+    assert ok is False
+    get_client.assert_not_called()  # bails before touching the DB

--- a/tests/billing/test_credit_ledger_store.py
+++ b/tests/billing/test_credit_ledger_store.py
@@ -104,3 +104,17 @@ def test_record_shadow_settlement_empty_ref_is_noop():
         )
     assert ok is False
     get_client.assert_not_called()  # bails before touching the DB
+
+
+def test_record_shadow_settlement_oversized_cost_is_noop():
+    # cost exceeds allowance+purchased -> split_charge raises InsufficientBalance,
+    # which the shadow path must swallow (return False, never raise, never insert).
+    client = _mock_client(existing_data=[])
+    with patch("src.config.supabase_config.get_supabase_client", return_value=client):
+        ok = asyncio.run(
+            record_shadow_settlement(
+                ref="req-over", user_id=7, cost="10.00", allowance="1.00", purchased="0.50"
+            )
+        )
+    assert ok is False
+    client.table.return_value.insert.assert_not_called()

--- a/tests/services/test_credit_handler.py
+++ b/tests/services/test_credit_handler.py
@@ -292,6 +292,87 @@ class TestHandleCreditsAndUsage:
         mock_rate_limit.assert_called_once()
 
     @pytest.mark.asyncio
+    @patch("src.services.billing.credit_ledger_store.record_shadow_settlement")
+    @patch("src.services.pricing.calculate_cost_async")
+    @patch("src.db.users.deduct_credits")
+    @patch("src.db.users.record_usage")
+    @patch("src.db.rate_limits.update_rate_limit_usage")
+    @patch("src.services.credit_handler._record_credit_metrics")
+    async def test_shadow_dual_write_skipped_when_flag_off(
+        self,
+        mock_metrics,
+        mock_rate_limit,
+        mock_record_usage,
+        mock_deduct,
+        mock_calc_cost,
+        mock_shadow,
+        mock_user,
+        mock_trial_inactive,
+    ):
+        """With CREDIT_LEDGER_SHADOW_ENABLED off (default), the shadow write must
+        never be attempted — the headline no-op guarantee."""
+        from src.config import Config
+
+        mock_calc_cost.return_value = 0.05
+        with patch.object(Config, "CREDIT_LEDGER_SHADOW_ENABLED", False):
+            cost = await handle_credits_and_usage(
+                api_key="test_key",
+                user=mock_user,
+                model="gpt-4",
+                trial=mock_trial_inactive,
+                total_tokens=1000,
+                prompt_tokens=500,
+                completion_tokens=500,
+                elapsed_ms=1000,
+                request_id="req-flagoff",
+            )
+
+        assert cost == 0.05
+        mock_deduct.assert_called_once()
+        mock_shadow.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("src.services.billing.credit_ledger_store.record_shadow_settlement")
+    @patch("src.services.pricing.calculate_cost_async")
+    @patch("src.db.users.deduct_credits")
+    @patch("src.db.users.record_usage")
+    @patch("src.db.rate_limits.update_rate_limit_usage")
+    @patch("src.services.credit_handler._record_credit_metrics")
+    async def test_shadow_dual_write_failure_never_breaks_billing(
+        self,
+        mock_metrics,
+        mock_rate_limit,
+        mock_record_usage,
+        mock_deduct,
+        mock_calc_cost,
+        mock_shadow,
+        mock_user,
+        mock_trial_inactive,
+    ):
+        """With the flag on, a shadow-write error must NOT propagate into billing:
+        the deduction still happens and the cost is returned unchanged."""
+        from src.config import Config
+
+        mock_calc_cost.return_value = 0.05
+        mock_shadow.side_effect = RuntimeError("ledger down")
+        with patch.object(Config, "CREDIT_LEDGER_SHADOW_ENABLED", True):
+            cost = await handle_credits_and_usage(
+                api_key="test_key",
+                user=mock_user,
+                model="gpt-4",
+                trial=mock_trial_inactive,
+                total_tokens=1000,
+                prompt_tokens=500,
+                completion_tokens=500,
+                elapsed_ms=1000,
+                request_id="req-flagon",
+            )
+
+        assert cost == 0.05  # billing unaffected by the shadow failure
+        mock_deduct.assert_called_once()  # authoritative deduction still happened
+        mock_shadow.assert_called_once()  # shadow was attempted (paid, non-admin, >threshold)
+
+    @pytest.mark.asyncio
     @patch("src.services.pricing.calculate_cost_async")
     @patch("src.db.users.deduct_credits")
     @patch("src.db.users.record_usage")


### PR DESCRIPTION
Follow-up to #2125. Implements the chosen Phase 3 rollout approach (shadow / dual-write first) and delivers the migration-apply guide and multi-region deploy plan. CI is billing-locked; verified against the full local suite — **zero new test failures vs the clean-HEAD baseline**.

## Phase 3 billing — shadow dual-write (code)
- `src/services/billing/credit_ledger_store.py` (NEW): `build_settled_entries()` (allowance-first split via the pure `credit_ledger` math) + `record_shadow_settlement()` — idempotent by `ref`, off-thread Supabase I/O, **never raises**.
- `credit_handler.handle_credits_and_usage`: guarded shadow write after a successful paid deduction. **Flag-gated** (`CREDIT_LEDGER_SHADOW_ENABLED`, default **false**) and **non-blocking** — a ledger failure can never affect billing.
- 7 unit tests (entry math + write / idempotency / non-blocking / empty-ref), Supabase mocked.
- **Dormant** until the Phase 3 migration is applied AND the flag is set.

## Docs (deliverables for the other two decisions)
- **Migration review + apply guide** (`docs/.../2026-06-17-phase1-3-migration-review.md`): both Phase 1/3 migrations are additive/idempotent → **LOW risk**; flags the `user_id`/FK confirm-before-apply; exact `supabase db push` steps, verification queries, rollback. **You apply** — not automated.
- **Multi-region deploy plan** (`docs/.../2026-06-17-phase5-multi-region-deploy-plan.md`): single-region → active-active, grounded in `region_router`; gates (credit balances, rate limits, DB writes) and a 5-phase sequencing that pins billing writes to a home region until the Phase 3 ledger cutover.

## Cutover sequence this enables
1. Apply Phase 3 migration (creates `credit_ledger`).
2. Set `CREDIT_LEDGER_SHADOW_ENABLED=true` → ledger shadows live deductions.
3. Reconcile ledger vs live system over real traffic (reconciliation tooling = next step).
4. Switch reads to ledger-authoritative behind a flag.

## Verification
Full local suite (`.gw-venv-full`): 0 new `FAILED` tests vs baseline. The only diff lines are pre-existing application log-ERRORs (one shifted by the +20-line hook edit) — no test regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Phase 1 & 3 migration guide with schema additions, safety assessment, and verification steps
  * Added Phase 5 multi-region deployment plan outlining rollout sequence and dependencies

* **New Features**
  * Introduced credit ledger shadow dual-write capability with optional configuration flag
  * Updated database indexing strategy for ledger idempotency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->