### PR TITLE
fix(migrations): Phase 1 canonical columns on the real `models` table

### DIFF
--- a/supabase/migrations/20260617000002_gatewayz_one_phase1_canonical_columns_on_models.sql
+++ b/supabase/migrations/20260617000002_gatewayz_one_phase1_canonical_columns_on_models.sql
@@ -1,0 +1,31 @@
+-- Migration: Gatewayz One Phase 1 (correction) — canonical-registry columns on `models`
+-- Created: 2026-06-17
+-- Why this exists:
+--   The Phase 1 registry migration (20260617000000) added the canonical-registry
+--   columns to `public.models_catalog`. But the catalog table in THIS codebase is
+--   `public.models` (the app targets `.table("models")` everywhere; `models_catalog`
+--   is just the conceptual name — `models_catalog_db.py` operates on `models`).
+--   `public.models_catalog` does not exist, so Part 2 of that migration was a no-op.
+--   This forward-fix adds the same columns to the real `public.models` table.
+--   (Forward-fix rather than editing the already-applied migration.)
+-- Safety: additive, idempotent, guarded — skips cleanly if `public.models` is absent.
+--   `models` already has some of these (e.g. modality); ADD COLUMN IF NOT EXISTS skips
+--   them. `capabilities` is NOT NULL DEFAULT '{}' — metadata-only add on PG 11+ (no rewrite).
+
+DO $$
+BEGIN
+    IF to_regclass('public.models') IS NULL THEN
+        RAISE NOTICE 'public.models not found — skipping canonical registry columns';
+        RETURN;
+    END IF;
+
+    ALTER TABLE public.models ADD COLUMN IF NOT EXISTS canonical_id text;
+    ALTER TABLE public.models ADD COLUMN IF NOT EXISTS capabilities jsonb NOT NULL DEFAULT '{}'::jsonb;
+    ALTER TABLE public.models ADD COLUMN IF NOT EXISTS modality text;
+    ALTER TABLE public.models ADD COLUMN IF NOT EXISTS context_length integer;
+    ALTER TABLE public.models ADD COLUMN IF NOT EXISTS deprecated_at timestamptz;
+
+    CREATE INDEX IF NOT EXISTS idx_models_canonical_id
+        ON public.models (canonical_id)
+        WHERE deprecated_at IS NULL;
+END$$;


### PR DESCRIPTION
The Phase 1 registry migration (#2125) ALTERed `public.models_catalog`, but the real catalog table is `public.models` — the app targets `.table("models")` 54× and `.table("models_catalog")` 0×; `models_catalog` doesn't exist (it's the conceptual name; `models_catalog_db.py` operates on `models`). So Part 2 of that migration was a permanent no-op.

This forward-fix adds the canonical-registry columns (`canonical_id`, `capabilities`, `modality`, `context_length`, `deprecated_at` + partial index) to the real `public.models` table. Additive, idempotent, `to_regclass`-guarded.

**Applied + verified on main** (`ynleroehyrmaafkgjgmr`): `canonical_id`/`capabilities`/`deprecated_at` added; `modality`/`context_length` already existed (skipped). `supabase migration list` shows 0000/0001/0002 all recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved database infrastructure with new metadata fields and enhanced indexing to support better backend performance and scalability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->