### PR TITLE
feat(billing): enable Phase 3 credit-ledger shadow in production (item 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,15 @@ OPENROUTER_API_KEY=sk-or-v1-...
 OPENROUTER_SITE_URL=https://your-site.com
 OPENROUTER_SITE_NAME=Openrouter AI Gateway
 
+# Abuse / Cost Controls (OPTIONAL — sensible defaults in src/config/config.py)
+# Allow unauthenticated inference. Default: false.
+# ANONYMOUS_ENABLED=false
+# Phase 3 credit ledger SHADOW dual-write (Gatewayz One §6.D). Records a settled
+# double-entry in public.credit_ledger alongside the authoritative deduction so it
+# can be reconciled before any billing cutover. Non-blocking; never touches real
+# balances. Defaults ON in production, OFF elsewhere — set explicitly to override.
+# CREDIT_LEDGER_SHADOW_ENABLED=true
+
 # Frontend URL (for CORS and redirects)
 FRONTEND_URL=http://localhost:3000
 

--- a/.env.template
+++ b/.env.template
@@ -7,6 +7,11 @@ OPENROUTER_API_KEY=your_openrouter_api_key
 OPENROUTER_SITE_URL=https://your-site.com
 OPENROUTER_SITE_NAME=Gatewayz API Gateway
 
+# Phase 3 credit ledger SHADOW dual-write (Gatewayz One §6.D). Non-blocking shadow
+# records for reconciliation before billing cutover; never touches real balances.
+# Defaults ON in production, OFF elsewhere — set explicitly to override.
+# CREDIT_LEDGER_SHADOW_ENABLED=true
+
 # Provider API Keys (OPTIONAL)
 DEEPINFRA_API_KEY=your_deepinfra_key
 FEATHERLESS_API_KEY=your_featherless_key

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -123,12 +123,18 @@ class Config:
     # Abuse / Cost Controls
     # Anonymous (unauthenticated) inference is off by default. Set to "true" to allow.
     ANONYMOUS_ENABLED = os.environ.get("ANONYMOUS_ENABLED", "false").lower() in {"1", "true", "yes"}
-    # Phase 3 credit ledger (Gatewayz One §6.D), SHADOW dual-write. Off by default.
+    # Phase 3 credit ledger (Gatewayz One §6.D), SHADOW dual-write.
     # When true, a settled double-entry is recorded in public.credit_ledger alongside
-    # the authoritative deduction (non-blocking) so the ledger can be reconciled before
-    # any cutover. Requires the credit_ledger migration to be applied first.
+    # the authoritative deduction (non-blocking, off-thread, never raises) so the
+    # ledger can be reconciled against live billing before any cutover. The shadow
+    # write only adds records — it never touches the authoritative balances — so it
+    # is safe to run in production. Requires the credit_ledger migration (applied).
+    #
+    # Default: ON in production (the deploy env where reconciliation data must
+    # accrue), OFF everywhere else (tests/dev unaffected). An explicit
+    # CREDIT_LEDGER_SHADOW_ENABLED env var overrides the per-env default either way.
     CREDIT_LEDGER_SHADOW_ENABLED = os.environ.get(
-        "CREDIT_LEDGER_SHADOW_ENABLED", "false"
+        "CREDIT_LEDGER_SHADOW_ENABLED", "true" if IS_PRODUCTION else "false"
     ).lower() in {"1", "true", "yes"}
     # Reject inference requests for models without a row in model_pricing.
     REQUIRE_MODEL_PRICING = os.environ.get("REQUIRE_MODEL_PRICING", "true").lower() in {"1", "true", "yes"}


### PR DESCRIPTION
## Item 1 of 4 — shadow→reconcile→cutover chain

**Goal:** start the Phase 3 credit ledger accruing shadow data so it can be reconciled against live billing before any cutover.

### What changed
- **`src/config/config.py`** — `CREDIT_LEDGER_SHADOW_ENABLED` now defaults to `true` when `APP_ENV=production`, `false` everywhere else. An explicit env var still overrides either way.
- **`.env.example` / `.env.template`** — documented the flag (previously undocumented) plus `ANONYMOUS_ENABLED`.

### Deploy env (Railway, verified)
- Production `APP_ENV=production` ✓, `SUPABASE_URL` → **yn** (live DB) ✓, `SUPABASE_SERVICE_ROLE_KEY` set ✓ (can write the RLS-only `credit_ledger` table).
- `CREDIT_LEDGER_SHADOW_ENABLED=true` set in the Railway production env (staged with `--skip-deploys`); **activates on the next deploy**.

### Safety
- The shadow write is non-blocking, off-thread, idempotent by `ref`, never raises, and **never touches authoritative balances** — it only appends to `public.credit_ledger`. Skips admin tier + sub-$0.000001 (matching `deduct_credits`).
- Tests unaffected: conftest pins `APP_ENV=testing` → `IS_PRODUCTION=False` → shadow stays off. Verified zero regressions vs base on `tests/config` + `tests/services/test_credit_handler.py` (identical 7 environmental failures with and without the change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added optional credit ledger shadow feature for cost control. Now enabled by default in production environments; disabled elsewhere unless explicitly configured via environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->