### PR TITLE
feat(billing): credit-ledger reconciliation tooling (item 2)

### DIFF
--- a/docs/superpowers/specs/2026-06-17-phase3-reconciliation-runbook.md
+++ b/docs/superpowers/specs/2026-06-17-phase3-reconciliation-runbook.md
@@ -1,0 +1,48 @@
+# Phase 3 — Credit-Ledger Reconciliation Runbook (Gatewayz One)
+
+**Item 2 of the shadow → reconcile → cutover chain.** Once the shadow ledger is
+accruing (item 1: `CREDIT_LEDGER_SHADOW_ENABLED=true` in the deploy env), this is
+how we prove the ledger agrees with live billing *before* cutting billing over to
+it.
+
+## Pieces
+- **`src/services/billing/ledger_reconciliation.py`** — pure reconciliation math
+  (unit-tested in `tests/services/test_ledger_reconciliation.py`). No I/O.
+- **`scripts/reconcile_credit_ledger.py`** — I/O + rendering shell. Pulls
+  `credit_ledger` + `usage_records` over a window and reports drift. Exit 0 = ok,
+  1 = drift/unbalanced (so it can gate a CI/cron check).
+
+## Running it
+Run against the **same project the gateway deploys against** (production → `ynleroehyrmaafkgjgmr`).
+On Railway the service-role key + URL are already in the deploy env, so:
+
+```bash
+railway run -- python scripts/reconcile_credit_ledger.py --since 7d
+railway run -- python scripts/reconcile_credit_ledger.py --since 2026-06-17T00:00:00Z --json
+```
+
+Scope `--since` to **after** shadow was enabled — older windows have usage but no
+ledger rows (drift = full usage total, expected and meaningless pre-accrual).
+
+## What it checks
+1. **Internal integrity** — every `ref` balances (Σdebit == Σcredit). Unbalanced
+   refs ⇒ a partial/corrupt write; reported by ref.
+2. **Ledger vs. live drift** — ledger REVENUE credit total vs. `usage_records.cost`,
+   per user and overall, within `--tolerance` (default ±$0.01).
+
+Like-for-like population: the shadow path skips admin tier + sub-$0.000001 charges,
+so the live side applies the same exclusions (`--min-cost`; admins resolved from
+`users.tier == 'admin'`). The REVENUE total is the authoritative figure — the
+allowance/purchased debit *split* can drift under concurrency (see the cutover
+TODO in `credit_handler`); reconciliation checks the REVENUE side, which stays
+correct.
+
+## Cutover gate (decision criteria)
+Cut billing over to the ledger only after, over a representative window where
+shadow was continuously on:
+- `report.ok` is true (zero unbalanced refs **and** total drift within tolerance), and
+- no individual user is persistently over tolerance, and
+- `ledger_ref_count` tracks the count of billable requests (no large coverage gap).
+
+Until then the ledger stays a shadow; live `subscription_allowance` /
+`purchased_credits` remain authoritative.

--- a/scripts/reconcile_credit_ledger.py
+++ b/scripts/reconcile_credit_ledger.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Reconcile the Phase 3 shadow credit ledger against live billing.
+
+Item 2 of the Gatewayz One shadow→reconcile→cutover chain. Pulls
+``public.credit_ledger`` (shadow settlements) and ``public.usage_records`` (what
+the live system recorded it charged) over a time window, then reports whether the
+ledger is internally balanced and agrees with live billing per user and overall.
+
+The reconciliation math lives in (and is unit-tested via)
+``src.services.billing.ledger_reconciliation`` — this script is only the I/O +
+rendering shell.
+
+Usage:
+    python scripts/reconcile_credit_ledger.py                 # last 7 days
+    python scripts/reconcile_credit_ledger.py --since 3d       # last 3 days
+    python scripts/reconcile_credit_ledger.py --since 2026-06-17T00:00:00Z
+    python scripts/reconcile_credit_ledger.py --tolerance 0.05 --json
+
+Exit code: 0 when the ledger reconciles (report.ok), 1 when there is drift or an
+unbalanced ref (so it can gate a cutover check in CI/cron).
+
+Requires SUPABASE_URL + a service-role key in the environment (the ledger table
+is RLS-locked to service_role). Run against the same project the gateway deploys
+against (production → ynleroehyrmaafkgjgmr).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.config.supabase_config import get_supabase_client  # noqa: E402
+from src.services.billing.ledger_reconciliation import (  # noqa: E402
+    DEFAULT_MIN_COST,
+    DEFAULT_TOLERANCE,
+    reconcile_rows,
+)
+
+_PAGE = 1000
+_REL_RE = re.compile(r"^(\d+)\s*([dh])$")  # "3d", "12h"
+
+
+def _parse_when(value: str, *, now: datetime) -> str:
+    """Parse an absolute ISO timestamp or a relative '<N>d'/'<N>h' into ISO-UTC."""
+    m = _REL_RE.match(value.strip())
+    if m:
+        n, unit = int(m.group(1)), m.group(2)
+        delta = timedelta(days=n) if unit == "d" else timedelta(hours=n)
+        return (now - delta).isoformat()
+    # Absolute: normalize a trailing 'Z' to +00:00 so fromisoformat accepts it.
+    iso = value.strip().replace("Z", "+00:00")
+    return datetime.fromisoformat(iso).astimezone(UTC).isoformat()
+
+
+def _fetch_all(table: str, time_col: str, since: str, until: str) -> list[dict]:
+    """Page through every row of ``table`` in [since, until) (Supabase caps at 1000)."""
+    client = get_supabase_client()
+    rows: list[dict] = []
+    start = 0
+    while True:
+        resp = (
+            client.table(table)
+            .select("*")
+            .gte(time_col, since)
+            .lt(time_col, until)
+            .order(time_col)
+            .range(start, start + _PAGE - 1)
+            .execute()
+        )
+        batch = getattr(resp, "data", None) or []
+        rows.extend(batch)
+        if len(batch) < _PAGE:
+            return rows
+        start += _PAGE
+
+
+def _admin_user_ids() -> frozenset:
+    """User ids the shadow path skips (tier == 'admin'). Empty set on any failure."""
+    try:
+        client = get_supabase_client()
+        resp = client.table("users").select("id").eq("tier", "admin").execute()
+        return frozenset(r["id"] for r in (getattr(resp, "data", None) or []) if r.get("id") is not None)
+    except Exception as e:  # column/table differences shouldn't break reconciliation
+        print(f"warning: could not resolve admin user ids ({e}); not excluding any", file=sys.stderr)
+        return frozenset()
+
+
+def _render(report, since: str, until: str, admin_count: int) -> str:
+    lines = []
+    status = "OK ✅" if report.ok else "DRIFT ❌"
+    lines.append(f"Credit-ledger reconciliation — {status}")
+    lines.append(f"  window:        {since}  →  {until}")
+    lines.append(f"  ledger refs:   {report.ledger_ref_count}")
+    lines.append(f"  usage rows:    {report.usage_row_count} (admins excluded: {admin_count})")
+    lines.append(f"  ledger revenue:{report.total_ledger_revenue:>18}")
+    lines.append(f"  live usage:    {report.total_usage_cost:>18}")
+    lines.append(f"  total drift:   {report.total_drift:>18}  (tolerance ±{report.tolerance})")
+    if report.unbalanced_refs:
+        lines.append(f"  UNBALANCED refs ({len(report.unbalanced_refs)}): {report.unbalanced_refs[:20]}")
+    offenders = [u for u in report.per_user if not u.within_tolerance]
+    if offenders:
+        lines.append(f"  per-user drift over tolerance ({len(offenders)}):")
+        for u in offenders[:25]:
+            lines.append(
+                f"    user {u.user_id}: ledger {u.ledger_revenue} vs usage {u.usage_cost} "
+                f"→ drift {u.drift}"
+            )
+    elif report.ok:
+        lines.append("  every user within tolerance; ledger balanced.")
+    return "\n".join(lines)
+
+
+def _to_jsonable(report, since, until, admin_count) -> dict:
+    return {
+        "ok": report.ok,
+        "window": {"since": since, "until": until},
+        "ledger_ref_count": report.ledger_ref_count,
+        "usage_row_count": report.usage_row_count,
+        "admin_excluded": admin_count,
+        "total_ledger_revenue": str(report.total_ledger_revenue),
+        "total_usage_cost": str(report.total_usage_cost),
+        "total_drift": str(report.total_drift),
+        "tolerance": str(report.tolerance),
+        "unbalanced_refs": report.unbalanced_refs,
+        "users_over_tolerance": [
+            {
+                "user_id": u.user_id,
+                "ledger_revenue": str(u.ledger_revenue),
+                "usage_cost": str(u.usage_cost),
+                "drift": str(u.drift),
+            }
+            for u in report.per_user
+            if not u.within_tolerance
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--since", default="7d", help="ISO timestamp or relative '<N>d'/'<N>h' (default 7d)")
+    parser.add_argument("--until", default=None, help="ISO timestamp (default: now)")
+    parser.add_argument("--tolerance", type=Decimal, default=DEFAULT_TOLERANCE, help="acceptable absolute drift (USD)")
+    parser.add_argument("--min-cost", type=Decimal, default=DEFAULT_MIN_COST, help="usage rows below this are excluded")
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of a text report")
+    args = parser.parse_args()
+
+    now = datetime.now(UTC)
+    since = _parse_when(args.since, now=now)
+    until = _parse_when(args.until, now=now) if args.until else now.isoformat()
+
+    ledger_rows = _fetch_all("credit_ledger", "created_at", since, until)
+    usage_rows = _fetch_all("usage_records", "timestamp", since, until)
+    admins = _admin_user_ids()
+
+    report = reconcile_rows(
+        ledger_rows,
+        usage_rows,
+        min_cost=args.min_cost,
+        exclude_user_ids=admins,
+        tolerance=args.tolerance,
+    )
+
+    if args.json:
+        print(json.dumps(_to_jsonable(report, since, until, len(admins)), indent=2))
+    else:
+        print(_render(report, since, until, len(admins)))
+
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/services/billing/ledger_reconciliation.py
+++ b/src/services/billing/ledger_reconciliation.py
@@ -1,0 +1,262 @@
+"""Credit-ledger reconciliation — shadow ledger vs. live billing (Gatewayz One, Phase 3).
+
+Item 2 of the shadow→reconcile→cutover chain. Once the shadow dual-write
+(:mod:`src.services.billing.credit_ledger_store`) is accruing settled entries in
+``public.credit_ledger``, this module measures whether the ledger agrees with the
+authoritative billing the gateway actually performed, so the cutover decision is
+made on evidence rather than hope.
+
+It is **pure** — it operates over plain lists of rows (the shape Supabase returns)
+and returns dataclasses, performing no I/O. The CLI (``scripts/reconcile_credit_ledger.py``)
+supplies the rows and renders the report.
+
+Two independent checks:
+
+  1. **Internal integrity** (ledger alone): every ``ref`` must balance
+     (Σdebit == Σcredit) — the double-entry invariant. Unbalanced refs mean a
+     partial/corrupt write and are reported by ref.
+  2. **Ledger vs. live drift** (cross-check): the ledger's REVENUE credit total
+     should equal what the live system recorded it charged (``usage_records.cost``),
+     per user and overall, within a tolerance.
+
+IMPORTANT — what can and cannot be compared:
+  * ``usage_records`` has no request-id column, so the cross-check is an
+    **aggregate per-user** comparison, not per-request.
+  * The shadow path deliberately skips the exact cases ``deduct_credits`` bypasses
+    (admin tier, sub-$0.000001 charges). To compare like-for-like, the live side
+    must apply the *same* exclusions: pass ``min_cost`` and the set of admin
+    ``user_id``s via ``exclude_user_ids`` (the CLI resolves admins from the users
+    table). Drift outside tolerance after those exclusions is a real discrepancy.
+  * The REVENUE total is the authoritative figure to compare. The allowance/
+    purchased debit *split* can drift under concurrency (see the cutover TODO in
+    ``credit_handler``); this module checks the REVENUE side, which stays correct.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+
+from src.services.credit_ledger import ALLOWANCE, PURCHASED, REVENUE
+
+# Mirror the shadow path's skip threshold (credit_handler / deduct_credits).
+DEFAULT_MIN_COST = Decimal("0.000001")
+# Default acceptable absolute drift (USD) for both per-user and overall checks.
+DEFAULT_TOLERANCE = Decimal("0.01")
+
+_ZERO = Decimal("0")
+
+
+def _d(value) -> Decimal:
+    """Coerce to Decimal via str (None/empty → 0); never raises on bad input."""
+    if value is None or value == "":
+        return _ZERO
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(str(value))
+    except Exception:
+        return _ZERO
+
+
+@dataclass(frozen=True)
+class LedgerSummary:
+    """Aggregates derived from ``credit_ledger`` rows."""
+
+    total_revenue: Decimal = _ZERO
+    revenue_by_user: dict = field(default_factory=dict)
+    ref_count: int = 0
+    entry_count: int = 0
+    unbalanced_refs: list = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class UsageSummary:
+    """Aggregates derived from ``usage_records`` rows (the comparison population)."""
+
+    total_cost: Decimal = _ZERO
+    cost_by_user: dict = field(default_factory=dict)
+    row_count: int = 0
+    excluded_count: int = 0
+
+
+@dataclass(frozen=True)
+class UserDrift:
+    """Per-user reconciliation result. ``drift = ledger_revenue - usage_cost``."""
+
+    user_id: object
+    ledger_revenue: Decimal
+    usage_cost: Decimal
+    drift: Decimal
+    within_tolerance: bool
+
+
+@dataclass(frozen=True)
+class ReconciliationReport:
+    total_ledger_revenue: Decimal
+    total_usage_cost: Decimal
+    total_drift: Decimal
+    within_tolerance: bool
+    unbalanced_refs: list
+    ledger_ref_count: int
+    usage_row_count: int
+    tolerance: Decimal
+    per_user: list  # list[UserDrift], worst drift first
+
+    @property
+    def ok(self) -> bool:
+        """True iff the ledger is internally balanced AND agrees with live billing."""
+        return self.within_tolerance and not self.unbalanced_refs
+
+
+def summarize_ledger(rows: list[dict]) -> LedgerSummary:
+    """Summarize ``credit_ledger`` rows: REVENUE per user + per-ref balance check.
+
+    Each row has ``ref``, ``user_id``, ``account``, ``debit``, ``credit``. A ref is
+    *balanced* when its total debits equal its total credits across all its lines.
+    """
+    revenue_by_user: dict = {}
+    total_revenue = _ZERO
+    # ref -> [sum_debit, sum_credit]
+    per_ref: dict = {}
+
+    for row in rows:
+        ref = row.get("ref")
+        account = row.get("account")
+        debit = _d(row.get("debit"))
+        credit = _d(row.get("credit"))
+
+        sums = per_ref.setdefault(ref, [_ZERO, _ZERO])
+        sums[0] += debit
+        sums[1] += credit
+
+        if account == REVENUE:
+            uid = row.get("user_id")
+            revenue_by_user[uid] = revenue_by_user.get(uid, _ZERO) + credit
+            total_revenue += credit
+
+    unbalanced = sorted(
+        str(ref) for ref, (d, c) in per_ref.items() if d != c
+    )
+    return LedgerSummary(
+        total_revenue=total_revenue,
+        revenue_by_user=revenue_by_user,
+        ref_count=len(per_ref),
+        entry_count=len(rows),
+        unbalanced_refs=unbalanced,
+    )
+
+
+def summarize_usage(
+    rows: list[dict],
+    *,
+    min_cost: Decimal = DEFAULT_MIN_COST,
+    exclude_user_ids: frozenset = frozenset(),
+) -> UsageSummary:
+    """Summarize ``usage_records`` rows over the shadow-comparable population.
+
+    Applies the *same* exclusions the shadow path applies, so the cross-check is
+    like-for-like: drops rows with ``cost < min_cost`` and rows whose ``user_id``
+    is in ``exclude_user_ids`` (admins).
+    """
+    cost_by_user: dict = {}
+    total_cost = _ZERO
+    included = 0
+    excluded = 0
+
+    for row in rows:
+        cost = _d(row.get("cost"))
+        uid = row.get("user_id")
+        if cost < min_cost or uid in exclude_user_ids:
+            excluded += 1
+            continue
+        cost_by_user[uid] = cost_by_user.get(uid, _ZERO) + cost
+        total_cost += cost
+        included += 1
+
+    return UsageSummary(
+        total_cost=total_cost,
+        cost_by_user=cost_by_user,
+        row_count=included,
+        excluded_count=excluded,
+    )
+
+
+def reconcile(
+    ledger: LedgerSummary,
+    usage: UsageSummary,
+    *,
+    tolerance: Decimal = DEFAULT_TOLERANCE,
+) -> ReconciliationReport:
+    """Compare ledger REVENUE against live usage cost, per user and overall.
+
+    A user (or the total) is *within tolerance* when ``abs(drift) <= tolerance``.
+    The report is ``ok`` only when everything is within tolerance and no ref is
+    unbalanced.
+    """
+    tolerance = _d(tolerance)
+    all_users = set(ledger.revenue_by_user) | set(usage.cost_by_user)
+
+    per_user: list = []
+    for uid in all_users:
+        rev = ledger.revenue_by_user.get(uid, _ZERO)
+        cost = usage.cost_by_user.get(uid, _ZERO)
+        drift = rev - cost
+        per_user.append(
+            UserDrift(
+                user_id=uid,
+                ledger_revenue=rev,
+                usage_cost=cost,
+                drift=drift,
+                within_tolerance=abs(drift) <= tolerance,
+            )
+        )
+    # Worst drift first; tie-break by a stable string form of user_id.
+    per_user.sort(key=lambda u: (-abs(u.drift), str(u.user_id)))
+
+    total_drift = ledger.total_revenue - usage.total_cost
+    return ReconciliationReport(
+        total_ledger_revenue=ledger.total_revenue,
+        total_usage_cost=usage.total_cost,
+        total_drift=total_drift,
+        within_tolerance=abs(total_drift) <= tolerance,
+        unbalanced_refs=list(ledger.unbalanced_refs),
+        ledger_ref_count=ledger.ref_count,
+        usage_row_count=usage.row_count,
+        tolerance=tolerance,
+        per_user=per_user,
+    )
+
+
+def reconcile_rows(
+    ledger_rows: list[dict],
+    usage_rows: list[dict],
+    *,
+    min_cost: Decimal = DEFAULT_MIN_COST,
+    exclude_user_ids: frozenset = frozenset(),
+    tolerance: Decimal = DEFAULT_TOLERANCE,
+) -> ReconciliationReport:
+    """Convenience: summarize both sides then reconcile (the CLI's one-call path)."""
+    return reconcile(
+        summarize_ledger(ledger_rows),
+        summarize_usage(usage_rows, min_cost=min_cost, exclude_user_ids=exclude_user_ids),
+        tolerance=tolerance,
+    )
+
+
+# Account-name re-exports so callers/tests need only this module.
+__all__ = [
+    "ALLOWANCE",
+    "PURCHASED",
+    "REVENUE",
+    "DEFAULT_MIN_COST",
+    "DEFAULT_TOLERANCE",
+    "LedgerSummary",
+    "UsageSummary",
+    "UserDrift",
+    "ReconciliationReport",
+    "summarize_ledger",
+    "summarize_usage",
+    "reconcile",
+    "reconcile_rows",
+]

--- a/tests/services/test_ledger_reconciliation.py
+++ b/tests/services/test_ledger_reconciliation.py
@@ -1,0 +1,211 @@
+"""Unit tests for the pure credit-ledger reconciliation core (Phase 3, item 2)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from src.services.billing.ledger_reconciliation import (
+    ALLOWANCE,
+    PURCHASED,
+    REVENUE,
+    UserDrift,
+    reconcile,
+    reconcile_rows,
+    summarize_ledger,
+    summarize_usage,
+)
+
+
+def _settled(ref, user_id, allowance, purchased):
+    """Build a balanced settled triple (allowance+purchased debit, revenue credit)."""
+    total = Decimal(str(allowance)) + Decimal(str(purchased))
+    rows = []
+    if Decimal(str(allowance)) > 0:
+        rows.append({"ref": ref, "user_id": user_id, "account": ALLOWANCE,
+                     "debit": str(allowance), "credit": "0", "state": "settled"})
+    if Decimal(str(purchased)) > 0:
+        rows.append({"ref": ref, "user_id": user_id, "account": PURCHASED,
+                     "debit": str(purchased), "credit": "0", "state": "settled"})
+    rows.append({"ref": ref, "user_id": user_id, "account": REVENUE,
+                 "debit": "0", "credit": str(total), "state": "settled"})
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# summarize_ledger
+# --------------------------------------------------------------------------- #
+
+def test_summarize_ledger_empty_is_clean():
+    s = summarize_ledger([])
+    assert s.total_revenue == Decimal("0")
+    assert s.ref_count == 0
+    assert s.entry_count == 0
+    assert s.unbalanced_refs == []
+    assert s.revenue_by_user == {}
+
+
+def test_summarize_ledger_aggregates_revenue_per_user():
+    rows = _settled("r1", 1, "0.02", "0.01") + _settled("r2", 1, "0.05", "0") \
+        + _settled("r3", 2, "0", "0.10")
+    s = summarize_ledger(rows)
+    assert s.ref_count == 3
+    assert s.revenue_by_user[1] == Decimal("0.08")  # 0.03 + 0.05
+    assert s.revenue_by_user[2] == Decimal("0.10")
+    assert s.total_revenue == Decimal("0.18")
+    assert s.unbalanced_refs == []
+
+
+def test_summarize_ledger_flags_unbalanced_ref():
+    rows = _settled("good", 1, "0.02", "0")
+    # A corrupt ref: debit 0.05 but revenue credit only 0.04
+    rows += [
+        {"ref": "bad", "user_id": 1, "account": ALLOWANCE, "debit": "0.05", "credit": "0"},
+        {"ref": "bad", "user_id": 1, "account": REVENUE, "debit": "0", "credit": "0.04"},
+    ]
+    s = summarize_ledger(rows)
+    assert s.unbalanced_refs == ["bad"]
+
+
+def test_summarize_ledger_handles_none_and_string_decimals():
+    rows = [
+        {"ref": "r", "user_id": 1, "account": REVENUE, "debit": None, "credit": "0.030000"},
+        {"ref": "r", "user_id": 1, "account": ALLOWANCE, "debit": "0.030000", "credit": None},
+    ]
+    s = summarize_ledger(rows)
+    assert s.total_revenue == Decimal("0.030000")
+    assert s.unbalanced_refs == []
+
+
+# --------------------------------------------------------------------------- #
+# summarize_usage
+# --------------------------------------------------------------------------- #
+
+def test_summarize_usage_aggregates_cost_per_user():
+    rows = [
+        {"user_id": 1, "cost": "0.03"},
+        {"user_id": 1, "cost": "0.05"},
+        {"user_id": 2, "cost": "0.10"},
+    ]
+    s = summarize_usage(rows)
+    assert s.cost_by_user[1] == Decimal("0.08")
+    assert s.cost_by_user[2] == Decimal("0.10")
+    assert s.total_cost == Decimal("0.18")
+    assert s.row_count == 3
+    assert s.excluded_count == 0
+
+
+def test_summarize_usage_excludes_below_min_cost():
+    rows = [
+        {"user_id": 1, "cost": "0.05"},
+        {"user_id": 1, "cost": "0.0000001"},  # sub-threshold, like shadow skips
+    ]
+    s = summarize_usage(rows)
+    assert s.total_cost == Decimal("0.05")
+    assert s.row_count == 1
+    assert s.excluded_count == 1
+
+
+def test_summarize_usage_excludes_admin_user_ids():
+    rows = [
+        {"user_id": 1, "cost": "0.05"},
+        {"user_id": 99, "cost": "0.20"},  # admin
+    ]
+    s = summarize_usage(rows, exclude_user_ids=frozenset({99}))
+    assert 99 not in s.cost_by_user
+    assert s.total_cost == Decimal("0.05")
+    assert s.excluded_count == 1
+
+
+# --------------------------------------------------------------------------- #
+# reconcile
+# --------------------------------------------------------------------------- #
+
+def test_reconcile_perfect_match_is_ok():
+    ledger = summarize_ledger(_settled("r1", 1, "0.03", "0") + _settled("r2", 2, "0.10", "0"))
+    usage = summarize_usage([{"user_id": 1, "cost": "0.03"}, {"user_id": 2, "cost": "0.10"}])
+    report = reconcile(ledger, usage)
+    assert report.ok
+    assert report.total_drift == Decimal("0")
+    assert report.within_tolerance
+    assert all(u.within_tolerance for u in report.per_user)
+
+
+def test_reconcile_detects_drift_outside_tolerance():
+    # Ledger recorded 0.10 for user 1 but live usage only billed 0.04 → drift 0.06.
+    ledger = summarize_ledger(_settled("r1", 1, "0.10", "0"))
+    usage = summarize_usage([{"user_id": 1, "cost": "0.04"}])
+    report = reconcile(ledger, usage, tolerance=Decimal("0.01"))
+    assert not report.ok
+    assert not report.within_tolerance
+    assert report.total_drift == Decimal("0.06")
+    worst = report.per_user[0]
+    assert worst.user_id == 1
+    assert worst.drift == Decimal("0.06")
+    assert not worst.within_tolerance
+
+
+def test_reconcile_within_tolerance_passes():
+    ledger = summarize_ledger(_settled("r1", 1, "0.100", "0"))
+    usage = summarize_usage([{"user_id": 1, "cost": "0.095"}])  # 0.005 drift
+    report = reconcile(ledger, usage, tolerance=Decimal("0.01"))
+    assert report.within_tolerance
+    assert report.ok
+
+
+def test_reconcile_unbalanced_ref_makes_report_not_ok():
+    ledger = summarize_ledger([
+        {"ref": "bad", "user_id": 1, "account": ALLOWANCE, "debit": "0.05", "credit": "0"},
+        {"ref": "bad", "user_id": 1, "account": REVENUE, "debit": "0", "credit": "0.05"},
+        {"ref": "bad", "user_id": 1, "account": PURCHASED, "debit": "0.01", "credit": "0"},
+    ])  # debits 0.06 != credit 0.05
+    usage = summarize_usage([{"user_id": 1, "cost": "0.05"}])
+    report = reconcile(ledger, usage)
+    # revenue side matches, but the ref is internally unbalanced → not ok
+    assert report.within_tolerance
+    assert report.unbalanced_refs == ["bad"]
+    assert not report.ok
+
+
+def test_reconcile_user_in_ledger_but_not_usage_shows_full_drift():
+    ledger = summarize_ledger(_settled("r1", 7, "0.09", "0"))
+    usage = summarize_usage([])
+    report = reconcile(ledger, usage)
+    assert report.per_user[0].user_id == 7
+    assert report.per_user[0].drift == Decimal("0.09")
+    assert not report.ok
+
+
+def test_reconcile_empty_both_sides_is_ok():
+    report = reconcile(summarize_ledger([]), summarize_usage([]))
+    assert report.ok
+    assert report.total_drift == Decimal("0")
+    assert report.per_user == []
+
+
+def test_reconcile_per_user_sorted_worst_first():
+    ledger = summarize_ledger(
+        _settled("a", 1, "0.10", "0") + _settled("b", 2, "0.10", "0") + _settled("c", 3, "0.10", "0")
+    )
+    usage = summarize_usage([
+        {"user_id": 1, "cost": "0.10"},   # drift 0
+        {"user_id": 2, "cost": "0.02"},   # drift 0.08
+        {"user_id": 3, "cost": "0.07"},   # drift 0.03
+    ])
+    report = reconcile(ledger, usage)
+    drifts = [u.drift for u in report.per_user]
+    assert drifts == [Decimal("0.08"), Decimal("0.03"), Decimal("0")]
+
+
+def test_reconcile_rows_one_call_path():
+    ledger_rows = _settled("r1", 1, "0.03", "0")
+    usage_rows = [{"user_id": 1, "cost": "0.03"}, {"user_id": 99, "cost": "0.50"}]
+    report = reconcile_rows(usage_rows=usage_rows, ledger_rows=ledger_rows,
+                            exclude_user_ids=frozenset({99}))
+    assert report.ok
+    assert report.total_drift == Decimal("0")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Item 2 of 4 — shadow→reconcile→cutover chain

**Goal:** prove the shadow credit ledger agrees with live billing before any cutover.

### What changed (additive only)
- **`src/services/billing/ledger_reconciliation.py`** — pure, I/O-free reconciliation core. Two independent checks:
  1. **Internal integrity** — every `ref` balances (Σdebit == Σcredit); unbalanced refs reported by ref.
  2. **Ledger vs. live drift** — ledger REVENUE credit total vs. `usage_records.cost`, per user and overall, within a tolerance (default ±$0.01).
  - Applies the *same* exclusions the shadow path applies (admin tier, sub-$0.000001) for a like-for-like compare. REVENUE is the authoritative figure compared (debit split can drift under concurrency — see the cutover TODO).
- **`scripts/reconcile_credit_ledger.py`** — I/O shell: pages `credit_ledger` + `usage_records` over a window, resolves admin user ids, renders text/`--json`, exits 1 on drift (gates a cutover check).
- **`docs/.../2026-06-17-phase3-reconciliation-runbook.md`** — usage + cutover decision criteria.

### Verification
- 15 unit tests on the pure core (balanced/drift/tolerance/coverage/empty), all pass.
- Ran end-to-end against the **live prod DB** via `railway run` (service-role key confirmed): usage side reads real data; ledger empty pre-accrual; report honest. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)