### PR TITLE
feat(routing,context): wire Phase 2 router + Phase 4 context into chat path (item 3)

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -138,6 +138,26 @@ class Config:
     ).lower() in {"1", "true", "yes"}
     # Reject inference requests for models without a row in model_pricing.
     REQUIRE_MODEL_PRICING = os.environ.get("REQUIRE_MODEL_PRICING", "true").lower() in {"1", "true", "yes"}
+
+    # Gatewayz One Phase 2 — smart router. When true, the live provider failover
+    # chain is REORDERED by the policy-based smart router using the Phase 1
+    # model_provider_offers projection. Off by default; no-ops (exact passthrough)
+    # when the offers table has no rows for the model, so it is safe to enable
+    # before the projection is populated. Never drops a provider from the chain.
+    SMART_ROUTER_ENABLED = os.environ.get("SMART_ROUTER_ENABLED", "false").lower() in {"1", "true", "yes"}
+    # Default routing policy when no per-key routing_policies row applies.
+    SMART_ROUTER_POLICY = os.environ.get("SMART_ROUTER_POLICY", "balanced").strip().lower()
+
+    # Gatewayz One Phase 4 — context assembly. When true, conversation messages are
+    # reassembled within a per-request token budget (system + memory + rolling
+    # summary + most-recent turns, oldest-first dropping) before the upstream call.
+    # Off by default; exact passthrough when disabled.
+    CONTEXT_ASSEMBLY_ENABLED = os.environ.get("CONTEXT_ASSEMBLY_ENABLED", "false").lower() in {"1", "true", "yes"}
+    # Fraction of a model's context window reserved for the assembled prompt
+    # (the rest is left for the completion). Only used when CONTEXT_ASSEMBLY_ENABLED.
+    CONTEXT_ASSEMBLY_BUDGET_RATIO = float(os.environ.get("CONTEXT_ASSEMBLY_BUDGET_RATIO", "0.7"))
+    # Fallback token budget when a model's context length is unknown.
+    CONTEXT_ASSEMBLY_DEFAULT_BUDGET = int(os.environ.get("CONTEXT_ASSEMBLY_DEFAULT_BUDGET", "8192"))
     # Subscription statuses that may NOT call the API (comma-separated).
     # Includes both American (Stripe) and British spellings of cancel*, plus all
     # Stripe failure states: past_due (charge failed), unpaid (multiple failures),

--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -806,6 +806,21 @@ async def chat_completions(
                     "Auto web search failed, continuing without augmentation: %s", str(e)
                 )
 
+        # Gatewayz One Phase 4 — context assembly (flag-gated, off by default).
+        # Reassemble the final messages within the model's token budget (system +
+        # per-user memory + rolling summary + most-recent turns, oldest dropped
+        # first). Exact passthrough when disabled; never raises.
+        if Config.CONTEXT_ASSEMBLY_ENABLED:
+            from src.services.context_assembly_bridge import apply_context_budget
+
+            messages = apply_context_budget(
+                messages,
+                model=model,
+                budget_ratio=Config.CONTEXT_ASSEMBLY_BUDGET_RATIO,
+                default_budget=Config.CONTEXT_ASSEMBLY_DEFAULT_BUDGET,
+                user_id=(user or {}).get("id") if not is_anonymous else None,
+            )
+
         # === 3) Call upstream (streaming or non-streaming) ===
         if req.stream:
             return await dispatch_streaming(

--- a/src/routes/chat_request.py
+++ b/src/routes/chat_request.py
@@ -196,6 +196,19 @@ async def prepare_upstream_request(
                     f"✓ Health check passed for model '{effective_model}' on '{primary_provider}'"
                 )
 
+        # Gatewayz One Phase 2 — smart-router reordering (flag-gated, off by default).
+        # Reorders the chain by the policy-based router using the Phase 1 offers
+        # projection; never drops a provider. No-ops to the original chain when the
+        # projection has no offers for this model, so it is safe to enable early.
+        from src.config import Config
+
+        if Config.SMART_ROUTER_ENABLED and provider_chain:
+            from src.services.smart_router_bridge import reorder_provider_chain
+
+            provider_chain = reorder_provider_chain(
+                effective_model, provider_chain, policy=Config.SMART_ROUTER_POLICY
+            )
+
         model = effective_model
 
     # Diagnostic logging for tools parameter

--- a/src/services/context_assembly_bridge.py
+++ b/src/services/context_assembly_bridge.py
@@ -1,0 +1,163 @@
+"""Context-assembly bridge — wire the pure Phase 4 assembler into the live chat path.
+
+The pure assembler (:mod:`src.services.context_assembly`) decides what fits in a
+token budget and in what order: ``[system] [memory] [summary] [recent turns]``,
+dropping the oldest turns first. This bridge maps the live chat message list
+(role/content dicts) onto that assembler and back:
+
+  * splits the request's system message(s) from the conversation turns,
+  * resolves a token budget from the model's context window,
+  * best-effort loads portable per-user memory (Phase 1 ``user_memory``) and an
+    optional rolling summary,
+  * returns the reassembled message list.
+
+Safety: gated by ``Config.CONTEXT_ASSEMBLY_ENABLED`` (off by default) at the call
+site. When disabled the caller never invokes this. When enabled but there is
+nothing to add (no memory/summary) and the budget is ample, the output equals the
+input turn order. Any failure returns the original messages unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from src.services.context_assembly import (
+    MemoryItem,
+    assemble_context,
+    estimate_tokens,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MEMORY_LIMIT = 20
+
+
+def _content_to_text(content) -> str:
+    """Flatten a message ``content`` (str or multimodal list) to plain text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return " ".join(
+            part.get("text", "")
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        )
+    return ""
+
+
+def split_messages(messages: list[dict]) -> tuple[str | None, list[dict]]:
+    """Split into (combined system message, conversation turns).
+
+    All ``role == "system"`` messages are merged (in order) into one system string;
+    every other message is kept verbatim as a turn (preserving multimodal content).
+    """
+    system_parts: list[str] = []
+    turns: list[dict] = []
+    for m in messages:
+        if m.get("role") == "system":
+            text = _content_to_text(m.get("content"))
+            if text:
+                system_parts.append(text)
+        else:
+            turns.append(m)
+    system_message = "\n\n".join(system_parts) if system_parts else None
+    return system_message, turns
+
+
+def _lookup_context_length(model: str) -> int | None:
+    """Best-effort model context-window lookup from the cached catalog. None on miss."""
+    try:
+        from src.services.models import get_cached_models
+
+        for m in get_cached_models("all") or []:
+            if m.get("id") == model:
+                cl = m.get("context_length")
+                return int(cl) if cl else None
+    except Exception as e:
+        logger.debug("context_assembly: context-length lookup failed for %s: %s", model, e)
+    return None
+
+
+def _resolve_budget(model: str | None, token_budget: int | None, ratio: float, default: int) -> int:
+    """Resolve the assembly token budget (explicit > model window × ratio > default)."""
+    if token_budget and token_budget > 0:
+        return token_budget
+    cl = _lookup_context_length(model) if model else None
+    if cl and cl > 0:
+        return max(1, int(cl * ratio))
+    return default
+
+
+def _load_user_memory(user_id, limit: int = _DEFAULT_MEMORY_LIMIT) -> list[MemoryItem]:
+    """Best-effort load of portable per-user memory (Phase 1 user_memory). [] on failure."""
+    if user_id is None:
+        return []
+    try:
+        from src.config.supabase_config import get_supabase_client
+
+        client = get_supabase_client()
+        resp = (
+            client.table("user_memory")
+            .select("content,salience,kind")
+            .eq("user_id", user_id)
+            .order("salience", desc=True)
+            .limit(limit)
+            .execute()
+        )
+        rows = getattr(resp, "data", None) or []
+        return [
+            MemoryItem(
+                content=r["content"],
+                salience=float(r.get("salience") if r.get("salience") is not None else 0.5),
+                kind=r.get("kind") or "fact",
+            )
+            for r in rows
+            if r.get("content")
+        ]
+    except Exception as e:
+        logger.debug("context_assembly: user_memory load failed for %s: %s", user_id, e)
+        return []
+
+
+def apply_context_budget(
+    messages: list[dict],
+    *,
+    model: str | None = None,
+    token_budget: int | None = None,
+    budget_ratio: float = 0.7,
+    default_budget: int = 8192,
+    user_id=None,
+    memory_items: list[MemoryItem] | None = None,
+    rolling_summary: str | None = None,
+) -> list[dict]:
+    """Reassemble ``messages`` within a token budget. Returns originals on failure.
+
+    ``memory_items`` may be injected (tests); otherwise loaded best-effort by
+    ``user_id``. ``rolling_summary`` is optional condensed older-history text.
+    """
+    if not messages:
+        return messages
+    try:
+        budget = _resolve_budget(model, token_budget, budget_ratio, default_budget)
+        system_message, turns = split_messages(messages)
+        if memory_items is None:
+            memory_items = _load_user_memory(user_id)
+        assembled = assemble_context(
+            recent_turns=turns,
+            system_message=system_message,
+            rolling_summary=rolling_summary,
+            memory_items=memory_items,
+            token_budget=budget,
+            token_counter=estimate_tokens,
+        )
+        if assembled.usage.turns_dropped:
+            logger.info(
+                "context_assembly: budget=%d dropped %d oldest turn(s) for model=%s",
+                budget,
+                assembled.usage.turns_dropped,
+                model,
+            )
+        return assembled.messages
+    except Exception as e:  # never break the request over context shaping
+        logger.warning("context_assembly failed (using original messages): %s", e)
+        return messages

--- a/src/services/smart_router_bridge.py
+++ b/src/services/smart_router_bridge.py
@@ -1,0 +1,144 @@
+"""Smart-router bridge — wire the pure Phase 2 router into the live chat path.
+
+The pure router (:mod:`src.services.smart_router`) ranks ``ProviderOffer``
+snapshots into an ordered failover chain. This bridge connects it to the live
+request path, where the chain is a plain list of provider *slugs* built by
+``prepare_upstream_request``:
+
+  * loads the (model × provider) offers from the Phase 1 ``model_provider_offers``
+    projection,
+  * runs the pure router over them with the configured policy,
+  * REORDERS the existing slug chain by the router's ranking — **without ever
+    dropping a provider** (failover coverage is preserved): ranked providers that
+    are also in the original chain come first (router order), then any remaining
+    original providers in their original order.
+
+Safety: if the offers table has no rows for the model (the current state until the
+projection is populated), or anything fails, the original chain is returned
+unchanged. Gated by ``Config.SMART_ROUTER_ENABLED`` (off by default) at the call
+site, so the default path is byte-for-byte unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from src.services.smart_router import (
+    DEFAULT_MARKUP,
+    ProviderOffer,
+    RoutingPolicy,
+    RoutingRequest,
+    build_failover_chain,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _policy(name: str) -> RoutingPolicy:
+    """Coerce a policy string to RoutingPolicy; unknown → BALANCED."""
+    try:
+        return RoutingPolicy(name)
+    except ValueError:
+        return RoutingPolicy.BALANCED
+
+
+def reorder_chain_by_ranking(chain: list[str], ranked_slugs: list[str]) -> list[str]:
+    """Reorder ``chain`` so providers in ``ranked_slugs`` lead (in ranked order).
+
+    Pure. Providers present in the chain but absent from the ranking keep their
+    original relative order and are appended after the ranked ones. No provider is
+    added or dropped — the result is a permutation of ``chain``.
+    """
+    in_chain = set(chain)
+    lead = [s for s in ranked_slugs if s in in_chain]
+    lead_set = set(lead)
+    tail = [s for s in chain if s not in lead_set]
+    return lead + tail
+
+
+def _offers_to_provider_offers(offers: list[dict], markup: float) -> list[ProviderOffer]:
+    """Map ``model_provider_offers`` rows to ProviderOffer snapshots.
+
+    ``price_per_1k`` is derived as ``upstream_cost * markup`` so every active offer
+    clears the router's margin floor (we never sell at a loss); the router then
+    orders by the policy. Missing latency/quality fall back to neutral values.
+    """
+    result: list[ProviderOffer] = []
+    for o in offers:
+        try:
+            upstream = float(o.get("upstream_cost") or 0.0)
+            result.append(
+                ProviderOffer(
+                    canonical_id=o["canonical_id"],
+                    provider_slug=o["provider_slug"],
+                    native_id=o.get("native_id") or o["provider_slug"],
+                    upstream_cost_per_1k=upstream,
+                    price_per_1k=upstream * markup,
+                    p50_ms=float(o.get("p50_ms") or 0.0),
+                    p95_ms=float(o.get("p95_ms") or 0.0),
+                    quality_prior=float(o.get("quality_prior") if o.get("quality_prior") is not None else 0.5),
+                    is_active=bool(o.get("is_active", True)),
+                )
+            )
+        except (KeyError, TypeError, ValueError):
+            continue  # skip malformed offer rows
+    return result
+
+
+def _load_offers(canonical_id: str) -> list[dict]:
+    """Fetch active offers for a model from the Phase 1 projection. [] on any failure."""
+    try:
+        from src.config.supabase_config import get_supabase_client
+
+        client = get_supabase_client()
+        resp = (
+            client.table("model_provider_offers")
+            .select("*")
+            .eq("canonical_id", canonical_id)
+            .eq("is_active", True)
+            .execute()
+        )
+        return getattr(resp, "data", None) or []
+    except Exception as e:
+        logger.debug("smart_router: offer load failed for %s: %s", canonical_id, e)
+        return []
+
+
+def reorder_provider_chain(
+    model: str,
+    provider_chain: list[str],
+    *,
+    policy: str = "balanced",
+    markup: float = DEFAULT_MARKUP,
+    offers: list[dict] | None = None,
+) -> list[str]:
+    """Reorder ``provider_chain`` for ``model`` via the smart router.
+
+    Returns the chain unchanged when there is nothing to reorder (no offers, single
+    provider, or an error). ``offers`` may be injected (tests); otherwise loaded
+    from the Phase 1 projection.
+    """
+    if not provider_chain or len(provider_chain) < 2:
+        return provider_chain
+    try:
+        rows = offers if offers is not None else _load_offers(model)
+        if not rows:
+            return provider_chain
+        provider_offers = _offers_to_provider_offers(rows, markup)
+        if not provider_offers:
+            return provider_chain
+        ranked = build_failover_chain(
+            provider_offers,
+            RoutingRequest(canonical_id=model, policy=_policy(policy)),
+            markup,
+        )
+        ranked_slugs = [o.provider_slug for o in ranked]
+        reordered = reorder_chain_by_ranking(provider_chain, ranked_slugs)
+        if reordered != provider_chain:
+            logger.info(
+                "smart_router reordered chain for %s: %s -> %s", model, provider_chain, reordered
+            )
+        return reordered
+    except Exception as e:  # never break provider selection
+        logger.warning("smart_router reorder failed for %s (using original chain): %s", model, e)
+        return provider_chain

--- a/tests/services/test_context_assembly_bridge.py
+++ b/tests/services/test_context_assembly_bridge.py
@@ -1,0 +1,110 @@
+"""Unit tests for the context-assembly bridge (Phase 4 wiring, item 3)."""
+
+from __future__ import annotations
+
+from src.services.context_assembly import MemoryItem
+from src.services.context_assembly_bridge import (
+    apply_context_budget,
+    split_messages,
+)
+
+
+# --------------------------------------------------------------------------- #
+# split_messages
+# --------------------------------------------------------------------------- #
+
+def test_split_separates_system_from_turns():
+    msgs = [
+        {"role": "system", "content": "be brief"},
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+    system, turns = split_messages(msgs)
+    assert system == "be brief"
+    assert turns == msgs[1:]
+
+
+def test_split_merges_multiple_system_messages():
+    msgs = [
+        {"role": "system", "content": "rule 1"},
+        {"role": "system", "content": "rule 2"},
+        {"role": "user", "content": "hi"},
+    ]
+    system, turns = split_messages(msgs)
+    assert system == "rule 1\n\nrule 2"
+    assert len(turns) == 1
+
+
+def test_split_no_system_returns_none():
+    msgs = [{"role": "user", "content": "hi"}]
+    system, turns = split_messages(msgs)
+    assert system is None
+    assert turns == msgs
+
+
+def test_split_flattens_multimodal_system_content():
+    msgs = [{"role": "system", "content": [{"type": "text", "text": "hello"}, {"type": "image"}]}]
+    system, _ = split_messages(msgs)
+    assert system == "hello"
+
+
+# --------------------------------------------------------------------------- #
+# apply_context_budget
+# --------------------------------------------------------------------------- #
+
+def test_empty_messages_passthrough():
+    assert apply_context_budget([]) == []
+
+
+def test_ample_budget_no_memory_preserves_turn_order():
+    msgs = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "q2"},
+    ]
+    out = apply_context_budget(msgs, token_budget=100000, memory_items=[])
+    assert out[0] == {"role": "system", "content": "sys"}
+    # turns preserved in order after the system message
+    assert [m["content"] for m in out[1:]] == ["q1", "a1", "q2"]
+
+
+def test_tight_budget_drops_oldest_turns():
+    msgs = [
+        {"role": "user", "content": "x" * 400},   # ~100 tokens
+        {"role": "user", "content": "y" * 400},   # ~100 tokens
+        {"role": "user", "content": "z" * 40},    # ~10 tokens (newest)
+    ]
+    out = apply_context_budget(msgs, token_budget=60, memory_items=[])
+    contents = [m["content"] for m in out]
+    # newest kept, oldest dropped
+    assert "z" * 40 in contents
+    assert "x" * 400 not in contents
+
+
+def test_memory_items_injected_as_system_note():
+    msgs = [{"role": "user", "content": "hi"}]
+    mem = [MemoryItem(content="user likes Python", salience=0.9)]
+    out = apply_context_budget(msgs, token_budget=100000, memory_items=mem)
+    joined = " ".join(m.get("content", "") for m in out if isinstance(m.get("content"), str))
+    assert "user likes Python" in joined
+
+
+def test_failure_returns_original_messages(monkeypatch):
+    msgs = [{"role": "user", "content": "hi"}]
+
+    def boom(*a, **k):
+        raise RuntimeError("budget calc failed")
+
+    monkeypatch.setattr("src.services.context_assembly_bridge.assemble_context", boom)
+    # memory_items=[] avoids the DB path; the assemble step raises → original returned
+    assert apply_context_budget(msgs, token_budget=100, memory_items=[]) == msgs
+
+
+def test_rolling_summary_included_when_provided():
+    msgs = [{"role": "user", "content": "hi"}]
+    out = apply_context_budget(
+        msgs, token_budget=100000, memory_items=[], rolling_summary="earlier we discussed X"
+    )
+    joined = " ".join(m.get("content", "") for m in out if isinstance(m.get("content"), str))
+    assert "earlier we discussed X" in joined

--- a/tests/services/test_smart_router_bridge.py
+++ b/tests/services/test_smart_router_bridge.py
@@ -1,0 +1,96 @@
+"""Unit tests for the smart-router bridge (Phase 2 wiring, item 3)."""
+
+from __future__ import annotations
+
+from src.services.smart_router_bridge import (
+    reorder_chain_by_ranking,
+    reorder_provider_chain,
+)
+
+
+def _offer(canonical_id, slug, upstream_cost, p95=100.0, quality=0.5):
+    return {
+        "canonical_id": canonical_id,
+        "provider_slug": slug,
+        "native_id": f"{slug}/{canonical_id}",
+        "upstream_cost": upstream_cost,
+        "p50_ms": p95 / 2,
+        "p95_ms": p95,
+        "quality_prior": quality,
+        "is_active": True,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# reorder_chain_by_ranking — pure permutation, never drops/adds
+# --------------------------------------------------------------------------- #
+
+def test_reorder_puts_ranked_first_preserves_rest():
+    chain = ["a", "b", "c", "d"]
+    ranked = ["c", "a"]
+    assert reorder_chain_by_ranking(chain, ranked) == ["c", "a", "b", "d"]
+
+
+def test_reorder_ignores_ranked_not_in_chain():
+    chain = ["a", "b"]
+    ranked = ["z", "b"]  # z absent from chain
+    assert reorder_chain_by_ranking(chain, ranked) == ["b", "a"]
+
+
+def test_reorder_is_a_permutation_of_chain():
+    chain = ["a", "b", "c"]
+    out = reorder_chain_by_ranking(chain, ["b"])
+    assert sorted(out) == sorted(chain)
+    assert len(out) == len(chain)
+
+
+def test_reorder_empty_ranking_is_identity():
+    chain = ["a", "b", "c"]
+    assert reorder_chain_by_ranking(chain, []) == chain
+
+
+# --------------------------------------------------------------------------- #
+# reorder_provider_chain — full bridge with injected offers
+# --------------------------------------------------------------------------- #
+
+def test_no_reorder_when_chain_too_short():
+    assert reorder_provider_chain("m", ["only"], offers=[_offer("m", "only", 0.01)]) == ["only"]
+    assert reorder_provider_chain("m", []) == []
+
+
+def test_passthrough_when_no_offers():
+    chain = ["openrouter", "together"]
+    assert reorder_provider_chain("m", chain, offers=[]) == chain
+
+
+def test_cost_policy_promotes_cheapest_offer():
+    chain = ["expensive", "cheap"]
+    offers = [_offer("m", "expensive", 0.10), _offer("m", "cheap", 0.01)]
+    out = reorder_provider_chain("m", chain, policy="cost", offers=offers)
+    assert out[0] == "cheap"
+    assert sorted(out) == sorted(chain)  # no drops
+
+
+def test_offers_for_other_models_do_not_affect_chain():
+    chain = ["a", "b"]
+    offers = [_offer("other", "a", 0.01), _offer("other", "b", 0.10)]
+    # router filters by canonical_id == request model → none eligible → passthrough
+    assert reorder_provider_chain("m", chain, policy="cost", offers=offers) == chain
+
+
+def test_providers_without_offers_kept_at_tail():
+    chain = ["no_offer", "cheap", "mid"]
+    offers = [_offer("m", "cheap", 0.01), _offer("m", "mid", 0.05)]
+    out = reorder_provider_chain("m", chain, policy="cost", offers=offers)
+    assert out[0] == "cheap"      # ranked first
+    assert out[1] == "mid"        # ranked second
+    assert out[2] == "no_offer"   # unranked → tail
+    assert sorted(out) == sorted(chain)
+
+
+def test_unknown_policy_falls_back_to_balanced():
+    chain = ["a", "b"]
+    offers = [_offer("m", "a", 0.01), _offer("m", "b", 0.02)]
+    # should not raise; returns a valid permutation
+    out = reorder_provider_chain("m", chain, policy="nonsense", offers=offers)
+    assert sorted(out) == sorted(chain)


### PR DESCRIPTION
## Item 3 of 4 — wire the additive Phase 2/4 modules into the live request path

The pure Phase 2 (smart router) and Phase 4 (context assembly) modules were merged but unused. This wires them into the live chat path **behind feature flags (default OFF)**, so the default path is byte-for-byte unchanged.

### What changed
- **`src/services/smart_router_bridge.py`** (new) — loads the Phase 1 `model_provider_offers` projection, runs the pure router, and **reorders** the live `provider_chain` by ranking **without dropping any provider** (failover coverage preserved). No-ops to passthrough when there are no offers for the model. Wired into `prepare_upstream_request` after health-based routing, gated by `SMART_ROUTER_ENABLED`.
- **`src/services/context_assembly_bridge.py`** (new) — maps chat messages onto the pure assembler (system + per-user memory + rolling summary + recent turns within a token budget, oldest dropped first) and back. Best-effort `user_memory` load; passthrough on failure. Wired into `chat_completions` before dispatch, gated by `CONTEXT_ASSEMBLY_ENABLED`.
- **`src/config/config.py`** — 5 new flags, all off/neutral by default.

### Safety / verification
- Both wirings are gated; with flags off the code paths are never entered.
- 20 new bridge unit tests pass; ruff clean.
- **Zero regressions vs base**: identical failure sets on chat-path + billing + conceptual-model suites with and without the change.
- Phase 1 tables (`model_provider_offers`, `user_memory`) are empty on prod, so both bridges no-op even if enabled until the projection is populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)