### PR TITLE
feat(region): wire Phase 5 region router to config — multi-region rollout 1 (item 4)

### DIFF
--- a/docs/superpowers/specs/2026-06-17-phase5-multi-region-deploy-plan.md
+++ b/docs/superpowers/specs/2026-06-17-phase5-multi-region-deploy-plan.md
@@ -1,6 +1,6 @@
 # Phase 5 — Multi-Region Deploy Plan (Gatewayz One)
 
-**Status:** plan only — no infra changes. The selection core (`src/services/region_router.py`) is built + tested; this is the rollout from single-region to active-active.
+**Status:** rollout phase 1 (inventory + wire) **DONE in code** — no infra/traffic change yet. The selection core (`src/services/region_router.py`) is built + tested; it is now wired to runtime config via `src/services/region_service.py` and the serving region is surfaced as the `X-Gatewayz-Region` response header (`src/middleware/region_middleware.py`). Single region still serves all traffic until `MULTI_REGION_ENABLED=true` + real infra. Phases 2–5 below remain owner/infra-driven.
 
 ## Current state
 - **Gateway (data plane):** stateless FastAPI app (Vercel `api/index.py` / Railway/Docker `start.sh`), single region.
@@ -26,7 +26,7 @@ client ─ GeoDNS/anycast ─┤                              ├─ Supabase (p
 | **Provider affinity** | Some providers are region-locked | Use `providers.region_affinity` (Phase 1) to bias `select_regions`/failover per region. |
 
 ## Rollout phases (each independently reversible)
-1. **Inventory + wire (no traffic change).** Feed real `Region` inventory (from config/registry) into `region_router`; expose `primary_region`/`select_regions` behind a flag; log the selected region as a header. Single region still serves all traffic. Tests: selection eligibility/ordering (already covered) + wiring.
+1. **Inventory + wire (no traffic change). ✅ DONE.** `region_service.py` feeds the config inventory (`GATEWAY_REGION` / `GATEWAY_REGIONS` / `GATEWAY_HOME_REGION`, gated by `MULTI_REGION_ENABLED`) into `region_router`; `RegionHeaderMiddleware` stamps `X-Gatewayz-Region` (+ `-Selected`) on every response; `region_status()` exposes the wiring. Single region still serves all traffic (flag off). Tested: `tests/services/test_region_service.py` (+ existing `region_router` selection tests).
 2. **Passive second region.** Deploy the gateway to region B pointed at the same Supabase primary + its own Redis. Health-check only; no user traffic. Verify catalog/inference parity.
 3. **Read-routed.** GeoDNS/anycast sends nearest-region traffic for **read/inference** paths; billing-affecting writes pinned to the home region (`select_regions(home=user_home)`). Watch latency + error budgets.
 4. **Active-active billing.** Only after the Phase 3 ledger is the billing source of truth (atomic reserve/settle handles concurrent debits). Then drop the home-region pin; both regions accept billing writes.

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -158,6 +158,27 @@ class Config:
     CONTEXT_ASSEMBLY_BUDGET_RATIO = float(os.environ.get("CONTEXT_ASSEMBLY_BUDGET_RATIO", "0.7"))
     # Fallback token budget when a model's context length is unknown.
     CONTEXT_ASSEMBLY_DEFAULT_BUDGET = int(os.environ.get("CONTEXT_ASSEMBLY_DEFAULT_BUDGET", "8192"))
+
+    # Gatewayz One Phase 5 — multi-region (rollout phase 1: inventory + wire, no
+    # traffic change). The region_router selection core is fed from these. Until
+    # MULTI_REGION_ENABLED is true the inventory is just this single region, so all
+    # traffic is served locally and selection is a no-op — this only exposes the
+    # serving region (X-Gatewayz-Region header / health) for observability.
+    # The name of the region THIS instance runs as (Railway injects RAILWAY_REPLICA_REGION).
+    GATEWAY_REGION = (
+        os.environ.get("GATEWAY_REGION")
+        or os.environ.get("RAILWAY_REPLICA_REGION")
+        or "primary"
+    )
+    # Region inventory: comma-separated "name" or "name:latency_ms" (e.g.
+    # "us-east:10,eu-west:80"). Empty → single region (GATEWAY_REGION). Only consulted
+    # when MULTI_REGION_ENABLED is true.
+    GATEWAY_REGIONS = os.environ.get("GATEWAY_REGIONS", "").strip()
+    # The home region for a user's billing-affecting writes (Phase 5 rollout step 3
+    # pins these to one region until the ledger is the billing source of truth).
+    GATEWAY_HOME_REGION = os.environ.get("GATEWAY_HOME_REGION", "").strip() or GATEWAY_REGION
+    # Master switch for multi-region behavior. Off by default (single region).
+    MULTI_REGION_ENABLED = os.environ.get("MULTI_REGION_ENABLED", "false").lower() in {"1", "true", "yes"}
     # Subscription statuses that may NOT call the API (comma-separated).
     # Includes both American (Stripe) and British spellings of cancel*, plus all
     # Stripe failure states: past_due (charge failed), unpaid (multiple failures),

--- a/src/main.py
+++ b/src/main.py
@@ -276,6 +276,12 @@ def create_app() -> FastAPI:
     app.add_middleware(RequestIDMiddleware)
     logger.info("  🆔 [4] Request ID middleware enabled (unique ID for all requests)")
 
+    # Region header — stamps X-Gatewayz-Region (Phase 5 rollout 1, observability only)
+    from src.middleware.region_middleware import RegionHeaderMiddleware
+
+    app.add_middleware(RegionHeaderMiddleware)
+    logger.info("  🌍 Region header middleware enabled (region: %s)", Config.GATEWAY_REGION)
+
     # [3] Concurrency — global admission gate; queues or sheds excess requests
     from src.middleware.concurrency_middleware import ConcurrencyMiddleware
 

--- a/src/middleware/region_middleware.py
+++ b/src/middleware/region_middleware.py
@@ -1,0 +1,43 @@
+"""Region header middleware (Gatewayz One Phase 5, rollout phase 1).
+
+Adds an ``X-Gatewayz-Region`` response header naming the region that served the
+request, and ``X-Gatewayz-Region-Selected`` (the region the router would pick for
+this instance's home). Observability only — no routing decision is made here and
+behavior is unchanged in single-region mode. Mirrors ``RequestIDMiddleware``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp
+
+logger = logging.getLogger(__name__)
+
+
+class RegionHeaderMiddleware(BaseHTTPMiddleware):
+    """Stamp the serving/selected region onto every response (never raises)."""
+
+    def __init__(self, app: ASGIApp):
+        super().__init__(app)
+        try:
+            from src.services.region_service import region_status
+
+            logger.info("RegionHeaderMiddleware initialized: %s", region_status())
+        except Exception:  # never block startup over an observability header
+            logger.debug("RegionHeaderMiddleware init: region_status unavailable", exc_info=True)
+
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        try:
+            from src.services.region_service import current_region, selected_region
+
+            response.headers["X-Gatewayz-Region"] = current_region()
+            sel = selected_region()
+            if sel is not None:
+                response.headers["X-Gatewayz-Region-Selected"] = sel.name
+        except Exception:  # header is best-effort; never affect the response
+            logger.debug("RegionHeaderMiddleware: could not stamp region header", exc_info=True)
+        return response

--- a/src/services/region_service.py
+++ b/src/services/region_service.py
@@ -1,0 +1,95 @@
+"""Region service — wire the pure Phase 5 region router to runtime config.
+
+Rollout phase 1 of the multi-region plan
+(``docs/superpowers/specs/2026-06-17-phase5-multi-region-deploy-plan.md``):
+feed a real region inventory (from config) into the pure selection core
+(:mod:`src.services.region_router`) and expose the serving/selected region for
+observability. **No traffic change** — until ``MULTI_REGION_ENABLED`` is true the
+inventory is just this single region, so selection is a no-op and all traffic is
+served locally.
+
+This is the in-process decision point the later infra layers (GeoDNS/anycast,
+read replicas, regional deploys) will consult. Those layers are owner-driven and
+out of scope here.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from src.config import Config
+from src.services.region_router import Region, primary_region, select_regions
+
+logger = logging.getLogger(__name__)
+
+
+def current_region() -> str:
+    """The region name THIS instance runs as."""
+    return Config.GATEWAY_REGION
+
+
+def home_region() -> str:
+    """The home region for a user's billing-affecting writes (rollout step 3 pin)."""
+    return Config.GATEWAY_HOME_REGION
+
+
+def _parse_inventory(raw: str) -> list[Region]:
+    """Parse ``"name" | "name:latency_ms"`` comma list into Region snapshots."""
+    regions: list[Region] = []
+    seen: set[str] = set()
+    for part in raw.split(","):
+        token = part.strip()
+        if not token:
+            continue
+        name, _, lat = token.partition(":")
+        name = name.strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        try:
+            latency = float(lat) if lat.strip() else 0.0
+        except ValueError:
+            latency = 0.0
+        regions.append(Region(name=name, is_active=True, healthy=True, latency_ms=latency))
+    return regions
+
+
+def region_inventory() -> list[Region]:
+    """The deployment's region inventory.
+
+    Single region (``GATEWAY_REGION``) unless ``MULTI_REGION_ENABLED`` is true, in
+    which case ``GATEWAY_REGIONS`` is parsed (falling back to the single region when
+    empty or unparseable). The current region is always guaranteed present.
+    """
+    single = [Region(name=current_region(), is_active=True, healthy=True, latency_ms=0.0)]
+    if not Config.MULTI_REGION_ENABLED:
+        return single
+    parsed = _parse_inventory(Config.GATEWAY_REGIONS)
+    if not parsed:
+        return single
+    if all(r.name != current_region() for r in parsed):
+        parsed.append(Region(name=current_region(), is_active=True, healthy=True, latency_ms=0.0))
+    return parsed
+
+
+def selected_region(home: str | None = None) -> Region | None:
+    """The region a request should be served from now (None if all are down)."""
+    return primary_region(region_inventory(), home=home or home_region())
+
+
+def failover_chain(home: str | None = None) -> list[Region]:
+    """Ordered region failover chain (best first); home-region preferred."""
+    return select_regions(region_inventory(), home=home or home_region())
+
+
+def region_status() -> dict:
+    """Observability snapshot of region wiring (for the X-Gatewayz-Region header / health)."""
+    inv = region_inventory()
+    sel = primary_region(inv, home=home_region())
+    return {
+        "current": current_region(),
+        "home": home_region(),
+        "selected": sel.name if sel else None,
+        "multi_region_enabled": Config.MULTI_REGION_ENABLED,
+        "inventory": [r.name for r in inv],
+    }

--- a/tests/services/test_region_service.py
+++ b/tests/services/test_region_service.py
@@ -1,0 +1,96 @@
+"""Unit tests for the region service wiring (Phase 5 rollout 1, item 4)."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import src.services.region_service as region_service
+
+
+@pytest.fixture
+def cfg(monkeypatch):
+    """Patch Config on the region_service module and return it for tweaking."""
+    from src.config import Config
+
+    # Default to a clean single-region 'primary' state.
+    monkeypatch.setattr(Config, "GATEWAY_REGION", "primary", raising=False)
+    monkeypatch.setattr(Config, "GATEWAY_REGIONS", "", raising=False)
+    monkeypatch.setattr(Config, "GATEWAY_HOME_REGION", "primary", raising=False)
+    monkeypatch.setattr(Config, "MULTI_REGION_ENABLED", False, raising=False)
+    return Config
+
+
+def test_single_region_when_multi_disabled(cfg):
+    inv = region_service.region_inventory()
+    assert [r.name for r in inv] == ["primary"]
+    assert region_service.selected_region().name == "primary"
+
+
+def test_multi_region_ignored_when_flag_off(cfg, monkeypatch):
+    monkeypatch.setattr(cfg, "GATEWAY_REGIONS", "us-east:10,eu-west:80", raising=False)
+    # flag still false → inventory stays single region
+    assert [r.name for r in region_service.region_inventory()] == ["primary"]
+
+
+def test_multi_region_inventory_parsed_when_enabled(cfg, monkeypatch):
+    monkeypatch.setattr(cfg, "MULTI_REGION_ENABLED", True, raising=False)
+    monkeypatch.setattr(cfg, "GATEWAY_REGION", "us-east", raising=False)
+    monkeypatch.setattr(cfg, "GATEWAY_HOME_REGION", "us-east", raising=False)
+    monkeypatch.setattr(cfg, "GATEWAY_REGIONS", "us-east:10,eu-west:80", raising=False)
+    names = [r.name for r in region_service.region_inventory()]
+    assert set(names) == {"us-east", "eu-west"}
+
+
+def test_home_region_preferred_in_selection(cfg, monkeypatch):
+    monkeypatch.setattr(cfg, "MULTI_REGION_ENABLED", True, raising=False)
+    monkeypatch.setattr(cfg, "GATEWAY_REGION", "eu-west", raising=False)
+    monkeypatch.setattr(cfg, "GATEWAY_HOME_REGION", "eu-west", raising=False)
+    # us-east has far lower latency, but home=eu-west should lead the chain
+    monkeypatch.setattr(cfg, "GATEWAY_REGIONS", "us-east:5,eu-west:90", raising=False)
+    assert region_service.selected_region().name == "eu-west"
+    chain = region_service.failover_chain()
+    assert chain[0].name == "eu-west"
+    assert {r.name for r in chain} == {"us-east", "eu-west"}
+
+
+def test_current_region_always_present_in_enabled_inventory(cfg, monkeypatch):
+    monkeypatch.setattr(cfg, "MULTI_REGION_ENABLED", True, raising=False)
+    monkeypatch.setattr(cfg, "GATEWAY_REGION", "ap-south", raising=False)
+    # inventory omits the current region → it must be appended
+    monkeypatch.setattr(cfg, "GATEWAY_REGIONS", "us-east:10,eu-west:80", raising=False)
+    names = [r.name for r in region_service.region_inventory()]
+    assert "ap-south" in names
+
+
+def test_empty_regions_falls_back_to_single(cfg, monkeypatch):
+    monkeypatch.setattr(cfg, "MULTI_REGION_ENABLED", True, raising=False)
+    monkeypatch.setattr(cfg, "GATEWAY_REGIONS", "  ,  ", raising=False)
+    assert [r.name for r in region_service.region_inventory()] == ["primary"]
+
+
+def test_region_status_shape(cfg):
+    status = region_service.region_status()
+    assert status == {
+        "current": "primary",
+        "home": "primary",
+        "selected": "primary",
+        "multi_region_enabled": False,
+        "inventory": ["primary"],
+    }
+
+
+def test_malformed_latency_is_tolerated(cfg, monkeypatch):
+    monkeypatch.setattr(cfg, "MULTI_REGION_ENABLED", True, raising=False)
+    monkeypatch.setattr(cfg, "GATEWAY_REGION", "a", raising=False)
+    monkeypatch.setattr(cfg, "GATEWAY_HOME_REGION", "a", raising=False)
+    monkeypatch.setattr(cfg, "GATEWAY_REGIONS", "a:notanumber,b:", raising=False)
+    inv = {r.name: r.latency_ms for r in region_service.region_inventory()}
+    assert inv["a"] == 0.0  # bad latency → 0.0, not a crash
+    assert inv["b"] == 0.0
+
+
+def test_module_imports_clean():
+    # guards against import-time errors in the wiring module
+    importlib.reload(region_service)


### PR DESCRIPTION
## Item 4 of 4 — execute Phase 5 (multi-region), rollout phase 1

Executes the multi-region plan's first independently-reversible, **code-only** step (inventory + wire, **no traffic change**). The remaining rollout phases (passive 2nd region, GeoDNS read-routing, active-active billing, failover drills) are owner/infra-driven and remain out of scope.

### What changed
- **`src/services/region_service.py`** (new) — builds the region inventory from config and feeds it to the pure `region_router` (`select_regions` / `primary_region`). Single region (`GATEWAY_REGION`) unless `MULTI_REGION_ENABLED`, then `GATEWAY_REGIONS` is parsed; current region always present; home-region preferred in selection. `region_status()` for observability.
- **`src/middleware/region_middleware.py`** (new, `RegionHeaderMiddleware`) — stamps `X-Gatewayz-Region` (+ `-Selected`) on every response. Observability only; never raises. Registered in `main.py` after `RequestIDMiddleware`.
- **`src/config/config.py`** — `GATEWAY_REGION` (defaults from `RAILWAY_REPLICA_REGION` → `primary`), `GATEWAY_REGIONS`, `GATEWAY_HOME_REGION`, `MULTI_REGION_ENABLED` (off by default).
- Plan doc updated: rollout phase 1 marked ✅ DONE.

### Safety / verification
- Single region serves all traffic until `MULTI_REGION_ENABLED=true` + real infra.
- 9 new unit tests pass; `create_app()` runtime-verified to build with the middleware and report correct region status.
- Pre-existing ruff `asyncio` warnings in `main.py` are unrelated (present on base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)