### PR TITLE
feat(routing): project catalog → model_provider_offers (activate smart router)

### DIFF
--- a/scripts/project_model_provider_offers.py
+++ b/scripts/project_model_provider_offers.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Project public.models → public.model_provider_offers (Gatewayz One Phase 1).
+
+Fills the registry projection the Phase 2 smart router scores over, from the live
+catalog. The transform is pure + unit-tested in
+``src.services.model_offers_projection``; this is the fetch + upsert shell.
+
+Usage:
+    railway run -- python scripts/project_model_provider_offers.py --dry-run
+    railway run -- python scripts/project_model_provider_offers.py            # full upsert
+    railway run -- python scripts/project_model_provider_offers.py --only-multi  # only models served by >1 gateway
+    railway run -- python scripts/project_model_provider_offers.py --json
+
+Idempotent: upserts on the (canonical_id, provider_slug) unique key. Run against
+the project the gateway deploys against (production → ynleroehyrmaafkgjgmr); the
+table is RLS-locked so a service-role key is required.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.services.model_offers_projection import build_offer_rows, offer_summary  # noqa: E402
+
+_PAGE = 1000
+_UPSERT_BATCH = 500
+_MODEL_COLS = (
+    "id,provider_id,provider_model_id,pricing_original_prompt,"
+    "success_rate,average_response_time_ms,is_active,modality"
+)
+
+
+def _client():
+    from src.config.supabase_config import get_supabase_client
+
+    return get_supabase_client()
+
+
+def _providers_by_id() -> dict:
+    resp = _client().table("providers").select("id,slug,name").execute()
+    out: dict = {}
+    for p in getattr(resp, "data", None) or []:
+        out[p["id"]] = p
+        out[str(p["id"])] = p  # tolerate int/str provider_id
+    return out
+
+
+def _fetch_active_models(limit: int | None) -> list[dict]:
+    client = _client()
+    rows: list[dict] = []
+    start = 0
+    while True:
+        end = start + _PAGE - 1
+        resp = (
+            client.table("models")
+            .select(_MODEL_COLS)
+            .eq("is_active", True)
+            .range(start, end)
+            .execute()
+        )
+        batch = getattr(resp, "data", None) or []
+        rows.extend(batch)
+        if limit and len(rows) >= limit:
+            return rows[:limit]
+        if len(batch) < _PAGE:
+            return rows
+        start += _PAGE
+
+
+def _filter_multi(offers: list[dict]) -> list[dict]:
+    counts: dict[str, int] = {}
+    for o in offers:
+        counts[o["canonical_id"]] = counts.get(o["canonical_id"], 0) + 1
+    return [o for o in offers if counts[o["canonical_id"]] > 1]
+
+
+def _upsert(offers: list[dict]) -> int:
+    client = _client()
+    stamp = datetime.now(UTC).isoformat()
+    written = 0
+    for i in range(0, len(offers), _UPSERT_BATCH):
+        batch = [dict(o, updated_at=stamp) for o in offers[i : i + _UPSERT_BATCH]]
+        client.table("model_provider_offers").upsert(
+            batch, on_conflict="canonical_id,provider_slug"
+        ).execute()
+        written += len(batch)
+    return written
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="build + report, do not write")
+    parser.add_argument("--only-multi", action="store_true", help="only models served by >1 gateway")
+    parser.add_argument("--limit", type=int, default=None, help="cap models scanned (testing)")
+    parser.add_argument("--json", action="store_true", help="emit JSON summary")
+    args = parser.parse_args()
+
+    providers = _providers_by_id()
+    models = _fetch_active_models(args.limit)
+    offers = build_offer_rows(models, providers)
+    if args.only_multi:
+        offers = _filter_multi(offers)
+
+    summary = offer_summary(offers)
+    summary["models_scanned"] = len(models)
+    summary["dry_run"] = args.dry_run
+    summary["only_multi"] = args.only_multi
+
+    if not args.dry_run:
+        summary["rows_written"] = _upsert(offers)
+
+    sample = sorted(offers, key=lambda o: o["canonical_id"])[:5]
+
+    if args.json:
+        print(json.dumps({"summary": summary, "sample": sample}, indent=2))
+    else:
+        print("model_provider_offers projection")
+        for k, v in summary.items():
+            print(f"  {k}: {v}")
+        print("  sample offers:")
+        for o in sample:
+            print(f"    {o['canonical_id']}  via {o['provider_slug']}  ${o['upstream_cost']}/1k")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/services/model_offers_projection.py
+++ b/src/services/model_offers_projection.py
@@ -1,0 +1,138 @@
+"""Model→provider offers projection (Gatewayz One, Phase 1 data pipeline).
+
+Builds the ``public.model_provider_offers`` rows the Phase 2 smart router scores
+over (see :mod:`src.services.smart_router` / :mod:`src.services.smart_router_bridge`)
+from the existing ``public.models`` catalog. Each catalog row is effectively a
+``(model × gateway)`` offer already; this projects it into the registry shape:
+
+  * **canonical_id** = ``provider_model_id`` — the native model id, which is shared
+    by every gateway that serves the same model. This is what groups offers so the
+    router has more than one provider to choose between (≈533 models on prod are
+    served by >1 gateway; the rest project to a single-offer group, a safe no-op).
+  * **provider_slug** = the gateway slug (``providers.slug`` via ``provider_id``).
+  * **upstream_cost** = the prompt price normalized to **per-1k tokens**. The raw
+    ``pricing_original_prompt`` is stored in inconsistent units across rows (some
+    per-token, some per-1M), so each value is normalized with the magnitude
+    heuristic ``auto_detect_format`` — self-calibrating and unit-correct per value.
+  * **quality_prior** = from ``success_rate`` when present, else the 0.5 neutral.
+  * **p50_ms** = ``average_response_time_ms`` when present (p95 left null — no data).
+
+This module is pure (no I/O): it transforms rows → offer dicts. The sync shell
+``scripts/project_model_provider_offers.py`` does the fetch + upsert.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from src.utils.pricing_normalization import auto_detect_format, normalize_to_per_token
+
+logger = logging.getLogger(__name__)
+
+# Modalities that are not chat completions and never appear in a chat provider
+# chain, so they are excluded from the router's offer set.
+_NON_CHAT_MODALITIES = {"image", "audio", "video"}
+
+
+def normalized_cost_per_1k(raw_price) -> float | None:
+    """Normalize a raw prompt price to per-1k tokens. None if missing/zero/invalid.
+
+    The raw value's unit is auto-detected from its magnitude (per-token / per-1k /
+    per-1M) and converted to per-token, then scaled to per-1k.
+    """
+    if raw_price is None or raw_price == "" or str(raw_price).lower() == "none":
+        return None
+    try:
+        fmt = auto_detect_format(raw_price)
+        per_token = normalize_to_per_token(raw_price, fmt)
+        if per_token is None:
+            return None
+        cost = float(per_token) * 1000.0
+        return cost if cost > 0 else None
+    except Exception:
+        return None
+
+
+def _quality_from_success_rate(success_rate) -> float:
+    """Map a success_rate (0..1 or 0..100) to a 0..1 quality prior; 0.5 if unknown."""
+    if success_rate is None or str(success_rate).lower() == "none":
+        return 0.5
+    try:
+        v = float(success_rate)
+    except (TypeError, ValueError):
+        return 0.5
+    if v > 1.0:  # stored as a percentage
+        v = v / 100.0
+    return max(0.0, min(1.0, v))
+
+
+def _to_int_or_none(value) -> int | None:
+    if value is None or str(value).lower() == "none" or value == "":
+        return None
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def build_offer_rows(models: list[dict], providers_by_id: dict) -> list[dict]:
+    """Project active catalog rows into deduped ``model_provider_offers`` insert rows.
+
+    ``providers_by_id`` maps ``provider_id`` → provider dict (must contain ``slug``).
+    Rows are skipped when inactive, non-chat modality, lacking a resolvable gateway
+    slug or a positive prompt cost. Duplicates on ``(canonical_id, provider_slug)``
+    are collapsed to the cheapest offer (satisfies the table's UNIQUE constraint).
+    """
+    best: dict[tuple, dict] = {}
+    for m in models:
+        if not m.get("is_active", True):
+            continue
+        modality = (m.get("modality") or "").lower()
+        if modality in _NON_CHAT_MODALITIES:
+            continue
+
+        canonical_id = m.get("provider_model_id")
+        if not canonical_id:
+            continue
+
+        provider = providers_by_id.get(m.get("provider_id")) or providers_by_id.get(
+            str(m.get("provider_id"))
+        )
+        slug = (provider or {}).get("slug")
+        if not slug:
+            continue
+
+        cost = normalized_cost_per_1k(m.get("pricing_original_prompt"))
+        if cost is None:
+            continue
+
+        key = (canonical_id, slug)
+        offer = {
+            "canonical_id": canonical_id,
+            "provider_slug": slug,
+            "native_id": m.get("provider_model_id") or str(m.get("id")),
+            "upstream_cost": round(cost, 10),
+            "quality_prior": _quality_from_success_rate(m.get("success_rate")),
+            "p50_ms": _to_int_or_none(m.get("average_response_time_ms")),
+            "p95_ms": None,
+            "is_active": True,
+        }
+        existing = best.get(key)
+        if existing is None or offer["upstream_cost"] < existing["upstream_cost"]:
+            best[key] = offer
+
+    return list(best.values())
+
+
+def offer_summary(offers: list[dict]) -> dict:
+    """Counts for reporting: total offers, distinct models, multi-provider models."""
+    by_canonical: dict[str, int] = {}
+    for o in offers:
+        by_canonical[o["canonical_id"]] = by_canonical.get(o["canonical_id"], 0) + 1
+    multi = {k: n for k, n in by_canonical.items() if n > 1}
+    return {
+        "total_offers": len(offers),
+        "distinct_models": len(by_canonical),
+        "multi_provider_models": len(multi),
+        "max_providers_for_one_model": max(by_canonical.values()) if by_canonical else 0,
+    }

--- a/tests/services/test_model_offers_projection.py
+++ b/tests/services/test_model_offers_projection.py
@@ -1,0 +1,134 @@
+"""Unit tests for the model→provider offers projection (Phase 1 pipeline)."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.services.model_offers_projection import (
+    build_offer_rows,
+    normalized_cost_per_1k,
+    offer_summary,
+)
+
+PROVIDERS = {
+    "98": {"slug": "onerouter"},
+    "110": {"slug": "openrouter"},
+    "88": {"slug": "chutes"},
+}
+
+
+def _model(**kw):
+    base = {
+        "id": "1",
+        "provider_id": "98",
+        "provider_model_id": "meta/llama-3.1-8b",
+        "pricing_original_prompt": "0.0000005",  # per-token
+        "success_rate": None,
+        "average_response_time_ms": None,
+        "is_active": True,
+        "modality": "text",
+    }
+    base.update(kw)
+    return base
+
+
+# --------------------------------------------------------------------------- #
+# normalized_cost_per_1k — self-calibrating units
+# --------------------------------------------------------------------------- #
+
+def test_per_token_price_normalized_to_per_1k():
+    # 5e-7 per token → $0.50/1M → per-1k = 0.0005
+    assert normalized_cost_per_1k("0.0000005") == pytest.approx(0.0005)
+
+
+def test_per_million_price_normalized_to_per_1k():
+    # 0.8 detected as per-1M → 0.8/1M per token → per-1k = 0.0008
+    assert normalized_cost_per_1k("0.8") == pytest.approx(0.0008)
+
+
+def test_none_and_zero_and_garbage_return_none():
+    assert normalized_cost_per_1k(None) is None
+    assert normalized_cost_per_1k("None") is None
+    assert normalized_cost_per_1k("0") is None
+    assert normalized_cost_per_1k("") is None
+    assert normalized_cost_per_1k("abc") is None
+
+
+# --------------------------------------------------------------------------- #
+# build_offer_rows
+# --------------------------------------------------------------------------- #
+
+def test_basic_offer_built():
+    rows = build_offer_rows([_model()], PROVIDERS)
+    assert len(rows) == 1
+    o = rows[0]
+    assert o["canonical_id"] == "meta/llama-3.1-8b"
+    assert o["provider_slug"] == "onerouter"
+    assert o["upstream_cost"] == pytest.approx(0.0005)
+    assert o["quality_prior"] == 0.5
+    assert o["is_active"] is True
+
+
+def test_skips_inactive_nonchat_and_unpriced():
+    models = [
+        _model(id="a", is_active=False),
+        _model(id="b", modality="image"),
+        _model(id="c", pricing_original_prompt=None),
+        _model(id="d", provider_id="9999"),  # unknown provider → no slug
+        _model(id="e", provider_model_id=None),
+    ]
+    assert build_offer_rows(models, PROVIDERS) == []
+
+
+def test_multi_provider_grouping():
+    models = [
+        _model(id="1", provider_id="98", pricing_original_prompt="0.0000005"),
+        _model(id="2", provider_id="110", pricing_original_prompt="0.0000007"),
+        _model(id="3", provider_id="88", pricing_original_prompt="0.0000003"),
+    ]
+    rows = build_offer_rows(models, PROVIDERS)
+    assert len(rows) == 3
+    summary = offer_summary(rows)
+    assert summary["distinct_models"] == 1
+    assert summary["multi_provider_models"] == 1
+    assert summary["max_providers_for_one_model"] == 3
+
+
+def test_dedup_keeps_cheapest():
+    # same (canonical_id, provider_slug) twice → keep the cheaper cost
+    models = [
+        _model(id="1", provider_id="98", pricing_original_prompt="0.0000009"),
+        _model(id="2", provider_id="98", pricing_original_prompt="0.0000004"),
+    ]
+    rows = build_offer_rows(models, PROVIDERS)
+    assert len(rows) == 1
+    assert rows[0]["upstream_cost"] == pytest.approx(0.0004)
+
+
+def test_quality_from_success_rate_percent_and_fraction():
+    r_pct = build_offer_rows([_model(success_rate="95")], PROVIDERS)[0]
+    assert r_pct["quality_prior"] == pytest.approx(0.95)
+    r_frac = build_offer_rows([_model(success_rate=0.8)], PROVIDERS)[0]
+    assert r_frac["quality_prior"] == pytest.approx(0.8)
+
+
+def test_p50_from_response_time():
+    r = build_offer_rows([_model(average_response_time_ms="320")], PROVIDERS)[0]
+    assert r["p50_ms"] == 320
+    assert r["p95_ms"] is None
+
+
+def test_provider_id_int_key_resolves():
+    # provider_id may come back as int; resolution tries str() too
+    rows = build_offer_rows([_model(provider_id=98)], PROVIDERS)
+    assert len(rows) == 1
+    assert rows[0]["provider_slug"] == "onerouter"
+
+
+def test_summary_empty():
+    assert offer_summary([]) == {
+        "total_offers": 0,
+        "distinct_models": 0,
+        "multi_provider_models": 0,
+        "max_providers_for_one_model": 0,
+    }


### PR DESCRIPTION
## Activate the Phase 2 smart router — fill its data source

PR #2131 wired the smart router into the chat path but it was a no-op because `model_provider_offers` was empty. This projects the live catalog into that table, so the router has offers to score.

### What changed (additive only)
- **`src/services/model_offers_projection.py`** (new, pure + 11 tests) — transforms `public.models` → offer rows:
  - `canonical_id = provider_model_id` (groups the same model across gateways)
  - `provider_slug` = gateway (via `providers.slug`)
  - `upstream_cost` = prompt price normalized to **per-1k** via `auto_detect_format` (handles the inconsistent per-token / per-1M units in `pricing_original_prompt`)
  - `quality_prior` from `success_rate`; `p50_ms` from `average_response_time_ms`
  - skips inactive / non-chat / unpriced / unknown-gateway; dedups `(canonical_id, provider_slug)` to the cheapest
- **`scripts/project_model_provider_offers.py`** (new) — fetch + idempotent upsert shell (`--dry-run` / `--only-multi` / `--json`).

### Ran against prod (yn)
- 13,724 models → **1,459 offers**, **1,220 distinct models**, **170 served by >1 gateway** (max 5).
- Normalization sane (cloudflare llama-3-8b $0.03/1M; gemini-3-pro-preview $1.25–2.0e-06/1k).
- **Bridge verified end-to-end**: a shuffled chain for `gemini-3-pro-preview` + cost policy → cheapest gateway (google-vertex) first, no provider dropped.

### Not enabling the flag yet
`SMART_ROUTER_ENABLED` stays off: offers carry no live health/circuit data, so cost ordering could override health-based routing. Enable after feeding health into offers (or sequencing the router before health routing). Re-run the projection after catalog/pricing syncs (schedulable as a Railway cron).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to manage model provider offers with automated filtering, cost normalization across pricing units, and duplicate detection. Supports reporting output and dry-run mode.

* **Tests**
  * Added comprehensive test coverage for model offer transformation, validation, and aggregation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->