### PR TITLE
feat(routing): health-aware smart router + enable in prod (chain step 1)

### DIFF
--- a/src/routes/chat_request.py
+++ b/src/routes/chat_request.py
@@ -155,6 +155,20 @@ async def prepare_upstream_request(
         provider_chain = enforce_model_failover_rules(effective_model, provider_chain)
         provider_chain = filter_by_circuit_breaker(effective_model, provider_chain)
 
+        # Gatewayz One Phase 2 — smart-router reordering (flag-gated, off by default).
+        # Reorders the chain by the policy-based router using the Phase 1 offers
+        # projection; never drops a provider, no-ops when there are no offers.
+        # Runs BEFORE health-based routing on purpose: health routing below gets the
+        # final say and will bump an unhealthy cost-winner off the front of the chain.
+        from src.config import Config
+
+        if Config.SMART_ROUTER_ENABLED and provider_chain:
+            from src.services.smart_router_bridge import reorder_provider_chain
+
+            provider_chain = reorder_provider_chain(
+                effective_model, provider_chain, policy=Config.SMART_ROUTER_POLICY
+            )
+
         # HEALTH FIX #1094: Check model health and reorder provider chain to prioritize healthy providers
         # This proactively routes requests away from unhealthy models BEFORE they fail
         if should_use_health_based_routing() and provider_chain:
@@ -195,19 +209,6 @@ async def prepare_upstream_request(
                 logger.debug(
                     f"✓ Health check passed for model '{effective_model}' on '{primary_provider}'"
                 )
-
-        # Gatewayz One Phase 2 — smart-router reordering (flag-gated, off by default).
-        # Reorders the chain by the policy-based router using the Phase 1 offers
-        # projection; never drops a provider. No-ops to the original chain when the
-        # projection has no offers for this model, so it is safe to enable early.
-        from src.config import Config
-
-        if Config.SMART_ROUTER_ENABLED and provider_chain:
-            from src.services.smart_router_bridge import reorder_provider_chain
-
-            provider_chain = reorder_provider_chain(
-                effective_model, provider_chain, policy=Config.SMART_ROUTER_POLICY
-            )
 
         model = effective_model
 


### PR DESCRIPTION
## Step 1 — make the smart router health-aware, then enable it

The offers projection (#2133) fed the router real data. This makes enabling it safe and turns it on.

### Change
- Moved the smart-router reorder to run **before** health-based routing in `prepare_upstream_request`. Pipeline is now: `filter_by_circuit_breaker` → **smart-router (cost/policy)** → health routing (final say).
- Open circuits are already removed upstream; health routing bumps an unhealthy cost-winner off the front. The router never drops a provider, so failover coverage is preserved.
- `SMART_ROUTER_ENABLED=true` set in Railway production (policy `balanced`); activates on deploy.

### Verification
- Bridge + endpoint-regression tests pass; ruff clean. Tests are unaffected (flag defaults false in test env).
- Reordering correctness already proven against prod data in #2133 (e.g. `gemini-3-pro-preview` → cheapest gateway first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)