### PR TITLE
feat(routing): auto-refresh offers projection after sync/price refresh (chain step 2)

### DIFF
--- a/scripts/project_model_provider_offers.py
+++ b/scripts/project_model_provider_offers.py
@@ -2,18 +2,19 @@
 """Project public.models → public.model_provider_offers (Gatewayz One Phase 1).
 
 Fills the registry projection the Phase 2 smart router scores over, from the live
-catalog. The transform is pure + unit-tested in
-``src.services.model_offers_projection``; this is the fetch + upsert shell.
+catalog. The transform + I/O live in (and are unit-tested via)
+``src.services.model_offers_projection``; this is just the CLI shell. The same
+``refresh_offers_projection`` runs automatically after each scheduled model sync /
+price refresh (see src/services/scheduled_sync.py).
 
 Usage:
     railway run -- python scripts/project_model_provider_offers.py --dry-run
     railway run -- python scripts/project_model_provider_offers.py            # full upsert
-    railway run -- python scripts/project_model_provider_offers.py --only-multi  # only models served by >1 gateway
+    railway run -- python scripts/project_model_provider_offers.py --only-multi
     railway run -- python scripts/project_model_provider_offers.py --json
 
-Idempotent: upserts on the (canonical_id, provider_slug) unique key. Run against
-the project the gateway deploys against (production → ynleroehyrmaafkgjgmr); the
-table is RLS-locked so a service-role key is required.
+Run against the project the gateway deploys against (production → ynleroehyrmaafkgjgmr);
+the table is RLS-locked so a service-role key is required.
 """
 
 from __future__ import annotations
@@ -21,76 +22,11 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from datetime import UTC, datetime
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from src.services.model_offers_projection import build_offer_rows, offer_summary  # noqa: E402
-
-_PAGE = 1000
-_UPSERT_BATCH = 500
-_MODEL_COLS = (
-    "id,provider_id,provider_model_id,pricing_original_prompt,"
-    "success_rate,average_response_time_ms,is_active,modality"
-)
-
-
-def _client():
-    from src.config.supabase_config import get_supabase_client
-
-    return get_supabase_client()
-
-
-def _providers_by_id() -> dict:
-    resp = _client().table("providers").select("id,slug,name").execute()
-    out: dict = {}
-    for p in getattr(resp, "data", None) or []:
-        out[p["id"]] = p
-        out[str(p["id"])] = p  # tolerate int/str provider_id
-    return out
-
-
-def _fetch_active_models(limit: int | None) -> list[dict]:
-    client = _client()
-    rows: list[dict] = []
-    start = 0
-    while True:
-        end = start + _PAGE - 1
-        resp = (
-            client.table("models")
-            .select(_MODEL_COLS)
-            .eq("is_active", True)
-            .range(start, end)
-            .execute()
-        )
-        batch = getattr(resp, "data", None) or []
-        rows.extend(batch)
-        if limit and len(rows) >= limit:
-            return rows[:limit]
-        if len(batch) < _PAGE:
-            return rows
-        start += _PAGE
-
-
-def _filter_multi(offers: list[dict]) -> list[dict]:
-    counts: dict[str, int] = {}
-    for o in offers:
-        counts[o["canonical_id"]] = counts.get(o["canonical_id"], 0) + 1
-    return [o for o in offers if counts[o["canonical_id"]] > 1]
-
-
-def _upsert(offers: list[dict]) -> int:
-    client = _client()
-    stamp = datetime.now(UTC).isoformat()
-    written = 0
-    for i in range(0, len(offers), _UPSERT_BATCH):
-        batch = [dict(o, updated_at=stamp) for o in offers[i : i + _UPSERT_BATCH]]
-        client.table("model_provider_offers").upsert(
-            batch, on_conflict="canonical_id,provider_slug"
-        ).execute()
-        written += len(batch)
-    return written
+from src.services.model_offers_projection import refresh_offers_projection  # noqa: E402
 
 
 def main() -> int:
@@ -101,21 +37,11 @@ def main() -> int:
     parser.add_argument("--json", action="store_true", help="emit JSON summary")
     args = parser.parse_args()
 
-    providers = _providers_by_id()
-    models = _fetch_active_models(args.limit)
-    offers = build_offer_rows(models, providers)
-    if args.only_multi:
-        offers = _filter_multi(offers)
-
-    summary = offer_summary(offers)
-    summary["models_scanned"] = len(models)
-    summary["dry_run"] = args.dry_run
-    summary["only_multi"] = args.only_multi
-
-    if not args.dry_run:
-        summary["rows_written"] = _upsert(offers)
-
-    sample = sorted(offers, key=lambda o: o["canonical_id"])[:5]
+    result = refresh_offers_projection(
+        only_multi=args.only_multi, dry_run=args.dry_run, limit=args.limit
+    )
+    summary = result["summary"]
+    sample = sorted(result["offers"], key=lambda o: o["canonical_id"])[:5]
 
     if args.json:
         print(json.dumps({"summary": summary, "sample": sample}, indent=2))

--- a/src/services/model_offers_projection.py
+++ b/src/services/model_offers_projection.py
@@ -136,3 +136,93 @@ def offer_summary(offers: list[dict]) -> dict:
         "multi_provider_models": len(multi),
         "max_providers_for_one_model": max(by_canonical.values()) if by_canonical else 0,
     }
+
+
+def filter_multi_provider(offers: list[dict]) -> list[dict]:
+    """Keep only offers for models served by more than one gateway (pure)."""
+    counts: dict[str, int] = {}
+    for o in offers:
+        counts[o["canonical_id"]] = counts.get(o["canonical_id"], 0) + 1
+    return [o for o in offers if counts[o["canonical_id"]] > 1]
+
+
+# --------------------------------------------------------------------------- #
+# I/O shell (used by the CLI and the scheduled-sync hook). Kept thin; the pure
+# transform above is what carries the unit-tested logic.
+# --------------------------------------------------------------------------- #
+
+_PAGE = 1000
+_UPSERT_BATCH = 500
+_MODEL_COLS = (
+    "id,provider_id,provider_model_id,pricing_original_prompt,"
+    "success_rate,average_response_time_ms,is_active,modality"
+)
+
+
+def _providers_by_id(client) -> dict:
+    resp = client.table("providers").select("id,slug,name").execute()
+    out: dict = {}
+    for p in getattr(resp, "data", None) or []:
+        out[p["id"]] = p
+        out[str(p["id"])] = p  # tolerate int/str provider_id
+    return out
+
+
+def _fetch_active_models(client, limit: int | None) -> list[dict]:
+    rows: list[dict] = []
+    start = 0
+    while True:
+        resp = (
+            client.table("models")
+            .select(_MODEL_COLS)
+            .eq("is_active", True)
+            .range(start, start + _PAGE - 1)
+            .execute()
+        )
+        batch = getattr(resp, "data", None) or []
+        rows.extend(batch)
+        if limit and len(rows) >= limit:
+            return rows[:limit]
+        if len(batch) < _PAGE:
+            return rows
+        start += _PAGE
+
+
+def _upsert_offers(client, offers: list[dict]) -> int:
+    from datetime import UTC, datetime
+
+    stamp = datetime.now(UTC).isoformat()
+    written = 0
+    for i in range(0, len(offers), _UPSERT_BATCH):
+        batch = [dict(o, updated_at=stamp) for o in offers[i : i + _UPSERT_BATCH]]
+        client.table("model_provider_offers").upsert(
+            batch, on_conflict="canonical_id,provider_slug"
+        ).execute()
+        written += len(batch)
+    return written
+
+
+def refresh_offers_projection(
+    *, only_multi: bool = False, dry_run: bool = False, limit: int | None = None
+) -> dict:
+    """Fetch the catalog, build offers, and upsert them. Returns {summary, offers}.
+
+    The single entry point for both ``scripts/project_model_provider_offers.py`` and
+    the scheduled-sync hook. Idempotent (upserts on the unique key).
+    """
+    from src.config.supabase_config import get_supabase_client
+
+    client = get_supabase_client()
+    providers = _providers_by_id(client)
+    models = _fetch_active_models(client, limit)
+    offers = build_offer_rows(models, providers)
+    if only_multi:
+        offers = filter_multi_provider(offers)
+
+    summary = offer_summary(offers)
+    summary["models_scanned"] = len(models)
+    summary["dry_run"] = dry_run
+    summary["only_multi"] = only_multi
+    if not dry_run:
+        summary["rows_written"] = _upsert_offers(client, offers)
+    return {"summary": summary, "offers": offers}

--- a/src/services/scheduled_sync.py
+++ b/src/services/scheduled_sync.py
@@ -111,6 +111,22 @@ async def warm_caches_after_sync(changed_providers: list[str]) -> None:
     logger.info("Cache warming complete after sync")
 
 
+async def refresh_offers_projection_after(reason: str) -> None:
+    """Best-effort refresh of model_provider_offers after a sync (Phase 1 pipeline).
+
+    Keeps the smart router's offer set fresh as the catalog/prices change. Runs the
+    blocking projection in a worker thread; never raises (a failure must not affect
+    the sync that triggered it).
+    """
+    try:
+        from src.services.model_offers_projection import refresh_offers_projection
+
+        result = await asyncio.to_thread(refresh_offers_projection)
+        logger.info("Offers projection refreshed after %s: %s", reason, result["summary"])
+    except Exception as e:
+        logger.warning("Offers projection refresh failed after %s (non-fatal): %s", reason, e)
+
+
 async def run_scheduled_model_sync():
     """
     Run the scheduled model sync job with incremental change detection.
@@ -173,6 +189,12 @@ async def run_scheduled_model_sync():
                     name="post_sync_cache_warm",
                 )
                 logger.info(f"Cache warming task queued for {len(changed)} changed providers")
+
+            # Refresh the smart router's offer projection from the updated catalog.
+            asyncio.create_task(
+                refresh_offers_projection_after("model sync"),
+                name="post_sync_offers_projection",
+            )
 
         else:
             # Failed
@@ -410,6 +432,13 @@ async def run_scheduled_price_refresh():
                 result.get("providers_checked", 0),
                 result.get("providers_failed", 0),
             )
+            # Prices feed the smart router's upstream_cost — re-project offers when
+            # any price actually changed.
+            if result.get("prices_updated", 0) > 0:
+                asyncio.create_task(
+                    refresh_offers_projection_after("price refresh"),
+                    name="post_price_refresh_offers_projection",
+                )
         else:
             # success=False means at least one provider failed; the rest still ran.
             _last_price_refresh_status["failed_runs"] += 1

--- a/tests/services/test_model_offers_projection.py
+++ b/tests/services/test_model_offers_projection.py
@@ -6,6 +6,7 @@ import pytest
 
 from src.services.model_offers_projection import (
     build_offer_rows,
+    filter_multi_provider,
     normalized_cost_per_1k,
     offer_summary,
 )
@@ -123,6 +124,18 @@ def test_provider_id_int_key_resolves():
     rows = build_offer_rows([_model(provider_id=98)], PROVIDERS)
     assert len(rows) == 1
     assert rows[0]["provider_slug"] == "onerouter"
+
+
+def test_filter_multi_provider_keeps_only_shared_models():
+    models = [
+        _model(id="1", provider_id="98", provider_model_id="shared"),
+        _model(id="2", provider_id="110", provider_model_id="shared"),
+        _model(id="3", provider_id="88", provider_model_id="solo"),
+    ]
+    offers = build_offer_rows(models, PROVIDERS)
+    multi = filter_multi_provider(offers)
+    assert {o["canonical_id"] for o in multi} == {"shared"}
+    assert len(multi) == 2
 
 
 def test_summary_empty():


### PR DESCRIPTION
## Step 2 — keep the offer projection fresh automatically

The router scores `model_provider_offers`; this re-projects them when the catalog or prices change, so costs never go stale.

### Change
- Moved the projection I/O into `src.services.model_offers_projection.refresh_offers_projection` — one shared entry point for the CLI and the scheduler. Pure transform stays unit-tested; added `filter_multi_provider` + test.
- `scheduled_sync.py`: fires a best-effort `refresh_offers_projection_after(...)` task after (a) a successful incremental model sync and (b) a price refresh that changed any price. Runs in a worker thread, never raises (a failure can't affect the sync).
- The CLI script is now a thin shell over the shared function.

### Verification
- 12 projection unit tests pass; ruff clean; parse OK.
- Refactored I/O path re-verified against prod via `railway run` (`--dry-run --limit 2000` → 504 offers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)