### PR TITLE
feat(context): user-memory store + route, enable context assembly (chain step 3)

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -156,8 +156,11 @@ class Config:
     # Fraction of a model's context window reserved for the assembled prompt
     # (the rest is left for the completion). Only used when CONTEXT_ASSEMBLY_ENABLED.
     CONTEXT_ASSEMBLY_BUDGET_RATIO = float(os.environ.get("CONTEXT_ASSEMBLY_BUDGET_RATIO", "0.7"))
-    # Fallback token budget when a model's context length is unknown.
-    CONTEXT_ASSEMBLY_DEFAULT_BUDGET = int(os.environ.get("CONTEXT_ASSEMBLY_DEFAULT_BUDGET", "8192"))
+    # Assumed budget when a model's context length is unknown. Deliberately large
+    # so an unknown window does NOT cause aggressive truncation — when we can't tell
+    # a model's real window, we pass the turns through (no worse than today) rather
+    # than risk dropping context that would have fit.
+    CONTEXT_ASSEMBLY_DEFAULT_BUDGET = int(os.environ.get("CONTEXT_ASSEMBLY_DEFAULT_BUDGET", "1000000"))
 
     # Gatewayz One Phase 5 — multi-region (rollout phase 1: inventory + wire, no
     # traffic change). The region_router selection core is fed from these. Until

--- a/src/db/user_memory.py
+++ b/src/db/user_memory.py
@@ -1,0 +1,115 @@
+"""Portable per-user memory store (Gatewayz One Phase 4).
+
+CRUD over ``public.user_memory`` — the model-agnostic facts/preferences the
+context assembler (:mod:`src.services.context_assembly_bridge`) injects into a
+request's context. The table is RLS-locked (service-role only), so all access
+goes through the backend service client here.
+
+Reads are served from a short in-process TTL cache so the chat hot path (which
+loads a user's memory on every request when context assembly is enabled) does not
+pay a DB round-trip per request — at most one query per user per ``_CACHE_TTL``.
+Reads never raise (return ``[]`` on failure); writes raise so callers/routes can
+surface the error, and invalidate the user's cache entry.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+
+logger = logging.getLogger(__name__)
+
+_TABLE = "user_memory"
+_CACHE_TTL = 60.0  # seconds
+_MAX_CONTENT_LEN = 4000
+
+# user_id -> (expires_at_monotonic, list[dict])
+_cache: dict = {}
+_lock = threading.Lock()
+
+
+def _invalidate(user_id) -> None:
+    with _lock:
+        _cache.pop(user_id, None)
+
+
+def get_memories(user_id, limit: int = 50, *, use_cache: bool = True) -> list[dict]:
+    """Return a user's memory items, highest salience first. [] on any failure."""
+    if user_id is None:
+        return []
+    if use_cache:
+        with _lock:
+            entry = _cache.get(user_id)
+            if entry and entry[0] > time.monotonic():
+                return entry[1][:limit]
+    try:
+        from src.config.supabase_config import get_supabase_client
+
+        resp = (
+            get_supabase_client()
+            .table(_TABLE)
+            .select("id,content,salience,kind,created_at")
+            .eq("user_id", user_id)
+            .order("salience", desc=True)
+            .limit(max(1, min(limit, 200)))
+            .execute()
+        )
+        rows = getattr(resp, "data", None) or []
+    except Exception as e:
+        logger.debug("user_memory read failed for %s: %s", user_id, e)
+        return []
+    with _lock:
+        _cache[user_id] = (time.monotonic() + _CACHE_TTL, rows)
+    return rows[:limit]
+
+
+def add_memory(user_id, content: str, *, kind: str = "fact", salience: float = 0.5) -> dict:
+    """Insert a memory item for a user. Raises ValueError/Exception on bad input or DB error."""
+    if user_id is None:
+        raise ValueError("user_id is required")
+    content = (content or "").strip()
+    if not content:
+        raise ValueError("content must be non-empty")
+    if len(content) > _MAX_CONTENT_LEN:
+        content = content[:_MAX_CONTENT_LEN]
+    salience = max(0.0, min(1.0, float(salience)))
+
+    from src.config.supabase_config import get_supabase_client
+
+    resp = (
+        get_supabase_client()
+        .table(_TABLE)
+        .insert(
+            {"user_id": user_id, "content": content, "kind": kind or "fact", "salience": salience}
+        )
+        .execute()
+    )
+    _invalidate(user_id)
+    rows = getattr(resp, "data", None) or []
+    return rows[0] if rows else {"user_id": user_id, "content": content, "kind": kind, "salience": salience}
+
+
+def delete_memory(memory_id, user_id) -> bool:
+    """Delete one of a user's memory items (scoped to the user). True if a row was removed."""
+    from src.config.supabase_config import get_supabase_client
+
+    resp = (
+        get_supabase_client()
+        .table(_TABLE)
+        .delete()
+        .eq("id", memory_id)
+        .eq("user_id", user_id)
+        .execute()
+    )
+    _invalidate(user_id)
+    return bool(getattr(resp, "data", None))
+
+
+def clear_memories(user_id) -> int:
+    """Delete all of a user's memory items. Returns the number removed."""
+    from src.config.supabase_config import get_supabase_client
+
+    resp = get_supabase_client().table(_TABLE).delete().eq("user_id", user_id).execute()
+    _invalidate(user_id)
+    return len(getattr(resp, "data", None) or [])

--- a/src/main.py
+++ b/src/main.py
@@ -541,6 +541,7 @@ def create_app() -> FastAPI:
         ("provider_credits", "Provider Credit Monitoring"),  # Monitor provider account balances
         ("code_router", "Code Router Settings"),  # Code-optimized routing configuration
         ("downtime_logs", "Downtime Incident Logs"),  # Downtime tracking and log capture
+        ("user_memory", "User Memory"),  # Portable per-user memory (Phase 4 context assembly)
     ]
 
     loaded_count = 0

--- a/src/routes/user_memory.py
+++ b/src/routes/user_memory.py
@@ -1,0 +1,67 @@
+"""User-memory management endpoints (Gatewayz One Phase 4).
+
+Lets a user (or the frontend on their behalf) read/write their portable,
+model-agnostic memory — the facts the context assembler injects into requests
+when ``CONTEXT_ASSEMBLY_ENABLED`` is on. Authenticated by the caller's API key;
+every operation is scoped to that user's id, so a key can only touch its own
+memory. Mounted under ``/v1/user/memory``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from src.db import user_memory as mem
+from src.security.deps import get_user_id
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/user/memory", tags=["User Memory"])
+
+
+class MemoryIn(BaseModel):
+    content: str = Field(..., min_length=1, max_length=4000)
+    kind: str = Field("fact", max_length=64)
+    salience: float = Field(0.5, ge=0.0, le=1.0)
+
+
+@router.get("")
+async def list_memory(user_id: int = Depends(get_user_id)):
+    """List the caller's memory items (highest salience first)."""
+    items = await asyncio.to_thread(mem.get_memories, user_id, 200, use_cache=False)
+    return {"items": items, "count": len(items)}
+
+
+@router.post("")
+async def create_memory(body: MemoryIn, user_id: int = Depends(get_user_id)):
+    """Add a memory item for the caller."""
+    try:
+        item = await asyncio.to_thread(
+            mem.add_memory, user_id, body.content, kind=body.kind, salience=body.salience
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        logger.warning("user_memory add failed for %s: %s", user_id, e)
+        raise HTTPException(status_code=502, detail="could not store memory") from e
+    return {"item": item}
+
+
+@router.delete("/{memory_id}")
+async def remove_memory(memory_id: int, user_id: int = Depends(get_user_id)):
+    """Delete one of the caller's memory items."""
+    deleted = await asyncio.to_thread(mem.delete_memory, memory_id, user_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="memory item not found")
+    return {"deleted": True}
+
+
+@router.delete("")
+async def clear_memory(user_id: int = Depends(get_user_id)):
+    """Delete all of the caller's memory items."""
+    count = await asyncio.to_thread(mem.clear_memories, user_id)
+    return {"deleted_count": count}

--- a/src/services/context_assembly_bridge.py
+++ b/src/services/context_assembly_bridge.py
@@ -89,22 +89,17 @@ def _resolve_budget(model: str | None, token_budget: int | None, ratio: float, d
 
 
 def _load_user_memory(user_id, limit: int = _DEFAULT_MEMORY_LIMIT) -> list[MemoryItem]:
-    """Best-effort load of portable per-user memory (Phase 1 user_memory). [] on failure."""
+    """Best-effort load of portable per-user memory (cached). [] on failure.
+
+    Delegates to :mod:`src.db.user_memory`, which serves reads from a short TTL
+    cache so the chat hot path doesn't pay a DB round-trip per request.
+    """
     if user_id is None:
         return []
     try:
-        from src.config.supabase_config import get_supabase_client
+        from src.db.user_memory import get_memories
 
-        client = get_supabase_client()
-        resp = (
-            client.table("user_memory")
-            .select("content,salience,kind")
-            .eq("user_id", user_id)
-            .order("salience", desc=True)
-            .limit(limit)
-            .execute()
-        )
-        rows = getattr(resp, "data", None) or []
+        rows = get_memories(user_id, limit)
         return [
             MemoryItem(
                 content=r["content"],

--- a/tests/services/test_user_memory_store.py
+++ b/tests/services/test_user_memory_store.py
@@ -1,0 +1,149 @@
+"""Unit tests for the user_memory store (Phase 4) with a mocked Supabase client."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+import src.db.user_memory as um
+
+
+class _Resp:
+    def __init__(self, data):
+        self.data = data
+
+
+class _Query:
+    """Minimal chainable stand-in for the Supabase query builder."""
+
+    def __init__(self, store, table):
+        self.store = store
+        self.table = table
+        self._op = None
+        self._insert = None
+        self._filters = {}
+
+    def select(self, *a, **k):
+        self._op = "select"
+        return self
+
+    def insert(self, row):
+        self._op = "insert"
+        self._insert = row
+        return self
+
+    def delete(self):
+        self._op = "delete"
+        return self
+
+    def eq(self, col, val):
+        self._filters[col] = val
+        return self
+
+    def order(self, *a, **k):
+        return self
+
+    def limit(self, *a, **k):
+        return self
+
+    def execute(self):
+        rows = self.store.setdefault(self.table, [])
+        if self._op == "select":
+            out = [r for r in rows if all(r.get(c) == v for c, v in self._filters.items())]
+            return _Resp(sorted(out, key=lambda r: r.get("salience", 0), reverse=True))
+        if self._op == "insert":
+            row = dict(self._insert)
+            row["id"] = len(rows) + 1
+            rows.append(row)
+            return _Resp([row])
+        if self._op == "delete":
+            removed = [r for r in rows if all(r.get(c) == v for c, v in self._filters.items())]
+            self.store[self.table] = [r for r in rows if r not in removed]
+            return _Resp(removed)
+        return _Resp([])
+
+
+class _Client:
+    def __init__(self):
+        self.store = {}
+
+    def table(self, name):
+        return _Query(self.store, name)
+
+
+@pytest.fixture
+def client(monkeypatch):
+    c = _Client()
+    fake_mod = types.ModuleType("src.config.supabase_config")
+    fake_mod.get_supabase_client = lambda: c
+    monkeypatch.setitem(sys.modules, "src.config.supabase_config", fake_mod)
+    um._cache.clear()
+    return c
+
+
+def test_add_then_get(client):
+    um.add_memory(7, "likes Python", salience=0.9)
+    um.add_memory(7, "prefers metric units", salience=0.4)
+    items = um.get_memories(7, use_cache=False)
+    assert [i["content"] for i in items] == ["likes Python", "prefers metric units"]  # salience desc
+
+
+def test_get_scoped_to_user(client):
+    um.add_memory(1, "fact A")
+    um.add_memory(2, "fact B")
+    assert [i["content"] for i in um.get_memories(1, use_cache=False)] == ["fact A"]
+
+
+def test_add_rejects_empty_content(client):
+    with pytest.raises(ValueError):
+        um.add_memory(1, "   ")
+
+
+def test_add_clamps_salience(client):
+    um.add_memory(1, "x", salience=5.0)
+    assert um.get_memories(1, use_cache=False)[0]["salience"] == 1.0
+
+
+def test_delete_scoped_and_invalidates(client):
+    um.add_memory(1, "keep")
+    um.add_memory(1, "drop")
+    rows = um.get_memories(1, use_cache=False)
+    drop_id = next(r["id"] for r in rows if r["content"] == "drop")
+    assert um.delete_memory(drop_id, 1) is True
+    assert [r["content"] for r in um.get_memories(1, use_cache=False)] == ["keep"]
+    # deleting another user's id does nothing
+    assert um.delete_memory(999, 1) is False
+
+
+def test_clear(client):
+    um.add_memory(3, "a")
+    um.add_memory(3, "b")
+    assert um.clear_memories(3) == 2
+    assert um.get_memories(3, use_cache=False) == []
+
+
+def test_read_cache_hit_avoids_second_query(client, monkeypatch):
+    um.add_memory(5, "cached fact")
+    first = um.get_memories(5)  # populates cache
+    # Break the client so a cache miss would error; cache hit must still return.
+    monkeypatch.setattr(um, "get_supabase_client", None, raising=False)
+    again = um.get_memories(5)
+    assert again == first
+
+
+def test_get_returns_empty_on_error(monkeypatch):
+    um._cache.clear()
+    fake_mod = types.ModuleType("src.config.supabase_config")
+
+    def boom():
+        raise RuntimeError("db down")
+
+    fake_mod.get_supabase_client = boom
+    monkeypatch.setitem(sys.modules, "src.config.supabase_config", fake_mod)
+    assert um.get_memories(1, use_cache=False) == []
+
+
+def test_get_none_user_is_empty():
+    assert um.get_memories(None) == []


### PR DESCRIPTION
## Step 3 — give Phase 4 a write path and enable it safely

Context assembly was wired (#2131) but dormant: no way to populate memory, and naive enabling risked the hot path. This makes it safe and turns it on.

### What changed
- **`src/db/user_memory.py`** (new) — CRUD over the RLS-locked `user_memory` table with a **60s in-process read cache**, so the per-request memory load on the chat hot path costs at most one query per user per minute (empty memory cached too). Reads never raise.
- **`src/routes/user_memory.py`** (new) — authenticated `GET/POST/DELETE /user/memory`, scoped to the caller's user id, so the frontend / a future extraction job can **populate** memory.
- **`context_assembly_bridge`** — loads memory via the cached module.
- **config** — `CONTEXT_ASSEMBLY_DEFAULT_BUDGET` 8192 → 1,000,000: an **unknown** model window no longer triggers aggressive truncation (pass-through instead of dropping context that would've fit). Known windows still trim at the ratio (overflow protection).
- Enabled `CONTEXT_ASSEMBLY_ENABLED=true` in Railway production.

### Why enabling is safe
- Memory injection only happens for users who have rows (**none yet** — opt-in via the route), so for normal requests it's a no-op beyond known-window overflow trimming.
- Over-trim risk fixed; per-request DB hit amortized by the cache; system messages merge (rare, equivalent).

### Verification
- 9 store unit tests (mocked client) + 10 existing bridge tests pass; ruff clean.
- `create_app()` mounts the route; prod DB read path verified read-only via `railway run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)