### PR TITLE
feat(billing): scheduled credit-ledger reconciliation (chain step 4)

### DIFF
--- a/scripts/reconcile_credit_ledger.py
+++ b/scripts/reconcile_credit_ledger.py
@@ -36,14 +36,12 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from src.config.supabase_config import get_supabase_client  # noqa: E402
 from src.services.billing.ledger_reconciliation import (  # noqa: E402
     DEFAULT_MIN_COST,
     DEFAULT_TOLERANCE,
-    reconcile_rows,
+    reconcile_window,
 )
 
-_PAGE = 1000
 _REL_RE = re.compile(r"^(\d+)\s*([dh])$")  # "3d", "12h"
 
 
@@ -57,39 +55,6 @@ def _parse_when(value: str, *, now: datetime) -> str:
     # Absolute: normalize a trailing 'Z' to +00:00 so fromisoformat accepts it.
     iso = value.strip().replace("Z", "+00:00")
     return datetime.fromisoformat(iso).astimezone(UTC).isoformat()
-
-
-def _fetch_all(table: str, time_col: str, since: str, until: str) -> list[dict]:
-    """Page through every row of ``table`` in [since, until) (Supabase caps at 1000)."""
-    client = get_supabase_client()
-    rows: list[dict] = []
-    start = 0
-    while True:
-        resp = (
-            client.table(table)
-            .select("*")
-            .gte(time_col, since)
-            .lt(time_col, until)
-            .order(time_col)
-            .range(start, start + _PAGE - 1)
-            .execute()
-        )
-        batch = getattr(resp, "data", None) or []
-        rows.extend(batch)
-        if len(batch) < _PAGE:
-            return rows
-        start += _PAGE
-
-
-def _admin_user_ids() -> frozenset:
-    """User ids the shadow path skips (tier == 'admin'). Empty set on any failure."""
-    try:
-        client = get_supabase_client()
-        resp = client.table("users").select("id").eq("tier", "admin").execute()
-        return frozenset(r["id"] for r in (getattr(resp, "data", None) or []) if r.get("id") is not None)
-    except Exception as e:  # column/table differences shouldn't break reconciliation
-        print(f"warning: could not resolve admin user ids ({e}); not excluding any", file=sys.stderr)
-        return frozenset()
 
 
 def _render(report, since: str, until: str, admin_count: int) -> str:
@@ -155,22 +120,14 @@ def main() -> int:
     since = _parse_when(args.since, now=now)
     until = _parse_when(args.until, now=now) if args.until else now.isoformat()
 
-    ledger_rows = _fetch_all("credit_ledger", "created_at", since, until)
-    usage_rows = _fetch_all("usage_records", "timestamp", since, until)
-    admins = _admin_user_ids()
-
-    report = reconcile_rows(
-        ledger_rows,
-        usage_rows,
-        min_cost=args.min_cost,
-        exclude_user_ids=admins,
-        tolerance=args.tolerance,
+    report, admin_count = reconcile_window(
+        since, until, tolerance=args.tolerance, min_cost=args.min_cost
     )
 
     if args.json:
-        print(json.dumps(_to_jsonable(report, since, until, len(admins)), indent=2))
+        print(json.dumps(_to_jsonable(report, since, until, admin_count), indent=2))
     else:
-        print(_render(report, since, until, len(admins)))
+        print(_render(report, since, until, admin_count))
 
     return 0 if report.ok else 1
 

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -136,6 +136,19 @@ class Config:
     CREDIT_LEDGER_SHADOW_ENABLED = os.environ.get(
         "CREDIT_LEDGER_SHADOW_ENABLED", "true" if IS_PRODUCTION else "false"
     ).lower() in {"1", "true", "yes"}
+    # Scheduled credit-ledger reconciliation (shadow vs live). Defaults to follow the
+    # shadow flag — there is nothing to reconcile until shadow is accruing. Read-only:
+    # it fetches the recent window, compares, and logs (drift logs at ERROR so it is
+    # alertable). It never mutates billing.
+    ENABLE_LEDGER_RECONCILIATION = os.environ.get(
+        "ENABLE_LEDGER_RECONCILIATION", str(CREDIT_LEDGER_SHADOW_ENABLED)
+    ).lower() in {"1", "true", "yes"}
+    LEDGER_RECONCILIATION_INTERVAL_MINUTES = int(
+        os.environ.get("LEDGER_RECONCILIATION_INTERVAL_MINUTES", "360")
+    )
+    LEDGER_RECONCILIATION_WINDOW_HOURS = int(
+        os.environ.get("LEDGER_RECONCILIATION_WINDOW_HOURS", "24")
+    )
     # Reject inference requests for models without a row in model_pricing.
     REQUIRE_MODEL_PRICING = os.environ.get("REQUIRE_MODEL_PRICING", "true").lower() in {"1", "true", "yes"}
 

--- a/src/services/billing/ledger_reconciliation.py
+++ b/src/services/billing/ledger_reconciliation.py
@@ -244,6 +244,75 @@ def reconcile_rows(
     )
 
 
+# --------------------------------------------------------------------------- #
+# I/O runner — shared by the CLI (scripts/reconcile_credit_ledger.py) and the
+# scheduled reconciliation job (src/services/scheduled_sync.py). The pure
+# functions above carry the unit-tested logic; this only fetches + delegates.
+# --------------------------------------------------------------------------- #
+
+_PAGE = 1000
+
+
+def _fetch_all(client, table: str, time_col: str, since: str, until: str) -> list[dict]:
+    """Page through every row of ``table`` in [since, until) (Supabase caps at 1000)."""
+    rows: list[dict] = []
+    start = 0
+    while True:
+        resp = (
+            client.table(table)
+            .select("*")
+            .gte(time_col, since)
+            .lt(time_col, until)
+            .order(time_col)
+            .range(start, start + _PAGE - 1)
+            .execute()
+        )
+        batch = getattr(resp, "data", None) or []
+        rows.extend(batch)
+        if len(batch) < _PAGE:
+            return rows
+        start += _PAGE
+
+
+def admin_user_ids(client) -> frozenset:
+    """User ids the shadow path skips (tier == 'admin'). Empty set on any failure."""
+    try:
+        resp = client.table("users").select("id").eq("tier", "admin").execute()
+        return frozenset(
+            r["id"] for r in (getattr(resp, "data", None) or []) if r.get("id") is not None
+        )
+    except Exception:
+        return frozenset()
+
+
+def reconcile_window(
+    since: str,
+    until: str,
+    *,
+    tolerance: Decimal = DEFAULT_TOLERANCE,
+    min_cost: Decimal = DEFAULT_MIN_COST,
+) -> tuple[ReconciliationReport, int]:
+    """Fetch ledger + usage in [since, until) and reconcile. Returns (report, admin_count).
+
+    Reads from the project the gateway is configured against (service-role key
+    required — the ledger table is RLS-locked).
+    """
+    from src.config.supabase_config import get_supabase_client
+
+    client = get_supabase_client()
+    ledger_rows = _fetch_all(client, "credit_ledger", "created_at", since, until)
+    usage_rows = _fetch_all(client, "usage_records", "timestamp", since, until)
+    admins = admin_user_ids(client)
+    report = reconcile_rows(
+        ledger_rows,
+        usage_rows,
+        min_cost=min_cost,
+        exclude_user_ids=admins,
+        tolerance=tolerance,
+    )
+    return report, len(admins)
+
+
 # Account-name re-exports so callers/tests need only this module.
 __all__ = [
     "ALLOWANCE",

--- a/src/services/scheduled_sync.py
+++ b/src/services/scheduled_sync.py
@@ -31,6 +31,7 @@ _scheduler: AsyncIOScheduler | None = None
 # Kept independent from _scheduler so the (currently disabled) full sync and the
 # price refresh can be enabled/disabled and started/stopped independently.
 _price_scheduler: AsyncIOScheduler | None = None
+_recon_scheduler: AsyncIOScheduler | None = None
 
 # Track last sync status for health monitoring
 _last_sync_status: dict[str, Any] = {
@@ -547,3 +548,108 @@ def get_price_refresh_status() -> dict[str, Any]:
         "last_duration_seconds": _last_price_refresh_status["last_duration_seconds"],
         "last_prices_updated": _last_price_refresh_status["last_prices_updated"],
     }
+
+
+# ============================================================================
+# Credit-ledger reconciliation (Gatewayz One Phase 3, item 4) — scheduled,
+# read-only. Compares the shadow ledger against live billing over a recent
+# window and logs the result; drift logs at ERROR so it is alertable. It never
+# mutates billing.
+# ============================================================================
+
+_last_recon_status: dict[str, Any] = {
+    "last_run_time": None,
+    "last_ok": None,
+    "last_total_drift": None,
+    "last_ledger_refs": None,
+}
+
+
+async def run_scheduled_ledger_reconciliation():
+    """Reconcile the shadow credit ledger vs live billing over the recent window."""
+    from datetime import timedelta
+
+    from src.services.billing.ledger_reconciliation import reconcile_window
+
+    now = datetime.now(UTC)
+    since = (now - timedelta(hours=Config.LEDGER_RECONCILIATION_WINDOW_HOURS)).isoformat()
+    until = now.isoformat()
+    _last_recon_status["last_run_time"] = now
+
+    try:
+        report, admin_count = await asyncio.to_thread(reconcile_window, since, until)
+        _last_recon_status["last_ok"] = report.ok
+        _last_recon_status["last_total_drift"] = str(report.total_drift)
+        _last_recon_status["last_ledger_refs"] = report.ledger_ref_count
+
+        if report.ledger_ref_count == 0:
+            logger.info(
+                "Ledger reconciliation: no ledger rows in last %sh (shadow not yet accruing)",
+                Config.LEDGER_RECONCILIATION_WINDOW_HOURS,
+            )
+        elif report.ok:
+            logger.info(
+                "✅ Ledger reconciliation OK | refs=%s revenue=%s usage=%s drift=%s (±%s)",
+                report.ledger_ref_count,
+                report.total_ledger_revenue,
+                report.total_usage_cost,
+                report.total_drift,
+                report.tolerance,
+            )
+        else:
+            offenders = [u for u in report.per_user if not u.within_tolerance]
+            logger.error(
+                "❌ Ledger reconciliation DRIFT | refs=%s drift=%s unbalanced=%s "
+                "users_over_tolerance=%s (admins excluded=%s)",
+                report.ledger_ref_count,
+                report.total_drift,
+                len(report.unbalanced_refs),
+                len(offenders),
+                admin_count,
+            )
+    except Exception as e:
+        logger.warning("Ledger reconciliation failed (non-fatal): %s", e)
+
+
+def start_ledger_reconciliation_scheduler():
+    """Start the APScheduler for credit-ledger reconciliation (app lifespan)."""
+    global _recon_scheduler
+
+    if not Config.ENABLE_LEDGER_RECONCILIATION:
+        logger.info("Ledger reconciliation DISABLED: ENABLE_LEDGER_RECONCILIATION=false")
+        return
+
+    interval_minutes = Config.LEDGER_RECONCILIATION_INTERVAL_MINUTES
+    logger.info("Starting credit-ledger reconciliation scheduler (interval: %s min)", interval_minutes)
+    try:
+        _recon_scheduler = AsyncIOScheduler()
+        _recon_scheduler.add_job(
+            run_scheduled_ledger_reconciliation,
+            trigger=IntervalTrigger(minutes=interval_minutes),
+            id="ledger_reconciliation",
+            name="Credit Ledger Reconciliation Job",
+            replace_existing=True,
+            max_instances=1,
+            coalesce=True,
+        )
+        _recon_scheduler.start()
+        logger.info("✅ Ledger reconciliation scheduler started (next run in %s min)", interval_minutes)
+    except Exception as e:
+        logger.error("❌ Failed to start ledger reconciliation scheduler: %s", e)
+        logger.exception(e)
+
+
+def stop_ledger_reconciliation_scheduler():
+    """Stop the reconciliation APScheduler gracefully (called during shutdown)."""
+    global _recon_scheduler
+
+    if _recon_scheduler is None:
+        return
+    logger.info("Stopping ledger reconciliation scheduler...")
+    try:
+        _recon_scheduler.shutdown(wait=True)
+        logger.info("✅ Ledger reconciliation scheduler stopped successfully")
+    except Exception as e:
+        logger.error("❌ Error stopping ledger reconciliation scheduler: %s", e)
+    finally:
+        _recon_scheduler = None

--- a/src/services/startup.py
+++ b/src/services/startup.py
@@ -629,6 +629,16 @@ async def lifespan(app):
         logger.warning(f"Failed to start price refresh scheduler: {e}")
         # Don't fail startup if price refresh fails to start
 
+    # Start scheduled credit-ledger reconciliation (Phase 3 shadow vs live)
+    try:
+        from src.services.scheduled_sync import start_ledger_reconciliation_scheduler
+
+        start_ledger_reconciliation_scheduler()
+        logger.info("Ledger reconciliation service initialized")
+    except Exception as e:
+        logger.warning(f"Failed to start ledger reconciliation scheduler: {e}")
+        # Don't fail startup if reconciliation fails to start
+
     # ---------------------------------------------------------------------------
     # Additional startup work (migrated from @app.on_event("startup"))
     # ---------------------------------------------------------------------------
@@ -742,6 +752,15 @@ async def lifespan(app):
         logger.info("Price refresh service stopped")
     except Exception as e:
         logger.warning(f"Price refresh shutdown warning: {e}")
+
+    # Stop scheduled credit-ledger reconciliation
+    try:
+        from src.services.scheduled_sync import stop_ledger_reconciliation_scheduler
+
+        stop_ledger_reconciliation_scheduler()
+        logger.info("Ledger reconciliation service stopped")
+    except Exception as e:
+        logger.warning(f"Ledger reconciliation shutdown warning: {e}")
 
     # Cancel any pending background tasks
     if _background_tasks:

--- a/tests/services/test_ledger_reconciliation.py
+++ b/tests/services/test_ledger_reconciliation.py
@@ -207,5 +207,81 @@ def test_reconcile_rows_one_call_path():
     assert report.total_drift == Decimal("0")
 
 
+# --------------------------------------------------------------------------- #
+# reconcile_window — I/O runner with a mocked Supabase client
+# --------------------------------------------------------------------------- #
+
+
+class _Resp:
+    def __init__(self, data):
+        self.data = data
+
+
+class _Query:
+    def __init__(self, table, store):
+        self.table_name = table
+        self.store = store
+
+    def select(self, *a, **k):
+        return self
+
+    def gte(self, *a, **k):
+        return self
+
+    def lt(self, *a, **k):
+        return self
+
+    def eq(self, *a, **k):
+        return self
+
+    def order(self, *a, **k):
+        return self
+
+    def range(self, start, end):
+        self._start = start
+        return self
+
+    def execute(self):
+        rows = self.store.get(self.table_name, [])
+        # _fetch_all pages via range(); return all on first page, empty after.
+        if getattr(self, "_start", 0) and self.table_name in ("credit_ledger", "usage_records"):
+            return _Resp([])
+        return _Resp(rows)
+
+
+class _Client:
+    def __init__(self, store):
+        self.store = store
+
+    def table(self, name):
+        return _Query(name, self.store)
+
+
+def test_reconcile_window_mocked(monkeypatch):
+    import sys
+    import types
+
+    from src.services.billing import ledger_reconciliation as lr
+
+    store = {
+        "credit_ledger": _settled("r1", 1, "0.03", "0") + _settled("r2", 2, "0.10", "0"),
+        "usage_records": [
+            {"user_id": 1, "cost": "0.03"},
+            {"user_id": 2, "cost": "0.10"},
+            {"user_id": 99, "cost": "0.50"},  # admin → excluded
+        ],
+        "users": [{"id": 99}],  # tier == 'admin'
+    }
+    fake_mod = types.ModuleType("src.config.supabase_config")
+    fake_mod.get_supabase_client = lambda: _Client(store)
+    monkeypatch.setitem(sys.modules, "src.config.supabase_config", fake_mod)
+
+    report, admin_count = lr.reconcile_window("2026-01-01T00:00:00+00:00", "2030-01-01T00:00:00+00:00")
+    assert admin_count == 1
+    assert report.ok
+    assert report.total_drift == Decimal("0")
+    assert report.ledger_ref_count == 2
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Step 4 — watch ledger drift continuously

Items 1–2 made the shadow ledger live + reconcilable on demand. This runs the reconciliation on a schedule so drift surfaces automatically (the standing signal that gates the eventual billing cutover).

### What changed
- **`ledger_reconciliation.py`** — added `reconcile_window(since, until)` I/O runner (paged fetch of `credit_ledger` + `usage_records` + admin resolution → `reconcile_rows`), shared by the CLI and the scheduler. The CLI script is simplified to call it.
- **`scheduled_sync.py`** — `run_scheduled_ledger_reconciliation` + an `AsyncIOScheduler` (start/stop) mirroring the price-refresh scheduler. Read-only: logs **OK at INFO**, **DRIFT/unbalanced at ERROR** (alertable). Never mutates billing.
- **`startup.py`** — start/stop the scheduler in the app lifespan.
- **config** — `ENABLE_LEDGER_RECONCILIATION` (defaults to follow `CREDIT_LEDGER_SHADOW_ENABLED` → on in prod), interval 360 min, window 24 h.

### Verification
- 16 reconciliation tests pass (pure + mocked `reconcile_window`); ruff clean.
- On prod via `railway run`: `reconcile_window` runs end-to-end (empty window → OK) and the flag resolves **on** in production. Auto-enables on deploy — no manual Railway var needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)