### PR TITLE
fix(routes): restore /ranking/models — frontend dropdowns 404'd

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -526,7 +526,7 @@ def create_app() -> FastAPI:
         ("payments", "Stripe Payments"),
         ("chat_history", "Chat History"),
         ("share", "Chat Share Links"),  # Shareable chat links
-        # ("ranking", "Model Ranking"),  # Removed — feature deprecated
+        ("ranking", "Model Ranking"),  # Re-enabled — frontend model dropdowns depend on /ranking/models
         ("activity", "Activity Tracking"),
         ("coupons", "Coupon Management"),
         ("referral", "Referral System"),


### PR DESCRIPTION
## Problem
Live bug: the **"Top Ranked Models" dropdowns are empty** across `/start/api` (blocks CLI onboarding), the homepage, onboarding, and organizations pages.

Root cause: the `ranking` router was commented out in `create_app()` as "deprecated", but **4 frontend pages still call `GET /ranking/models`** (via the Next.js proxy `/api/ranking/models`). The endpoint returned **404**, so every dropdown rendered empty.

## Fix
Re-enable the one route line in `src/main.py`. The route module and `src/db/ranking.py` were never removed, and the `latest_models` table has **80 live rows**.

## Why it's safe
- `catalog` now mounts under `/v1`, so the historical catch-all shadowing that prompted the removal no longer applies at root.
- Verified locally: app builds, both `/ranking/models` and `/ranking/apps` register, and `get_all_latest_models()` returns 80 rows against the live DB.

## Scope
One line. Part of a larger live-incident sweep (chat session-expired, Stripe checkout/webhook) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the Model Ranking page/route so it loads again at startup and is available to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->