### PR TITLE
fix(payments): return 400 (not 500) on missing/invalid checkout price_id

### DIFF
--- a/src/services/billing/payments.py
+++ b/src/services/billing/payments.py
@@ -1406,6 +1406,15 @@ class StripeService:
             SubscriptionCheckoutResponse with session_id and checkout URL
         """
         try:
+            # Validate price_id up front. A missing/blank price_id otherwise reaches Stripe
+            # and surfaces as an opaque 500 — the frontend "Get Started" button then silently
+            # no-ops. Fail fast with a 400 (ValueError) and an actionable message instead.
+            if not request.price_id or not str(request.price_id).strip():
+                raise ValueError(
+                    "price_id is required to start a subscription checkout. "
+                    "Ensure the pricing tier is configured with a valid Stripe price ID."
+                )
+
             # Get user details
             user = get_user_by_id(user_id)
             if not user:
@@ -1503,6 +1512,12 @@ class StripeService:
 
         except stripe.StripeError as e:
             logger.error(f"Stripe error creating subscription checkout: {e}")
+            # Client-fixable Stripe errors (HTTP 4xx) — e.g. an invalid/unknown price_id, or a
+            # test/live mode mismatch — should surface as a 400 with the real reason, not a
+            # generic 500. Genuine Stripe outages (5xx/network) stay as 500.
+            http_status = getattr(e, "http_status", None)
+            if http_status and 400 <= http_status < 500:
+                raise ValueError(f"Stripe rejected the checkout request: {str(e)}") from e
             raise Exception(f"Payment processing error: {str(e)}") from e
 
         except Exception as e:


### PR DESCRIPTION
## Problem
Part of the "Get Started does nothing" live incident. When `create_subscription_checkout` received an empty or invalid `price_id`, it passed it straight to Stripe, which raised an error the route mapped to a generic **500**. The frontend button then silently no-opped with no actionable reason.

## Fix
- Missing/blank `price_id` → fail fast with `ValueError` (→ **400**) and a clear message.
- Client-fixable Stripe errors (HTTP **4xx** — unknown price, test/live mode mismatch) → surfaced as **400** with the real Stripe reason. Genuine Stripe outages (5xx/network) still **500**.

## Verified
Locally: empty `price_id` → `ValueError`; a Stripe 4xx → `ValueError`.

## Context
The actual checkout failure was a config mismatch (prod uses a LIVE Stripe key but the DB/frontend were wired for TEST). That's fixed separately: `subscription_products` now holds the live product IDs, and the frontend `pricing-config.ts` carries the live product/price IDs. This PR is the defense-in-depth so a future misconfig is diagnosable instead of an opaque 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)