### PR TITLE
fix(chat): streaming 500 — bind client_ip for authenticated requests

### DIFF
--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -371,23 +371,27 @@ async def chat_completions(
     try:
         # === 1) User + plan/trial prechecks (OPTIMIZED: parallelized DB calls) ===
         with tracker.stage("auth_validation"):
+            # Resolve client IP for ALL requests (anonymous and authenticated).
+            # Used by the streaming dispatch, anonymous rate limiting, and audit
+            # logging. This MUST be bound unconditionally — previously it was only
+            # set inside the `is_anonymous` branch, so authenticated streaming
+            # requests hit `UnboundLocalError: client_ip` in dispatch_streaming and
+            # every streamed chat returned a 500.
+            client_ip = "unknown"
+            if request:
+                # Parse X-Forwarded-For header with defensive bounds checking
+                forwarded_for = request.headers.get("X-Forwarded-For", "")
+                if forwarded_for:
+                    parts = forwarded_for.split(",")
+                    if parts:  # Defensive check (split always returns at least [''])
+                        client_ip = parts[0].strip()
+                if not client_ip:
+                    client_ip = request.headers.get("X-Real-IP", "")
+                if not client_ip and hasattr(request, "client") and request.client:
+                    client_ip = request.client.host or "unknown"
+
             if is_anonymous:
                 # Anonymous user - validate model whitelist and rate limits
-                # Get client IP for rate limiting
-                client_ip = "unknown"
-                if request:
-                    # Parse X-Forwarded-For header with defensive bounds checking
-                    forwarded_for = request.headers.get("X-Forwarded-For", "")
-                    if forwarded_for:
-                        parts = forwarded_for.split(",")
-                        if parts:  # Defensive check (split always returns at least [''])
-                            client_ip = parts[0].strip()
-
-                    if not client_ip:
-                        client_ip = request.headers.get("X-Real-IP", "")
-                    if not client_ip and hasattr(request, "client") and request.client:
-                        client_ip = request.client.host or "unknown"
-
                 # Validate anonymous request (model whitelist + rate limit)
                 anon_validation = await _to_thread(validate_anonymous_request, client_ip, req.model)
                 if not anon_validation["allowed"]:

--- a/tests/routes/test_chat_client_ip_regression.py
+++ b/tests/routes/test_chat_client_ip_regression.py
@@ -1,0 +1,70 @@
+"""Regression test for the streaming chat 500 (UnboundLocalError: client_ip).
+
+Bug: `client_ip` was assigned only inside the ``if is_anonymous:`` branch of
+``chat_completions``. For authenticated requests it was therefore never bound,
+and the streaming dispatch (``dispatch_streaming(..., client_ip=client_ip)``)
+raised ``UnboundLocalError`` — so *every* streamed chat (i.e. all website chat)
+returned HTTP 500 while non-streaming requests worked.
+
+Fix: hoist the client-IP resolution so it runs for all requests, before the
+``if is_anonymous`` branch.
+
+This test guards the invariant structurally (no live providers required): inside
+``chat_completions`` there must be a ``client_ip`` assignment that is NOT nested
+inside an ``if is_anonymous`` block, guaranteeing it is bound on every path that
+reaches the streaming dispatch.
+"""
+
+import ast
+from pathlib import Path
+
+CHAT_PY = Path(__file__).resolve().parents[2] / "src" / "routes" / "chat.py"
+
+
+def _find_function(tree: ast.AST, name: str) -> ast.AsyncFunctionDef | ast.FunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"function {name!r} not found in chat.py")
+
+
+def _is_anonymous_if(node: ast.AST) -> bool:
+    """True if `node` is an `if is_anonymous:` statement."""
+    return (
+        isinstance(node, ast.If)
+        and isinstance(node.test, ast.Name)
+        and node.test.id == "is_anonymous"
+    )
+
+
+def _assigns_client_ip(node: ast.AST) -> bool:
+    targets = []
+    if isinstance(node, ast.Assign):
+        targets = node.targets
+    elif isinstance(node, ast.AnnAssign):
+        targets = [node.target]
+    return any(isinstance(t, ast.Name) and t.id == "client_ip" for t in targets)
+
+
+def test_client_ip_is_assigned_unconditionally():
+    tree = ast.parse(CHAT_PY.read_text())
+    fn = _find_function(tree, "chat_completions")
+
+    # Collect every `if is_anonymous:` node so we can tell which assignments are
+    # gated behind it.
+    anon_if_nodes = [n for n in ast.walk(fn) if _is_anonymous_if(n)]
+    anon_descendants = set()
+    for anon_if in anon_if_nodes:
+        for child in ast.walk(anon_if):
+            anon_descendants.add(id(child))
+
+    client_ip_assignments = [n for n in ast.walk(fn) if _assigns_client_ip(n)]
+    assert client_ip_assignments, "expected at least one `client_ip = ...` assignment"
+
+    unconditional = [a for a in client_ip_assignments if id(a) not in anon_descendants]
+    assert unconditional, (
+        "`client_ip` is only assigned inside an `if is_anonymous:` branch. "
+        "Authenticated streaming requests will hit `UnboundLocalError: client_ip` "
+        "in dispatch_streaming and every streamed chat will 500. Hoist the "
+        "client-IP resolution above the `is_anonymous` branch."
+    )


### PR DESCRIPTION
## Severity: critical — all website chat was down

Every **streamed** chat completion returned **HTTP 500**; non-streaming worked. Since the website chats in streaming mode, all chat was broken (this is what users saw, not just "session expired").

## Root cause
`client_ip` was assigned **only inside the `if is_anonymous:` branch** of `chat_completions` (chat.py). For authenticated requests it was never bound, so the streaming dispatch:

```python
return await dispatch_streaming(..., client_ip=client_ip)
```

raised `UnboundLocalError: cannot access local variable 'client_ip'`. The non-streaming dispatch doesn't pass `client_ip`, which is why only streaming 500'd.

Captured from a local repro (production hides it behind the sanitized error envelope):
```
File "src/routes/chat.py", line 852, in chat_completions
    client_ip=client_ip,
UnboundLocalError: cannot access local variable 'client_ip' where it is not associated with a value
```

## Fix
Hoist the client-IP resolution above the `is_anonymous` branch so it's bound on every path. Authenticated streaming now also gets a real IP for audit logging instead of crashing.

## Verification (local, against the live provider)
- authenticated **streaming** → SSE chunks ✅ (was 500)
- authenticated non-streaming → 200 ✅
- anonymous (no key) → clean 401 ✅
- zero `UnboundLocalError` in logs after the fix
- Added an AST regression test asserting `client_ip` is assigned unconditionally.

## Note
Pre-dates this branch — the bug was already on `main` (likely from the Phase 2/4 chat-path wiring); my earlier deploy just surfaced it. e2e streaming tests exist but are skipped in CI (need live keys), so it slipped through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed client IP handling for chat requests so it is always set, including authenticated streaming requests.
  * Improved fallback IP detection using forwarded and direct request headers to avoid missing values.

* **Tests**
  * Added a regression test to verify client IP is assigned in all chat request paths and prevent recurrence of the streaming error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->