### PR TITLE
fix(chat): surface provider 429 as 429, not 502 (free models looked broken)

### DIFF
--- a/src/handlers/chat_handler.py
+++ b/src/handlers/chat_handler.py
@@ -82,9 +82,7 @@ def _loss_proof_cost_split(
             or float(served_pricing.get("completion", 0) or 0) > 0
         )
         if has_real_price:
-            served = calculate_cost_split(
-                provider_model_id, prompt_tokens, completion_tokens
-            )
+            served = calculate_cost_split(provider_model_id, prompt_tokens, completion_tokens)
             if served[0] > base[0]:
                 logger.info(
                     "[Pricing] Failover re-price: served provider model %r cost $%.6f "
@@ -122,7 +120,10 @@ class ChatInferenceHandler:
     """
 
     def __init__(
-        self, api_key: str | None, background_tasks: Any | None = None, request: Request | None = None
+        self,
+        api_key: str | None,
+        background_tasks: Any | None = None,
+        request: Request | None = None,
     ):
         """
         Initialize the handler with user context.
@@ -141,7 +142,9 @@ class ChatInferenceHandler:
         self.request_id = str(uuid.uuid4())
         self.start_time = time.monotonic()
 
-        logger.debug(f"[ChatHandler] Initialized with request_id={self.request_id}, anonymous={self.is_anonymous}")
+        logger.debug(
+            f"[ChatHandler] Initialized with request_id={self.request_id}, anonymous={self.is_anonymous}"
+        )
 
     async def _initialize_user_context(self) -> None:
         """
@@ -191,9 +194,7 @@ class ChatInferenceHandler:
 
         self.trial = {"is_valid": True, "is_trial": False}
 
-        logger.debug(
-            f"[ChatHandler] User context loaded: user_id={self.user.get('id')}"
-        )
+        logger.debug(f"[ChatHandler] User context loaded: user_id={self.user.get('id')}")
 
     async def _check_credit_sufficiency(
         self,
@@ -382,7 +383,31 @@ class ChatInferenceHandler:
                     exc_info=True,
                 )
 
-                # Create detailed provider error
+                # Surface upstream rate limits (e.g. OpenRouter free-tier 429) as a
+                # retryable 429 with Retry-After instead of a generic 502 — otherwise
+                # rate-limited models look "broken" in the model selector.
+                from src.services.provider_failover import map_provider_error
+
+                mapped = map_provider_error(provider_name, model_id, e)
+                if mapped.status_code == 429:
+                    retry_after = None
+                    if mapped.headers and "Retry-After" in mapped.headers:
+                        try:
+                            retry_after = int(mapped.headers["Retry-After"])
+                        except (TypeError, ValueError):
+                            retry_after = None
+                    error_response = DetailedErrorFactory.rate_limit_exceeded(
+                        limit_type="provider_rate_limit",
+                        retry_after=retry_after,
+                        request_id=self.request_id,
+                    )
+                    raise HTTPException(
+                        status_code=429,
+                        detail=error_response.dict(exclude_none=True),
+                        headers=mapped.headers,
+                    ) from e
+
+                # Other provider errors keep the existing 502 provider-error contract.
                 error_response = DetailedErrorFactory.provider_error(
                     provider=provider_name,
                     model=model_id,

--- a/src/services/provider_failover.py
+++ b/src/services/provider_failover.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 
 import httpx
 from fastapi import HTTPException
@@ -77,9 +78,7 @@ def _get_failover_priority() -> tuple[str, ...]:
         ]
         if prioritized:
             prioritized.sort()
-            return tuple(
-                slug for _, slug in prioritized if is_provider_enabled(slug)
-            )
+            return tuple(slug for _, slug in prioritized if is_provider_enabled(slug))
     except Exception as exc:
         logger.warning("Failed to load failover priority from DB: %s", exc)
     return tuple(p for p in FALLBACK_PROVIDER_PRIORITY if is_provider_enabled(p))
@@ -648,9 +647,34 @@ def map_provider_error(
             status_code=503, detail=f"Provider '{provider}' service unavailable for model '{model}'"
         )
 
-    # Final fallback - include provider and model for better error tracking
+    # Final fallback. Before defaulting to 502, best-effort extract the upstream
+    # HTTP status from the message: some provider clients re-raise upstream errors
+    # as plain exceptions whose text preserves the status (e.g. the OpenAI SDK's
+    # "Error code: 429 - {...}"). A rate limit must surface as a retryable 429 with
+    # Retry-After, not a misleading 502 (this is why OpenRouter free-tier models
+    # appeared "broken" in the model selector).
+    msg = str(exc)
+    code_match = re.search(r"Error code:\s*(\d{3})", msg)
+    parsed_status = int(code_match.group(1)) if code_match else None
+    is_rate_limited = (
+        parsed_status == 429 or "rate limit" in msg.lower() or "too many requests" in msg.lower()
+    )
+    if is_rate_limited:
+        return HTTPException(
+            status_code=429,
+            detail=(
+                f"Provider '{provider}' rate limit exceeded for model '{model}'. "
+                "Please retry shortly."
+            ),
+            headers={"Retry-After": "30"},
+        )
+    if parsed_status == 404:
+        return HTTPException(
+            status_code=404, detail=f"Model {model} not found or unavailable on {provider}"
+        )
+
     return HTTPException(
-        status_code=502, detail=f"Provider '{provider}' error for model '{model}': {str(exc)}"
+        status_code=502, detail=f"Provider '{provider}' error for model '{model}': {msg}"
     )
 
 

--- a/tests/services/test_provider_error_429_mapping.py
+++ b/tests/services/test_provider_error_429_mapping.py
@@ -1,0 +1,52 @@
+"""Regression tests for upstream 429 mapping (free-tier models looked "broken").
+
+Rate-limited provider responses (e.g. OpenRouter free-tier) reach the chat
+handler as plain exceptions whose text preserves the upstream status — the
+OpenAI SDK renders `RateLimitError` as ``"Error code: 429 - {...}"``. The
+handler used to wrap *every* provider exception as a generic 502, so a 429
+(retryable) was surfaced to clients as a 502 (looks like a gateway failure),
+which made free models appear permanently broken in the model selector.
+
+`map_provider_error` must extract a 429 from such stringified errors and return
+a retryable 429 with Retry-After. Genuine non-status errors still map to 502.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from src.services.provider_failover import map_provider_error
+
+
+def test_stringified_429_maps_to_429_with_retry_after():
+    exc = Exception(
+        "Error code: 429 - {'error': {'message': 'Provider returned error', 'code': 429}}"
+    )
+    result = map_provider_error("openrouter", "openai/gpt-oss-120b:free", exc)
+    assert isinstance(result, HTTPException)
+    assert result.status_code == 429
+    assert result.headers and "Retry-After" in result.headers
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Provider returned a rate limit error",
+        "429 Too Many Requests",
+        "Error code: 429 - rate limited",
+    ],
+)
+def test_rate_limit_phrasings_map_to_429(message):
+    result = map_provider_error("openrouter", "some/model:free", Exception(message))
+    assert result.status_code == 429
+
+
+def test_stringified_404_maps_to_404():
+    exc = Exception("Error code: 404 - {'error': {'message': 'No endpoints found'}}")
+    result = map_provider_error("openrouter", "google/gemma-3-27b-it:free", exc)
+    assert result.status_code == 404
+
+
+def test_unknown_provider_error_still_maps_to_502():
+    exc = Exception("something unexpected blew up")
+    result = map_provider_error("openrouter", "some/model", exc)
+    assert result.status_code == 502


### PR DESCRIPTION
## Problem
Part of "hundreds of options, none working". OpenRouter free-tier models return **429** (hard free-tier caps), but the chat handler wrapped every provider exception as a hardcoded **502**, so a retryable rate-limit looked like a gateway failure and free models appeared permanently broken.

## Fix
- `map_provider_error` final fallback now best-effort extracts the upstream status from the message (the OpenAI SDK renders `RateLimitError` as `"Error code: 429 - {...}"`): **429 → 429 (with Retry-After)**, **404 → 404**, else 502.
- `chat_handler` non-streaming path returns a proper **429** (`rate_limit_exceeded`, with Retry-After) when the mapped status is 429; other provider errors keep the 502 contract. The streaming path already classifies 429 via its error-string check.

## Tests
Added `tests/services/test_provider_error_429_mapping.py` (6 cases, all pass). Existing `map_provider_error` tests pass; the 5 failing `BuildProviderFailoverChain` tests are pre-existing/env-dependent (verified identical failures on unmodified code — local providers table has no active rows).

## Note
This makes free models report "rate limited, try again" instead of "broken". The complementary change — hiding chronically-failing free models from the selector — is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)