### PR TITLE
feat(catalog): active model health sweep + health-gated catalog

### DIFF
--- a/.github/workflows/model-health-sweep.yml
+++ b/.github/workflows/model-health-sweep.yml
@@ -1,0 +1,43 @@
+name: Model Health Sweep (cron)
+
+# Runs an active inference sweep across every served catalog model and persists
+# FRESH per-model health verdicts. Models that CONSISTENTLY hard-fail
+# (dead / 404 / 5xx) are marked 'down' and hidden from the catalog; models that
+# merely rate-limit (429), time out, or have auth issues are never hidden.
+#
+# REQUIRED SECRET: ADMIN_API_KEY — an admin API key accepted by require_admin on
+# POST /admin/live-test/run. Set it in the repo's Actions secrets.
+
+on:
+  schedule:
+    - cron: "0 */6 * * *" # every 6 hours
+  workflow_dispatch:
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - name: Trigger persisted live model sweep
+        run: |
+          set -euo pipefail
+          if [ -z "${ADMIN_API_KEY:-}" ]; then
+            echo "::error::ADMIN_API_KEY secret is not set — cannot run the sweep."
+            exit 1
+          fi
+          # --max-time bounds the whole request; the sweep itself is bounded server-side.
+          http_code=$(curl -sS -o /tmp/sweep_response.json -w "%{http_code}" \
+            --max-time 2100 \
+            -X POST "https://api.gatewayz.ai/admin/live-test/run?persist=true" \
+            -H "Authorization: Bearer ${ADMIN_API_KEY}" \
+            -H "Content-Type: application/json")
+          echo "HTTP status: ${http_code}"
+          echo "----- response (truncated) -----"
+          head -c 2000 /tmp/sweep_response.json || true
+          echo
+          case "${http_code}" in
+            2*) echo "Sweep completed successfully." ;;
+            *)  echo "::error::Sweep failed with HTTP ${http_code}"; exit 1 ;;
+          esac
+        env:
+          ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -150,14 +150,22 @@ class Config:
         os.environ.get("LEDGER_RECONCILIATION_WINDOW_HOURS", "24")
     )
     # Reject inference requests for models without a row in model_pricing.
-    REQUIRE_MODEL_PRICING = os.environ.get("REQUIRE_MODEL_PRICING", "true").lower() in {"1", "true", "yes"}
+    REQUIRE_MODEL_PRICING = os.environ.get("REQUIRE_MODEL_PRICING", "true").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
 
     # Gatewayz One Phase 2 — smart router. When true, the live provider failover
     # chain is REORDERED by the policy-based smart router using the Phase 1
     # model_provider_offers projection. Off by default; no-ops (exact passthrough)
     # when the offers table has no rows for the model, so it is safe to enable
     # before the projection is populated. Never drops a provider from the chain.
-    SMART_ROUTER_ENABLED = os.environ.get("SMART_ROUTER_ENABLED", "false").lower() in {"1", "true", "yes"}
+    SMART_ROUTER_ENABLED = os.environ.get("SMART_ROUTER_ENABLED", "false").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
     # Default routing policy when no per-key routing_policies row applies.
     SMART_ROUTER_POLICY = os.environ.get("SMART_ROUTER_POLICY", "balanced").strip().lower()
 
@@ -165,7 +173,11 @@ class Config:
     # reassembled within a per-request token budget (system + memory + rolling
     # summary + most-recent turns, oldest-first dropping) before the upstream call.
     # Off by default; exact passthrough when disabled.
-    CONTEXT_ASSEMBLY_ENABLED = os.environ.get("CONTEXT_ASSEMBLY_ENABLED", "false").lower() in {"1", "true", "yes"}
+    CONTEXT_ASSEMBLY_ENABLED = os.environ.get("CONTEXT_ASSEMBLY_ENABLED", "false").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
     # Fraction of a model's context window reserved for the assembled prompt
     # (the rest is left for the completion). Only used when CONTEXT_ASSEMBLY_ENABLED.
     CONTEXT_ASSEMBLY_BUDGET_RATIO = float(os.environ.get("CONTEXT_ASSEMBLY_BUDGET_RATIO", "0.7"))
@@ -173,14 +185,20 @@ class Config:
     # ("my name is…", "I prefer…", "remember that…") are extracted from a user's
     # messages and saved to user_memory (post-response background task) so the
     # context assembler can recall them. High-precision + capped; off by default.
-    MEMORY_CAPTURE_ENABLED = os.environ.get("MEMORY_CAPTURE_ENABLED", "false").lower() in {"1", "true", "yes"}
+    MEMORY_CAPTURE_ENABLED = os.environ.get("MEMORY_CAPTURE_ENABLED", "false").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
     MEMORY_MAX_PER_USER = int(os.environ.get("MEMORY_MAX_PER_USER", "100"))
 
     # Assumed budget when a model's context length is unknown. Deliberately large
     # so an unknown window does NOT cause aggressive truncation — when we can't tell
     # a model's real window, we pass the turns through (no worse than today) rather
     # than risk dropping context that would have fit.
-    CONTEXT_ASSEMBLY_DEFAULT_BUDGET = int(os.environ.get("CONTEXT_ASSEMBLY_DEFAULT_BUDGET", "1000000"))
+    CONTEXT_ASSEMBLY_DEFAULT_BUDGET = int(
+        os.environ.get("CONTEXT_ASSEMBLY_DEFAULT_BUDGET", "1000000")
+    )
 
     # Gatewayz One Phase 5 — multi-region (rollout phase 1: inventory + wire, no
     # traffic change). The region_router selection core is fed from these. Until
@@ -189,9 +207,7 @@ class Config:
     # serving region (X-Gatewayz-Region header / health) for observability.
     # The name of the region THIS instance runs as (Railway injects RAILWAY_REPLICA_REGION).
     GATEWAY_REGION = (
-        os.environ.get("GATEWAY_REGION")
-        or os.environ.get("RAILWAY_REPLICA_REGION")
-        or "primary"
+        os.environ.get("GATEWAY_REGION") or os.environ.get("RAILWAY_REPLICA_REGION") or "primary"
     )
     # Region inventory: comma-separated "name" or "name:latency_ms" (e.g.
     # "us-east:10,eu-west:80"). Empty → single region (GATEWAY_REGION). Only consulted
@@ -201,7 +217,11 @@ class Config:
     # pins these to one region until the ledger is the billing source of truth).
     GATEWAY_HOME_REGION = os.environ.get("GATEWAY_HOME_REGION", "").strip() or GATEWAY_REGION
     # Master switch for multi-region behavior. Off by default (single region).
-    MULTI_REGION_ENABLED = os.environ.get("MULTI_REGION_ENABLED", "false").lower() in {"1", "true", "yes"}
+    MULTI_REGION_ENABLED = os.environ.get("MULTI_REGION_ENABLED", "false").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
     # Subscription statuses that may NOT call the API (comma-separated).
     # Includes both American (Stripe) and British spellings of cancel*, plus all
     # Stripe failure states: past_due (charge failed), unpaid (multiple failures),
@@ -583,6 +603,15 @@ class Config:
         if _raw_enabled.strip()
         else None  # None = all providers enabled
     )
+
+    # Health-gated catalog. When true, models whose models.health_status == 'down'
+    # are hidden from the served catalog. This is INERT until an active health sweep
+    # (see src/services/monitoring/model_health_sweep.py) actually marks a model
+    # 'down' — which only happens for models that CONSISTENTLY hard-fail
+    # (dead / 404 / 5xx). Models that merely rate-limit (429), time out, or have
+    # auth problems are NEVER hidden. Defaults ON but inert until fresh sweep data
+    # exists; set HEALTH_GATING_ENABLED=false to disable the filter entirely.
+    HEALTH_GATING_ENABLED: bool = os.getenv("HEALTH_GATING_ENABLED", "true").lower() == "true"
 
     # Pricing markup — multiplier applied on top of upstream provider cost.
     # 1.0 = pass-through (no profit), 1.25 = 25% margin, 1.30 = 30% margin.

--- a/src/routes/catalog.py
+++ b/src/routes/catalog.py
@@ -85,6 +85,92 @@ DESC_GRADUATED_MODELS_ONLY = "Graduated models only"
 DESC_NON_GRADUATED_MODELS_ONLY = "Non-graduated models only"
 
 
+# ============================================================================
+# HEALTH GATING
+# Hide models that an active health sweep has marked 'down' (consistently
+# hard-failing / dead / 404 / 5xx). Feature-flagged and INERT until a sweep
+# actually marks a model down — 429 / timeout / auth failures never hide a model.
+# ============================================================================
+
+# Short-lived cache of the "down" model id-set so the gating filter doesn't hit
+# the DB on every catalog request. Kept small; refreshed on TTL expiry.
+_DOWN_MODEL_IDS_CACHE: dict[str, Any] = {"ids": None, "ts": 0.0}
+_DOWN_MODEL_IDS_TTL_SECONDS = 60.0
+
+
+def _get_down_model_id_set() -> set[str]:
+    """Return the set of identifiers (id / model_name / provider_model_id /
+    canonical_id) for models currently marked ``health_status == 'down'``.
+
+    Cached for a short TTL. Fails open (empty set) so gating can never break the
+    catalog. Only consulted for served models that lack an inline health_status.
+    """
+    now = time.monotonic()
+    cached = _DOWN_MODEL_IDS_CACHE.get("ids")
+    if cached is not None and (now - _DOWN_MODEL_IDS_CACHE["ts"]) < _DOWN_MODEL_IDS_TTL_SECONDS:
+        return cached
+
+    ids: set[str] = set()
+    try:
+        from src.db.models_catalog_db import get_models_by_health_status
+
+        for row in get_models_by_health_status("down") or []:
+            for key in (
+                row.get("provider_model_id"),
+                row.get("model_name"),
+                row.get("canonical_id"),
+                row.get("id"),
+            ):
+                if key:
+                    ids.add(str(key))
+    except Exception as e:
+        logger.debug(f"health gating: failed to load down-set (failing open): {e}")
+
+    _DOWN_MODEL_IDS_CACHE["ids"] = ids
+    _DOWN_MODEL_IDS_CACHE["ts"] = now
+    return ids
+
+
+def _apply_health_gating(models: list) -> list:
+    """Remove models marked ``health_status == 'down'`` from a served model list.
+
+    Guarded by ``Config.HEALTH_GATING_ENABLED``. Inert until a sweep marks a model
+    down. Fails open (returns the input unchanged) on any error.
+    """
+    from src.config.config import Config
+
+    if not getattr(Config, "HEALTH_GATING_ENABLED", False):
+        return models
+    if not models:
+        return models
+
+    try:
+        down_ids: set[str] | None = None
+        filtered: list = []
+        for m in models:
+            if not isinstance(m, dict):
+                filtered.append(m)
+                continue
+            health = str(m.get("health_status") or "").lower()
+            if health == "down":
+                continue
+            if health:
+                # Known and not 'down' → keep without a DB lookup.
+                filtered.append(m)
+                continue
+            # No inline health_status → consult the down-set (loaded lazily/once).
+            if down_ids is None:
+                down_ids = _get_down_model_id_set()
+            model_id = m.get("id")
+            if model_id and str(model_id) in down_ids:
+                continue
+            filtered.append(m)
+        return filtered
+    except Exception as e:
+        logger.warning(f"health gating failed, returning ungated models: {e}")
+        return models
+
+
 @router.get("/routers", tags=["routers"])
 async def get_intelligent_routers():
     """
@@ -760,6 +846,11 @@ async def get_models(
         cached_response = await get_cached_catalog_response(gateway_value, cache_params)
         if cached_response:
             logger.info(f"✅ Returning cached response for gateway={gateway_value}")
+            # Defense-in-depth: re-apply health gating to cached data in case the
+            # entry was cached before a model was marked 'down' (inert otherwise).
+            gated_data = _apply_health_gating(cached_response.get("data", []))
+            if len(gated_data) != len(cached_response.get("data", [])):
+                cached_response = {**cached_response, "data": gated_data}
             cached_json = _dumps_fast(cached_response)
             etag_data = json.dumps(cached_response.get("data", [])[:5], sort_keys=True)
             etag_value = hashlib.md5(etag_data.encode(), usedforsecurity=False).hexdigest()[:16]
@@ -961,6 +1052,17 @@ async def get_models(
                 logger.info(
                     f"Filtered to exclude private models: {original_count} -> {len(models)}"
                 )
+
+        # Health gating: drop models an active sweep marked 'down' BEFORE counting
+        # and paginating, so totals/pagination stay correct. Inert until a sweep
+        # marks a model down; 429/timeout/auth never hide a model.
+        _pre_gate_count = len(models)
+        models = _apply_health_gating(models)
+        if len(models) != _pre_gate_count:
+            logger.info(
+                f"Health gating removed {_pre_gate_count - len(models)} 'down' models "
+                f"({_pre_gate_count} -> {len(models)})"
+            )
 
         total_models = len(models)
         logger.info(f"Catalog response: {total_models} total models, gateway={gateway_value}")

--- a/src/routes/live_model_test.py
+++ b/src/routes/live_model_test.py
@@ -84,6 +84,7 @@ class LiveTestReport(BaseModel):
     by_provider: list[ProviderSummary] = []
     failures: list[ModelTestResult] = []
     results: list[ModelTestResult] = []
+    persistence: dict | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -289,6 +290,15 @@ async def run_live_model_test(
     concurrency: int = Query(10, ge=1, le=20, description="Parallel requests"),
     timeout: float = Query(60.0, ge=5, le=120, description="Per-model timeout (s)"),
     skip_unhealthy: bool = Query(True, description="Skip models with health_status=down"),
+    persist: bool = Query(
+        False,
+        description=(
+            "Persist FRESH per-model health verdicts from this sweep. When true, "
+            "records precise call outcomes and marks consistently hard-failing "
+            "(dead/404/5xx) models 'down'. 429/timeout/auth never hide a model. "
+            "Default false (existing behavior unchanged)."
+        ),
+    ),
     admin_user: dict = Depends(require_admin),
 ) -> LiveTestReport:
     """
@@ -408,6 +418,18 @@ async def run_live_model_test(
         report.pass_rate,
         duration,
     )
+
+    # Optionally persist FRESH per-model health verdicts from this sweep.
+    # Defensive: persistence must never fail the endpoint.
+    if persist:
+        try:
+            from src.services.monitoring.model_health_sweep import persist_sweep_results
+
+            report.persistence = await persist_sweep_results(results)
+            logger.info("Live test persistence summary: %s", report.persistence)
+        except Exception as exc:
+            logger.error("Live test persistence failed: %s", exc)
+            report.persistence = {"error": str(exc)[:200]}
 
     return report
 

--- a/src/services/monitoring/model_health_sweep.py
+++ b/src/services/monitoring/model_health_sweep.py
@@ -1,0 +1,323 @@
+"""
+Model health sweep — classify live-probe results and persist FRESH per-model
+health verdicts.
+
+This module turns the raw pass/fail/timeout/error results produced by the admin
+live-model-test sweep (``src/routes/live_model_test.py``) into:
+
+1. A precise per-model call record in ``model_health_tracking`` (via
+   ``record_model_call``) so soft failures (429 / timeout / auth) stay
+   distinguishable from hard failures (404 / 5xx / dead model).
+2. A conservative catalog verdict written to the ``models`` table
+   (``health_status`` column) via ``update_model_health``.
+
+Safety property
+---------------
+The pipeline NEVER hides a model that merely rate-limits (429), times out, or has
+auth problems — those recover or are config issues. Only models that *consistently
+hard-fail* (dead / 404 / 5xx) reach ``health_status='down'``, and only after
+``HARD_FAIL_THRESHOLD`` consecutive hard failures. Everything is wrapped
+defensively: this runs from an admin endpoint / cron and must never raise.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Number of consecutive hard failures required before a model is marked "down".
+HARD_FAIL_THRESHOLD = 3
+
+# Substrings (checked case-insensitively) that indicate a model genuinely does not
+# exist / has no serving endpoint — i.e. a HARD failure worth hiding.
+_NOT_FOUND_PATTERNS = (
+    "not found",
+    "no endpoints",
+    "no allowed providers",
+    "does not exist",
+)
+# Substrings that indicate a transient rate-limit — a SOFT failure (never hide).
+_RATE_LIMIT_PATTERNS = ("rate limit", "too many requests", "rate_limited")
+# Substrings that indicate an auth/config problem — a SOFT failure (never hide).
+_AUTH_PATTERNS = ("unauthorized", "authentication", "api key")
+
+
+def classify_probe_result(status: str, status_code: int | None, error: str | None) -> str:
+    """Classify a single live-probe result into a health outcome.
+
+    Args:
+        status: The probe status ("pass", "fail", "timeout", "error", "skip").
+        status_code: HTTP status code from the probe, if any.
+        error: Error text from the probe, if any.
+
+    Returns:
+        One of "healthy", "hard_fail", "soft", "skip".
+
+    The default for any ambiguous failure is "soft" — we never hide a model on
+    uncertain evidence.
+    """
+    s = (status or "").strip().lower()
+    err = (error or "").lower()
+
+    if s == "pass":
+        return "healthy"
+    if s == "skip":
+        return "skip"
+    if s == "timeout":
+        return "soft"
+
+    if s == "fail":
+        if status_code == 404 or any(p in err for p in _NOT_FOUND_PATTERNS):
+            return "hard_fail"
+        if status_code == 429 or any(p in err for p in _RATE_LIMIT_PATTERNS):
+            return "soft"
+        if status_code in (401, 403) or any(p in err for p in _AUTH_PATTERNS):
+            return "soft"
+        if isinstance(status_code, int) and status_code >= 500:
+            return "hard_fail"
+        # Anything else (400, unknown) → soft: never hide on ambiguous evidence.
+        return "soft"
+
+    if s == "error":
+        # Transport/exception errors are soft unless the text clearly says the
+        # model does not exist (e.g. "No endpoints found for model X").
+        if any(p in err for p in _NOT_FOUND_PATTERNS):
+            return "hard_fail"
+        return "soft"
+
+    # Unknown status → soft (safe default).
+    return "soft"
+
+
+def _precise_status(outcome: str, status_code: int | None, error: str | None) -> str:
+    """Map an outcome to the precise ``model_health_tracking.last_status`` value.
+
+    Keeping this precise (rather than a blanket "error") is what makes soft
+    failures distinguishable from hard ones on later reads.
+    """
+    err = (error or "").lower()
+    if outcome == "healthy":
+        return "success"
+    if outcome == "hard_fail":
+        if status_code == 404 or any(p in err for p in _NOT_FOUND_PATTERNS):
+            return "not_found"
+        return "provider_error"
+    # soft
+    if status_code == 429 or any(p in err for p in _RATE_LIMIT_PATTERNS):
+        return "rate_limited"
+    if status_code in (401, 403) or any(p in err for p in _AUTH_PATTERNS):
+        return "unauthorized"
+    return "error"
+
+
+def _field(result: Any, name: str, default: Any = None) -> Any:
+    """Read ``name`` from a ModelTestResult-like object OR a plain dict."""
+    if isinstance(result, dict):
+        return result.get(name, default)
+    return getattr(result, name, default)
+
+
+def _build_model_pk_map(model_ids: list[str]) -> dict[str, int]:
+    """Batch-resolve string catalog ids → integer ``models`` primary keys.
+
+    The catalog id is ``provider_model_id`` (falling back to ``model_name``), so we
+    look up both columns. Tolerant of misses — unresolved ids are simply absent
+    from the returned map.
+    """
+    mapping: dict[str, int] = {}
+    unique_ids = [mid for mid in dict.fromkeys(model_ids) if mid]
+    if not unique_ids:
+        return mapping
+
+    try:
+        from src.config.supabase_config import get_client_for_query
+
+        supabase = get_client_for_query(read_only=True)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("model_health_sweep: cannot get supabase client for PK lookup: %s", exc)
+        return mapping
+
+    chunk_size = 200
+    for i in range(0, len(unique_ids), chunk_size):
+        chunk = unique_ids[i : i + chunk_size]
+        chunk_set = set(chunk)
+        for column in ("provider_model_id", "model_name"):
+            try:
+                resp = (
+                    supabase.table("models")
+                    .select("id, model_name, provider_model_id")
+                    .in_(column, chunk)
+                    .execute()
+                )
+            except Exception as exc:
+                logger.warning("model_health_sweep: PK lookup by %s failed: %s", column, exc)
+                continue
+            for row in resp.data or []:
+                pk = row.get("id")
+                if pk is None:
+                    continue
+                for key in (row.get("provider_model_id"), row.get("model_name")):
+                    if key and key in chunk_set and key not in mapping:
+                        mapping[key] = pk
+    return mapping
+
+
+def _update_hard_fail_streak(
+    provider: str, model: str, gateway: str | None, consecutive_failures: int
+) -> None:
+    """Persist the hard-failure streak counter on ``model_health_tracking``.
+
+    ``record_model_call`` maintains call/success/error counts and ``last_status``
+    but does NOT touch ``consecutive_failures``; we maintain that counter here so
+    the "consistently hard-failing" verdict actually works. Best-effort only.
+    """
+    try:
+        from src.config.supabase_config import get_supabase_client
+
+        supabase = get_supabase_client()
+        payload = {
+            "provider": provider,
+            "model": model,
+            "gateway": gateway or provider,
+            "consecutive_failures": consecutive_failures,
+            "consecutive_successes": 0 if consecutive_failures > 0 else 1,
+        }
+        supabase.table("model_health_tracking").upsert(
+            payload, on_conflict="provider,model"
+        ).execute()
+    except Exception as exc:
+        logger.warning(
+            "model_health_sweep: failed to update hard-fail streak for %s/%s: %s",
+            provider,
+            model,
+            exc,
+        )
+
+
+async def persist_sweep_results(results: list) -> dict:
+    """Persist classified sweep results and compute per-model health verdicts.
+
+    For each result (``ModelTestResult``-like object or dict):
+      * classify → outcome; skip "skip" outcomes entirely.
+      * record a precise call in ``model_health_tracking`` via ``record_model_call``.
+      * maintain the consecutive hard-failure streak.
+      * write a conservative verdict to the ``models`` table:
+          - "healthy"   → health_status='healthy' (recovery)
+          - "hard_fail" → health_status='down' ONLY once the streak reaches
+                          HARD_FAIL_THRESHOLD consecutive hard failures.
+          - "soft"      → no change (neutral: 429 / timeout / auth never hide).
+
+    Never raises. Returns a summary dict of counts.
+    """
+    summary = {
+        "processed": 0,
+        "healthy": 0,
+        "hard_fail": 0,
+        "soft": 0,
+        "skipped": 0,
+        "marked_down": 0,
+        "recovered": 0,
+        "errors": 0,
+    }
+
+    # Deferred imports keep this module import-light and avoid import cycles.
+    try:
+        from src.db.model_health import get_model_health, record_model_call
+        from src.db.models_catalog_db import update_model_health
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("model_health_sweep: cannot import DB helpers: %s", exc)
+        return summary
+
+    # First pass: record calls + maintain streaks, collect verdicts to write.
+    verdicts: dict[str, str] = {}  # model_id -> "down" | "healthy"
+    for result in results or []:
+        try:
+            status = _field(result, "status", "")
+            status_code = _field(result, "status_code")
+            error = _field(result, "error")
+            outcome = classify_probe_result(status, status_code, error)
+
+            if outcome == "skip":
+                summary["skipped"] += 1
+                continue
+
+            summary["processed"] += 1
+            summary[outcome] = summary.get(outcome, 0) + 1
+
+            model_id = _field(result, "model_id") or ""
+            provider = _field(result, "provider") or _field(result, "gateway") or "unknown"
+            gateway = _field(result, "gateway")
+            latency = _field(result, "latency_ms") or 0
+
+            if not model_id:
+                continue
+
+            precise = _precise_status(outcome, status_code, error)
+
+            # Read the current streak BEFORE recording (record_model_call preserves
+            # consecutive_failures, so this reflects the prior state).
+            prev = get_model_health(provider, model_id) or {}
+            prev_streak = int(prev.get("consecutive_failures") or 0)
+
+            record_model_call(
+                provider,
+                model=model_id,
+                response_time_ms=latency,
+                status=precise,
+                error_message=error,
+                gateway=gateway,
+            )
+
+            if outcome == "healthy":
+                new_streak = 0
+            elif outcome == "hard_fail":
+                new_streak = prev_streak + 1
+            else:  # soft — neutral, leave streak unchanged
+                new_streak = prev_streak
+
+            # Only write the streak when it changes (healthy reset or hard bump).
+            if outcome in ("healthy", "hard_fail"):
+                _update_hard_fail_streak(provider, model_id, gateway, new_streak)
+
+            if outcome == "healthy":
+                verdicts[model_id] = "healthy"
+            elif outcome == "hard_fail" and new_streak >= HARD_FAIL_THRESHOLD:
+                verdicts[model_id] = "down"
+        except Exception as exc:
+            summary["errors"] += 1
+            logger.warning("model_health_sweep: error processing a result: %s", exc)
+
+    # Second pass: resolve PKs in one batch and write catalog verdicts.
+    if verdicts:
+        try:
+            pk_map = _build_model_pk_map(list(verdicts.keys()))
+        except Exception as exc:
+            logger.warning("model_health_sweep: PK batch lookup failed: %s", exc)
+            pk_map = {}
+
+        for model_id, verdict in verdicts.items():
+            pk = pk_map.get(model_id)
+            if pk is None:
+                logger.debug(
+                    "model_health_sweep: no models PK for '%s'; skipping verdict '%s'",
+                    model_id,
+                    verdict,
+                )
+                continue
+            try:
+                update_model_health(pk, verdict)
+                if verdict == "down":
+                    summary["marked_down"] += 1
+                    logger.info("model_health_sweep: marked '%s' (pk=%s) down", model_id, pk)
+                else:
+                    summary["recovered"] += 1
+            except Exception as exc:
+                summary["errors"] += 1
+                logger.warning(
+                    "model_health_sweep: failed writing verdict for %s: %s", model_id, exc
+                )
+
+    logger.info("model_health_sweep: persistence summary %s", summary)
+    return summary

--- a/tests/services/test_model_health_sweep.py
+++ b/tests/services/test_model_health_sweep.py
@@ -1,0 +1,131 @@
+"""
+Pure unit tests for the model health sweep classifier and the catalog health
+gating filter. No DB / network — classification is pure and gating is fed plain
+dicts that all carry an inline ``health_status`` (so the DB down-set is never
+consulted).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.services.monitoring.model_health_sweep import (
+    HARD_FAIL_THRESHOLD,
+    classify_probe_result,
+)
+
+
+class TestClassifyProbeResult:
+    def test_pass_is_healthy(self):
+        assert classify_probe_result("pass", 200, None) == "healthy"
+
+    def test_skip_is_skip(self):
+        assert classify_probe_result("skip", None, "non-chat modality") == "skip"
+
+    def test_fail_404_is_hard_fail(self):
+        assert classify_probe_result("fail", 404, "HTTP 404: model missing") == "hard_fail"
+
+    def test_fail_429_is_soft(self):
+        assert classify_probe_result("fail", 429, "HTTP 429: slow down") == "soft"
+
+    def test_fail_401_is_soft(self):
+        assert classify_probe_result("fail", 401, "HTTP 401: bad key") == "soft"
+
+    def test_fail_403_is_soft(self):
+        assert classify_probe_result("fail", 403, "HTTP 403: forbidden") == "soft"
+
+    def test_fail_503_is_hard_fail(self):
+        assert classify_probe_result("fail", 503, "HTTP 503: upstream error") == "hard_fail"
+
+    def test_fail_500_is_hard_fail(self):
+        assert classify_probe_result("fail", 500, "HTTP 500: server error") == "hard_fail"
+
+    def test_timeout_is_soft(self):
+        assert classify_probe_result("timeout", None, "Timed out after 60s") == "soft"
+
+    def test_fail_no_endpoints_text_is_hard_fail(self):
+        # No status code, but the error text clearly indicates a dead model.
+        assert classify_probe_result("fail", None, "No endpoints found for model X") == "hard_fail"
+
+    def test_fail_no_allowed_providers_is_hard_fail(self):
+        assert (
+            classify_probe_result("fail", 400, "No allowed providers are available") == "hard_fail"
+        )
+
+    def test_ambiguous_fail_is_soft(self):
+        # 400 with a generic message → soft (never hide on ambiguous evidence).
+        assert classify_probe_result("fail", 400, "Bad request: invalid params") == "soft"
+
+    def test_error_with_not_found_text_is_hard_fail(self):
+        assert classify_probe_result("error", None, "model does not exist") == "hard_fail"
+
+    def test_generic_error_is_soft(self):
+        assert classify_probe_result("error", None, "Connection reset by peer") == "soft"
+
+    def test_rate_limit_text_without_code_is_soft(self):
+        assert classify_probe_result("fail", None, "rate limit exceeded") == "soft"
+
+    def test_unknown_status_is_soft(self):
+        assert classify_probe_result("weird", None, None) == "soft"
+
+    def test_hard_fail_threshold_constant(self):
+        assert HARD_FAIL_THRESHOLD == 3
+
+
+class TestApplyHealthGating:
+    @pytest.fixture
+    def models(self):
+        return [
+            {"id": "openai/gpt-x", "health_status": "healthy"},
+            {"id": "dead/model", "health_status": "down"},
+            {"id": "meta/unknown", "health_status": "unknown"},
+            {"id": "no/status"},  # missing health_status entirely
+        ]
+
+    def test_flag_on_removes_only_down(self, models, monkeypatch):
+        from src.config.config import Config
+        from src.routes import catalog
+
+        monkeypatch.setattr(Config, "HEALTH_GATING_ENABLED", True)
+        # Force the down-set (used only for the model lacking health_status) empty
+        # so the test never touches the DB.
+        monkeypatch.setattr(catalog, "_get_down_model_id_set", lambda: set())
+
+        result = catalog._apply_health_gating(list(models))
+        ids = [m["id"] for m in result]
+
+        assert "dead/model" not in ids
+        assert ids == ["openai/gpt-x", "meta/unknown", "no/status"]
+
+    def test_flag_off_removes_nothing(self, models, monkeypatch):
+        from src.config.config import Config
+        from src.routes import catalog
+
+        monkeypatch.setattr(Config, "HEALTH_GATING_ENABLED", False)
+
+        result = catalog._apply_health_gating(list(models))
+        assert len(result) == len(models)
+        assert [m["id"] for m in result] == [m["id"] for m in models]
+
+    def test_flag_on_drops_model_in_down_set(self, monkeypatch):
+        from src.config.config import Config
+        from src.routes import catalog
+
+        monkeypatch.setattr(Config, "HEALTH_GATING_ENABLED", True)
+        # A served model lacking inline health_status but present in the down-set
+        # must be dropped.
+        monkeypatch.setattr(catalog, "_get_down_model_id_set", lambda: {"no/status"})
+
+        models = [
+            {"id": "openai/gpt-x", "health_status": "healthy"},
+            {"id": "no/status"},
+        ]
+        result = catalog._apply_health_gating(models)
+        assert [m["id"] for m in result] == ["openai/gpt-x"]
+
+    def test_empty_input_returns_empty(self, monkeypatch):
+        from src.config.config import Config
+        from src.routes import catalog
+
+        monkeypatch.setattr(Config, "HEALTH_GATING_ENABLED", True)
+        assert catalog._apply_health_gating([]) == []


### PR DESCRIPTION
## Summary

Adds a model health-gating pipeline: an active health-check sweep persists FRESH per-model health verdicts, and the served catalog hides models that **consistently hard-fail** (dead / 404 / 5xx). Models that merely rate-limit (429), time out, or have auth issues are **never** hidden — those recover or are config problems.

## Design

**1. Classifier + persistence — `src/services/monitoring/model_health_sweep.py` (new)**
- `classify_probe_result(status, status_code, error)` → `"healthy" | "hard_fail" | "soft" | "skip"`. Ambiguous failures default to `soft` (never hide on uncertain evidence). `HARD_FAIL_THRESHOLD = 3`.
- `persist_sweep_results(results)`:
  - Records a **precise** `last_status` via `record_model_call` (`success` / `not_found` / `provider_error` / `rate_limited` / `unauthorized` / `timeout`/`error`) so soft vs hard stay distinguishable.
  - Maintains a **consecutive hard-fail streak** on `model_health_tracking.consecutive_failures` (which `record_model_call` does not touch): reset on healthy, +1 on hard_fail, unchanged on soft.
  - Writes a conservative verdict to `models.health_status` via `update_model_health`: `healthy` on recovery; `down` only once the streak reaches `HARD_FAIL_THRESHOLD`; **nothing** on soft.
  - Batches string-id → integer-PK lookups; tolerates misses; **never raises**.

**2. Sweep wiring — `src/routes/live_model_test.py`**
- New `?persist=false` query param on `POST /admin/live-test/run`. When true, runs `persist_sweep_results` and returns the summary under `persistence`. Default false → existing behavior unchanged.

**3. Catalog filter — `src/routes/catalog.py`**
- `_apply_health_gating(models)` removes `health_status == "down"` models. Applied on **both** return paths of `get_models` — on the main path **before pagination** so totals/pagination stay correct. Served models lacking an inline `health_status` are checked against a short-TTL cached "down" id-set (`get_models_by_health_status("down")`). Guarded by `Config.HEALTH_GATING_ENABLED`; **fails open** on any error.

**4. Config — `src/config/config.py`**
- `HEALTH_GATING_ENABLED` (env-backed, default `true`).

**5. Cron — `.github/workflows/model-health-sweep.yml`**
- Every 6h (`0 */6 * * *`) + `workflow_dispatch`; curls `POST /admin/live-test/run?persist=true` with `Authorization: Bearer ${{ secrets.ADMIN_API_KEY }}`, fails on non-2xx. **Requires the `ADMIN_API_KEY` secret** (noted in the workflow).

## Safety property

- **Inert until a sweep marks a model down.** `HEALTH_GATING_ENABLED` defaults on but is a no-op until fresh sweep data actually sets a model's `health_status='down'`. No model is `down` today, so the filter removes nothing.
- **429 / timeout / auth never hide a model** — classified `soft`, which is neutral (no `health_status` change) and never resets... only hard failures (404 / 5xx / dead) accrue toward the down verdict.
- Down-marking requires **3 consecutive hard failures**, not a single blip.
- All persistence + gating is wrapped defensively (logs, never raises / 500s).

## Tests

`tests/services/test_model_health_sweep.py` — 21 pure unit tests (no DB / network) for the classifier and the gating filter.

```
python -m pytest tests/services/test_model_health_sweep.py -o addopts="" -q
21 passed
```
`black --line-length 100 --check` and `ruff check` clean on all changed files.

## Deviations from spec

- The live-test router prefix is **`/admin/live-test`** (not `/live-model-test`); the cron curls `POST /admin/live-test/run?persist=true` accordingly.
- Gating is applied inside `get_models` (the actual assembly fn that `get_all_models` delegates to) — strictly covers `get_all_models` and every other caller.
- `record_model_call` does **not** maintain `consecutive_failures`, so the streak is maintained explicitly in `persist_sweep_results` (via a small best-effort upsert, mirroring `intelligent_health_monitor`) to make the down verdict actually functional while staying safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated model health sweep that runs on a schedule and can also be triggered manually.
  * Added optional persistence for live model test results, including a summary of saved health updates.

* **Bug Fixes**
  * Model listings now hide models marked as down when health gating is enabled.
  * Cached model responses are rechecked for health before being returned, improving consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->