### PR TITLE
feat(chat): friendly message + alert for provider budget errors; stop leaking key

### DIFF
--- a/src/handlers/chat_handler.py
+++ b/src/handlers/chat_handler.py
@@ -407,11 +407,53 @@ class ChatInferenceHandler:
                         headers=mapped.headers,
                     ) from e
 
-                # Other provider errors keep the existing 502 provider-error contract.
+                # Provider account/key budget exhausted (e.g. an OpenRouter key hitting its
+                # weekly spend limit -> upstream 402). This is a gateway-side capacity issue,
+                # NOT the user's — show a friendly message, never leak the upstream key/URL,
+                # and fire a distinct Sentry alert so the team is notified to top up.
+                from src.utils.error_messages import (
+                    PROVIDER_CAPACITY_MESSAGE,
+                    is_provider_budget_error,
+                    sanitize_provider_error_for_user,
+                )
+
+                if mapped.status_code == 402 or is_provider_budget_error(str(e)):
+                    try:
+                        from src.utils.sentry_context import capture_provider_error
+
+                        capture_provider_error(
+                            e,
+                            provider=provider_name,
+                            model=model_id,
+                            request_id=self.request_id,
+                            endpoint="/v1/chat/completions",
+                            extra_context={
+                                "error_category": "provider_budget_exhausted",
+                                "alert": True,
+                            },
+                        )
+                    except Exception:
+                        logger.warning("Failed to capture provider-budget alert", exc_info=True)
+
+                    error_response = DetailedErrorFactory.provider_error(
+                        provider=provider_name,
+                        model=model_id,
+                        provider_message=PROVIDER_CAPACITY_MESSAGE,
+                        status_code=503,
+                        request_id=self.request_id,
+                    )
+                    raise HTTPException(
+                        status_code=error_response.error.status,
+                        detail=error_response.dict(exclude_none=True),
+                        headers={"Retry-After": "30"},
+                    ) from e
+
+                # Other provider errors keep the existing 502 provider-error contract,
+                # sanitized so we never leak upstream URLs/key ids to end users.
                 error_response = DetailedErrorFactory.provider_error(
                     provider=provider_name,
                     model=model_id,
-                    provider_message=str(e),
+                    provider_message=sanitize_provider_error_for_user(str(e)),
                     status_code=502,
                     request_id=self.request_id,
                 )

--- a/src/routes/chat_streaming.py
+++ b/src/routes/chat_streaming.py
@@ -438,10 +438,34 @@ async def stream_generator(
         error_message = "Streaming error occurred"
         error_type = "stream_error"
 
+        from src.utils.error_messages import (
+            PROVIDER_CAPACITY_MESSAGE,
+            is_provider_budget_error,
+            sanitize_provider_error_for_user,
+        )
+
         # Check for rate limit errors
         if "rate limit" in error_str or "429" in error_str or "too many" in error_str:
             error_message = "Rate limit exceeded. Please wait a moment and try again."
             error_type = "rate_limit_error"
+        # Provider account/key out of budget (e.g. OpenRouter weekly key limit -> 402).
+        # Gateway-side capacity issue, not the user's: friendly message + alert the team.
+        elif is_provider_budget_error(error_str):
+            error_message = PROVIDER_CAPACITY_MESSAGE
+            error_type = "capacity_error"
+            try:
+                from src.utils.sentry_context import capture_provider_error
+
+                capture_provider_error(
+                    e,
+                    provider=provider,
+                    model=model,
+                    request_id=request_id,
+                    endpoint="/v1/chat/completions",
+                    extra_context={"error_category": "provider_budget_exhausted", "alert": True},
+                )
+            except Exception:
+                logger.warning("Failed to capture provider-budget alert (stream)", exc_info=True)
         # Check for authentication errors
         elif "401" in error_str or "unauthorized" in error_str or "authentication" in error_str:
             error_message = "Authentication failed. Please check your API key or sign in again."
@@ -465,9 +489,10 @@ async def stream_generator(
             error_type = "not_found_error"
         # For other errors, include a sanitized version of the error message
         else:
-            # Include the actual error message but truncate it for safety
-            sanitized_msg = str(e)[:300].replace("\n", " ").replace("\r", " ")
-            error_message = f"Streaming error: {sanitized_msg}"
+            # Strip URLs/secret-like tokens (upstream errors embed key ids in URLs) and truncate
+            error_message = (
+                f"Streaming error: {sanitize_provider_error_for_user(str(e), max_length=300)}"
+            )
 
         # Auto-refund for clear provider failures if credits were already deducted.
         # In the current streaming architecture, credits are deducted in the background

--- a/src/services/provider_failover.py
+++ b/src/services/provider_failover.py
@@ -7,6 +7,11 @@ import re
 import httpx
 from fastapi import HTTPException
 
+from src.utils.error_messages import (
+    is_provider_budget_error,
+    sanitize_provider_error_for_user,
+)
+
 logger = logging.getLogger(__name__)
 # OpenAI Python SDK raises its own exception hierarchy which we need to
 # translate into HTTP responses. Make these imports optional so the module
@@ -672,9 +677,22 @@ def map_provider_error(
         return HTTPException(
             status_code=404, detail=f"Model {model} not found or unavailable on {provider}"
         )
+    # Provider account/key out of budget (e.g. OpenRouter weekly key limit). Keep the 402
+    # status so failover logic still applies, but never surface the raw upstream message
+    # (it embeds the key id in a dashboard URL).
+    if parsed_status == 402 or is_provider_budget_error(msg):
+        return HTTPException(
+            status_code=402,
+            detail=f"Provider '{provider}' capacity limit reached for model '{model}'.",
+        )
 
+    # Default: sanitize the upstream message so we never leak URLs/key ids to end users.
     return HTTPException(
-        status_code=502, detail=f"Provider '{provider}' error for model '{model}': {msg}"
+        status_code=502,
+        detail=(
+            f"Provider '{provider}' error for model '{model}': "
+            f"{sanitize_provider_error_for_user(msg)}"
+        ),
     )
 
 

--- a/src/utils/error_messages.py
+++ b/src/utils/error_messages.py
@@ -11,7 +11,60 @@ Usage:
     suggestions = get_suggestions(ErrorCode.MODEL_NOT_FOUND)
 """
 
+import re
+
 from src.utils.error_codes import ErrorCode
+
+# User-facing, friendly message for provider account/key budget exhaustion (e.g. an
+# OpenRouter key hitting its weekly spend limit). Never expose the upstream key/URL.
+PROVIDER_CAPACITY_MESSAGE = (
+    "This model is temporarily unavailable due to a capacity limit on our side. "
+    "Please try a different model or try again shortly."
+)
+
+# Patterns that indicate an upstream provider ran out of budget/credits rather than a
+# problem with the user's own request. Matched case-insensitively against the raw error.
+_PROVIDER_BUDGET_PATTERNS = (
+    "requires more credits",
+    "can only afford",
+    "adjust the key",
+    "weekly limit",
+    "insufficient_quota",
+    "payment required",
+)
+
+_URL_RE = re.compile(r"https?://\S+")
+# Long hex tokens (32+ chars) are almost always secrets/key hashes (e.g. an OpenRouter
+# key id leaked in an error URL). Strip them from anything shown to end users.
+_HEX_SECRET_RE = re.compile(r"\b[0-9a-fA-F]{32,}\b")
+
+
+def is_provider_budget_error(raw_error: str | None) -> bool:
+    """True if the raw provider error indicates the provider account/key is out of budget."""
+    if not raw_error:
+        return False
+    lowered = str(raw_error).lower()
+    if "error code: 402" in lowered or '"code": 402' in lowered or "'code': 402" in lowered:
+        return True
+    return any(pattern in lowered for pattern in _PROVIDER_BUDGET_PATTERNS)
+
+
+def sanitize_provider_error_for_user(raw_error: str | None, max_length: int = 200) -> str:
+    """Strip URLs and secret-like tokens from a provider error before showing it to a user.
+
+    Upstream providers (notably OpenRouter) embed dashboard URLs containing the API key id
+    directly in their error text. Passing that through leaks a credential-ish identifier to
+    end users, so we remove URLs and long hex tokens and truncate the result.
+    """
+    if not raw_error:
+        return ""
+    cleaned = _URL_RE.sub("[link removed]", str(raw_error))
+    cleaned = _HEX_SECRET_RE.sub("[redacted]", cleaned)
+    cleaned = cleaned.replace("\n", " ").replace("\r", " ").strip()
+    if len(cleaned) > max_length:
+        cleaned = cleaned[:max_length].rstrip() + "…"
+    return cleaned
+
 
 # Error message templates with placeholders
 ERROR_MESSAGES: dict[ErrorCode, str] = {

--- a/tests/services/test_provider_budget_error.py
+++ b/tests/services/test_provider_budget_error.py
@@ -1,0 +1,69 @@
+"""Tests for provider-budget (402) handling: friendly message + no credential leak.
+
+OpenRouter (and similar) return an upstream 402 when the gateway's API key hits its
+spend limit, and the raw error embeds the key id in a dashboard URL. We must:
+  - detect it (is_provider_budget_error),
+  - never leak the URL/key to users (sanitize_provider_error_for_user),
+  - map it to a clean 402 (map_provider_error) with no raw message.
+"""
+
+from fastapi import HTTPException
+
+from src.services.provider_failover import map_provider_error
+from src.utils.error_messages import (
+    is_provider_budget_error,
+    sanitize_provider_error_for_user,
+)
+
+# The real upstream error a user hit (key id redacted here only for the test literal length;
+# the point is the sanitizer removes it).
+REAL_402 = (
+    "Error code: 402 - {'error': {'message': \"This request requires more credits, or fewer "
+    "max_tokens. You requested up to 2000 tokens, but can only afford 897. To increase, visit "
+    "https://openrouter.ai/workspaces/default/keys/"
+    "f001429593544cd92610592c96fee5e341f53e759e3f07aa5089c82159c5ed03 and adjust the key's "
+    "weekly limit\", 'code': 402}}"
+)
+
+
+def test_is_provider_budget_error_detects_402_budget():
+    assert is_provider_budget_error(REAL_402) is True
+    assert is_provider_budget_error("Error code: 402 - payment required") is True
+    assert is_provider_budget_error("can only afford 12 tokens") is True
+    assert is_provider_budget_error(None) is False
+    assert is_provider_budget_error("Error code: 429 - rate limited") is False
+    assert is_provider_budget_error("some random error") is False
+
+
+def test_sanitizer_removes_url_and_key_hash():
+    cleaned = sanitize_provider_error_for_user(REAL_402)
+    assert "http" not in cleaned
+    assert "openrouter.ai" not in cleaned
+    # the 64-char key hash must be gone
+    assert "f001429593544cd92610592c96fee5e341f53e759e3f07aa5089c82159c5ed03" not in cleaned
+    assert "\n" not in cleaned
+
+
+def test_sanitizer_truncates_and_handles_empty():
+    assert sanitize_provider_error_for_user("") == ""
+    assert sanitize_provider_error_for_user(None) == ""
+    long = "x" * 500
+    assert len(sanitize_provider_error_for_user(long, max_length=100)) <= 101  # + ellipsis
+
+
+def test_map_provider_error_402_is_clean_no_leak():
+    result = map_provider_error("openrouter", "anthropic/claude-haiku-4.5", Exception(REAL_402))
+    assert isinstance(result, HTTPException)
+    assert result.status_code == 402
+    detail = str(result.detail)
+    assert "openrouter.ai" not in detail
+    assert "f001429593544cd92610592c96fee5e341f53e759e3f07aa5089c82159c5ed03" not in detail
+    assert "capacity" in detail.lower()
+
+
+def test_map_provider_error_generic_message_is_sanitized():
+    exc = Exception("boom see https://openrouter.ai/keys/deadbeefdeadbeefdeadbeefdeadbeef00")
+    result = map_provider_error("openrouter", "some/model", exc)
+    detail = str(result.detail)
+    assert "http" not in detail
+    assert "deadbeefdeadbeefdeadbeefdeadbeef00" not in detail


### PR DESCRIPTION
## Problem
A user hit: `Error code: 402 - ... can only afford 897 ... visit https://openrouter.ai/.../keys/<KEY_ID> and adjust the key's weekly limit`. Two issues:
1. **Credential leak** — the raw OpenRouter error (with the **key id in a URL**) was passed straight to end users.
2. **Bad UX** — a gateway-side budget problem was shown as "payment required", implying the *user* must pay.

## Fix
For provider-budget errors (upstream **402** / "requires more credits" / "can only afford" / "weekly limit"):
- **Friendly message** (HTTP 503 + `Retry-After`): *"This model is temporarily unavailable due to a capacity limit on our side. Please try a different model or try again shortly."* — never the raw URL/key.
- **Distinct Sentry alert** (`error_category=provider_budget_exhausted`) so the team is notified to top up / raise the key limit. Wired on **both** the non-streaming (`chat_handler`) and streaming (`chat_streaming`) paths.
- **All** provider errors surfaced to users are now sanitized (`sanitize_provider_error_for_user` strips URLs + long hex key tokens).

Does **not** touch the legitimate user-credit 402 pre-check (insufficient Gatewayz credits) — separate, correct path.

## Tests
`tests/services/test_provider_budget_error.py` — detection, sanitization (URL + 64-char key hash removed), and clean 402 mapping. 11 pass (incl. the 429 suite). black/ruff clean on changed files.

## Related
Builds on the 429→429 mapping (#2145). Complements the OpenRouter **ops** fix (raise the key's weekly limit / top up credits), which is the durable resolution for budget exhaustion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)