### PR TITLE
fix(billing): harden credit grants, webhook dedup, and stop double-charge

### DIFF
--- a/src/db/users.py
+++ b/src/db/users.py
@@ -501,6 +501,72 @@ def get_user_by_username(username: str) -> dict[str, Any] | None:
         return None
 
 
+def _atomic_add_credits_rpc(
+    client,
+    *,
+    user_id: int,
+    credits: float,
+    transaction_type: str,
+    description: str,
+    payment_id: int | None,
+    metadata: dict | None,
+    request_id: str | None,
+    created_by: str | None,
+) -> dict | None:
+    """Call the atomic_add_credits stored procedure.
+
+    Returns the parsed JSONB result dict on a definitive outcome (a real grant
+    or an idempotent no-op), or ``None`` when the RPC is unavailable/unusable so
+    the caller falls back to the legacy read-modify-write path. Raises
+    ``ValueError`` for business errors (e.g. user_not_found).
+    """
+    rpc_params = {
+        "p_user_id": user_id,
+        "p_credits": float(credits),
+        "p_transaction_type": transaction_type,
+        "p_description": description,
+        "p_target": "purchased",
+        "p_metadata": metadata or {},
+    }
+    if payment_id is not None:
+        rpc_params["p_payment_id"] = payment_id
+    if request_id:
+        rpc_params["p_request_id"] = str(request_id)
+    if created_by:
+        rpc_params["p_created_by"] = created_by
+
+    try:
+        rpc_result = client.rpc("atomic_add_credits", rpc_params).execute()
+    except Exception as rpc_exc:
+        # RPC not deployed yet, or a transport error -- fall back to legacy path.
+        logger.info(
+            "atomic_add_credits RPC unavailable for user %s (%s), using legacy path.",
+            sanitize_for_logging(str(user_id)),
+            type(rpc_exc).__name__,
+        )
+        return None
+
+    data = rpc_result.data
+    if isinstance(data, list) and data:
+        data = data[0]
+    if not isinstance(data, dict):
+        return None
+
+    if data.get("success") is True:
+        return data
+
+    error = data.get("error", "unknown_rpc_error")
+    if error == "user_not_found":
+        raise ValueError(f"User with ID {user_id} not found")
+    # Other RPC-level errors -- fall back to the legacy path rather than losing the grant.
+    logger.warning(
+        "atomic_add_credits RPC error '%s' for user %s; falling back to legacy path.",
+        error,
+        sanitize_for_logging(str(user_id)),
+    )
+    return None
+
+
 def add_credits_to_user(
     user_id: int,
     credits: float,
@@ -509,6 +575,7 @@ def add_credits_to_user(
     payment_id: int | None = None,
     metadata: dict | None = None,
     created_by: str | None = None,
+    request_id: str | None = None,
 ) -> None:
     """
     Add credits to user account by user ID and log the transaction.
@@ -523,6 +590,10 @@ def add_credits_to_user(
         payment_id: Optional payment ID if this is from a payment
         metadata: Optional metadata dictionary
         created_by: Optional identifier of who created the transaction (e.g. "admin:123")
+        request_id: Optional UUID idempotency key. When supplied, the grant is
+            applied at most once even under concurrent/duplicate delivery (e.g.
+            Stripe webhook retries), enforced by the unique index on
+            credit_transactions.request_id.
     """
     if credits <= 0:
         raise ValueError("Credits must be positive")
@@ -532,6 +603,45 @@ def add_credits_to_user(
 
         client = get_supabase_client()
 
+        # ---------------------------------------------------------------
+        # ATOMIC PATH: atomic_add_credits RPC performs the balance update and the
+        # ledger insert in one transaction under a row lock, and is idempotent on
+        # request_id. Falls back to the legacy read-modify-write below when the
+        # RPC isn't deployed yet.
+        # ---------------------------------------------------------------
+        atomic_result = _atomic_add_credits_rpc(
+            client,
+            user_id=user_id,
+            credits=credits,
+            transaction_type=transaction_type,
+            description=description,
+            payment_id=payment_id,
+            metadata=metadata,
+            request_id=request_id,
+            created_by=created_by,
+        )
+        if atomic_result is not None:
+            if atomic_result.get("idempotent"):
+                logger.info(
+                    "Idempotent skip: credit grant already applied (request_id=%s, user %s)",
+                    sanitize_for_logging(str(request_id)),
+                    sanitize_for_logging(str(user_id)),
+                )
+            else:
+                logger.info(
+                    "ATOMIC added %s credits to user %s. New balance: %s",
+                    sanitize_for_logging(str(credits)),
+                    sanitize_for_logging(str(user_id)),
+                    sanitize_for_logging(str(atomic_result.get("new_balance"))),
+                )
+            invalidate_user_cache_by_id(user_id)
+            return
+
+        # ---------------------------------------------------------------
+        # LEGACY PATH: non-atomic read-modify-write (pre-migration fallback).
+        # request_id is still forwarded to the ledger insert so the unique index
+        # rejects duplicates, though the balance update is not atomic with it.
+        # ---------------------------------------------------------------
         # Get current balances
         user_result = (
             client.table("users")
@@ -593,6 +703,7 @@ def add_credits_to_user(
                 "purchased_after": purchased_after,
             },
             created_by=created_by,
+            request_id=request_id,
         )
 
         logger.info(

--- a/src/db/webhook_events.py
+++ b/src/db/webhook_events.py
@@ -37,6 +37,101 @@ def _maybe_log_missing_table_hint(error: Exception) -> None:
         _missing_table_warning_logged = True
 
 
+def _is_duplicate_error(error: Exception) -> bool:
+    """True if *error* is a Postgres unique-violation (duplicate event_id)."""
+    message = str(error).lower()
+    return (
+        "23505" in message
+        or "duplicate key" in message
+        or "already exists" in message
+        or "unique constraint" in message
+    )
+
+
+def claim_event(
+    event_id: str,
+    event_type: str,
+    user_id: int | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> str:
+    """Atomically claim a webhook event for processing (insert-first idempotency).
+
+    Inserts the event row up front and relies on the UNIQUE constraint on
+    ``stripe_webhook_events.event_id`` to reject a second, concurrent delivery of
+    the same event. This closes the check-then-act (TOCTOU) race that the old
+    ``is_event_processed`` + ``record_processed_event`` pair had.
+
+    Returns one of:
+      * ``"claimed"``     — this caller owns the event; run the handler, then keep
+                            the row (it is the permanent processed marker) on
+                            success, or call :func:`release_event` on failure so
+                            Stripe's retry can re-claim it.
+      * ``"duplicate"``   — the event was already claimed/processed; skip it.
+      * ``"unavailable"`` — the table is missing or the DB is unreachable; the
+                            caller should fail OPEN and rely on downstream
+                            (grant-level) idempotency rather than dropping the
+                            event.
+    """
+    try:
+
+        def _claim(client):
+            return (
+                client.table("stripe_webhook_events")
+                .insert(
+                    {
+                        "event_id": event_id,
+                        "event_type": event_type,
+                        "user_id": user_id,
+                        "metadata": metadata or {},
+                        "processed_at": datetime.now(UTC).isoformat(),
+                    }
+                )
+                .execute()
+            )
+
+        execute_with_retry(_claim, max_retries=2, retry_delay=0.2)
+        logger.info(f"Claimed webhook event for processing: {event_id} ({event_type})")
+        return "claimed"
+
+    except Exception as e:
+        if _is_duplicate_error(e):
+            logger.warning(f"Duplicate webhook event detected, skipping: {event_id}")
+            return "duplicate"
+        _maybe_log_missing_table_hint(e)
+        # Table missing or DB error: do NOT silently drop the event. Signal the
+        # caller to fail open and lean on grant-level idempotency (request_id).
+        logger.critical(
+            "Webhook dedup unavailable for %s (%s). Processing WITHOUT dedup; "
+            "relying on downstream idempotency. Apply migrations if this persists.",
+            event_id,
+            type(e).__name__,
+        )
+        return "unavailable"
+
+
+def release_event(event_id: str) -> None:
+    """Release a previously claimed event so Stripe's retry can re-process it.
+
+    Called when a handler raises after :func:`claim_event` returned ``"claimed"``,
+    so a transient failure doesn't permanently mark the event as processed.
+    """
+    try:
+
+        def _release(client):
+            return (
+                client.table("stripe_webhook_events")
+                .delete()
+                .eq("event_id", event_id)
+                .execute()
+            )
+
+        execute_with_retry(_release, max_retries=2, retry_delay=0.2)
+        logger.info(f"Released webhook event claim after handler failure: {event_id}")
+    except Exception as e:
+        _maybe_log_missing_table_hint(e)
+        logger.error(f"Failed to release webhook event claim {event_id}: {e}", exc_info=True)
+
+
 def is_event_processed(event_id: str) -> bool:
     """
     Check if a webhook event has already been processed

--- a/src/handlers/post_processing.py
+++ b/src/handlers/post_processing.py
@@ -49,6 +49,7 @@ async def _handle_credits_and_usage(
     elapsed_ms: int,
     is_streaming: bool = False,
     request_id: str | None = None,
+    already_charged: bool = False,
 ) -> float:
     """
     Centralized credit/trial handling logic.
@@ -59,6 +60,9 @@ async def _handle_credits_and_usage(
     Args:
         is_streaming: Whether this is a streaming request (affects retry behavior)
         request_id: Optional UUID idempotency key to prevent duplicate deductions
+        already_charged: When True, the unified handler already deducted credits and
+            recorded usage; skip the duplicate deduction here (rate-limit + shadow
+            ledger bookkeeping still runs).
 
     Returns: cost (float)
     """
@@ -76,6 +80,7 @@ async def _handle_credits_and_usage(
         endpoint="/v1/chat/completions",
         is_streaming=is_streaming,
         request_id=request_id,
+        already_charged=already_charged,
     )
 
 

--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -943,7 +943,13 @@ async def chat_completions(
                         headers=rl_final_hdrs or None,
                     )
 
-        # Credit/usage tracking (only for authenticated users)
+        # Credit/usage tracking (only for authenticated users).
+        # The authenticated non-streaming path runs entirely through the unified
+        # ChatInferenceHandler (see dispatch_non_streaming), which has ALREADY
+        # deducted credits and recorded usage. Pass already_charged=True so this
+        # call performs only the route-owned bookkeeping (rate-limit + shadow
+        # ledger) and does NOT deduct a second time — the prior behaviour billed
+        # paid users twice per request.
         if not is_anonymous:
             cost = await _handle_credits_and_usage(
                 api_key=api_key,
@@ -956,6 +962,7 @@ async def chat_completions(
                 elapsed_ms=int(elapsed * 1000),
                 is_streaming=False,
                 request_id=request_id,
+                already_charged=True,
             )
             await _to_thread(increment_api_key_usage, api_key)
         else:

--- a/src/services/billing/credit_handler.py
+++ b/src/services/billing/credit_handler.py
@@ -201,6 +201,7 @@ async def handle_credits_and_usage(
     endpoint: str = "/v1/chat/completions",
     is_streaming: bool = False,
     request_id: str | None = None,
+    already_charged: bool = False,
 ) -> float:
     """
     Centralized credit/trial handling logic for all chat endpoints.
@@ -225,6 +226,11 @@ async def handle_credits_and_usage(
         endpoint: API endpoint for logging (default: /v1/chat/completions)
         is_streaming: Whether this is a streaming request (affects retry behavior)
         request_id: Optional UUID idempotency key to prevent duplicate deductions on retries
+        already_charged: When True, the caller (the unified ChatInferenceHandler)
+            has ALREADY deducted credits and recorded usage for this request, so
+            this function skips the paid-user deduction + usage record to avoid a
+            double charge. It still performs the route-owned bookkeeping the
+            handler does not do (rate-limit usage update, shadow-ledger write).
 
     Returns:
         float: Calculated cost in USD
@@ -361,6 +367,42 @@ async def handle_credits_and_usage(
                     "endpoint": endpoint,
                 },
             )
+    elif already_charged:
+        # The unified handler already deducted credits and recorded usage for this
+        # request (authenticated non-streaming path). Skip the duplicate deduction
+        # and usage record here — doing them again double-charges the user — but
+        # still run the route-owned bookkeeping below (rate-limit + shadow ledger).
+        latency = time.monotonic() - start_time
+        _record_credit_metrics("success", cost, endpoint, is_streaming, latency)
+
+        try:
+            await _to_thread(update_rate_limit_usage, api_key, total_tokens)
+        except Exception as e:
+            logger.warning(
+                f"Failed to update rate limit usage (already-charged path) for user {user.get('id')}: {e}"
+            )
+
+        try:
+            from src.config import Config
+
+            if (
+                Config.CREDIT_LEDGER_SHADOW_ENABLED
+                and user
+                and float(cost or 0) >= 0.000001
+                and user.get("tier") != "admin"
+            ):
+                from src.services.billing.credit_ledger_store import record_shadow_settlement
+
+                await record_shadow_settlement(
+                    ref=request_id,
+                    user_id=user.get("id"),
+                    cost=cost,
+                    allowance=user.get("subscription_allowance") or 0,
+                    purchased=user.get("purchased_credits") or 0,
+                )
+        except Exception as e:
+            logger.warning("credit_ledger shadow dual-write failed (non-fatal): %s", e)
+
     else:
         # Paid user - deduct credits with retry logic
         last_error = None

--- a/src/services/billing/payments.py
+++ b/src/services/billing/payments.py
@@ -6,6 +6,7 @@ Handles all Stripe payment operations
 
 import logging
 import os
+import uuid
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import Any
@@ -20,7 +21,7 @@ from src.db.payments import (
 )
 from src.db.subscription_products import get_tier_from_product_id
 from src.db.users import add_credits_to_user, get_user_by_id
-from src.db.webhook_events import is_event_processed, record_processed_event
+from src.db.webhook_events import claim_event, release_event
 from src.schemas.payments import (
     CancelSubscriptionRequest,
     CheckoutSessionResponse,
@@ -70,6 +71,15 @@ class StripeService:
         # Set Stripe API key
         stripe.api_key = self.api_key
 
+        # Pin the Stripe API version so webhook payload shapes are deterministic
+        # from the code side rather than riding on the account default (which
+        # Stripe can advance under us). This module's helpers are written for the
+        # "Basil" generation (2025-08-27.basil+), where period bounds and the
+        # invoice→subscription link moved onto sub-objects. Override via
+        # STRIPE_API_VERSION only after confirming the account + code agree.
+        self.api_version = os.getenv("STRIPE_API_VERSION", "2025-08-27.basil")
+        stripe.api_version = self.api_version
+
         # Configuration
         self.default_currency = StripeCurrency.USD
         self.min_amount = 50  # $0.50 minimum
@@ -108,6 +118,45 @@ class StripeService:
             return dict(metadata)
         except Exception:
             return {}
+
+    # Stable namespace for deriving credit-grant idempotency keys. The
+    # credit_transactions.request_id column is UUID-typed with a partial unique
+    # index, but Stripe identifiers (evt_/pi_/cs_) are not UUIDs — so we map each
+    # source id to a deterministic UUIDv5. The same Stripe id always yields the
+    # same key, making a grant idempotent across webhook retries / duplicate
+    # deliveries. Never change this namespace value or existing keys shift.
+    _GRANT_ID_NAMESPACE = uuid.UUID("6f9619ff-8b86-d011-b42d-00c04fc964ff")
+
+    @classmethod
+    def _grant_idempotency_key(cls, source: str) -> str:
+        """Derive a deterministic UUID idempotency key for a credit grant.
+
+        ``source`` is a namespaced Stripe identifier, e.g. ``"pi:pi_123"`` or
+        ``"cs:cs_456"``. Returns a string UUID suitable for the
+        credit_transactions.request_id unique index.
+        """
+        return str(uuid.uuid5(cls._GRANT_ID_NAMESPACE, f"grant:{source}"))
+
+    @staticmethod
+    def _apply_topup_fee(amount_dollars: float) -> tuple[float, float, float]:
+        """Compute the credit top-up fee split for a one-time payment.
+
+        Returns ``(fee_rate, topup_fee, credits_granted)``. When
+        ``CREDIT_TOPUP_FEE_RATE`` is 0 (the default) ``credits_granted`` equals
+        ``amount_dollars`` (no fee). The rate is clamped to [0.0, 0.5] and any
+        malformed value falls back to 0.0.
+
+        This is the single source of truth for the top-up fee so that BOTH
+        one-time payment paths — checkout sessions (``_handle_checkout_completed``)
+        and payment intents (``_handle_payment_succeeded``) — apply it identically.
+        """
+        try:
+            fee_rate = max(0.0, min(0.5, float(os.getenv("CREDIT_TOPUP_FEE_RATE", "0.0"))))
+        except (TypeError, ValueError):
+            fee_rate = 0.0
+        topup_fee = round(amount_dollars * fee_rate, 6)
+        credits_granted = round(amount_dollars - topup_fee, 6)
+        return fee_rate, topup_fee, credits_granted
 
     # ==================== Checkout Sessions ====================
 
@@ -742,17 +791,6 @@ class StripeService:
 
             logger.info(f"Processing webhook: {event['type']} (ID: {event['id']})")
 
-            # Check for duplicate event (idempotency)
-            if is_event_processed(event["id"]):
-                logger.warning(f"Duplicate webhook event detected, skipping: {event['id']}")
-                return WebhookProcessingResult(
-                    success=True,
-                    event_type=event["type"],
-                    event_id=event["id"],
-                    message=f"Event {event['id']} already processed (duplicate)",
-                    processed_at=datetime.now(UTC),
-                )
-
             # Extract user_id from event metadata if available
             user_id = None
             try:
@@ -764,40 +802,57 @@ class StripeService:
             except (AttributeError, ValueError, TypeError, KeyError):
                 pass
 
-            # One-time payment events
-            if event["type"] == "checkout.session.completed":
-                self._handle_checkout_completed(event["data"]["object"])
-            elif event["type"] == "payment_intent.succeeded":
-                self._handle_payment_succeeded(event["data"]["object"])
-            elif event["type"] == "payment_intent.payment_failed":
-                self._handle_payment_failed(event["data"]["object"])
-
-            # Subscription events
-            elif event["type"] == "customer.subscription.created":
-                self._handle_subscription_created(event["data"]["object"])
-            elif event["type"] == "customer.subscription.updated":
-                self._handle_subscription_updated(event["data"]["object"])
-            elif event["type"] == "customer.subscription.deleted":
-                self._handle_subscription_deleted(event["data"]["object"])
-            elif event["type"] == "invoice.paid":
-                self._handle_invoice_paid(event["data"]["object"])
-            elif event["type"] == "invoice.payment_failed":
-                self._handle_invoice_payment_failed(event["data"]["object"])
-
-            # Record the event as processed ONLY after its handler succeeded.
-            # If a handler raises, we deliberately do NOT record the event so that
-            # Stripe's automatic retry re-runs it. The credit-granting handlers are
-            # idempotent (they skip already-completed payments), so an at-least-once
-            # retry cannot double-credit. This replaces the previous
-            # "mark-before-handler" behaviour, which silently dropped credit grants
-            # whenever a handler hit a transient DB/Stripe error.
-            record_processed_event(
+            # Claim the event up front (insert-first idempotency). This closes the
+            # TOCTOU window the old check-then-record pair had: a concurrent
+            # duplicate delivery loses the INSERT race on the UNIQUE(event_id)
+            # constraint and is reported as a duplicate here.
+            claim = claim_event(
                 event_id=event["id"],
                 event_type=event["type"],
                 user_id=user_id,
                 metadata={"stripe_account": event.get("account")},
             )
+            if claim == "duplicate":
+                logger.warning(f"Duplicate webhook event detected, skipping: {event['id']}")
+                return WebhookProcessingResult(
+                    success=True,
+                    event_type=event["type"],
+                    event_id=event["id"],
+                    message=f"Event {event['id']} already processed (duplicate)",
+                    processed_at=datetime.now(UTC),
+                )
+            # claim == "unavailable" → dedup table down; fall through and process
+            # anyway (fail open). The credit-granting handlers are idempotent at the
+            # ledger level (request_id), so an at-least-once retry cannot double-credit.
 
+            try:
+                # One-time payment events
+                if event["type"] == "checkout.session.completed":
+                    self._handle_checkout_completed(event["data"]["object"])
+                elif event["type"] == "payment_intent.succeeded":
+                    self._handle_payment_succeeded(event["data"]["object"])
+                elif event["type"] == "payment_intent.payment_failed":
+                    self._handle_payment_failed(event["data"]["object"])
+
+                # Subscription events
+                elif event["type"] == "customer.subscription.created":
+                    self._handle_subscription_created(event["data"]["object"])
+                elif event["type"] == "customer.subscription.updated":
+                    self._handle_subscription_updated(event["data"]["object"])
+                elif event["type"] == "customer.subscription.deleted":
+                    self._handle_subscription_deleted(event["data"]["object"])
+                elif event["type"] == "invoice.paid":
+                    self._handle_invoice_paid(event["data"]["object"])
+                elif event["type"] == "invoice.payment_failed":
+                    self._handle_invoice_payment_failed(event["data"]["object"])
+            except Exception:
+                # Handler failed: release our claim so Stripe's automatic retry can
+                # re-process this event instead of it being permanently marked done.
+                if claim == "claimed":
+                    release_event(event["id"])
+                raise
+
+            # Success: the claim row stays as the permanent processed marker.
             return WebhookProcessingResult(
                 success=True,
                 event_type=event["type"],
@@ -993,10 +1048,19 @@ class StripeService:
                 metadata=metadata,
             )
 
+            # Credit top-up fee (OpenRouter-style monetization). When
+            # CREDIT_TOPUP_FEE_RATE > 0, withhold that fraction of the paid
+            # amount as revenue and grant the remainder as usable credits.
+            # Default 0.0 → credits_granted == amount_dollars (no change).
+            fee_rate, topup_fee, credits_granted = self._apply_topup_fee(amount_dollars)
+
             # Build transaction metadata including verification audit trail
             transaction_metadata = {
                 "stripe_session_id": session_id,
                 "stripe_payment_intent_id": payment_intent_id,
+                "amount_paid": amount_dollars,
+                "topup_fee_rate": fee_rate,
+                "topup_fee": topup_fee,
                 "amount_verification": {
                     "verified": verification_result.get("verified", False),
                     "severity": verification_result.get("severity", "unknown"),
@@ -1007,14 +1071,21 @@ class StripeService:
                 },
             }
 
-            # Add credits and log transaction
+            # Add credits and log transaction. The request_id makes this grant
+            # idempotent at the ledger level (keyed on the Stripe session), so even
+            # if the payment-status guard above is bypassed by a concurrent
+            # duplicate delivery, the credits are granted at most once.
             add_credits_to_user(
                 user_id=user_id,
-                credits=amount_dollars,
+                credits=credits_granted,
                 transaction_type="purchase",
-                description=f"Stripe checkout - ${amount_dollars}",
+                description=(
+                    f"Stripe checkout - ${amount_dollars}"
+                    + (f" (−${topup_fee} fee)" if topup_fee else "")
+                ),
                 payment_id=payment_id,
                 metadata=transaction_metadata,
+                request_id=self._grant_idempotency_key(f"cs:{session_id}"),
             )
 
             # Update payment
@@ -1025,7 +1096,10 @@ class StripeService:
                 stripe_session_id=session_id,
             )
 
-            logger.info(f"Checkout completed: Added {amount_dollars} credits to user {user_id}")
+            logger.info(
+                f"Checkout completed: paid ${amount_dollars}, fee ${topup_fee}, "
+                f"granted {credits_granted} credits to user {user_id}"
+            )
 
             # Clear trial status for the user when they purchase credits
             # This converts trial users to paid users (pay-per-use, NOT subscription)
@@ -1122,6 +1196,7 @@ class StripeService:
                                 "stripe_session_id": session_id,
                                 "trigger_amount": amount_dollars,
                             },
+                            request_id=self._grant_idempotency_key(f"bonus:{session_id}"),
                         )
                         logger.info(
                             f"First top-up bonus applied! User {user_id} received $5 "
@@ -1438,15 +1513,28 @@ class StripeService:
                     )
                     return
                 update_payment_status(payment_id=payment["id"], status="completed")
-                # Add credits and log transaction
-                amount = payment.get("amount_usd", payment.get("amount", 0))
+                # Add credits and log transaction. Apply the same top-up fee as the
+                # checkout path so the fee model is consistent across both one-time
+                # payment flows (previously the fee was only withheld on checkout
+                # sessions, letting payment-intent top-ups skip it).
+                amount = float(payment.get("amount_usd", payment.get("amount", 0)) or 0)
+                fee_rate, topup_fee, credits_granted = self._apply_topup_fee(amount)
                 add_credits_to_user(
                     user_id=payment["user_id"],
-                    credits=amount,
+                    credits=credits_granted,
                     transaction_type="purchase",
-                    description=f"Stripe payment - ${amount}",
+                    description=(
+                        f"Stripe payment - ${amount}"
+                        + (f" (−${topup_fee} fee)" if topup_fee else "")
+                    ),
                     payment_id=payment["id"],
-                    metadata={"stripe_payment_intent_id": payment_intent.id},
+                    metadata={
+                        "stripe_payment_intent_id": payment_intent.id,
+                        "amount_paid": amount,
+                        "topup_fee_rate": fee_rate,
+                        "topup_fee": topup_fee,
+                    },
+                    request_id=self._grant_idempotency_key(f"pi:{payment_intent.id}"),
                 )
                 logger.info(f"Payment succeeded: {payment_intent.id}")
         except Exception as e:
@@ -2073,7 +2161,11 @@ class StripeService:
             # canceled_at is when the user clicked "cancel", NOT when the subscription
             # actually ends. For scheduled cancellations (cancel_at_period_end=True),
             # the subscription remains active until current_period_end.
-            current_period_end = self._get_stripe_object_value(subscription, "current_period_end")
+            # Use the Basil-safe helper: in the 2025-08+ API generation the period
+            # bounds moved from the Subscription onto its items, so a direct read of
+            # current_period_end returns None and the effective_date would silently
+            # fall back to now().
+            current_period_end = self._get_subscription_period_end(subscription)
             if isinstance(current_period_end, (int, float)) and current_period_end > 0:
                 effective_date = datetime.fromtimestamp(current_period_end, tz=UTC).isoformat()
             else:

--- a/supabase/migrations/20260705000001_add_atomic_add_credits.sql
+++ b/supabase/migrations/20260705000001_add_atomic_add_credits.sql
@@ -1,0 +1,237 @@
+-- Migration: Add atomic_add_credits stored procedure
+-- Mirror of atomic_deduct_credits (20260223000003) for the GRANT direction.
+--
+-- Problem:
+-- The Python add_credits_to_user() did a non-atomic read-modify-write:
+--   1. SELECT purchased_credits/subscription_allowance
+--   2. compute new = before + credits
+--   3. UPDATE users SET ...
+--   4. INSERT INTO credit_transactions (...)
+-- Two concurrent grants that read the same "before" lose one increment, and a
+-- duplicate webhook delivery that slips past the payment-status guard grants the
+-- credits twice. Deduction was already atomic + idempotent; granting was not.
+--
+-- Solution:
+-- A PostgreSQL function that locks the user row (FOR UPDATE), performs the
+-- balance update and the ledger insert in one transaction, and enforces
+-- idempotency via the existing partial-unique index on
+-- credit_transactions.request_id (idx_credit_transactions_request_id). If a
+-- transaction with the same request_id already exists, the grant is skipped and
+-- reported as an idempotent no-op.
+--
+-- Parameters:
+--   p_user_id          - The user to credit
+--   p_credits          - Amount to add (positive)
+--   p_transaction_type - Type of transaction (e.g. 'purchase', 'first_topup_bonus')
+--   p_description      - Human-readable description
+--   p_target           - 'purchased' (default) or 'allowance' — which balance to credit
+--   p_payment_id       - Optional payments.id FK to record on the ledger row
+--   p_metadata         - Optional JSONB metadata
+--   p_request_id       - Optional UUID idempotency key (unique per logical grant)
+--   p_created_by       - Optional actor identifier (e.g. 'admin:123')
+--
+-- Returns JSONB:
+--   { "success": bool, "idempotent": bool, "transaction_id": bigint|null,
+--     "new_purchased": numeric, "new_allowance": numeric, "new_balance": numeric,
+--     "error": text|null }
+
+-- ============================================================================
+-- PRE-CREATE CLEANUP (make migration idempotent)
+-- ============================================================================
+DROP FUNCTION IF EXISTS atomic_add_credits(
+    BIGINT, NUMERIC, VARCHAR, TEXT, VARCHAR, BIGINT, JSONB, UUID, TEXT
+);
+
+-- ============================================================================
+-- FUNCTION DEFINITION
+-- ============================================================================
+CREATE OR REPLACE FUNCTION atomic_add_credits(
+    p_user_id          BIGINT,
+    p_credits          NUMERIC,
+    p_transaction_type VARCHAR(50),
+    p_description      TEXT,
+    p_target           VARCHAR(20) DEFAULT 'purchased',
+    p_payment_id       BIGINT DEFAULT NULL,
+    p_metadata         JSONB DEFAULT '{}'::JSONB,
+    p_request_id       UUID DEFAULT NULL,
+    p_created_by       TEXT DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_allowance_before  NUMERIC;
+    v_purchased_before  NUMERIC;
+    v_allowance_after   NUMERIC;
+    v_purchased_after   NUMERIC;
+    v_balance_before    NUMERIC;
+    v_balance_after     NUMERIC;
+    v_transaction_id    BIGINT;
+    v_existing_id       BIGINT;
+BEGIN
+    -- ======================================================================
+    -- VALIDATION
+    -- ======================================================================
+    IF p_credits <= 0 THEN
+        RETURN jsonb_build_object(
+            'success', false, 'idempotent', false, 'error', 'credits must be positive',
+            'transaction_id', NULL, 'new_purchased', NULL,
+            'new_allowance', NULL, 'new_balance', NULL
+        );
+    END IF;
+
+    IF p_target NOT IN ('purchased', 'allowance') THEN
+        RETURN jsonb_build_object(
+            'success', false, 'idempotent', false,
+            'error', 'target must be purchased or allowance',
+            'transaction_id', NULL, 'new_purchased', NULL,
+            'new_allowance', NULL, 'new_balance', NULL
+        );
+    END IF;
+
+    -- ======================================================================
+    -- STEP 1: Lock the user row to serialize concurrent grants/deductions.
+    -- ======================================================================
+    SELECT subscription_allowance, purchased_credits
+    INTO v_allowance_before, v_purchased_before
+    FROM users
+    WHERE id = p_user_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RETURN jsonb_build_object(
+            'success', false, 'idempotent', false, 'error', 'user_not_found',
+            'transaction_id', NULL, 'new_purchased', NULL,
+            'new_allowance', NULL, 'new_balance', NULL
+        );
+    END IF;
+
+    v_allowance_before := COALESCE(v_allowance_before, 0);
+    v_purchased_before := COALESCE(v_purchased_before, 0);
+    v_balance_before := v_allowance_before + v_purchased_before;
+
+    -- ======================================================================
+    -- STEP 2: Idempotency check (while holding the user lock so duplicate
+    -- deliveries for the same user serialize here rather than racing).
+    -- ======================================================================
+    IF p_request_id IS NOT NULL THEN
+        SELECT id INTO v_existing_id
+        FROM credit_transactions
+        WHERE request_id = p_request_id
+        LIMIT 1;
+
+        IF FOUND THEN
+            RETURN jsonb_build_object(
+                'success', true, 'idempotent', true,
+                'transaction_id', v_existing_id,
+                'new_purchased', v_purchased_before,
+                'new_allowance', v_allowance_before,
+                'new_balance', v_balance_before,
+                'error', NULL
+            );
+        END IF;
+    END IF;
+
+    -- ======================================================================
+    -- STEP 3: Apply the grant to the requested balance.
+    -- ======================================================================
+    IF p_target = 'allowance' THEN
+        v_allowance_after := v_allowance_before + p_credits;
+        v_purchased_after := v_purchased_before;
+    ELSE
+        v_purchased_after := v_purchased_before + p_credits;
+        v_allowance_after := v_allowance_before;
+    END IF;
+    v_balance_after := v_allowance_after + v_purchased_after;
+
+    UPDATE users
+    SET subscription_allowance = v_allowance_after,
+        purchased_credits = v_purchased_after,
+        updated_at = NOW()
+    WHERE id = p_user_id;
+
+    -- ======================================================================
+    -- STEP 4: Ledger insert (same transaction). The partial-unique index on
+    -- request_id is the final backstop against duplicates.
+    -- ======================================================================
+    INSERT INTO credit_transactions (
+        user_id, amount, transaction_type, description,
+        balance_before, balance_after, payment_id, request_id, metadata, created_at
+    ) VALUES (
+        p_user_id, p_credits, p_transaction_type, p_description,
+        v_balance_before, v_balance_after, p_payment_id, p_request_id,
+        COALESCE(p_metadata, '{}'::JSONB) || jsonb_build_object(
+            'target', p_target,
+            'allowance_before', v_allowance_before,
+            'allowance_after', v_allowance_after,
+            'purchased_before', v_purchased_before,
+            'purchased_after', v_purchased_after,
+            'atomic_procedure', true
+        ) || CASE
+            WHEN p_created_by IS NOT NULL
+            THEN jsonb_build_object('created_by', p_created_by)
+            ELSE '{}'::JSONB
+        END,
+        NOW()
+    )
+    RETURNING id INTO v_transaction_id;
+
+    RETURN jsonb_build_object(
+        'success', true, 'idempotent', false,
+        'transaction_id', v_transaction_id,
+        'new_purchased', v_purchased_after,
+        'new_allowance', v_allowance_after,
+        'new_balance', v_balance_after,
+        'error', NULL
+    );
+
+EXCEPTION
+    -- A concurrent grant with the same request_id that committed between our
+    -- idempotency SELECT and the INSERT trips the unique index. Treat it as an
+    -- idempotent no-op rather than an error (the credits were granted once).
+    WHEN unique_violation THEN
+        SELECT id INTO v_existing_id
+        FROM credit_transactions
+        WHERE request_id = p_request_id
+        LIMIT 1;
+        RETURN jsonb_build_object(
+            'success', true, 'idempotent', true,
+            'transaction_id', v_existing_id,
+            'new_purchased', v_purchased_before,
+            'new_allowance', v_allowance_before,
+            'new_balance', v_balance_before,
+            'error', NULL
+        );
+    WHEN OTHERS THEN
+        -- Any other unexpected error rolls back the whole transaction.
+        RETURN jsonb_build_object(
+            'success', false, 'idempotent', false, 'error', SQLERRM,
+            'transaction_id', NULL, 'new_purchased', NULL,
+            'new_allowance', NULL, 'new_balance', NULL
+        );
+END;
+$$;
+
+-- ============================================================================
+-- PERMISSIONS
+-- ============================================================================
+REVOKE ALL ON FUNCTION atomic_add_credits(BIGINT, NUMERIC, VARCHAR, TEXT, VARCHAR, BIGINT, JSONB, UUID, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION atomic_add_credits(BIGINT, NUMERIC, VARCHAR, TEXT, VARCHAR, BIGINT, JSONB, UUID, TEXT) FROM anon;
+REVOKE ALL ON FUNCTION atomic_add_credits(BIGINT, NUMERIC, VARCHAR, TEXT, VARCHAR, BIGINT, JSONB, UUID, TEXT) FROM authenticated;
+GRANT EXECUTE ON FUNCTION atomic_add_credits(BIGINT, NUMERIC, VARCHAR, TEXT, VARCHAR, BIGINT, JSONB, UUID, TEXT) TO service_role;
+
+-- ============================================================================
+-- DOCUMENTATION
+-- ============================================================================
+COMMENT ON FUNCTION atomic_add_credits(BIGINT, NUMERIC, VARCHAR, TEXT, VARCHAR, BIGINT, JSONB, UUID, TEXT) IS
+'Atomically adds credits to a user and logs the transaction in a single database
+transaction. Uses SELECT ... FOR UPDATE to serialize concurrent balance changes,
+and the partial-unique index on credit_transactions.request_id to make the grant
+idempotent across duplicate webhook deliveries. Mirror of atomic_deduct_credits.';
+
+-- ============================================================================
+-- DOWN MIGRATION (commented out - run manually to rollback)
+-- ============================================================================
+-- DROP FUNCTION IF EXISTS atomic_add_credits(BIGINT, NUMERIC, VARCHAR, TEXT, VARCHAR, BIGINT, JSONB, UUID, TEXT);

--- a/supabase/migrations/20260705000002_webhook_events_unique_event_id.sql
+++ b/supabase/migrations/20260705000002_webhook_events_unique_event_id.sql
@@ -1,0 +1,33 @@
+-- Migration: Enforce UNIQUE(event_id) on stripe_webhook_events
+--
+-- Problem:
+-- The table was created two different ways across the migration history:
+--   * 20251009030427_remote_schema.sql        -> PRIMARY KEY (event_id)  [unique]
+--   * 20251230000001_restore_dropped_tables   -> plain column + NON-unique index
+-- Depending on which path a database took, event_id may NOT be unique. Without a
+-- unique constraint the insert-first webhook dedup (claim_event) cannot reject a
+-- concurrent duplicate delivery, reopening the double-processing window.
+--
+-- Solution:
+-- De-duplicate any existing rows (keep the earliest per event_id), drop the
+-- non-unique index, and add a unique index. All steps are idempotent so this is
+-- safe to run regardless of which historical shape the table has (a pre-existing
+-- PRIMARY KEY on event_id already satisfies uniqueness; the extra unique index is
+-- harmless).
+
+-- 1. Remove duplicate rows, keeping the physically-earliest row per event_id.
+DELETE FROM stripe_webhook_events a
+USING stripe_webhook_events b
+WHERE a.ctid > b.ctid
+  AND a.event_id = b.event_id;
+
+-- 2. Drop the non-unique index created by restore_dropped_tables (if present).
+DROP INDEX IF EXISTS idx_stripe_webhook_events_event_id;
+
+-- 3. Enforce uniqueness. IF NOT EXISTS keeps this a no-op where event_id is
+--    already the primary key.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_stripe_webhook_events_event_id
+    ON stripe_webhook_events (event_id);
+
+COMMENT ON INDEX uq_stripe_webhook_events_event_id IS
+'Enforces one row per Stripe event id so claim_event() (insert-first webhook dedup) can reject concurrent duplicate deliveries.';

--- a/tests/services/test_credit_topup_fee.py
+++ b/tests/services/test_credit_topup_fee.py
@@ -1,0 +1,70 @@
+"""Regression tests for the credit top-up fee (OpenRouter-style monetization).
+
+The fee is config-gated via CREDIT_TOPUP_FEE_RATE and defaults to 0.0, so
+existing behaviour (1:1 credit grant) must be preserved unless explicitly
+enabled. See docs/BUSINESS_PIVOT_DIRECT_SUPPLY.md §8.
+
+These tests exercise the REAL production helper (StripeService._apply_topup_fee)
+so a change to the fee formula is actually caught here. _apply_topup_fee is a
+staticmethod, so no Stripe credentials / service instance are required.
+"""
+
+from src.services.billing.payments import StripeService
+
+
+def _grant_math(amount_dollars: float) -> tuple[float, float]:
+    """Call the production helper and return (topup_fee, credits_granted)."""
+    _fee_rate, topup_fee, credits_granted = StripeService._apply_topup_fee(amount_dollars)
+    return topup_fee, credits_granted
+
+
+def test_default_no_fee_grants_full_amount(monkeypatch):
+    monkeypatch.delenv("CREDIT_TOPUP_FEE_RATE", raising=False)
+    fee, granted = _grant_math(10.0)
+    assert fee == 0.0
+    assert granted == 10.0
+
+
+def test_five_percent_fee(monkeypatch):
+    monkeypatch.setenv("CREDIT_TOPUP_FEE_RATE", "0.05")
+    fee, granted = _grant_math(10.0)
+    assert fee == 0.5
+    assert granted == 9.5
+
+
+def test_five_percent_fee_odd_amount(monkeypatch):
+    monkeypatch.setenv("CREDIT_TOPUP_FEE_RATE", "0.05")
+    fee, granted = _grant_math(7.0)
+    assert fee == 0.35
+    assert granted == 6.65
+    # invariant: fee + granted always reconstructs the paid amount
+    assert round(fee + granted, 6) == 7.0
+
+
+def test_fee_rate_clamped_to_50_percent(monkeypatch):
+    monkeypatch.setenv("CREDIT_TOPUP_FEE_RATE", "0.99")
+    fee, granted = _grant_math(10.0)
+    assert fee == 5.0  # clamped to 0.5
+    assert granted == 5.0
+
+
+def test_malformed_fee_rate_falls_back_to_zero(monkeypatch):
+    monkeypatch.setenv("CREDIT_TOPUP_FEE_RATE", "not-a-number")
+    fee, granted = _grant_math(10.0)
+    assert fee == 0.0
+    assert granted == 10.0
+
+
+def test_negative_fee_rate_clamped_to_zero(monkeypatch):
+    monkeypatch.setenv("CREDIT_TOPUP_FEE_RATE", "-0.10")
+    fee, granted = _grant_math(10.0)
+    assert fee == 0.0
+    assert granted == 10.0
+
+
+def test_fee_rate_returned_for_audit(monkeypatch):
+    monkeypatch.setenv("CREDIT_TOPUP_FEE_RATE", "0.05")
+    fee_rate, topup_fee, credits_granted = StripeService._apply_topup_fee(20.0)
+    assert fee_rate == 0.05
+    assert topup_fee == 1.0
+    assert credits_granted == 19.0

--- a/tests/services/test_double_charge_guard.py
+++ b/tests/services/test_double_charge_guard.py
@@ -1,0 +1,91 @@
+"""Regression test for the authenticated non-streaming double-charge bug.
+
+The unified ChatInferenceHandler deducts credits + records usage for authenticated
+non-streaming requests. The route then called handle_credits_and_usage(), which
+deducted AGAIN under a different request_id (the idempotency guard only collapses
+matching request_ids), charging paid users twice per request.
+
+The fix: the route passes already_charged=True, so handle_credits_and_usage skips
+the duplicate deduction + usage record but still performs the route-owned
+bookkeeping (rate-limit usage update).
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.services.billing.credit_handler import handle_credits_and_usage
+
+
+@pytest.fixture
+def _patch_billing_deps(monkeypatch):
+    """Patch the functions handle_credits_and_usage imports at call time.
+
+    handle_credits_and_usage does function-local imports, so we patch the
+    attributes on the source module objects (object form of setattr) — that is
+    what the ``from X import Y`` inside the function resolves against.
+    """
+    import src.db.rate_limits as rate_limits_mod
+    import src.db.trials as trials_mod
+    import src.db.users as users_mod
+    import src.services.pricing as pricing_mod
+
+    deduct = MagicMock()
+    record = MagicMock()
+    rate_limit = MagicMock()
+
+    monkeypatch.setattr(users_mod, "deduct_credits", deduct)
+    monkeypatch.setattr(users_mod, "record_usage", record)
+    monkeypatch.setattr(users_mod, "log_api_usage_transaction", MagicMock())
+    monkeypatch.setattr(rate_limits_mod, "update_rate_limit_usage", rate_limit)
+    monkeypatch.setattr(trials_mod, "track_trial_usage_for_key", MagicMock())
+    monkeypatch.setattr(pricing_mod, "calculate_cost_async", AsyncMock(return_value=0.02))
+    return {"deduct": deduct, "record": record, "rate_limit": rate_limit}
+
+
+_PAID_USER = {"id": 123, "tier": "pro", "subscription_allowance": 0, "purchased_credits": 100}
+_NOT_TRIAL = {"is_trial": False, "is_expired": False}
+
+
+@pytest.mark.asyncio
+async def test_already_charged_skips_deduction(_patch_billing_deps):
+    """already_charged=True must NOT deduct (handler already did) but MUST still
+    update rate-limit usage."""
+    cost = await handle_credits_and_usage(
+        api_key="gw_test",
+        user=_PAID_USER,
+        model="openai/gpt-4o",
+        trial=_NOT_TRIAL,
+        total_tokens=100,
+        prompt_tokens=60,
+        completion_tokens=40,
+        elapsed_ms=250,
+        request_id="route-uuid-1",
+        already_charged=True,
+    )
+
+    assert cost == 0.02
+    _patch_billing_deps["deduct"].assert_not_called()  # no double charge
+    _patch_billing_deps["record"].assert_not_called()  # no double usage record
+    _patch_billing_deps["rate_limit"].assert_called_once()  # route bookkeeping preserved
+
+
+@pytest.mark.asyncio
+async def test_not_already_charged_still_deducts(_patch_billing_deps):
+    """Default path (already_charged=False) must deduct exactly once — the fix
+    must not break endpoints where the handler did not charge."""
+    await handle_credits_and_usage(
+        api_key="gw_test",
+        user=_PAID_USER,
+        model="openai/gpt-4o",
+        trial=_NOT_TRIAL,
+        total_tokens=100,
+        prompt_tokens=60,
+        completion_tokens=40,
+        elapsed_ms=250,
+        request_id="route-uuid-2",
+        already_charged=False,
+    )
+
+    _patch_billing_deps["deduct"].assert_called_once()
+    _patch_billing_deps["rate_limit"].assert_called_once()


### PR DESCRIPTION
## Summary

Payment-system hardening surfaced by an audit, plus a confirmed live double-charge fix. Scoped to billing only (no BYOK/routing changes).

### Fixes
- **Atomic + idempotent credit grants** — new `atomic_add_credits` RPC (row lock + `request_id` idempotency); `add_credits_to_user` routed through it with a legacy fallback. All Stripe grant sites pass a deterministic idempotency key so a duplicate/retried webhook can no longer double-credit. (Granting previously was a non-atomic read-modify-write; deduction was already atomic.)
- **Webhook dedup** — insert-first `claim_event`/`release_event` closes the TOCTOU window and releases the claim on handler failure. New migration enforces `UNIQUE(stripe_webhook_events.event_id)` (reconciles divergent historical migrations). Fails *open* (relies on grant-level idempotency) if the table is missing, rather than silently dropping events.
- **Top-up fee consistency** — single `_apply_topup_fee` helper now applied on **both** the checkout and payment-intent paths (payment intents previously skipped the fee). Test rewritten to exercise the real helper instead of a copy.
- **Stripe API version pinned** (`2025-08-27.basil`, env-overridable) so webhook payload shapes are deterministic; `subscription.deleted` now uses the Basil-safe period read.
- **Double-charge fix** ⭐ — authenticated non-streaming `/v1/chat/completions` deducted credits **twice** (unified handler + route, different `request_id`s defeated the idempotency guard). The route now passes `already_charged=True`, skipping the duplicate `deduct_credits`/`record_usage` while preserving rate-limit + shadow-ledger bookkeeping. Streaming was already single-charge.

### Migrations (2)
- `20260705000001_add_atomic_add_credits.sql`
- `20260705000002_webhook_events_unique_event_id.sql`

Both **already applied to staging** (`nzsgoitgrndfxziyrgte`). They degrade gracefully if unapplied (legacy grant fallback + fail-open dedup).

### Tests
32 passing: top-up fee (real helper), double-charge guard (new), Basil compat, BYOK helpers. The `atomic_add_credits`/dedup paths fall back safely pre-migration.

### Not included
BYOK inference wiring is intentionally deferred (needs a per-user key threaded through ~30 provider clients + fee applied at the now-single charge point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Credit top-ups and webhook processing are now handled more reliably to prevent duplicate actions.
  * One-time credit purchases now consistently apply configured top-up fees, with clearer credited amounts.

* **Bug Fixes**
  * Fixed double-charging in non-streaming chat requests.
  * Improved Stripe webhook handling so retries and duplicate deliveries don’t create duplicate records or charges.
  * Credit grants are now more resilient to retries and partial failures.

* **Tests**
  * Added regression coverage for fee calculation and double-charge prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->