### PR TITLE
feat(byok): serve requests on customers' own provider keys + routing fee

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -600,6 +600,24 @@ class Config:
     # This is the primary revenue lever for inference requests.
     PRICING_MARKUP: float = float(os.environ.get("PRICING_MARKUP", "1.25"))
 
+    # BYOK routing fee — fraction charged as revenue when a request is served
+    # using a customer's own provider key (bring-your-own-key). Inference cost
+    # is paid on the customer's upstream account, so we bill only this routing
+    # fee (fraction of the computed upstream cost) instead of debiting credits.
+    # 0.0 = disabled (default); 0.05 = 5% routing fee. See Phase 5 in
+    # docs/BUSINESS_PIVOT_DIRECT_SUPPLY.md.
+    BYOK_ROUTING_FEE_RATE: float = float(os.environ.get("BYOK_ROUTING_FEE_RATE", "0.0"))
+
+    # Master switch for bring-your-own-key routing. Off by default: when disabled
+    # the inference path does no per-request BYOK lookup, so there is zero added
+    # latency. Enable to let users serve requests on their own stored provider
+    # keys (billed at BYOK_ROUTING_FEE_RATE instead of full credit cost).
+    BYOK_ENABLED: bool = os.environ.get("BYOK_ENABLED", "false").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
     # Pricing Sync Configuration - DEPRECATED 2026-02 (Phase 3, Issue #1063)
     # Pricing is now synced via model sync (provider_model_sync_service.py)
     # No separate pricing sync configuration needed

--- a/src/db/user_provider_keys.py
+++ b/src/db/user_provider_keys.py
@@ -1,0 +1,96 @@
+"""BYOK (bring-your-own-key) storage — Phase 5 of the direct-supply pivot.
+
+Stores a customer's own upstream provider API key, encrypted at rest with the
+Fernet keyring. The plaintext key is recovered ONLY server-side to make the
+upstream provider call (via ``get_decrypted_provider_key``); it is never
+returned to any client. See docs/BUSINESS_PIVOT_DIRECT_SUPPLY.md.
+"""
+
+import logging
+from typing import Any
+
+from src.config.supabase_config import get_supabase_client
+from src.utils.crypto import decrypt_api_key, encrypt_api_key, last4
+
+logger = logging.getLogger(__name__)
+
+_TABLE = "user_provider_keys"
+
+
+def upsert_provider_key(user_id: int, provider_slug: str, plaintext_key: str) -> dict[str, Any]:
+    """Encrypt and store (or replace) a user's BYOK key for a provider.
+
+    Returns a safe record (no plaintext, no ciphertext) suitable for API
+    responses. Raises RuntimeError if encryption is not configured (we never
+    store a provider key in plaintext).
+    """
+    encrypted_key, key_version = encrypt_api_key(plaintext_key)
+    row = {
+        "user_id": user_id,
+        "provider_slug": provider_slug,
+        "encrypted_key": encrypted_key,
+        "key_version": key_version,
+        "key_last4": last4(plaintext_key),
+        "is_active": True,
+    }
+    client = get_supabase_client()
+    client.table(_TABLE).upsert(row, on_conflict="user_id,provider_slug").execute()
+    return {
+        "user_id": user_id,
+        "provider_slug": provider_slug,
+        "key_last4": row["key_last4"],
+        "is_active": True,
+    }
+
+
+def list_provider_keys(user_id: int) -> list[dict[str, Any]]:
+    """List a user's BYOK keys — masked (last4 only), never the secret."""
+    client = get_supabase_client()
+    result = (
+        client.table(_TABLE)
+        .select("provider_slug,key_last4,is_active,created_at,updated_at")
+        .eq("user_id", user_id)
+        .eq("is_active", True)
+        .execute()
+    )
+    return result.data or []
+
+
+def delete_provider_key(user_id: int, provider_slug: str) -> bool:
+    """Hard-delete a user's BYOK key for a provider. Returns True if removed."""
+    client = get_supabase_client()
+    result = (
+        client.table(_TABLE)
+        .delete()
+        .eq("user_id", user_id)
+        .eq("provider_slug", provider_slug)
+        .execute()
+    )
+    return bool(result.data)
+
+
+def get_decrypted_provider_key(user_id: int, provider_slug: str) -> str | None:
+    """Return the plaintext BYOK key for (user, provider), or None.
+
+    SERVER-SIDE ONLY — the result is used to authenticate the upstream provider
+    call and must never be returned to a client. Returns None when the user has
+    no active BYOK key for the provider or decryption fails.
+    """
+    try:
+        client = get_supabase_client()
+        result = (
+            client.table(_TABLE)
+            .select("encrypted_key,key_version")
+            .eq("user_id", user_id)
+            .eq("provider_slug", provider_slug)
+            .eq("is_active", True)
+            .limit(1)
+            .execute()
+        )
+        if not result.data:
+            return None
+        row = result.data[0]
+        return decrypt_api_key(row["encrypted_key"], row.get("key_version"))
+    except Exception as e:
+        logger.warning("BYOK key lookup failed for provider %s: %s", provider_slug, e)
+        return None

--- a/src/handlers/chat_handler.py
+++ b/src/handlers/chat_handler.py
@@ -158,6 +158,10 @@ class ChatInferenceHandler:
         self.trial: dict[str, Any] | None = None
         self.request_id = str(uuid.uuid4())
         self.start_time = time.monotonic()
+        # Set True by _call_provider(_stream) when the served request used the
+        # customer's own provider key (BYOK); consumed at billing time to charge a
+        # routing fee instead of the full credit cost.
+        self.is_byok = False
 
         logger.debug(
             f"[ChatHandler] Initialized with request_id={self.request_id}, anonymous={self.is_anonymous}"
@@ -303,6 +307,44 @@ class ChatInferenceHandler:
         )
         return max_tokens
 
+    def _bind_byok(self, provider_name: str):
+        """Bind the customer's own key for *provider_name* to the request context.
+
+        No-op (returns None) for anonymous users, when BYOK is disabled for the
+        deployment, or when the user has no stored key for this provider. When it
+        returns a token, the central key-resolution points substitute the
+        customer's key for the upstream call, and billing charges a routing fee.
+        """
+        if self.is_anonymous or not self.user:
+            return None
+        try:
+            from src.services.byok import byok_enabled, resolve_byok_key, set_byok_context
+
+            if not byok_enabled():
+                return None
+            key = resolve_byok_key(self.user.get("id"), provider_name)
+            if key:
+                logger.info(
+                    "[ChatHandler] Using BYOK key for provider=%s (user_id=%s)",
+                    provider_name,
+                    self.user.get("id"),
+                )
+                return set_byok_context(provider_name, key)
+        except Exception as e:
+            logger.warning("[ChatHandler] BYOK bind failed for %s: %s", provider_name, e)
+        return None
+
+    @staticmethod
+    def _unbind_byok(token) -> None:
+        if token is None:
+            return
+        try:
+            from src.services.byok import reset_byok_context
+
+            reset_byok_context(token)
+        except Exception:
+            pass
+
     def _call_provider(
         self,
         provider_name: str,
@@ -333,6 +375,9 @@ class ChatInferenceHandler:
         logger.info(f"[ChatHandler] Calling provider={provider_name}, model={model_id}")
 
         with tag_wrapper({"provider": provider_name, "model": model_id}):
+            # Bind the customer's own key (if any) for the duration of this call so
+            # the provider client uses it instead of the platform key.
+            byok_token = self._bind_byok(provider_name)
             try:
                 # Route to appropriate provider
                 # OpenRouter has native async — check via DB flag with fallback
@@ -348,21 +393,26 @@ class ChatInferenceHandler:
                     _is_openrouter_async = provider_name == "openrouter"
 
                 if _is_openrouter_async:
-                    return make_openrouter_request_openai(messages, model_id, **kwargs)
+                    result = make_openrouter_request_openai(messages, model_id, **kwargs)
+                else:
+                    # Registry-based dispatch for all other providers
+                    from src.handlers.provider_registry import PROVIDER_ROUTING
 
-                # Registry-based dispatch for all other providers
-                from src.handlers.provider_registry import PROVIDER_ROUTING
+                    routing = PROVIDER_ROUTING.get(provider_name)
+                    if routing and routing.get("request"):
+                        result = routing["request"](messages, model_id, **kwargs)
+                    else:
+                        # Fallback to OpenRouter for unknown providers
+                        logger.warning(
+                            f"[ChatHandler] Provider '{provider_name}' not in PROVIDER_ROUTING, "
+                            f"falling back to OpenRouter"
+                        )
+                        result = make_openrouter_request_openai(messages, model_id, **kwargs)
 
-                routing = PROVIDER_ROUTING.get(provider_name)
-                if routing and routing.get("request"):
-                    return routing["request"](messages, model_id, **kwargs)
-
-                # Fallback to OpenRouter for unknown providers
-                logger.warning(
-                    f"[ChatHandler] Provider '{provider_name}' not in PROVIDER_ROUTING, "
-                    f"falling back to OpenRouter"
-                )
-                return make_openrouter_request_openai(messages, model_id, **kwargs)
+                # Record BYOK status only on success, so failover to a platform-key
+                # provider correctly reflects the provider that actually served.
+                self.is_byok = byok_token is not None
+                return result
             except HTTPException:
                 # Re-raise HTTP exceptions (already formatted)
                 raise
@@ -479,6 +529,9 @@ class ChatInferenceHandler:
                     status_code=error_response.error.status,
                     detail=error_response.dict(exclude_none=True),
                 )
+            finally:
+                # Always clear the BYOK key binding for this attempt.
+                self._unbind_byok(byok_token)
 
     async def _call_provider_stream(
         self,
@@ -538,6 +591,13 @@ class ChatInferenceHandler:
         from src.utils.profiling import tag_wrapper
         from src.utils.error_factory import DetailedErrorFactory
 
+        # Bind the customer's BYOK key (if any) only around stream CREATION — the
+        # key is consumed when the client/stream is built. It is reset before any
+        # chunk is yielded so the binding can never leak across an async-generator
+        # suspension point into the caller's context.
+        byok_token = self._bind_byok(provider_name)
+        stream = None
+        is_sync_stream = False
         try:
             with tag_wrapper({"provider": provider_name, "model": model_id}):
                 # OpenRouter has native async streaming — check via DB flag
@@ -557,8 +617,6 @@ class ChatInferenceHandler:
                     stream = await make_openrouter_request_openai_stream_async(
                         messages, model_id, **kwargs
                     )
-                    async for chunk in stream:
-                        yield chunk
                 else:
                     # Registry-based dispatch for all other providers
                     from src.handlers.provider_registry import PROVIDER_ROUTING
@@ -567,8 +625,7 @@ class ChatInferenceHandler:
                     if routing and routing.get("stream"):
                         # All non-OpenRouter providers use sync streaming clients
                         stream = routing["stream"](messages, model_id, **kwargs)
-                        async for chunk in _iterate_sync_stream(stream):
-                            yield chunk
+                        is_sync_stream = True
                     else:
                         # Fallback to OpenRouter for unknown providers
                         logger.warning(
@@ -578,8 +635,8 @@ class ChatInferenceHandler:
                         stream = await make_openrouter_request_openai_stream_async(
                             messages, model_id, **kwargs
                         )
-                        async for chunk in stream:
-                            yield chunk
+                # Record BYOK status only on successful stream creation.
+                self.is_byok = byok_token is not None
         except CircuitBreakerError as e:
             # Circuit breaker is open - provider temporarily unavailable
             logger.warning(
@@ -607,6 +664,40 @@ class ChatInferenceHandler:
                 status_code=error_response.error.status,
                 detail=error_response.dict(exclude_none=True),
             )
+        finally:
+            # Clear the BYOK binding before yielding any chunks.
+            self._unbind_byok(byok_token)
+
+        # Iterate outside the BYOK binding — the key was already applied when the
+        # stream was created above.
+        if is_sync_stream:
+            async for chunk in _iterate_sync_stream(stream):
+                yield chunk
+        else:
+            async for chunk in stream:
+                yield chunk
+
+    def _apply_byok_fee(self, cost: float) -> float:
+        """Return the amount to bill, applying the BYOK routing fee when applicable.
+
+        When the request was served on the customer's own provider key
+        (``self.is_byok``), the inference cost was paid on their upstream account,
+        so we bill only ``byok_routing_fee(cost)`` (a fraction, default 0) instead
+        of the full credit cost. Otherwise the cost is unchanged.
+        """
+        if not getattr(self, "is_byok", False):
+            return cost
+        from src.services.byok import byok_routing_fee
+
+        fee = byok_routing_fee(cost)
+        logger.info(
+            "[ChatHandler] BYOK request: billing routing fee $%.6f instead of upstream "
+            "cost $%.6f (request_id=%s)",
+            fee,
+            cost,
+            self.request_id,
+        )
+        return fee
 
     async def _charge_user(
         self,
@@ -915,6 +1006,11 @@ class ChatInferenceHandler:
                 f"input=${input_cost:.6f}, output=${output_cost:.6f}"
             )
 
+            # BYOK: bill a routing fee instead of the full upstream cost when the
+            # request was served on the customer's own key. cost flows into the
+            # request record and response below, so they reflect the billed amount.
+            cost = self._apply_byok_fee(cost)
+
             # Step 6: Charge user
             await self._charge_user(cost, request.model, prompt_tokens, completion_tokens)
 
@@ -1208,6 +1304,9 @@ class ChatInferenceHandler:
             )
 
             logger.debug(f"[ChatHandler] Streaming cost: ${cost:.6f}")
+
+            # BYOK: bill a routing fee instead of the full upstream cost.
+            cost = self._apply_byok_fee(cost)
 
             await self._charge_user(cost, request.model, prompt_tokens, completion_tokens)
 

--- a/src/main.py
+++ b/src/main.py
@@ -542,6 +542,7 @@ def create_app() -> FastAPI:
         ("code_router", "Code Router Settings"),  # Code-optimized routing configuration
         ("downtime_logs", "Downtime Incident Logs"),  # Downtime tracking and log capture
         ("user_memory", "User Memory"),  # Portable per-user memory (Phase 4 context assembly)
+        ("user_provider_keys", "BYOK Provider Keys"),  # Bring-your-own-key management (pivot Phase 5)
     ]
 
     loaded_count = 0

--- a/src/routes/user_provider_keys.py
+++ b/src/routes/user_provider_keys.py
@@ -1,0 +1,65 @@
+"""BYOK management API — Phase 5 of the direct-supply pivot.
+
+Lets a customer register, list, and revoke their own upstream provider keys.
+The plaintext key is accepted on write, encrypted at rest, and NEVER returned.
+See docs/BUSINESS_PIVOT_DIRECT_SUPPLY.md.
+"""
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from src.db.user_provider_keys import (
+    delete_provider_key,
+    list_provider_keys,
+    upsert_provider_key,
+)
+from src.security.deps import get_user_id
+from src.services.gateway_registry import get_valid_gateway_values
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class ProviderKeyRequest(BaseModel):
+    provider_slug: str = Field(..., description="Provider slug, e.g. 'deepinfra'")
+    api_key: str = Field(..., min_length=8, description="Your upstream provider API key")
+
+
+@router.post("/user/provider-keys", tags=["byok"])
+async def add_provider_key(
+    body: ProviderKeyRequest, user_id: int = Depends(get_user_id)
+) -> dict[str, Any]:
+    """Register (or replace) the caller's BYOK key for a provider."""
+    slug = body.provider_slug.lower().strip()
+    if slug not in get_valid_gateway_values() or slug == "all":
+        raise HTTPException(status_code=400, detail=f"Unknown provider '{slug}'")
+    try:
+        record = upsert_provider_key(user_id, slug, body.api_key)
+    except RuntimeError as e:
+        # Encryption not configured — refuse rather than store plaintext.
+        raise HTTPException(
+            status_code=503, detail="Key storage unavailable (encryption not configured)"
+        ) from e
+    return {"success": True, "data": record}
+
+
+@router.get("/user/provider-keys", tags=["byok"])
+async def get_provider_keys(user_id: int = Depends(get_user_id)) -> dict[str, Any]:
+    """List the caller's BYOK keys (masked — last 4 digits only)."""
+    keys = list_provider_keys(user_id)
+    return {"success": True, "data": keys, "count": len(keys)}
+
+
+@router.delete("/user/provider-keys/{provider_slug}", tags=["byok"])
+async def remove_provider_key(
+    provider_slug: str, user_id: int = Depends(get_user_id)
+) -> dict[str, Any]:
+    """Revoke the caller's BYOK key for a provider."""
+    removed = delete_provider_key(user_id, provider_slug.lower().strip())
+    if not removed:
+        raise HTTPException(status_code=404, detail="No BYOK key for that provider")
+    return {"success": True, "provider_slug": provider_slug}

--- a/src/services/byok.py
+++ b/src/services/byok.py
@@ -1,0 +1,129 @@
+"""BYOK routing/billing logic — Phase 5 of the direct-supply pivot.
+
+Helpers the inference paths use:
+  * ``byok_enabled`` — deployment flag gating all BYOK work (zero hot-path cost off).
+  * ``resolve_byok_key`` — a customer's decrypted own key for a provider, or None.
+  * ``resolve_provider_key`` — prefer a customer's own key, else the platform key.
+  * ``byok_routing_fee`` — the fee charged (instead of credit debit) when a
+    request is served on a customer's key.
+
+Key injection uses a provider-scoped context variable (``byok_context``): the
+handler sets it around a provider call, and the central key-resolution points
+(``gateway_registry.get_provider_api_key`` and the OpenRouter pooled client) read
+it via ``get_byok_key_for`` and substitute the customer's key. This avoids
+threading an ``api_key`` argument through every provider client. The context is
+copied into ``asyncio.to_thread`` workers automatically, so sync provider clients
+see it too.
+
+See docs/BUSINESS_PIVOT_DIRECT_SUPPLY.md Phase 5.
+"""
+
+import contextvars
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+# (provider_slug, api_key) currently in effect for the running request, or None.
+_byok_context: contextvars.ContextVar[tuple[str, str] | None] = contextvars.ContextVar(
+    "byok_context", default=None
+)
+
+
+def byok_enabled() -> bool:
+    """True if BYOK is enabled for this deployment (env BYOK_ENABLED, default off).
+
+    Read via Config so .env files and test overrides apply; falls back to the raw
+    env var if Config is unavailable.
+    """
+    try:
+        from src.config import Config
+
+        return bool(getattr(Config, "BYOK_ENABLED", False))
+    except Exception:
+        return os.getenv("BYOK_ENABLED", "false").strip().lower() in ("1", "true", "yes")
+
+
+def set_byok_context(provider_slug: str, api_key: str):
+    """Bind *api_key* as the BYOK key for *provider_slug* for the current context.
+
+    Returns a token to pass to :func:`reset_byok_context` in a ``finally`` block.
+    """
+    return _byok_context.set((provider_slug, api_key))
+
+
+def reset_byok_context(token) -> None:
+    """Undo a prior :func:`set_byok_context` using its token."""
+    try:
+        _byok_context.reset(token)
+    except (ValueError, LookupError):
+        # Token from a different context (e.g. reset in a worker thread). Clearing
+        # is best-effort; a stale value cannot leak across requests because the
+        # context is per-request.
+        _byok_context.set(None)
+
+
+def get_byok_key_for(provider_slug: str) -> str | None:
+    """Return the BYOK key bound for *provider_slug* in the current context, else None.
+
+    Provider-scoped so a key bound for one provider is never used for another
+    (e.g. during failover to a different upstream).
+    """
+    ctx = _byok_context.get()
+    if ctx and ctx[0] == provider_slug:
+        return ctx[1]
+    return None
+
+
+def resolve_byok_key(user_id: int | None, provider_slug: str) -> str | None:
+    """Return the customer's decrypted own key for *provider_slug*, or None.
+
+    Never raises — a lookup/decryption failure logs and returns None so inference
+    falls back to the platform key.
+    """
+    if user_id is None:
+        return None
+    try:
+        from src.db.user_provider_keys import get_decrypted_provider_key
+
+        return get_decrypted_provider_key(user_id, provider_slug) or None
+    except Exception as e:  # never let BYOK lookup break inference
+        logger.warning("BYOK resolve failed for %s: %s", provider_slug, e)
+        return None
+
+
+def resolve_provider_key(user_id: int | None, provider_slug: str) -> tuple[str | None, bool]:
+    """Resolve the API key to use for an upstream call to *provider_slug*.
+
+    Returns ``(key, is_byok)``:
+      * the customer's decrypted BYOK key when they have one (is_byok=True), else
+      * the platform key from the gateway registry (is_byok=False), else
+      * ``(None, False)`` when neither exists.
+    """
+    byok = resolve_byok_key(user_id, provider_slug)
+    if byok:
+        return byok, True
+
+    try:
+        from src.services.gateway_registry import get_provider_api_key
+
+        return get_provider_api_key(provider_slug), False
+    except Exception:
+        return None, False
+
+
+def byok_routing_fee(upstream_cost: float) -> float:
+    """Fee charged for serving a request on a customer's own key.
+
+    ``upstream_cost`` is the computed provider-side cost of the request (already
+    paid on the customer's upstream account). We bill only a fraction of it as a
+    routing fee. Rate is env-driven (``BYOK_ROUTING_FEE_RATE``), default 0.0,
+    clamped to [0, 0.5].
+    """
+    try:
+        rate = max(0.0, min(0.5, float(os.getenv("BYOK_ROUTING_FEE_RATE", "0.0"))))
+    except (TypeError, ValueError):
+        rate = 0.0
+    if upstream_cost <= 0:
+        return 0.0
+    return round(upstream_cost * rate, 6)

--- a/src/services/connection_pool.py
+++ b/src/services/connection_pool.py
@@ -394,14 +394,29 @@ def get_provider_pooled_client(slug: str) -> OpenAI:
 # Provider-specific helper functions (thin wrappers for backward compat)
 # ---------------------------------------------------------------------------
 def get_openrouter_pooled_client() -> OpenAI:
-    """Get pooled client for OpenRouter."""
-    if not Config.OPENROUTER_API_KEY:
+    """Get pooled client for OpenRouter.
+
+    Honours a bring-your-own-key override bound for "openrouter" in the current
+    request context. get_pooled_client caches per api_key, so a customer key gets
+    its own pooled client with no cross-tenant leakage.
+    """
+    api_key = Config.OPENROUTER_API_KEY
+    try:
+        from src.services.byok import get_byok_key_for
+
+        byok = get_byok_key_for("openrouter")
+        if byok:
+            api_key = byok
+    except Exception:
+        pass
+
+    if not api_key:
         raise ValueError("OpenRouter API key not configured")
 
     return get_pooled_client(
         provider="openrouter",
         base_url="https://openrouter.ai/api/v1",
-        api_key=Config.OPENROUTER_API_KEY,
+        api_key=api_key,
         default_headers={
             "HTTP-Referer": Config.OPENROUTER_SITE_URL,
             "X-Title": Config.OPENROUTER_SITE_NAME,

--- a/src/services/gateway_registry.py
+++ b/src/services/gateway_registry.py
@@ -527,10 +527,21 @@ def get_provider_fetch_timeout(slug: str) -> int:
 def get_provider_api_key(slug: str) -> str | None:
     """Resolve the actual API key value for *slug*.
 
-    Reads ``api_key_env_var`` from the registry, then resolves it via
-    ``Config`` (which mirrors ``os.environ`` for known vars) with a
-    fallback to ``os.environ.get()``.
+    If a bring-your-own-key override is bound for *slug* in the current request
+    context (see src.services.byok), that customer key wins. Otherwise reads
+    ``api_key_env_var`` from the registry and resolves it via ``Config`` (which
+    mirrors ``os.environ`` for known vars) with a fallback to ``os.environ.get()``.
     """
+    # BYOK override (only ever set during an inference call with the flag on).
+    try:
+        from src.services.byok import get_byok_key_for
+
+        byok = get_byok_key_for(slug)
+        if byok:
+            return byok
+    except Exception:
+        pass
+
     registry = _get_registry()
     entry = registry.get(slug)
     if not entry:

--- a/src/utils/crypto.py
+++ b/src/utils/crypto.py
@@ -63,6 +63,40 @@ def encrypt_api_key(plaintext: str) -> tuple[str, int]:
         raise RuntimeError(f"Failed to encrypt API key: {str(e)}") from e
 
 
+def decrypt_api_key(token: str, key_version: int | None = None) -> str:
+    """Decrypt a token produced by ``encrypt_api_key``.
+
+    Reversible counterpart used where the plaintext key must be recovered for
+    outbound use (e.g. BYOK: calling an upstream provider with a customer's own
+    key). API-key auth does NOT use this — it matches by hash. Tries the given
+    key_version first, then every keyring entry (supports key rotation).
+
+    Raises RuntimeError if encryption is unavailable and ValueError if the
+    token cannot be decrypted with any configured key.
+    """
+    if Fernet is None:
+        raise RuntimeError("Cryptography library not available. Cannot decrypt.")
+    if not isinstance(_KEYRING, dict) or not _KEYRING:
+        raise RuntimeError(
+            "No encryption keys configured. Set KEY_VERSION and KEYRING_<version>."
+        )
+
+    raw = token.encode("utf-8")
+    versions = []
+    if key_version is not None and key_version in _KEYRING:
+        versions.append(key_version)
+    versions.extend(v for v in _KEYRING if v not in versions)
+
+    for ver in versions:
+        try:
+            return _KEYRING[ver].decrypt(raw).decode("utf-8")
+        except InvalidToken:
+            continue
+        except Exception:
+            continue
+    raise ValueError("Failed to decrypt token with any configured key.")
+
+
 def sha256_key_hash(plaintext: str) -> str:
     """Deterministic hash for lookup/rate limiting. Requires configured salt via env.
 

--- a/supabase/migrations/20260704000003_add_user_provider_keys.sql
+++ b/supabase/migrations/20260704000003_add_user_provider_keys.sql
@@ -1,0 +1,26 @@
+-- BYOK (bring-your-own-key) storage — Phase 5 of the direct-supply pivot.
+-- Stores a customer's own upstream provider API key, encrypted at rest with
+-- the Fernet keyring (KEY_VERSION / KEYRING_<version>). The plaintext key is
+-- only ever recovered server-side to make the upstream provider call; it is
+-- never returned by any API. See docs/BUSINESS_PIVOT_DIRECT_SUPPLY.md.
+
+CREATE TABLE IF NOT EXISTS user_provider_keys (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    provider_slug TEXT NOT NULL,
+    encrypted_key TEXT NOT NULL,
+    key_version INTEGER NOT NULL DEFAULT 1,
+    key_last4 TEXT,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- One key per (user, provider); re-adding updates in place.
+    CONSTRAINT uq_user_provider UNIQUE (user_id, provider_slug)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_provider_keys_user
+    ON user_provider_keys (user_id)
+    WHERE is_active;
+
+-- RLS: a user can only see/modify their own BYOK keys.
+ALTER TABLE user_provider_keys ENABLE ROW LEVEL SECURITY;

--- a/tests/services/test_byok.py
+++ b/tests/services/test_byok.py
@@ -1,0 +1,108 @@
+"""Tests for BYOK (Phase 5): crypto round-trip, fee logic, key resolution.
+
+See docs/BUSINESS_PIVOT_DIRECT_SUPPLY.md Phase 5.
+"""
+
+import importlib
+
+import pytest
+from cryptography.fernet import Fernet
+
+from src.services.byok import byok_routing_fee, resolve_provider_key
+
+
+# --- routing fee -----------------------------------------------------------
+
+def test_fee_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("BYOK_ROUTING_FEE_RATE", raising=False)
+    assert byok_routing_fee(1.0) == 0.0
+
+
+def test_five_percent_routing_fee(monkeypatch):
+    monkeypatch.setenv("BYOK_ROUTING_FEE_RATE", "0.05")
+    assert byok_routing_fee(2.0) == 0.1
+
+
+def test_fee_zero_for_nonpositive_cost(monkeypatch):
+    monkeypatch.setenv("BYOK_ROUTING_FEE_RATE", "0.05")
+    assert byok_routing_fee(0.0) == 0.0
+    assert byok_routing_fee(-5.0) == 0.0
+
+
+def test_fee_rate_clamped(monkeypatch):
+    monkeypatch.setenv("BYOK_ROUTING_FEE_RATE", "9.0")
+    assert byok_routing_fee(1.0) == 0.5  # clamped to 0.5
+
+
+def test_fee_malformed_falls_back_to_zero(monkeypatch):
+    monkeypatch.setenv("BYOK_ROUTING_FEE_RATE", "abc")
+    assert byok_routing_fee(1.0) == 0.0
+
+
+# --- key resolution priority ----------------------------------------------
+
+def test_byok_key_preferred_over_platform(monkeypatch):
+    monkeypatch.setattr(
+        "src.db.user_provider_keys.get_decrypted_provider_key",
+        lambda uid, slug: "customer-key",
+    )
+    key, is_byok = resolve_provider_key(42, "deepinfra")
+    assert key == "customer-key"
+    assert is_byok is True
+
+
+def test_falls_back_to_platform_key(monkeypatch):
+    monkeypatch.setattr(
+        "src.db.user_provider_keys.get_decrypted_provider_key",
+        lambda uid, slug: None,
+    )
+    monkeypatch.setattr(
+        "src.services.gateway_registry.get_provider_api_key",
+        lambda slug: "platform-key",
+    )
+    key, is_byok = resolve_provider_key(42, "deepinfra")
+    assert key == "platform-key"
+    assert is_byok is False
+
+
+def test_anonymous_user_uses_platform_key(monkeypatch):
+    monkeypatch.setattr(
+        "src.services.gateway_registry.get_provider_api_key",
+        lambda slug: "platform-key",
+    )
+    key, is_byok = resolve_provider_key(None, "deepinfra")
+    assert key == "platform-key"
+    assert is_byok is False
+
+
+# --- crypto round-trip (BYOK requires REVERSIBLE encryption) ---------------
+
+def test_encrypt_decrypt_round_trip(monkeypatch):
+    key = Fernet.generate_key().decode()
+    monkeypatch.setenv("KEY_VERSION", "1")
+    monkeypatch.setenv("KEYRING_1", key)
+    # reload crypto so it picks up the keyring from env
+    import src.utils.crypto as crypto
+
+    importlib.reload(crypto)
+    try:
+        secret = "sk-provider-abc123456789"
+        token, version = crypto.encrypt_api_key(secret)
+        assert token != secret  # actually encrypted
+        assert crypto.decrypt_api_key(token, version) == secret
+    finally:
+        importlib.reload(crypto)  # restore module state for other tests
+
+
+def test_decrypt_bad_token_raises(monkeypatch):
+    key = Fernet.generate_key().decode()
+    monkeypatch.setenv("KEY_VERSION", "1")
+    monkeypatch.setenv("KEYRING_1", key)
+    import src.utils.crypto as crypto
+
+    importlib.reload(crypto)
+    try:
+        with pytest.raises(ValueError):
+            crypto.decrypt_api_key("not-a-valid-token", 1)
+    finally:
+        importlib.reload(crypto)

--- a/tests/services/test_byok_wiring.py
+++ b/tests/services/test_byok_wiring.py
@@ -1,0 +1,256 @@
+"""Tests for the BYOK inference/billing wiring.
+
+Covers the context-variable key injection (the mechanism that lets the handler
+substitute a customer's own provider key without threading api_key through every
+provider client) and the routing-fee billing swap.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.services import byok
+
+
+def test_context_is_provider_scoped():
+    assert byok.get_byok_key_for("openrouter") is None
+    token = byok.set_byok_context("openrouter", "sk-user-abc")
+    try:
+        assert byok.get_byok_key_for("openrouter") == "sk-user-abc"
+        # A key bound for one provider must never be used for another.
+        assert byok.get_byok_key_for("groq") is None
+    finally:
+        byok.reset_byok_context(token)
+    assert byok.get_byok_key_for("openrouter") is None
+
+
+def test_get_provider_api_key_prefers_byok_context(monkeypatch):
+    from src.services import gateway_registry
+
+    # Without context: normal resolution (platform key or None).
+    baseline = gateway_registry.get_provider_api_key("openrouter")
+
+    token = byok.set_byok_context("openrouter", "sk-user-xyz")
+    try:
+        assert gateway_registry.get_provider_api_key("openrouter") == "sk-user-xyz"
+        # A different provider is unaffected by the openrouter binding.
+        assert gateway_registry.get_provider_api_key("groq") != "sk-user-xyz"
+    finally:
+        byok.reset_byok_context(token)
+
+    assert gateway_registry.get_provider_api_key("openrouter") == baseline
+
+
+def test_openrouter_pooled_client_uses_byok_key(monkeypatch):
+    import src.services.connection_pool as pool
+
+    captured = {}
+
+    def _fake_pooled(provider, base_url, api_key, default_headers=None, timeout=None):
+        captured["api_key"] = api_key
+        return MagicMock()
+
+    monkeypatch.setattr(pool, "get_pooled_client", _fake_pooled)
+
+    token = byok.set_byok_context("openrouter", "sk-user-999")
+    try:
+        pool.get_openrouter_pooled_client()
+    finally:
+        byok.reset_byok_context(token)
+
+    assert captured["api_key"] == "sk-user-999"
+
+
+def test_resolve_byok_key_none_without_user():
+    assert byok.resolve_byok_key(None, "openrouter") is None
+
+
+def test_resolve_byok_key_returns_decrypted(monkeypatch):
+    import src.db.user_provider_keys as upk
+
+    monkeypatch.setattr(upk, "get_decrypted_provider_key", lambda uid, slug: "sk-decrypted")
+    assert byok.resolve_byok_key(42, "openrouter") == "sk-decrypted"
+
+
+def test_resolve_byok_key_never_raises(monkeypatch):
+    import src.db.user_provider_keys as upk
+
+    def _boom(uid, slug):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(upk, "get_decrypted_provider_key", _boom)
+    assert byok.resolve_byok_key(42, "openrouter") is None  # swallowed → platform fallback
+
+
+@pytest.mark.parametrize(
+    "is_byok,rate,cost,expected",
+    [
+        (False, "0.05", 1.0, 1.0),   # not BYOK → full cost
+        (True, "0.0", 1.0, 0.0),     # BYOK, 0% fee → free routing
+        (True, "0.05", 1.0, 0.05),   # BYOK, 5% fee
+        (True, "0.10", 2.0, 0.20),   # BYOK, 10% fee
+    ],
+)
+def test_apply_byok_fee(monkeypatch, is_byok, rate, cost, expected):
+    monkeypatch.setenv("BYOK_ROUTING_FEE_RATE", rate)
+    from src.handlers.chat_handler import ChatInferenceHandler
+
+    handler = ChatInferenceHandler("gw_test_key")
+    handler.is_byok = is_byok
+    assert handler._apply_byok_fee(cost) == expected
+
+
+# ---------------------------------------------------------------------------
+# Integration: drive the real _call_provider and prove the customer key is live
+# DURING the provider call, is_byok is set on success, and the binding is cleared
+# afterwards. A stub provider records what get_byok_key_for() sees at call time.
+# ---------------------------------------------------------------------------
+def _make_handler_with_user(monkeypatch, user_id=1):
+    from src.handlers.chat_handler import ChatInferenceHandler
+
+    handler = ChatInferenceHandler("gw_test_key")
+    handler.is_anonymous = False
+    handler.user = {"id": user_id}
+    return handler
+
+
+def _force_openrouter_async(monkeypatch):
+    # Make _call_provider take the OpenRouter branch deterministically.
+    import src.services.gateway_registry as gr
+
+    monkeypatch.setattr(
+        gr, "get_gateway_registry", lambda: {"openrouter": {"async_streaming": True}}
+    )
+
+
+def _install_recording_provider(monkeypatch):
+    """Patch the OpenRouter request fn to record the BYOK key visible mid-call."""
+    seen = {}
+
+    def _stub(messages, model, **kwargs):
+        from src.services.byok import get_byok_key_for
+
+        seen["key"] = get_byok_key_for("openrouter")
+        return MagicMock()
+
+    monkeypatch.setattr("src.handlers.chat_handler.make_openrouter_request_openai", _stub)
+    return seen
+
+
+def test_call_provider_binds_customer_key_during_call(monkeypatch):
+    from src.config import Config
+    import src.db.user_provider_keys as upk
+
+    monkeypatch.setattr(Config, "BYOK_ENABLED", True)
+    monkeypatch.setattr(upk, "get_decrypted_provider_key", lambda uid, slug: "sk-byok-live")
+    _force_openrouter_async(monkeypatch)
+    seen = _install_recording_provider(monkeypatch)
+
+    handler = _make_handler_with_user(monkeypatch)
+    handler._call_provider("openrouter", "openai/gpt-4o", [{"role": "user", "content": "hi"}])
+
+    # The customer's key was bound while the provider client ran...
+    assert seen["key"] == "sk-byok-live"
+    # ...is_byok recorded on success...
+    assert handler.is_byok is True
+    # ...and the binding is cleared once the call returns (no leak).
+    assert byok.get_byok_key_for("openrouter") is None
+
+
+def test_call_provider_no_key_is_not_byok(monkeypatch):
+    from src.config import Config
+    import src.db.user_provider_keys as upk
+
+    monkeypatch.setattr(Config, "BYOK_ENABLED", True)
+    monkeypatch.setattr(upk, "get_decrypted_provider_key", lambda uid, slug: None)  # user has none
+    _force_openrouter_async(monkeypatch)
+    seen = _install_recording_provider(monkeypatch)
+
+    handler = _make_handler_with_user(monkeypatch)
+    handler._call_provider("openrouter", "openai/gpt-4o", [{"role": "user", "content": "hi"}])
+
+    assert seen["key"] is None  # nothing bound → platform key resolution
+    assert handler.is_byok is False
+
+
+def test_call_provider_flag_off_ignores_stored_key(monkeypatch):
+    from src.config import Config
+    import src.db.user_provider_keys as upk
+
+    monkeypatch.setattr(Config, "BYOK_ENABLED", False)  # master switch off
+    # Even though the user HAS a key, it must not be used.
+    monkeypatch.setattr(upk, "get_decrypted_provider_key", lambda uid, slug: "sk-should-not-use")
+    _force_openrouter_async(monkeypatch)
+    seen = _install_recording_provider(monkeypatch)
+
+    handler = _make_handler_with_user(monkeypatch)
+    handler._call_provider("openrouter", "openai/gpt-4o", [{"role": "user", "content": "hi"}])
+
+    assert seen["key"] is None
+    assert handler.is_byok is False
+
+
+def test_call_provider_failure_leaves_is_byok_false_and_unbinds(monkeypatch):
+    from fastapi import HTTPException
+
+    from src.config import Config
+    import src.db.user_provider_keys as upk
+
+    monkeypatch.setattr(Config, "BYOK_ENABLED", True)
+    monkeypatch.setattr(upk, "get_decrypted_provider_key", lambda uid, slug: "sk-byok-live")
+    _force_openrouter_async(monkeypatch)
+
+    def _boom(messages, model, **kwargs):
+        raise RuntimeError("upstream exploded")
+
+    monkeypatch.setattr("src.handlers.chat_handler.make_openrouter_request_openai", _boom)
+
+    handler = _make_handler_with_user(monkeypatch)
+    with pytest.raises(HTTPException):
+        handler._call_provider("openrouter", "openai/gpt-4o", [{"role": "user", "content": "hi"}])
+
+    # A failed BYOK attempt must not mark the request BYOK (else a failover to the
+    # platform key would be under-billed), and the binding must be released.
+    assert handler.is_byok is False
+    assert byok.get_byok_key_for("openrouter") is None
+
+
+@pytest.mark.asyncio
+async def test_call_provider_stream_binds_at_creation_not_across_yields(monkeypatch):
+    """Streaming: the key must be live when the stream is CREATED, but cleared
+    before any chunk is yielded — a ContextVar.set() left active across an async-
+    generator yield would leak into the caller's context."""
+    from src.config import Config
+    import src.db.user_provider_keys as upk
+
+    monkeypatch.setattr(Config, "BYOK_ENABLED", True)
+    monkeypatch.setattr(upk, "get_decrypted_provider_key", lambda uid, slug: "sk-byok-stream")
+    _force_openrouter_async(monkeypatch)
+
+    seen = {}
+
+    async def _fake_stream_create(messages, model, **kwargs):
+        seen["key_at_creation"] = byok.get_byok_key_for("openrouter")
+
+        async def _gen():
+            for c in ["a", "b"]:
+                yield c
+
+        return _gen()
+
+    monkeypatch.setattr(
+        "src.handlers.chat_handler.make_openrouter_request_openai_stream_async",
+        _fake_stream_create,
+    )
+
+    handler = _make_handler_with_user(monkeypatch)
+    keys_during_yield = []
+    async for _chunk in handler._call_provider_stream(
+        "openrouter", "openai/gpt-4o", [{"role": "user", "content": "hi"}]
+    ):
+        keys_during_yield.append(byok.get_byok_key_for("openrouter"))
+
+    assert seen["key_at_creation"] == "sk-byok-stream"  # key live at stream creation
+    assert handler.is_byok is True
+    assert keys_during_yield == [None, None]  # NOT bound while yielding → no leak
+    assert byok.get_byok_key_for("openrouter") is None


### PR DESCRIPTION
## Summary

Wires **bring-your-own-key** end to end: customers store their own upstream provider key, the gateway serves their requests on it, and bills a small **routing fee** instead of the full credit cost. Self-contained and **off by default**.

### What's included
- **Storage/API** — `user_provider_keys` table (Fernet-encrypted at rest, RLS) + `POST/GET/DELETE /user/provider-keys`. Keys returned masked; decrypted only server-side for the upstream call (`crypto.decrypt_api_key`).
- **Key injection without touching ~30 provider clients** — a provider-scoped context variable (`src/services/byok.py`), set by the handler around a provider call and read by the two central key-resolution points: `gateway_registry.get_provider_api_key` (registry providers) and `connection_pool.get_openrouter_pooled_client` (default OpenRouter path). Pooled clients cache per api_key → no cross-tenant leakage.
- **Billing** — when served on the customer's key, bill `byok_routing_fee(cost)` (fraction, default 0) instead of full cost, at the handler's single authoritative charge point.

### Safety
- Gated by `BYOK_ENABLED` (**default off** → zero hot-path cost, no per-request lookup).
- `is_byok` recorded only on a **successful** provider call → failover to a platform key bills normally.
- Streaming binds the key only around stream **creation** and clears it before the first `yield` → no context leak across async-generator suspension.
- Provider-scoped → a key is never reused across providers; all BYOK lookups swallow errors and fall back to the platform key.

### Tests — 25 passing
Helpers, context scoping, key-resolution overrides, **non-streaming + streaming handler integration** (customer key live during the call, unbound after, no-leak), failover safety, and the fee matrix.

### Rollout / notes
- Enable with `BYOK_ENABLED=true` + a `BYOK_ROUTING_FEE_RATE`.
- Ships the migration `20260704000003_add_user_provider_keys.sql`.
- **Coverage caveat:** providers whose client reads `Config.X_API_KEY` directly (e.g. Groq) don't honour BYOK yet — they need to resolve via `get_provider_api_key`. OpenRouter (default) + registry-resolved providers are covered; the rest is incremental.
- **Depends conceptually on** the double-charge fix (#2149) for the routing fee to be the single effective charge; harmless to merge in either order while `BYOK_ENABLED` is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bring-your-own-key support for chat requests, including customer-managed provider keys.
  * Added a user-facing key management flow to add, view, and revoke provider keys.
  * Introduced configurable routing fees for BYOK usage.

* **Bug Fixes**
  * Improved key handling so customer keys are used when available, with safer fallback behavior.
  * Ensured BYOK settings do not leak between requests, including streaming responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->