### PR TITLE
chore(lint): green Run Linters (ruff cleanup + black formatting)

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -350,7 +350,6 @@ class Config:
     # Soundsgood Configuration (GLM-4.5-Air distilled model)
     SOUNDSGOOD_API_KEY = os.environ.get("SOUNDSGOOD_API_KEY")
 
-
     # Cloudflare Workers AI Configuration
     CLOUDFLARE_API_TOKEN = os.environ.get("CLOUDFLARE_API_TOKEN")
     CLOUDFLARE_ACCOUNT_ID = os.environ.get("CLOUDFLARE_ACCOUNT_ID")

--- a/src/config/logging_config.py
+++ b/src/config/logging_config.py
@@ -380,6 +380,7 @@ def configure_logging() -> bool:
         bool: True if Loki integration was enabled, False otherwise
     """
     import os
+
     _env = os.getenv("ENVIRONMENT", "development").lower()
     _default_level = "WARNING" if _env == "production" else "INFO"
     _level_name = os.getenv("LOG_LEVEL", _default_level).upper()

--- a/src/db/client.py
+++ b/src/db/client.py
@@ -5,8 +5,6 @@ Preferred import point for database access. Routes and services should import
 from here rather than from src.config.supabase_config directly.
 """
 from src.config.supabase_config import (
-    execute_with_retry,
-    get_initialization_status,
     get_supabase_client,
 )
 

--- a/src/db/client.py
+++ b/src/db/client.py
@@ -4,6 +4,7 @@ Database client facade.
 Preferred import point for database access. Routes and services should import
 from here rather than from src.config.supabase_config directly.
 """
+
 from src.config.supabase_config import (
     get_supabase_client,
 )

--- a/src/db/coupons.py
+++ b/src/db/coupons.py
@@ -359,7 +359,12 @@ def redeem_coupon(
         coupon_value = validation["coupon_value"]
 
         # Step 2: Get current user balance
-        user_result = client.table("users").select("purchased_credits, subscription_allowance").eq("id", user_id).execute()
+        user_result = (
+            client.table("users")
+            .select("purchased_credits, subscription_allowance")
+            .eq("id", user_id)
+            .execute()
+        )
 
         if not user_result.data:
             return {
@@ -380,7 +385,10 @@ def redeem_coupon(
 
         # Step 3: Update purchased_credits
         update_result = (
-            client.table("users").update({"purchased_credits": new_purchased}).eq("id", user_id).execute()
+            client.table("users")
+            .update({"purchased_credits": new_purchased})
+            .eq("id", user_id)
+            .execute()
         )
 
         if not update_result.data:
@@ -393,9 +401,7 @@ def redeem_coupon(
         # have double-counted times_used had the function existed. The nested
         # `.execute().data[0]` was also unguarded and could IndexError if the
         # coupon row was missing. Collapsed to one guarded increment.
-        current_usage = (
-            client.table("coupons").select("times_used").eq("id", coupon_id).execute()
-        )
+        current_usage = client.table("coupons").select("times_used").eq("id", coupon_id).execute()
         times_used = (current_usage.data[0].get("times_used") or 0) if current_usage.data else 0
         client.table("coupons").update({"times_used": times_used + 1}).eq("id", coupon_id).execute()
 

--- a/src/db/credit_transactions.py
+++ b/src/db/credit_transactions.py
@@ -439,10 +439,18 @@ def add_credits(
 
         # Get user by ID if provided, otherwise by API key
         if user_id:
-            user_result = client.table("users").select("id, purchased_credits, subscription_allowance").eq("id", user_id).execute()
+            user_result = (
+                client.table("users")
+                .select("id, purchased_credits, subscription_allowance")
+                .eq("id", user_id)
+                .execute()
+            )
         else:
             user_result = (
-                client.table("users").select("id, purchased_credits, subscription_allowance").eq("api_key", api_key).execute()
+                client.table("users")
+                .select("id, purchased_credits, subscription_allowance")
+                .eq("api_key", api_key)
+                .execute()
             )
 
         if not user_result.data:

--- a/src/db/models_catalog_db.py
+++ b/src/db/models_catalog_db.py
@@ -1076,9 +1076,7 @@ def _sync_categories(supabase, upserted_models: list[dict[str, Any]]) -> None:
 
         @with_retry(max_attempts=3)
         def _update_chunk(chunk_ids: list[Any], tags: list[str]) -> None:
-            supabase.table("models").update({"categories": tags}).in_(
-                "id", chunk_ids
-            ).execute()
+            supabase.table("models").update({"categories": tags}).in_("id", chunk_ids).execute()
 
         updated = 0
         failed = 0

--- a/src/db/trials.py
+++ b/src/db/trials.py
@@ -5,8 +5,8 @@ from typing import Any
 
 from src.config.redis_config import get_redis_config
 from src.config.supabase_config import get_supabase_client
-from src.utils.profiling import tag_wrapper
 from src.utils.db_safety import DatabaseResultError, safe_get_first
+from src.utils.profiling import tag_wrapper
 
 logger = logging.getLogger(__name__)
 

--- a/src/db/user_memory.py
+++ b/src/db/user_memory.py
@@ -87,7 +87,11 @@ def add_memory(user_id, content: str, *, kind: str = "fact", salience: float = 0
     )
     _invalidate(user_id)
     rows = getattr(resp, "data", None) or []
-    return rows[0] if rows else {"user_id": user_id, "content": content, "kind": kind, "salience": salience}
+    return (
+        rows[0]
+        if rows
+        else {"user_id": user_id, "content": content, "kind": kind, "salience": salience}
+    )
 
 
 def delete_memory(memory_id, user_id) -> bool:

--- a/src/db/users.py
+++ b/src/db/users.py
@@ -5,7 +5,6 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from src.config.supabase_config import get_supabase_client
-from src.config.usage_limits import TRIAL_DURATION_DAYS
 from src.db.api_keys import create_api_key
 from src.utils.db_instrumentation import track_database_query
 from src.utils.db_safety import DatabaseResultError, safe_get_first, safe_get_value
@@ -2067,9 +2066,6 @@ def get_user_profile(api_key: str) -> dict[str, Any]:
         total_credits_val = subscription_allowance_val + purchased_credits_val
 
         # No unit conversion — DB value IS the credit count
-        subscription_allowance_cents = subscription_allowance_val
-        purchased_credits_cents = purchased_credits_val
-        total_credits_cents = total_credits_val
 
         # Return profile data
         profile = {

--- a/src/db/users.py
+++ b/src/db/users.py
@@ -768,7 +768,9 @@ def log_api_usage_transaction(
             return
 
         user_id = user["id"]
-        balance_before = float(user.get("subscription_allowance", 0) or 0) + float(user.get("purchased_credits", 0) or 0)
+        balance_before = float(user.get("subscription_allowance", 0) or 0) + float(
+            user.get("purchased_credits", 0) or 0
+        )
         balance_after = balance_before - cost if not is_trial else balance_before
 
         # Log the transaction (negative amount for usage)
@@ -1549,9 +1551,7 @@ def get_user_usage_metrics(api_key: str) -> dict[str, Any]:
         key_result = client.table("api_keys_new").select("user_id").eq("api_key", api_key).execute()
         if not key_result.data:
             # Fallback to legacy users table
-            user_result = (
-                client.table("users").select("id").eq("api_key", api_key).execute()
-            )
+            user_result = client.table("users").select("id").eq("api_key", api_key).execute()
             if not user_result.data:
                 return None
             user_id = user_result.data[0]["id"]
@@ -1559,11 +1559,18 @@ def get_user_usage_metrics(api_key: str) -> dict[str, Any]:
             user_id = key_result.data[0]["user_id"]
 
         # Get user credits
-        user_result = client.table("users").select("purchased_credits, subscription_allowance").eq("id", user_id).execute()
+        user_result = (
+            client.table("users")
+            .select("purchased_credits, subscription_allowance")
+            .eq("id", user_id)
+            .execute()
+        )
         if not user_result.data:
             return None
 
-        current_credits = float(user_result.data[0].get("purchased_credits", 0) or 0) + float(user_result.data[0].get("subscription_allowance", 0) or 0)
+        current_credits = float(user_result.data[0].get("purchased_credits", 0) or 0) + float(
+            user_result.data[0].get("subscription_allowance", 0) or 0
+        )
 
         # Use the database function to get usage metrics
         result = client.rpc("get_user_usage_metrics", {"user_api_key": api_key}).execute()
@@ -1642,7 +1649,10 @@ def get_admin_monitor_data() -> dict[str, Any]:
 
             # Then get user data for credit calculations (limited to avoid memory issues)
             users_result = (
-                client.table("users").select("id, purchased_credits, subscription_allowance, api_key").limit(10000).execute()
+                client.table("users")
+                .select("id, purchased_credits, subscription_allowance, api_key")
+                .limit(10000)
+                .execute()
             )
             users = users_result.data or []
         except Exception as e:

--- a/src/db/webhook_events.py
+++ b/src/db/webhook_events.py
@@ -118,12 +118,7 @@ def release_event(event_id: str) -> None:
     try:
 
         def _release(client):
-            return (
-                client.table("stripe_webhook_events")
-                .delete()
-                .eq("event_id", event_id)
-                .execute()
-            )
+            return client.table("stripe_webhook_events").delete().eq("event_id", event_id).execute()
 
         execute_with_retry(_release, max_retries=2, retry_delay=0.2)
         logger.info(f"Released webhook event claim after handler failure: {event_id}")

--- a/src/handlers/chat_handler.py
+++ b/src/handlers/chat_handler.py
@@ -25,6 +25,8 @@ from src.schemas.internal.chat import (
 )
 from src.services.circuit_breaker import CircuitBreakerError
 from src.services.credit_precheck import estimate_and_check_credits
+from src.services.pricing import calculate_cost_split, get_model_pricing
+from src.services.provider_selector import get_selector
 
 # Providers with native async streaming use direct imports (currently OpenRouter).
 # All other providers are dispatched via PROVIDER_ROUTING (lazy-imported to avoid
@@ -33,8 +35,6 @@ from src.services.providers.openrouter_client import (
     make_openrouter_request_openai,
     make_openrouter_request_openai_stream_async,
 )
-from src.services.pricing import calculate_cost_split, get_model_pricing
-from src.services.provider_selector import get_selector
 
 logger = logging.getLogger(__name__)
 
@@ -369,8 +369,8 @@ class ChatInferenceHandler:
         """
         from fastapi import HTTPException
 
-        from src.utils.profiling import tag_wrapper
         from src.utils.error_factory import DetailedErrorFactory
+        from src.utils.profiling import tag_wrapper
 
         logger.info(f"[ChatHandler] Calling provider={provider_name}, model={model_id}")
 
@@ -588,8 +588,8 @@ class ChatInferenceHandler:
         # Route to appropriate provider with circuit breaker error handling
         from fastapi import HTTPException
 
-        from src.utils.profiling import tag_wrapper
         from src.utils.error_factory import DetailedErrorFactory
+        from src.utils.profiling import tag_wrapper
 
         # Bind the customer's BYOK key (if any) only around stream CREATION — the
         # key is consumed when the client/stream is built. It is reset before any
@@ -1240,7 +1240,9 @@ class ChatInferenceHandler:
                             chunk_usage = _rfield(provider_chunk, "usage")
                             if chunk_usage:
                                 prompt_tokens = _rfield(chunk_usage, "prompt_tokens", 0) or 0
-                                completion_tokens = _rfield(chunk_usage, "completion_tokens", 0) or 0
+                                completion_tokens = (
+                                    _rfield(chunk_usage, "completion_tokens", 0) or 0
+                                )
 
                             # Yield internal chunk
                             internal_chunk = InternalStreamChunk(

--- a/src/handlers/chat_handler.py
+++ b/src/handlers/chat_handler.py
@@ -33,7 +33,7 @@ from src.services.providers.openrouter_client import (
     make_openrouter_request_openai,
     make_openrouter_request_openai_stream_async,
 )
-from src.services.pricing import calculate_cost, calculate_cost_split, get_model_pricing
+from src.services.pricing import calculate_cost_split, get_model_pricing
 from src.services.provider_selector import get_selector
 
 logger = logging.getLogger(__name__)
@@ -796,24 +796,24 @@ class ChatInferenceHandler:
         else:
             pricing_source = "calculated"  # DB default; tokens/cost will be 0
 
-        save_kwargs = dict(
-            request_id=self.request_id,
-            model_name=model_name,
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            processing_time_ms=elapsed_ms,
-            cost_usd=cost_usd,
-            input_cost_usd=input_cost_usd,
-            output_cost_usd=output_cost_usd,
-            pricing_source=pricing_source,
-            status=status,
-            error_message=error_message,
-            user_id=self.user.get("id") if self.user else None,
-            provider_name=provider_name,
-            model_id=None,
-            api_key_id=self.user.get("key_id") if self.user else None,
-            is_anonymous=self.is_anonymous,
-        )
+        save_kwargs = {
+            "request_id": self.request_id,
+            "model_name": model_name,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "processing_time_ms": elapsed_ms,
+            "cost_usd": cost_usd,
+            "input_cost_usd": input_cost_usd,
+            "output_cost_usd": output_cost_usd,
+            "pricing_source": pricing_source,
+            "status": status,
+            "error_message": error_message,
+            "user_id": self.user.get("id") if self.user else None,
+            "provider_name": provider_name,
+            "model_id": None,
+            "api_key_id": self.user.get("key_id") if self.user else None,
+            "is_anonymous": self.is_anonymous,
+        }
 
         if self.background_tasks:
             self.background_tasks.add_task(save_chat_completion_request_with_cost, **save_kwargs)

--- a/src/handlers/provider_registry.py
+++ b/src/handlers/provider_registry.py
@@ -43,9 +43,7 @@ def _safe_import_provider(provider_name: str, imports_list: list[str]) -> dict:
         logger.debug(f"Loaded {provider_name} provider client")
         return result
     except Exception as e:
-        error_msg = (
-            f"Failed to load {provider_name} provider client: {type(e).__name__}: {str(e)}"
-        )
+        error_msg = f"Failed to load {provider_name} provider client: {type(e).__name__}: {str(e)}"
         logger.error(error_msg)
         _provider_import_errors[provider_name] = str(e)
 

--- a/src/main.py
+++ b/src/main.py
@@ -73,9 +73,7 @@ if Config.SENTRY_ENABLED and Config.SENTRY_DSN:
         return 0.1
 
     _on_vercel = bool(os.getenv("VERCEL"))
-    _profiles_rate = (
-        0.0 if _on_vercel else float(os.getenv("SENTRY_PROFILES_SAMPLE_RATE", "0.05"))
-    )
+    _profiles_rate = 0.0 if _on_vercel else float(os.getenv("SENTRY_PROFILES_SAMPLE_RATE", "0.05"))
     _sentry_init_kwargs = {
         "dsn": Config.SENTRY_DSN,
         "send_default_pii": True,
@@ -525,7 +523,10 @@ def create_app() -> FastAPI:
         ("payments", "Stripe Payments"),
         ("chat_history", "Chat History"),
         ("share", "Chat Share Links"),  # Shareable chat links
-        ("ranking", "Model Ranking"),  # Re-enabled — frontend model dropdowns depend on /ranking/models
+        (
+            "ranking",
+            "Model Ranking",
+        ),  # Re-enabled — frontend model dropdowns depend on /ranking/models
         ("activity", "Activity Tracking"),
         ("coupons", "Coupon Management"),
         ("referral", "Referral System"),
@@ -541,7 +542,10 @@ def create_app() -> FastAPI:
         ("code_router", "Code Router Settings"),  # Code-optimized routing configuration
         ("downtime_logs", "Downtime Incident Logs"),  # Downtime tracking and log capture
         ("user_memory", "User Memory"),  # Portable per-user memory (Phase 4 context assembly)
-        ("user_provider_keys", "BYOK Provider Keys"),  # Bring-your-own-key management (pivot Phase 5)
+        (
+            "user_provider_keys",
+            "BYOK Provider Keys",
+        ),  # Bring-your-own-key management (pivot Phase 5)
     ]
 
     loaded_count = 0

--- a/src/main.py
+++ b/src/main.py
@@ -349,7 +349,6 @@ def create_app() -> FastAPI:
         # Refresh Redis INFO gauges on each scrape (run in threadpool to avoid blocking).
         # Hard cap at 5 s so a slow Upstash round-trip never causes the Prometheus scrape
         # to time out (scrape_timeout=10s in prometheus.yml → up{job="gatewayz_production"}=0).
-        import asyncio
 
         try:
             await asyncio.wait_for(

--- a/src/middleware/observability_middleware.py
+++ b/src/middleware/observability_middleware.py
@@ -31,7 +31,6 @@ from src.services.prometheus_metrics import (
     http_request_duration,
     record_http_response,
 )
-
 from src.utils.profiling import tag_wrapper as _pyroscope_tag_wrapper
 
 logger = logging.getLogger(__name__)

--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -165,7 +165,8 @@ async def admin_add_credits(req: AddCreditsRequest, admin_user: dict = Depends(r
         return {
             "status": "success",
             "message": f"Added {req.credits} credits to user {user.get('username', user['id'])}",
-            "new_balance": float(updated_user.get("subscription_allowance", 0) or 0) + float(updated_user.get("purchased_credits", 0) or 0),
+            "new_balance": float(updated_user.get("subscription_allowance", 0) or 0)
+            + float(updated_user.get("purchased_credits", 0) or 0),
             "user_id": user["id"],
             "reason": description,
         }
@@ -189,7 +190,8 @@ async def admin_get_all_balances(admin_user: dict = Depends(require_admin)):
             user_balances.append(
                 {
                     "api_key": user["api_key"],
-                    "credits": float(user.get("subscription_allowance", 0) or 0) + float(user.get("purchased_credits", 0) or 0),
+                    "credits": float(user.get("subscription_allowance", 0) or 0)
+                    + float(user.get("purchased_credits", 0) or 0),
                     "created_at": user.get("created_at"),
                     "updated_at": user.get("updated_at"),
                 }
@@ -860,11 +862,18 @@ async def get_users_stats(
         if api_key:
             credits_query = (
                 client.table("users")
-                .select("subscription_allowance, purchased_credits, api_keys_new!inner(api_key)", count="exact")
+                .select(
+                    "subscription_allowance, purchased_credits, api_keys_new!inner(api_key)",
+                    count="exact",
+                )
                 .limit(100000)
             )
         else:
-            credits_query = client.table("users").select("subscription_allowance, purchased_credits", count="exact").limit(100000)
+            credits_query = (
+                client.table("users")
+                .select("subscription_allowance, purchased_credits", count="exact")
+                .limit(100000)
+            )
 
         # Apply same filters to credits query
         if email_pattern:
@@ -878,7 +887,11 @@ async def get_users_stats(
         credits_data = credits_result.data if credits_result.data else []
 
         # Calculate credit statistics
-        total_credits = sum(float(u.get("subscription_allowance", 0) or 0) + float(u.get("purchased_credits", 0) or 0) for u in credits_data)
+        total_credits = sum(
+            float(u.get("subscription_allowance", 0) or 0)
+            + float(u.get("purchased_credits", 0) or 0)
+            for u in credits_data
+        )
         avg_credits = round(total_credits / total_users, 2) if total_users > 0 else 0
         logger.info(
             f"Stats calculated - active: {active_users}, credits: {total_credits}, avg: {avg_credits}"
@@ -1357,7 +1370,8 @@ async def get_user_by_api_key(
             "id": user_data.get("user_id"),
             "username": user_data.get("username"),
             "email": user_data.get("email"),
-            "credits": float(user_data.get("subscription_allowance", 0) or 0) + float(user_data.get("purchased_credits", 0) or 0),
+            "credits": float(user_data.get("subscription_allowance", 0) or 0)
+            + float(user_data.get("purchased_credits", 0) or 0),
             "is_active": user_data.get("is_active", True),
             "role": user_data.get("role", "user"),
             "subscription_status": user_data.get("subscription_status", "trial"),
@@ -1483,7 +1497,8 @@ async def get_api_key_details_by_id(api_key_id: int, admin_user: dict = Depends(
                 "id": user_data.get("id"),
                 "email": user_data.get("email"),
                 "username": user_data.get("username"),
-                "credits": float(user_data.get("subscription_allowance", 0) or 0) + float(user_data.get("purchased_credits", 0) or 0),
+                "credits": float(user_data.get("subscription_allowance", 0) or 0)
+                + float(user_data.get("purchased_credits", 0) or 0),
                 "is_active": user_data.get("is_active"),
                 "role": user_data.get("role"),
                 "subscription_status": user_data.get("subscription_status"),
@@ -1646,7 +1661,8 @@ async def delete_users_by_domain(
                 "email": u.get("email"),
                 "username": u.get("username"),
                 "created_at": u.get("created_at"),
-                "credits": float(u.get("subscription_allowance", 0) or 0) + float(u.get("purchased_credits", 0) or 0),
+                "credits": float(u.get("subscription_allowance", 0) or 0)
+                + float(u.get("purchased_credits", 0) or 0),
             }
             for u in users_to_delete
         ]

--- a/src/routes/audio.py
+++ b/src/routes/audio.py
@@ -24,8 +24,8 @@ from fastapi.responses import JSONResponse
 from src.config import Config
 from src.db.api_keys import increment_api_key_usage
 from src.db.users import deduct_credits, get_user, record_usage
-from src.security.inference_gates import enforce_subscription_status_gate
 from src.security.deps import get_api_key
+from src.security.inference_gates import enforce_subscription_status_gate
 from src.services.connection_pool import get_openai_pooled_client
 from src.utils.ai_tracing import AIRequestType, AITracer
 from src.utils.rate_limit_guard import enforce_request_rate_limit
@@ -195,7 +195,9 @@ async def _deduct_audio_credits(
         # Fetch fresh balance after deduction for accurate reporting
         updated_user = await loop.run_in_executor(executor, get_user, api_key)
         if updated_user:
-            actual_balance_after = float(updated_user.get("subscription_allowance", 0) or 0) + float(updated_user.get("purchased_credits", 0) or 0)
+            actual_balance_after = float(
+                updated_user.get("subscription_allowance", 0) or 0
+            ) + float(updated_user.get("purchased_credits", 0) or 0)
 
         await loop.run_in_executor(
             executor,
@@ -489,7 +491,11 @@ async def create_transcription(
             "user_balance_after": (
                 actual_balance_after
                 if actual_balance_after is not None
-                else (float(user.get("subscription_allowance", 0) or 0) + float(user.get("purchased_credits", 0) or 0)) - total_cost
+                else (
+                    float(user.get("subscription_allowance", 0) or 0)
+                    + float(user.get("purchased_credits", 0) or 0)
+                )
+                - total_cost
             ),
             "user_api_key": f"{api_key[:10]}...",
             "used_fallback_pricing": used_fallback_pricing,
@@ -720,7 +726,11 @@ async def create_transcription_base64(
             "user_balance_after": (
                 actual_balance_after
                 if actual_balance_after is not None
-                else (float(user.get("subscription_allowance", 0) or 0) + float(user.get("purchased_credits", 0) or 0)) - total_cost
+                else (
+                    float(user.get("subscription_allowance", 0) or 0)
+                    + float(user.get("purchased_credits", 0) or 0)
+                )
+                - total_cost
             ),
             "user_api_key": f"{api_key[:10]}...",
             "used_fallback_pricing": used_fallback_pricing,

--- a/src/routes/auth.py
+++ b/src/routes/auth.py
@@ -254,7 +254,9 @@ def _handle_existing_user(
         api_key_to_return = None
 
     # user_credits is only used for legacy migration detection below; tiered fields are used for response
-    user_credits = float(existing_user.get("subscription_allowance") or 0) + float(existing_user.get("purchased_credits") or 0)
+    user_credits = float(existing_user.get("subscription_allowance") or 0) + float(
+        existing_user.get("purchased_credits") or 0
+    )
 
     tier = existing_user.get("tier")
     tier_display_name = _get_tier_display_name(tier)
@@ -284,17 +286,25 @@ def _handle_existing_user(
         # Write back to DB so deduction RPC sees the correct values
         try:
             _supabase = supabase_config.get_supabase_client()
-            _supabase.table("users").update({
-                "subscription_allowance": subscription_allowance_dollars,
-                "purchased_credits": purchased_credits_dollars,
-            }).eq("id", existing_user["id"]).execute()
+            _supabase.table("users").update(
+                {
+                    "subscription_allowance": subscription_allowance_dollars,
+                    "purchased_credits": purchased_credits_dollars,
+                }
+            ).eq("id", existing_user["id"]).execute()
             logger.info(
                 "Migrated legacy credits for user %s: $%.2f → subscription_allowance=$%.2f, purchased_credits=$%.2f",
-                existing_user["id"], legacy_credits_dollars,
-                subscription_allowance_dollars, purchased_credits_dollars,
+                existing_user["id"],
+                legacy_credits_dollars,
+                subscription_allowance_dollars,
+                purchased_credits_dollars,
             )
         except Exception as _migration_err:
-            logger.warning("Failed to persist legacy credit migration for user %s: %s", existing_user["id"], _migration_err)
+            logger.warning(
+                "Failed to persist legacy credit migration for user %s: %s",
+                existing_user["id"],
+                _migration_err,
+            )
 
     total_credits_dollars = subscription_allowance_dollars + purchased_credits_dollars
 
@@ -1196,7 +1206,8 @@ async def privy_auth(
                         "user_id": created_user["id"],
                         "username": created_user.get("username", username),
                         "email": created_user.get("email", fallback_email),
-                        "credits": float(created_user.get("purchased_credits", 0) or 0) + float(created_user.get("subscription_allowance", 0) or 0),
+                        "credits": float(created_user.get("purchased_credits", 0) or 0)
+                        + float(created_user.get("subscription_allowance", 0) or 0),
                         "primary_api_key": api_key_value,
                         "api_key": api_key_value,
                         "scope_permissions": created_user.get("scope_permissions", {}),
@@ -1537,7 +1548,8 @@ async def register_user(
                     "user_id": created_user["id"],
                     "username": created_user.get("username", request.username),
                     "email": created_user.get("email", request.email),
-                    "credits": float(created_user.get("purchased_credits", 0) or 0) + float(created_user.get("subscription_allowance", 0) or 0),
+                    "credits": float(created_user.get("purchased_credits", 0) or 0)
+                    + float(created_user.get("subscription_allowance", 0) or 0),
                     "primary_api_key": api_key_value,
                     "api_key": api_key_value,
                     "scope_permissions": created_user.get("scope_permissions", {}),

--- a/src/routes/catalog.py
+++ b/src/routes/catalog.py
@@ -47,14 +47,14 @@ from src.services.models import (
     get_model_count_by_provider,
     normalize_provider_slug,
 )
+from src.services.prometheus_metrics import set_gateway_model_count
+from src.services.providers import enhance_providers_with_logos_and_sites, get_cached_providers
 from src.services.providers.modelz_client import (
     check_model_exists_on_modelz,
     fetch_modelz_tokens,
     get_modelz_model_details,
     get_modelz_model_ids,
 )
-from src.services.prometheus_metrics import set_gateway_model_count
-from src.services.providers import enhance_providers_with_logos_and_sites, get_cached_providers
 from src.utils.security_validators import sanitize_for_logging
 
 # Initialize logging

--- a/src/routes/chat_routing.py
+++ b/src/routes/chat_routing.py
@@ -116,7 +116,9 @@ async def resolve_model_routing(
                 from src.services.general_router import (
                     parse_router_model_string as parse_general_router,
                 )
-                from src.services.general_router import route_general_prompt
+                from src.services.general_router import (
+                    route_general_prompt,
+                )
 
                 # Parse mode from model string
                 is_general_router, router_mode = parse_general_router(normalized_model.lower())

--- a/src/routes/credits.py
+++ b/src/routes/credits.py
@@ -696,7 +696,10 @@ async def get_credits_summary_endpoint(
 
             # Get user info
             user_result = (
-                client.table("users").select("id, username, subscription_allowance, purchased_credits").eq("id", user_id).execute()
+                client.table("users")
+                .select("id, username, subscription_allowance, purchased_credits")
+                .eq("id", user_id)
+                .execute()
             )
             user_info = user_result.data[0] if user_result.data else None
 
@@ -704,7 +707,14 @@ async def get_credits_summary_endpoint(
                 "status": "success",
                 "user_id": user_id,
                 "user_info": user_info,
-                "current_balance": (float(user_info.get("subscription_allowance", 0) or 0) + float(user_info.get("purchased_credits", 0) or 0)) if user_info else 0,
+                "current_balance": (
+                    (
+                        float(user_info.get("subscription_allowance", 0) or 0)
+                        + float(user_info.get("purchased_credits", 0) or 0)
+                    )
+                    if user_info
+                    else 0
+                ),
                 "summary": summary,
                 "filters": {
                     "from_date": from_date,
@@ -715,11 +725,19 @@ async def get_credits_summary_endpoint(
         else:
             # Get system-wide summary
             # Get all users with their balances
-            users_result = client.table("users").select("id, subscription_allowance, purchased_credits").execute()
+            users_result = (
+                client.table("users")
+                .select("id, subscription_allowance, purchased_credits")
+                .execute()
+            )
             users = users_result.data or []
 
             total_users = len(users)
-            total_credits = sum(float(u.get("subscription_allowance", 0) or 0) + float(u.get("purchased_credits", 0) or 0) for u in users)
+            total_credits = sum(
+                float(u.get("subscription_allowance", 0) or 0)
+                + float(u.get("purchased_credits", 0) or 0)
+                for u in users
+            )
             avg_credits = total_credits / total_users if total_users > 0 else 0
 
             # Get transaction counts

--- a/src/routes/general_router.py
+++ b/src/routes/general_router.py
@@ -102,10 +102,7 @@ async def get_available_models() -> dict[str, Any]:
 
     fallback_models = get_fallback_models()
 
-    models = [
-        {"mode": mode, "gatewayz_id": model_id}
-        for mode, model_id in fallback_models.items()
-    ]
+    models = [{"mode": mode, "gatewayz_id": model_id} for mode, model_id in fallback_models.items()]
 
     return {
         "success": True,

--- a/src/routes/images.py
+++ b/src/routes/images.py
@@ -15,16 +15,16 @@ from src.db.users import deduct_credits, get_user, record_usage
 from src.models import ImageGenerationRequest, ImageGenerationResponse
 from src.security.deps import get_api_key
 from src.security.inference_gates import enforce_subscription_status_gate
+from src.services.pricing_lookup import get_image_pricing
 from src.services.providers.fal_image_client import make_fal_image_request
 from src.services.providers.image_generation_client import (
     make_deepinfra_image_request,
     make_google_vertex_image_request,
     process_image_generation_response,
 )
-from src.services.pricing_lookup import get_image_pricing
 from src.utils.ai_tracing import AIRequestType, AITracer
-from src.utils.rate_limit_guard import enforce_request_rate_limit
 from src.utils.performance_tracker import PerformanceTracker
+from src.utils.rate_limit_guard import enforce_request_rate_limit
 
 # Initialize logging
 logger = logging.getLogger(__name__)
@@ -415,9 +415,12 @@ async def generate_images(
 
             # Calculate actual cost using the provider that was used (may differ from requested)
             # Resolution multiplier is applied based on requested size
-            total_cost, cost_per_image, used_fallback_pricing, resolution_multiplier = (
-                get_image_cost(actual_provider, model, req.n, size=req.size)
-            )
+            (
+                total_cost,
+                cost_per_image,
+                used_fallback_pricing,
+                resolution_multiplier,
+            ) = get_image_cost(actual_provider, model, req.n, size=req.size)
 
             # Audit log: resolution-adjusted pricing for billing transparency
             logger.info(
@@ -459,7 +462,9 @@ async def generate_images(
                 # This avoids stale data from the pre-request user lookup
                 updated_user = await loop.run_in_executor(executor, get_user, api_key)
                 if updated_user:
-                    actual_balance_after = float(updated_user.get("subscription_allowance", 0) or 0) + float(updated_user.get("purchased_credits", 0) or 0)
+                    actual_balance_after = float(
+                        updated_user.get("subscription_allowance", 0) or 0
+                    ) + float(updated_user.get("purchased_credits", 0) or 0)
 
                 await loop.run_in_executor(
                     executor,
@@ -499,7 +504,11 @@ async def generate_images(
                 "user_balance_after": (
                     actual_balance_after
                     if actual_balance_after is not None
-                    else (float(user.get("subscription_allowance", 0) or 0) + float(user.get("purchased_credits", 0) or 0)) - total_cost  # Fallback to estimate if fetch failed
+                    else (
+                        float(user.get("subscription_allowance", 0) or 0)
+                        + float(user.get("purchased_credits", 0) or 0)
+                    )
+                    - total_cost  # Fallback to estimate if fetch failed
                 ),
                 "user_api_key": f"{api_key[:10]}...",
                 "images_generated": req.n,

--- a/src/routes/notifications.py
+++ b/src/routes/notifications.py
@@ -185,7 +185,8 @@ async def send_usage_report(
             "total_requests": 1000,
             "tokens_used": 50000,
             "credits_spent": 5.00,
-            "remaining_credits": float(user.get("subscription_allowance", 0) or 0) + float(user.get("purchased_credits", 0) or 0),
+            "remaining_credits": float(user.get("subscription_allowance", 0) or 0)
+            + float(user.get("purchased_credits", 0) or 0),
         }
 
         success = enhanced_notification_service.send_monthly_usage_report(

--- a/src/routes/status_page.py
+++ b/src/routes/status_page.py
@@ -70,7 +70,8 @@ async def get_overall_status():
 
         # Get active incidents count
         incidents_response = (
-            get_db().table("model_health_incidents")
+            get_db()
+            .table("model_health_incidents")
             .select("id", count="exact")
             .eq("status", "active")
             .execute()
@@ -245,7 +246,8 @@ async def get_model_status(provider: str, model_id: str, gateway: str | None = Q
     """
     try:
         query = (
-            get_db().table("model_status_current")
+            get_db()
+            .table("model_status_current")
             .select("*")
             .eq("provider", provider)
             .eq("model", model_id)
@@ -387,7 +389,8 @@ async def get_model_uptime_history(
 
         # Query aggregated data
         query = (
-            get_db().table("model_health_aggregates")
+            get_db()
+            .table("model_health_aggregates")
             .select("*")
             .eq("provider", provider)
             .eq("model", model_id)
@@ -445,7 +448,8 @@ async def search_models(
         sanitized_q = q.replace(",", "").replace("(", "").replace(")", "").replace(".", "")
 
         query = (
-            get_db().table("model_status_current")
+            get_db()
+            .table("model_status_current")
             .select("*")
             .or_(f"model.ilike.%{sanitized_q}%,provider.ilike.%{sanitized_q}%")
             .limit(limit)
@@ -485,7 +489,8 @@ async def get_stats():
     try:
         # Get model counts by tier
         tier_counts_response = (
-            get_db().table("model_health_tracking")
+            get_db()
+            .table("model_health_tracking")
             .select("monitoring_tier", count="exact")
             .eq("is_enabled", True)
             .execute()
@@ -499,7 +504,8 @@ async def get_stats():
 
         # Get incident statistics
         incidents_response = (
-            get_db().table("model_health_incidents")
+            get_db()
+            .table("model_health_incidents")
             .select("severity,status", count="exact")
             .execute()
         )
@@ -510,7 +516,8 @@ async def get_stats():
         # Get check statistics from last 24h
         yesterday = datetime.now(UTC) - timedelta(hours=24)
         checks_response = (
-            get_db().table("model_health_history")
+            get_db()
+            .table("model_health_history")
             .select("status", count="exact")
             .gte("checked_at", yesterday.isoformat())
             .execute()

--- a/src/routes/system.py
+++ b/src/routes/system.py
@@ -17,6 +17,20 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from fastapi.responses import HTMLResponse
 
 from src.security.deps import require_admin
+from src.services.huggingface_models import fetch_models_from_hug
+from src.services.model_catalog_cache import (
+    clear_models_cache,
+    clear_providers_cache,
+)
+from src.services.model_catalog_cache import get_gateway_cache_metadata as get_models_cache
+from src.services.model_catalog_cache import get_provider_cache_metadata as get_providers_cache
+from src.services.pricing_lookup import get_model_pricing, refresh_pricing_cache
+from src.services.providers import (
+    fetch_models_from_cerebras,
+    fetch_models_from_nebius,
+    fetch_models_from_novita,
+    fetch_models_from_xai,
+)
 
 # Import fetch_models functions from their respective client files
 from src.services.providers.aimo_client import fetch_models_from_aimo
@@ -25,25 +39,17 @@ from src.services.providers.fal_image_client import fetch_models_from_fal
 from src.services.providers.featherless_client import fetch_models_from_featherless
 from src.services.providers.fireworks_client import fetch_models_from_fireworks
 from src.services.providers.groq_client import fetch_models_from_groq
-from src.services.huggingface_models import fetch_models_from_hug
-from src.services.model_catalog_cache import (
-    clear_models_cache,
-    clear_providers_cache,
+from src.services.providers.modelz_client import (
+    clear_modelz_cache,
 )
-from src.services.model_catalog_cache import get_gateway_cache_metadata as get_models_cache
-from src.services.model_catalog_cache import get_provider_cache_metadata as get_providers_cache
-from src.services.providers.modelz_client import clear_modelz_cache
-from src.services.providers.modelz_client import get_modelz_cache_status as get_modelz_cache_status_func
-from src.services.providers.modelz_client import refresh_modelz_cache
+from src.services.providers.modelz_client import (
+    get_modelz_cache_status as get_modelz_cache_status_func,
+)
+from src.services.providers.modelz_client import (
+    refresh_modelz_cache,
+)
 from src.services.providers.near_client import fetch_models_from_near
 from src.services.providers.openrouter_client import fetch_models_from_openrouter
-from src.services.pricing_lookup import get_model_pricing, refresh_pricing_cache
-from src.services.providers import (
-    fetch_models_from_cerebras,
-    fetch_models_from_nebius,
-    fetch_models_from_novita,
-    fetch_models_from_xai,
-)
 from src.services.providers.together_client import fetch_models_from_together
 
 # Initialize logging

--- a/src/schemas/proxy.py
+++ b/src/schemas/proxy.py
@@ -516,8 +516,6 @@ class ToolDefinition(BaseModel):
         extra = "allow"
 
 
-
-
 # ============================================================================
 # Anthropic Messages API Response Schemas
 # ============================================================================
@@ -574,5 +572,3 @@ class ToolUseBlockResponse(BaseModel):
 
     class Config:
         extra = "allow"
-
-

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -147,7 +147,7 @@ class _RelocatedModuleFinder(importlib.abc.MetaPathFinder):
         if not fullname.startswith(self._PREFIX):
             return None
         # e.g. fullname = "src.services.prometheus_metrics"
-        remainder = fullname[len(self._PREFIX):]
+        remainder = fullname[len(self._PREFIX) :]
         # Only handle single-level names (not "src.services.metrics.prometheus_metrics")
         if "." in remainder:
             return None

--- a/src/services/billing/credit_precheck.py
+++ b/src/services/billing/credit_precheck.py
@@ -115,7 +115,9 @@ def calculate_affordable_max_tokens(
     if remaining <= 0:
         logger.debug(
             "User cannot afford output for %s: credits=%.6f, input_cost=%.6f",
-            model_id, user_credits, input_cost,
+            model_id,
+            user_credits,
+            input_cost,
         )
         return None
 
@@ -134,7 +136,10 @@ def calculate_affordable_max_tokens(
 
     logger.debug(
         "Affordable max_tokens for %s: %d (remaining=%.6f, rate=%.10f)",
-        model_id, affordable, remaining, effective_rate,
+        model_id,
+        affordable,
+        remaining,
+        effective_rate,
     )
     return affordable
 
@@ -184,7 +189,11 @@ def check_credit_sufficiency(
         capped_cost = calculate_cost(model_id, input_tokens, affordable)
         logger.info(
             "Credit cap: %s max_tokens %d→%d (credits=%.4f, capped_cost=%.6f)",
-            model_id, max_tokens, affordable, user_credits, capped_cost,
+            model_id,
+            max_tokens,
+            affordable,
+            user_credits,
+            capped_cost,
         )
         return {
             "allowed": True,
@@ -207,8 +216,8 @@ def check_credit_sufficiency(
         "suggestion": (
             f"Reduce max_tokens from {max_tokens} to lower the maximum cost, "
             f"or add ${shortfall:.4f} in credits."
-            ),
-        }
+        ),
+    }
 
 
 def estimate_and_check_credits(
@@ -250,7 +259,11 @@ def estimate_and_check_credits(
 
     # Check sufficiency (with affordability-based capping)
     check_result = check_credit_sufficiency(
-        user_credits, max_cost, model_id, max_output_tokens, is_trial,
+        user_credits,
+        max_cost,
+        model_id,
+        max_output_tokens,
+        is_trial,
         input_tokens=input_tokens,
     )
 

--- a/src/services/billing/ledger_reconciliation.py
+++ b/src/services/billing/ledger_reconciliation.py
@@ -135,9 +135,7 @@ def summarize_ledger(rows: list[dict]) -> LedgerSummary:
             revenue_by_user[uid] = revenue_by_user.get(uid, _ZERO) + credit
             total_revenue += credit
 
-    unbalanced = sorted(
-        str(ref) for ref, (d, c) in per_ref.items() if d != c
-    )
+    unbalanced = sorted(str(ref) for ref, (d, c) in per_ref.items() if d != c)
     return LedgerSummary(
         total_revenue=total_revenue,
         revenue_by_user=revenue_by_user,

--- a/src/services/billing/payments.py
+++ b/src/services/billing/payments.py
@@ -261,7 +261,9 @@ class StripeService:
         parent = self._get_stripe_object_value(invoice, "parent")
         if parent:
             details = self._get_stripe_object_value(parent, "subscription_details")
-            sub_id = _as_id(self._get_stripe_object_value(details, "subscription")) if details else None
+            sub_id = (
+                _as_id(self._get_stripe_object_value(details, "subscription")) if details else None
+            )
             if sub_id:
                 return sub_id
 
@@ -275,7 +277,11 @@ class StripeService:
                     if line_parent
                     else None
                 )
-                sub_id = _as_id(self._get_stripe_object_value(item_details, "subscription")) if item_details else None
+                sub_id = (
+                    _as_id(self._get_stripe_object_value(item_details, "subscription"))
+                    if item_details
+                    else None
+                )
                 if sub_id:
                     return sub_id
         return None
@@ -2690,9 +2696,7 @@ class StripeService:
                 start_date = datetime.now(UTC)
                 _upd_period_end = self._get_subscription_period_end(updated_subscription)
                 if _upd_period_end:
-                    end_date = datetime.fromtimestamp(
-                        _upd_period_end, tz=UTC
-                    )
+                    end_date = datetime.fromtimestamp(_upd_period_end, tz=UTC)
                 else:
                     end_date = start_date + timedelta(days=30)
 
@@ -2957,9 +2961,7 @@ class StripeService:
                 start_date = datetime.now(UTC)
                 _upd_period_end = self._get_subscription_period_end(updated_subscription)
                 if _upd_period_end:
-                    end_date = datetime.fromtimestamp(
-                        _upd_period_end, tz=UTC
-                    )
+                    end_date = datetime.fromtimestamp(_upd_period_end, tz=UTC)
                 else:
                     end_date = start_date + timedelta(days=30)
 
@@ -3148,7 +3150,11 @@ class StripeService:
 
                 effective_date = (
                     datetime.fromtimestamp(_cancel_period_end, tz=UTC)
-                    if (_cancel_period_end := self._get_subscription_period_end(updated_subscription))
+                    if (
+                        _cancel_period_end := self._get_subscription_period_end(
+                            updated_subscription
+                        )
+                    )
                     else None
                 )
 

--- a/src/services/general_router.py
+++ b/src/services/general_router.py
@@ -181,6 +181,7 @@ class GeneralRouter:
             "fallback_reason": reason,
         }
 
+
 # Module-level singleton
 _router: GeneralRouter | None = None
 

--- a/src/services/memory_extraction.py
+++ b/src/services/memory_extraction.py
@@ -21,12 +21,40 @@ logger = logging.getLogger(__name__)
 # Each pattern captures group(1) = the salient phrase. Applied to USER messages only.
 # (regex, fact template, salience, kind). Templates use {0} for the captured phrase.
 _PATTERNS: list[tuple[re.Pattern, str, float, str]] = [
-    (re.compile(r"\bmy name is ([A-Z][\w'’-]+(?:\s[A-Z][\w'’-]+){0,2})"), "User's name is {0}", 0.9, "identity"),
+    (
+        re.compile(r"\bmy name is ([A-Z][\w'’-]+(?:\s[A-Z][\w'’-]+){0,2})"),
+        "User's name is {0}",
+        0.9,
+        "identity",
+    ),
     (re.compile(r"\b(?:call me|i go by) ([A-Z][\w'’-]+)"), "User goes by {0}", 0.85, "identity"),
-    (re.compile(r"\bremember (?:that |this[:,]? )?([^.?!\n]{4,120})", re.IGNORECASE), "{0}", 0.85, "fact"),
-    (re.compile(r"\bI work (?:at|for|as)\s+([^.?!\n]{2,60})", re.IGNORECASE), "User works {0}", 0.7, "fact"),
-    (re.compile(r"\bI (?:prefer|like to use|always use|usually use|use)\s+([^.?!\n]{2,60})", re.IGNORECASE), "User prefers {0}", 0.6, "preference"),
-    (re.compile(r"\bI'?m (?:a |an )([a-z][^.?!\n]{2,50})", re.IGNORECASE), "User is a {0}", 0.55, "identity"),
+    (
+        re.compile(r"\bremember (?:that |this[:,]? )?([^.?!\n]{4,120})", re.IGNORECASE),
+        "{0}",
+        0.85,
+        "fact",
+    ),
+    (
+        re.compile(r"\bI work (?:at|for|as)\s+([^.?!\n]{2,60})", re.IGNORECASE),
+        "User works {0}",
+        0.7,
+        "fact",
+    ),
+    (
+        re.compile(
+            r"\bI (?:prefer|like to use|always use|usually use|use)\s+([^.?!\n]{2,60})",
+            re.IGNORECASE,
+        ),
+        "User prefers {0}",
+        0.6,
+        "preference",
+    ),
+    (
+        re.compile(r"\bI'?m (?:a |an )([a-z][^.?!\n]{2,50})", re.IGNORECASE),
+        "User is a {0}",
+        0.55,
+        "identity",
+    ),
 ]
 
 _MAX_CANDIDATES_PER_CALL = 5

--- a/src/services/metrics/prometheus_metrics.py
+++ b/src/services/metrics/prometheus_metrics.py
@@ -1090,7 +1090,8 @@ def record_credits_used(provider: str, model: str, user_id: str, credits: float)
     credits_used.labels(provider=provider, model=model).inc(credits)
 
 
-from src.utils.db_instrumentation import track_database_query  # re-export for backward compat  # noqa: E402,F401
+# re-export for backward compat (imported from here by metrics_aggregator)
+from src.utils.db_instrumentation import track_database_query  # noqa: E402,F401
 
 
 def record_cache_hit(cache_name: str, key: str | None = None, item_size: int | None = None):

--- a/src/services/model_catalog_sync.py
+++ b/src/services/model_catalog_sync.py
@@ -14,6 +14,12 @@ from src.db.providers_db import (
     create_provider,
     get_provider_by_slug,
 )
+from src.services.huggingface_models import fetch_models_from_huggingface_api
+from src.services.pricing_normalization import (
+    PricingFormat,
+    get_provider_format,
+    normalize_to_per_token,
+)
 from src.services.providers.aimo_client import fetch_models_from_aimo
 from src.services.providers.alibaba_cloud_client import fetch_models_from_alibaba
 from src.services.providers.anthropic_client import fetch_models_from_anthropic
@@ -31,7 +37,6 @@ from src.services.providers.featherless_client import fetch_models_from_featherl
 from src.services.providers.fireworks_client import fetch_models_from_fireworks
 from src.services.providers.google_vertex_catalog import fetch_models_from_google_vertex
 from src.services.providers.groq_client import fetch_models_from_groq
-from src.services.huggingface_models import fetch_models_from_huggingface_api
 from src.services.providers.modelz_client import fetch_models_from_modelz
 from src.services.providers.morpheus_client import fetch_models_from_morpheus
 from src.services.providers.near_client import fetch_models_from_near
@@ -39,11 +44,6 @@ from src.services.providers.nebius_client import fetch_models_from_nebius
 from src.services.providers.novita_client import fetch_models_from_novita
 from src.services.providers.openai_client import fetch_models_from_openai
 from src.services.providers.openrouter_client import fetch_models_from_openrouter
-from src.services.pricing_normalization import (
-    PricingFormat,
-    get_provider_format,
-    normalize_to_per_token,
-)
 from src.services.providers.simplismart_client import fetch_models_from_simplismart
 from src.services.providers.sybil_client import fetch_models_from_sybil
 from src.services.providers.together_client import fetch_models_from_together
@@ -1014,8 +1014,7 @@ def sync_all_providers(
                 logger.warning("Failed to load providers from DB; using hardcoded fallback")
                 all_providers = list(PROVIDER_FETCH_FUNCTIONS.keys())
             providers_to_sync = [
-                p for p in all_providers
-                if p not in skip_set and is_provider_enabled(p)
+                p for p in all_providers if p not in skip_set and is_provider_enabled(p)
             ]
             if skip_set:
                 logger.info(

--- a/src/services/model_categorizer.py
+++ b/src/services/model_categorizer.py
@@ -35,10 +35,10 @@ class CategoryRule:
     """One tunable rule, mirroring a row of the category_rules table."""
 
     category: str
-    dimension: str          # blended_price | latency_tier | context_length | quality
-                            # | quality_code | is_reasoning | modality | is_free
-                            # | value_ratio | quality_band
-    operator: str           # lte | gte | eq | contains | band
+    dimension: str  # blended_price | latency_tier | context_length | quality
+    # | quality_code | is_reasoning | modality | is_free
+    # | value_ratio | quality_band
+    operator: str  # lte | gte | eq | contains | band
     threshold: float | None = None
     threshold2: float | None = None
     params: dict[str, Any] = field(default_factory=dict)
@@ -48,16 +48,22 @@ class CategoryRule:
 # In-code fallback rules — MUST stay in sync with the seed block of
 # supabase/migrations/20260704000000_add_model_categories.sql.
 DEFAULT_RULES: list[CategoryRule] = [
-    CategoryRule("cheapest", "blended_price", "lte", 0.50,
-                 params={"weight_input": 0.25, "weight_output": 0.75}),
+    CategoryRule(
+        "cheapest",
+        "blended_price",
+        "lte",
+        0.50,
+        params={"weight_input": 0.25, "weight_output": 0.75},
+    ),
     CategoryRule("fastest", "latency_tier", "lte", 2),
     CategoryRule("largest", "context_length", "gte", 200_000),
     CategoryRule("smartest", "quality", "gte", 85),
     CategoryRule("long-context", "context_length", "gte", 128_000),
     CategoryRule("coding", "quality_code", "gte", 85),
     CategoryRule("reasoning", "is_reasoning", "eq"),
-    CategoryRule("vision", "modality", "contains",
-                 params={"needles": ["image", "vision", "multimodal"]}),
+    CategoryRule(
+        "vision", "modality", "contains", params={"needles": ["image", "vision", "multimodal"]}
+    ),
     CategoryRule("free", "is_free", "eq"),
     CategoryRule("balanced", "value_ratio", "gte", 200),
     CategoryRule("flagship", "quality_band", "band", 90),
@@ -75,10 +81,10 @@ class ModelSignals:
     is_reasoning: bool = False
     is_free: bool = False
     modality: str | None = None
-    input_price_per_token: float | None = None   # normalized $/token
+    input_price_per_token: float | None = None  # normalized $/token
     output_price_per_token: float | None = None  # normalized $/token
-    quality_overall: float | None = None         # 0..100
-    quality_code: float | None = None            # 0..100
+    quality_overall: float | None = None  # 0..100
+    quality_code: float | None = None  # 0..100
 
 
 # --------------------------------------------------------------------------- #
@@ -297,9 +303,7 @@ def load_rules(supabase: Any = None, force_refresh: bool = False) -> list[Catego
                     category=r["category"],
                     dimension=r["dimension"],
                     operator=r["operator"],
-                    threshold=(
-                        float(r["threshold"]) if r.get("threshold") is not None else None
-                    ),
+                    threshold=(float(r["threshold"]) if r.get("threshold") is not None else None),
                     threshold2=(
                         float(r["threshold2"]) if r.get("threshold2") is not None else None
                     ),

--- a/src/services/model_quality_gate.py
+++ b/src/services/model_quality_gate.py
@@ -32,9 +32,18 @@ _JUNK_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"\b(GPTQ|AWQ|EXL2|EXL3)\b", re.I), "quant:weightformat"),
     (re.compile(r"(?<![a-z0-9])(?:int4|int8|4bit|8bit|3bit|2bit)(?![a-z0-9])", re.I), "quant:bits"),
     # Frankenmerges / passthrough merges — hobbyist noise.
-    (re.compile(r"(?<![a-z0-9])(?:slerp|frankenmerge|passthrough|della|dare[-_]?ties|ties[-_]?merge)(?![a-z0-9])", re.I), "merge"),
+    (
+        re.compile(
+            r"(?<![a-z0-9])(?:slerp|frankenmerge|passthrough|della|dare[-_]?ties|ties[-_]?merge)(?![a-z0-9])",
+            re.I,
+        ),
+        "merge",
+    ),
     # RP / ERP / uncensored spam catalogs.
-    (re.compile(r"(?<![a-z0-9])(?:erp|nsfw|waifu|uncensored|roleplay)(?![a-z0-9])", re.I), "adult-rp"),
+    (
+        re.compile(r"(?<![a-z0-9])(?:erp|nsfw|waifu|uncensored|roleplay)(?![a-z0-9])", re.I),
+        "adult-rp",
+    ),
 ]
 
 

--- a/src/services/models.py
+++ b/src/services/models.py
@@ -7,7 +7,7 @@ from concurrent.futures import as_completed
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter

--- a/src/services/notification.py
+++ b/src/services/notification.py
@@ -147,7 +147,9 @@ class NotificationService:
             if not preferences or not preferences.email_notifications:
                 return None
 
-            current_credits = float(user_data.get("subscription_allowance", 0) or 0) + float(user_data.get("purchased_credits", 0) or 0)
+            current_credits = float(user_data.get("subscription_allowance", 0) or 0) + float(
+                user_data.get("purchased_credits", 0) or 0
+            )
 
             # All users get notified when credits fall below $5
             low_balance_threshold = 5.0
@@ -209,7 +211,9 @@ class NotificationService:
             if not preferences or not preferences.email_notifications:
                 return None
 
-            current_credits = float(user_data.get("subscription_allowance", 0) or 0) + float(user_data.get("purchased_credits", 0) or 0)
+            current_credits = float(user_data.get("subscription_allowance", 0) or 0) + float(
+                user_data.get("purchased_credits", 0) or 0
+            )
 
             if current_credits <= 0.0:
                 # Avoid duplicate notifications within 24 hours

--- a/src/services/price_refresh.py
+++ b/src/services/price_refresh.py
@@ -171,9 +171,7 @@ def _refresh_provider_prices(provider_slug: str, dry_run: bool) -> dict[str, Any
             existing_by_pmid[pmid] = row
 
     for model in normalized_models:
-        provider_model_id = (
-            model.get("provider_model_id") or model.get("id") or model.get("slug")
-        )
+        provider_model_id = model.get("provider_model_id") or model.get("id") or model.get("slug")
         if not provider_model_id:
             continue
         provider_model_id = str(provider_model_id)
@@ -264,9 +262,7 @@ def refresh_all_prices(dry_run: bool = False) -> dict[str, Any]:
 
     provider_slugs = list(PROVIDER_FETCH_FUNCTIONS.keys())
 
-    logger.info(
-        f"Price refresh starting (dry_run={dry_run}) for {len(provider_slugs)} providers"
-    )
+    logger.info(f"Price refresh starting (dry_run={dry_run}) for {len(provider_slugs)} providers")
 
     for provider_slug in provider_slugs:
         try:

--- a/src/services/pricing/__init__.py
+++ b/src/services/pricing/__init__.py
@@ -8,9 +8,9 @@ from src.services.pricing.pricing import *  # noqa: F401,F403
 from src.services.pricing.pricing import (  # noqa: F401  # explicit names for IDE support
     _default_pricing_tracker,
     _track_default_pricing_usage,
+    calculate_code_router_savings,
     calculate_cost,
     calculate_cost_async,
-    calculate_code_router_savings,
     clear_pricing_cache,
     get_default_pricing_stats,
     get_model_pricing,

--- a/src/services/pricing/pricing.py
+++ b/src/services/pricing/pricing.py
@@ -1111,6 +1111,7 @@ def calculate_cost_split(
         completion_cost = float(completion_tokens) * float(pricing.get("completion", 0.0))
         # Apply the same markup the total received (preserve sum invariant).
         from src.config.config import Config
+
         markup = Config.PRICING_MARKUP
         return (total, prompt_cost * markup, completion_cost * markup)
     except Exception as e:

--- a/src/services/pricing/pricing_lookup.py
+++ b/src/services/pricing/pricing_lookup.py
@@ -416,7 +416,9 @@ def _resolve_pricing_from_db(
                         if prompt_price is not None and completion_price is not None:
                             logger.debug(
                                 "[DB] Pricing for %s via %s=%s (model_pricing table)",
-                                model_id, column, candidate,
+                                model_id,
+                                column,
+                                candidate,
                             )
                             return {
                                 "prompt": validate_pricing_value(prompt_price, "prompt", model_id),
@@ -439,12 +441,12 @@ def _resolve_pricing_from_db(
                         if prompt_price is not None and completion_price is not None:
                             logger.debug(
                                 "[DB] Pricing for %s via %s=%s (metadata.pricing_raw)",
-                                model_id, column, candidate,
+                                model_id,
+                                column,
+                                candidate,
                             )
                             return {
-                                "prompt": validate_pricing_value(
-                                    prompt_price, "prompt", model_id
-                                ),
+                                "prompt": validate_pricing_value(prompt_price, "prompt", model_id),
                                 "completion": validate_pricing_value(
                                     completion_price, "completion", model_id
                                 ),
@@ -560,9 +562,7 @@ def get_all_pricing_batch() -> dict[str, dict]:
                         "request": validate_pricing_value(
                             pricing_raw.get("request", 0), "request", key
                         ),
-                        "image": validate_pricing_value(
-                            pricing_raw.get("image", 0), "image", key
-                        ),
+                        "image": validate_pricing_value(pricing_raw.get("image", 0), "image", key),
                         "source": "metadata_batch",
                     }
 

--- a/src/services/pricing/pricing_lookup.py
+++ b/src/services/pricing/pricing_lookup.py
@@ -16,11 +16,9 @@ If you add a new pricing source, use normalize_pricing_dict() with the correct
 PricingFormat constant before returning values from this module.
 """
 
-import json
 import logging
 import threading
 import time
-from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)

--- a/src/services/pricing_normalization.py
+++ b/src/services/pricing_normalization.py
@@ -1,2 +1,3 @@
 """Backward compatibility re-export. Moved to src/utils/pricing_normalization.py"""
+
 from src.utils.pricing_normalization import *  # noqa: F401,F403

--- a/src/services/providers/__init__.py
+++ b/src/services/providers/__init__.py
@@ -23,15 +23,15 @@ _spec.loader.exec_module(_mod)
 
 # Re-export every public symbol
 from src.services._providers_legacy import (  # noqa: E402, F401
-    get_cached_providers,
-    fetch_providers_from_openrouter,
-    get_provider_logo_from_services,
-    get_provider_info,
     enhance_providers_with_logos_and_sites,
     fetch_models_from_cerebras,
-    fetch_models_from_xai,
+    fetch_models_from_morpheus,
     fetch_models_from_nebius,
     fetch_models_from_novita,
-    fetch_models_from_morpheus,
     fetch_models_from_simplismart,
+    fetch_models_from_xai,
+    fetch_providers_from_openrouter,
+    get_cached_providers,
+    get_provider_info,
+    get_provider_logo_from_services,
 )

--- a/src/services/providers/aimo_client.py
+++ b/src/services/providers/aimo_client.py
@@ -8,11 +8,11 @@ from src.cache import (
     set_gateway_error,
 )
 from src.config import Config
-from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.services.model_catalog_cache import (
     cache_gateway_catalog,
     get_cached_gateway_catalog,
 )
+from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.utils.model_name_validator import clean_model_name
 from src.utils.security_validators import sanitize_for_logging
 

--- a/src/services/providers/akash_client.py
+++ b/src/services/providers/akash_client.py
@@ -8,8 +8,8 @@ API Base: https://api.akashml.com/v1
 import logging
 
 from src.config import Config
-from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.services.connection_pool import get_akash_pooled_client
+from src.services.providers.anthropic_transformer import extract_message_with_tools
 
 # Initialize logging
 logger = logging.getLogger(__name__)

--- a/src/services/providers/alibaba_cloud_client.py
+++ b/src/services/providers/alibaba_cloud_client.py
@@ -14,8 +14,8 @@ except ImportError:  # pragma: no cover
 
 from src.config import Config
 from src.config.redis_config import get_redis_manager
-from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.services.model_catalog_cache import cache_gateway_catalog, get_cached_gateway_catalog
+from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.utils.model_name_validator import clean_model_name
 from src.utils.security_validators import sanitize_for_logging
 

--- a/src/services/providers/anthropic_client.py
+++ b/src/services/providers/anthropic_client.py
@@ -13,9 +13,9 @@ import logging
 import httpx
 
 from src.config import Config
-from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.services.connection_pool import get_anthropic_pooled_client
 from src.services.model_catalog_cache import cache_gateway_catalog
+from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.utils.model_name_validator import clean_model_name
 from src.utils.security_validators import sanitize_for_logging
 

--- a/src/services/providers/canopywave_client.py
+++ b/src/services/providers/canopywave_client.py
@@ -31,9 +31,9 @@ from openai import OpenAI
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
 
 from src.config import Config
-from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.services.connection_pool import get_canopywave_pooled_client
 from src.services.model_catalog_cache import cache_gateway_catalog
+from src.services.providers.anthropic_transformer import extract_message_with_tools
 
 # Initialize logging
 logger = logging.getLogger(__name__)

--- a/src/services/providers/chutes_client.py
+++ b/src/services/providers/chutes_client.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from openai import OpenAI
 
 from src.config import Config
-from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.services.model_catalog_cache import cache_gateway_catalog
+from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.utils.model_name_validator import clean_model_name
 from src.utils.security_validators import sanitize_for_logging
 

--- a/src/services/providers/clarifai_client.py
+++ b/src/services/providers/clarifai_client.py
@@ -20,10 +20,10 @@ Model ID Format:
 import logging
 
 from src.config import Config
-from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.services.connection_pool import get_clarifai_pooled_client
 from src.services.model_catalog_cache import cache_gateway_catalog
 from src.services.pricing_lookup import enrich_model_with_pricing
+from src.services.providers.anthropic_transformer import extract_message_with_tools
 
 # Initialize logging
 logger = logging.getLogger(__name__)

--- a/src/services/providers/cloudflare_workers_ai_client.py
+++ b/src/services/providers/cloudflare_workers_ai_client.py
@@ -27,9 +27,9 @@ from typing import Any
 import httpx
 
 from src.config import Config
-from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.services.connection_pool import get_cloudflare_workers_ai_pooled_client
 from src.services.model_catalog_cache import cache_gateway_catalog
+from src.services.providers.anthropic_transformer import extract_message_with_tools
 
 # Initialize logging
 logger = logging.getLogger(__name__)

--- a/src/services/providers/deepinfra_client.py
+++ b/src/services/providers/deepinfra_client.py
@@ -4,8 +4,8 @@ import httpx
 from openai import OpenAI
 
 from src.config import Config
-from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.services.model_catalog_cache import cache_gateway_catalog
+from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.utils.model_name_validator import clean_model_name
 
 # Initialize logging

--- a/src/services/providers/featherless_client.py
+++ b/src/services/providers/featherless_client.py
@@ -5,9 +5,9 @@ from pathlib import Path
 import httpx
 
 from src.config import Config
-from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.services.connection_pool import get_featherless_pooled_client
 from src.services.model_catalog_cache import cache_gateway_catalog
+from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.utils.model_name_validator import clean_model_name
 from src.utils.security_validators import sanitize_for_logging
 

--- a/src/services/providers/fireworks_client.py
+++ b/src/services/providers/fireworks_client.py
@@ -3,9 +3,9 @@ import logging
 import httpx
 
 from src.config import Config
-from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.services.connection_pool import get_fireworks_pooled_client
 from src.services.model_catalog_cache import cache_gateway_catalog
+from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.utils.model_name_validator import clean_model_name
 
 # Initialize logging

--- a/src/services/providers/groq_client.py
+++ b/src/services/providers/groq_client.py
@@ -13,7 +13,6 @@ import logging
 import httpx
 
 from src.config import Config
-from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.services.circuit_breaker import (
     CircuitBreakerConfig,
     CircuitBreakerError,
@@ -21,6 +20,7 @@ from src.services.circuit_breaker import (
 )
 from src.services.connection_pool import get_groq_pooled_client
 from src.services.model_catalog_cache import cache_gateway_catalog
+from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.utils.model_name_validator import clean_model_name
 from src.utils.sentry_context import capture_provider_error
 

--- a/src/services/providers/morpheus_client.py
+++ b/src/services/providers/morpheus_client.py
@@ -11,8 +11,8 @@ import logging
 import httpx
 
 from src.config import Config
-from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.services.connection_pool import get_morpheus_pooled_client
+from src.services.providers.anthropic_transformer import extract_message_with_tools
 
 # Initialize logging
 logger = logging.getLogger(__name__)

--- a/src/services/providers/near_client.py
+++ b/src/services/providers/near_client.py
@@ -3,9 +3,9 @@ import logging
 import httpx
 
 from src.config import Config
-from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.services.connection_pool import get_pooled_client
 from src.services.model_catalog_cache import cache_gateway_catalog
+from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.utils.model_name_validator import clean_model_name
 from src.utils.security_validators import sanitize_for_logging
 

--- a/src/services/providers/nosana_client.py
+++ b/src/services/providers/nosana_client.py
@@ -22,8 +22,8 @@ from typing import Any
 import httpx
 
 from src.config import Config
-from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.services.connection_pool import get_nosana_pooled_client
+from src.services.providers.anthropic_transformer import extract_message_with_tools
 
 # Initialize logging
 logger = logging.getLogger(__name__)

--- a/src/services/providers/openrouter_client.py
+++ b/src/services/providers/openrouter_client.py
@@ -8,7 +8,6 @@ from fastapi import APIRouter
 from openai import APIStatusError, AsyncOpenAI, BadRequestError
 
 from src.config import Config
-from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.services.circuit_breaker import (
     CircuitBreakerConfig,
     CircuitBreakerError,
@@ -18,6 +17,7 @@ from src.services.connection_pool import get_openrouter_pooled_client, get_poole
 from src.services.model_catalog_cache import (
     update_provider_catalog_incremental,
 )
+from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.utils.security_validators import sanitize_for_logging
 from src.utils.sentry_context import capture_provider_error
 

--- a/src/services/providers/simplismart_client.py
+++ b/src/services/providers/simplismart_client.py
@@ -53,8 +53,8 @@ Supported Speech-to-Text models (per audio minute):
 import logging
 
 from src.config import Config
-from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.services.connection_pool import get_simplismart_pooled_client
+from src.services.providers.anthropic_transformer import extract_message_with_tools
 
 # Initialize logging
 logger = logging.getLogger(__name__)

--- a/src/services/providers/sybil_client.py
+++ b/src/services/providers/sybil_client.py
@@ -29,8 +29,8 @@ import logging
 import httpx
 
 from src.config import Config
-from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.services.connection_pool import get_sybil_pooled_client
+from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.utils.model_name_validator import clean_model_name
 
 # Initialize logging

--- a/src/services/providers/together_client.py
+++ b/src/services/providers/together_client.py
@@ -3,7 +3,6 @@ import logging
 import httpx
 
 from src.config import Config
-from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.services.circuit_breaker import (
     CircuitBreakerConfig,
     CircuitBreakerError,
@@ -11,6 +10,7 @@ from src.services.circuit_breaker import (
 )
 from src.services.connection_pool import get_together_pooled_client
 from src.services.model_catalog_cache import cache_gateway_catalog
+from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.utils.model_name_validator import clean_model_name
 from src.utils.sentry_context import capture_provider_error
 

--- a/src/services/providers/xai_client.py
+++ b/src/services/providers/xai_client.py
@@ -1,8 +1,8 @@
 import logging
 
 from src.config import Config
-from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.services.connection_pool import get_xai_pooled_client
+from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.utils.model_name_validator import clean_model_name
 
 # Initialize logging

--- a/src/services/providers/zai_client.py
+++ b/src/services/providers/zai_client.py
@@ -12,9 +12,9 @@ import logging
 import httpx
 
 from src.config import Config
-from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.services.connection_pool import get_zai_pooled_client
 from src.services.model_catalog_cache import cache_gateway_catalog
+from src.services.providers.anthropic_transformer import extract_message_with_tools
 from src.utils.model_name_validator import clean_model_name
 from src.utils.security_validators import sanitize_for_logging
 

--- a/src/services/rate_limiting.py
+++ b/src/services/rate_limiting.py
@@ -17,8 +17,8 @@ from typing import Any
 import redis
 
 from src.db.rate_limits import get_rate_limit_config, update_rate_limit_config
-from src.utils.profiling import tag_wrapper
 from src.services.rate_limiting_fallback import get_fallback_rate_limit_manager
+from src.utils.profiling import tag_wrapper
 
 logger = logging.getLogger(__name__)
 
@@ -863,9 +863,7 @@ def _fail_open_allowed() -> bool:
     return os.getenv("RATE_LIMIT_FAIL_CLOSED", "false").lower() != "true"
 
 
-def sliding_window_check(
-    key: str, limit: int, window_seconds: int
-) -> tuple[bool, int, int | None]:
+def sliding_window_check(key: str, limit: int, window_seconds: int) -> tuple[bool, int, int | None]:
     """Redis-backed sliding window primitive.
 
     Returns:

--- a/src/services/referral.py
+++ b/src/services/referral.py
@@ -211,7 +211,9 @@ The AI Gateway Team
 REFERRAL_CODE_LENGTH = 8
 MAX_REFERRAL_USES = 10  # Each referral code can be used by 10 different users
 MIN_PURCHASE_AMOUNT = 10.0  # $10 minimum
-REFERRAL_BONUS = 10.0  # Legacy constant; referrals no longer grant any credits (kept for back-compat/tests)
+REFERRAL_BONUS = (
+    10.0  # Legacy constant; referrals no longer grant any credits (kept for back-compat/tests)
+)
 
 
 def generate_referral_code() -> str:
@@ -514,7 +516,8 @@ def get_referral_stats(user_id: int) -> dict[str, Any] | None:
             "remaining_uses": remaining_uses,
             "max_uses": MAX_REFERRAL_USES,
             "total_earned": float(total_earned),
-            "current_balance": float(user.get("subscription_allowance", 0) or 0) + float(user.get("purchased_credits", 0) or 0),
+            "current_balance": float(user.get("subscription_allowance", 0) or 0)
+            + float(user.get("purchased_credits", 0) or 0),
             "referred_by_code": user.get("referred_by_code"),
             "referrals": referral_details,
         }

--- a/src/services/scheduled_sync.py
+++ b/src/services/scheduled_sync.py
@@ -495,9 +495,7 @@ def start_price_refresh_scheduler():
             coalesce=True,  # Combine missed runs
         )
         _price_scheduler.start()
-        logger.info(
-            "✅ Price refresh scheduler started (next run in %s minutes)", interval_minutes
-        )
+        logger.info("✅ Price refresh scheduler started (next run in %s minutes)", interval_minutes)
     except Exception as e:
         logger.error(f"❌ Failed to start price refresh scheduler: {e}")
         logger.exception(e)
@@ -620,7 +618,9 @@ def start_ledger_reconciliation_scheduler():
         return
 
     interval_minutes = Config.LEDGER_RECONCILIATION_INTERVAL_MINUTES
-    logger.info("Starting credit-ledger reconciliation scheduler (interval: %s min)", interval_minutes)
+    logger.info(
+        "Starting credit-ledger reconciliation scheduler (interval: %s min)", interval_minutes
+    )
     try:
         _recon_scheduler = AsyncIOScheduler()
         _recon_scheduler.add_job(
@@ -633,7 +633,9 @@ def start_ledger_reconciliation_scheduler():
             coalesce=True,
         )
         _recon_scheduler.start()
-        logger.info("✅ Ledger reconciliation scheduler started (next run in %s min)", interval_minutes)
+        logger.info(
+            "✅ Ledger reconciliation scheduler started (next run in %s min)", interval_minutes
+        )
     except Exception as e:
         logger.error("❌ Failed to start ledger reconciliation scheduler: %s", e)
         logger.exception(e)

--- a/src/services/smart_router_bridge.py
+++ b/src/services/smart_router_bridge.py
@@ -76,7 +76,9 @@ def _offers_to_provider_offers(offers: list[dict], markup: float) -> list[Provid
                     price_per_1k=upstream * markup,
                     p50_ms=float(o.get("p50_ms") or 0.0),
                     p95_ms=float(o.get("p95_ms") or 0.0),
-                    quality_prior=float(o.get("quality_prior") if o.get("quality_prior") is not None else 0.5),
+                    quality_prior=float(
+                        o.get("quality_prior") if o.get("quality_prior") is not None else 0.5
+                    ),
                     is_active=bool(o.get("is_active", True)),
                 )
             )

--- a/src/services/startup.py
+++ b/src/services/startup.py
@@ -205,8 +205,8 @@ async def lifespan(app):
 
         # Sync DB providers table with ENABLED_PROVIDERS env var
         try:
-            from src.utils.provider_filter import is_provider_enabled, get_enabled_providers
             from src.config.supabase_config import get_client_for_query
+            from src.utils.provider_filter import get_enabled_providers, is_provider_enabled
 
             enabled = get_enabled_providers()
             if enabled is not None:
@@ -215,24 +215,32 @@ async def lifespan(app):
                 resp = supabase.table("providers").select("slug, is_active").execute()
                 all_providers = resp.data or []
                 to_deactivate = [
-                    p["slug"] for p in all_providers
+                    p["slug"]
+                    for p in all_providers
                     if p.get("is_active") and not is_provider_enabled(p["slug"])
                 ]
                 to_activate = [
-                    p["slug"] for p in all_providers
+                    p["slug"]
+                    for p in all_providers
                     if not p.get("is_active") and is_provider_enabled(p["slug"])
                 ]
                 for slug in to_deactivate:
-                    supabase.table("providers").update({"is_active": False}).eq("slug", slug).execute()
+                    supabase.table("providers").update({"is_active": False}).eq(
+                        "slug", slug
+                    ).execute()
                 for slug in to_activate:
-                    supabase.table("providers").update({"is_active": True}).eq("slug", slug).execute()
+                    supabase.table("providers").update({"is_active": True}).eq(
+                        "slug", slug
+                    ).execute()
                 if to_deactivate or to_activate:
                     logger.info(
                         f"  providers synced with ENABLED_PROVIDERS={','.join(sorted(enabled))} "
                         f"(activated: {to_activate or 'none'}, deactivated: {len(to_deactivate)} providers)"
                     )
                 else:
-                    logger.info(f"  providers already in sync with ENABLED_PROVIDERS={','.join(sorted(enabled))}")
+                    logger.info(
+                        f"  providers already in sync with ENABLED_PROVIDERS={','.join(sorted(enabled))}"
+                    )
         except Exception as e:
             logger.warning(f"Failed to sync providers with ENABLED_PROVIDERS: {e}")
 
@@ -647,6 +655,7 @@ async def lifespan(app):
     # Config.validate() checks additional fields and logs a summary)
     try:
         from src.config import Config as _Config
+
         _Config.validate()
         logger.info("  [OK] Configuration validated")
     except Exception as e:
@@ -655,7 +664,9 @@ async def lifespan(app):
     # Warn if admin key is missing in production (don't fail startup)
     try:
         import os as _os
+
         from src.config import Config as _Config2
+
         if _Config2.IS_PRODUCTION and not _os.environ.get("ADMIN_API_KEY"):
             logger.warning(
                 "  [WARN] ADMIN_API_KEY is not set in production. "
@@ -691,9 +702,7 @@ async def lifespan(app):
                 return
 
             client = get_supabase_client()
-            result = (
-                client.table("users").select("id, role").eq("email", ADMIN_EMAIL).execute()
-            )
+            result = client.table("users").select("id, role").eq("email", ADMIN_EMAIL).execute()
             if result.data:
                 user = result.data[0]
                 if user.get("role", "user") != UserRole.ADMIN:
@@ -715,10 +724,12 @@ async def lifespan(app):
         logger.info("   Initializing analytics services...")
 
         from src.services.statsig_service import statsig_service
+
         await statsig_service.initialize()
         logger.info("   Statsig analytics initialized")
 
         from src.services.posthog_service import posthog_service
+
         posthog_service.initialize()
         logger.info("   PostHog analytics initialized")
 

--- a/src/utils/crypto.py
+++ b/src/utils/crypto.py
@@ -77,9 +77,7 @@ def decrypt_api_key(token: str, key_version: int | None = None) -> str:
     if Fernet is None:
         raise RuntimeError("Cryptography library not available. Cannot decrypt.")
     if not isinstance(_KEYRING, dict) or not _KEYRING:
-        raise RuntimeError(
-            "No encryption keys configured. Set KEY_VERSION and KEYRING_<version>."
-        )
+        raise RuntimeError("No encryption keys configured. Set KEY_VERSION and KEYRING_<version>.")
 
     raw = token.encode("utf-8")
     versions = []

--- a/tests/billing/test_credit_ledger_store.py
+++ b/tests/billing/test_credit_ledger_store.py
@@ -9,11 +9,11 @@ import asyncio
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
-from src.services.credit_ledger import ALLOWANCE, PURCHASED, REVENUE, EntryState, is_balanced
 from src.services.billing.credit_ledger_store import (
     build_settled_entries,
     record_shadow_settlement,
 )
+from src.services.credit_ledger import ALLOWANCE, PURCHASED, REVENUE, EntryState, is_balanced
 
 
 # --------------------------------------------------------------------------- #
@@ -70,7 +70,9 @@ def test_record_shadow_settlement_writes_rows():
     # one insert of the settled rows (allowance debit + revenue credit)
     inserted = client.table.return_value.insert.call_args.args[0]
     assert {r["account"] for r in inserted} == {ALLOWANCE, REVENUE}
-    assert all(r["state"] == "settled" and r["user_id"] == 7 and r["ref"] == "req-10" for r in inserted)
+    assert all(
+        r["state"] == "settled" and r["user_id"] == 7 and r["ref"] == "req-10" for r in inserted
+    )
 
 
 def test_record_shadow_settlement_idempotent_skips_existing_ref():
@@ -100,7 +102,9 @@ def test_record_shadow_settlement_non_blocking_on_error():
 def test_record_shadow_settlement_empty_ref_is_noop():
     with patch("src.config.supabase_config.get_supabase_client") as get_client:
         ok = asyncio.run(
-            record_shadow_settlement(ref="", user_id=7, cost="1.00", allowance="5.00", purchased="0")
+            record_shadow_settlement(
+                ref="", user_id=7, cost="1.00", allowance="5.00", purchased="0"
+            )
         )
     assert ok is False
     get_client.assert_not_called()  # bails before touching the DB

--- a/tests/conceptual_model/test_cm01_auth_api_key_security.py
+++ b/tests/conceptual_model/test_cm01_auth_api_key_security.py
@@ -150,7 +150,6 @@ class TestCM05EncryptedKeyNotPlaintextInDb:
             patch("src.db.api_keys.check_plan_entitlements", return_value={}),
             patch("src.db.api_keys.check_key_name_uniqueness", return_value=True),
         ):
-
             # Capture what gets inserted
             captured_payload = {}
             original_insert = mock_supabase.table.return_value.insert

--- a/tests/conceptual_model/test_cm04_intelligent_routing.py
+++ b/tests/conceptual_model/test_cm04_intelligent_routing.py
@@ -222,7 +222,6 @@ class TestCodeRouterParsing:
             patch("src.services.code_router.get_baselines", return_value=mock_priors["baselines"]),
             patch("src.services.code_router.get_classifier") as mock_classifier_fn,
         ):
-
             mock_classifier = MagicMock()
             mock_classifier.classify.return_value = {
                 "category": "code_generation",
@@ -313,7 +312,6 @@ class TestCodeRouterParsing:
             patch("src.services.code_router.get_baselines", return_value=mock_priors["baselines"]),
             patch("src.services.code_router.get_classifier") as mock_classifier_fn,
         ):
-
             mock_classifier = MagicMock()
             mock_classifier_fn.return_value = mock_classifier
 

--- a/tests/conceptual_model/test_cm07_plans_trials.py
+++ b/tests/conceptual_model/test_cm07_plans_trials.py
@@ -358,7 +358,6 @@ def test_team_has_higher_rate_limits_than_dev(mock_supabase):
         patch("src.db.plans.is_admin_tier_user", return_value=False),
         patch("src.db.plans.get_user_plan") as mock_get_plan,
     ):
-
         # First call for Dev user, second for Team user
         mock_get_plan.side_effect = [dev_plan_data, team_plan_data]
 

--- a/tests/db/test_models_catalog_db_cache.py
+++ b/tests/db/test_models_catalog_db_cache.py
@@ -7,6 +7,7 @@ functions do not exist — the real public helpers for the full active-only
 catalog are `get_cached_full_catalog` and `cache_full_catalog`. We adapt to the
 real names per the plan's step B1.1 instruction.
 """
+
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -24,12 +25,11 @@ def test_get_all_models_for_catalog_uses_cache_on_second_call(sb):
     """Second call within TTL should not hit Supabase."""
     fake_rows = [{"id": 1, "model_name": "test"}]
 
-    with patch("src.db.models_catalog_db.get_client_for_query") as mock_client, patch(
-        "src.services.cache.model_catalog_cache.get_cached_full_catalog"
-    ) as mock_get, patch(
-        "src.services.cache.model_catalog_cache.cache_full_catalog"
-    ) as mock_set:
-
+    with (
+        patch("src.db.models_catalog_db.get_client_for_query") as mock_client,
+        patch("src.services.cache.model_catalog_cache.get_cached_full_catalog") as mock_get,
+        patch("src.services.cache.model_catalog_cache.cache_full_catalog") as mock_set,
+    ):
         # First call: cache miss → fetch from Supabase → set cache.
         # Second call: cache hit → return cached data, no Supabase call.
         mock_get.side_effect = [None, fake_rows]

--- a/tests/db/test_plans.py
+++ b/tests/db/test_plans.py
@@ -55,6 +55,4 @@ class TestGetPlanIdByTier:
 
         get_plan_id_by_tier("basic")
 
-        fake_supabase.table.return_value.select.return_value.eq.assert_called_with(
-            "tier", "basic"
-        )
+        fake_supabase.table.return_value.select.return_value.eq.assert_called_with("tier", "basic")

--- a/tests/integration/test_credit_deduction_models.py
+++ b/tests/integration/test_credit_deduction_models.py
@@ -114,7 +114,6 @@ class TestCreditDeductionForOpenAIModels:
             patch("src.services.credit_handler.calculate_cost_async") as mock_cost,
             patch("src.services.credit_handler.asyncio.to_thread") as mock_to_thread,
         ):
-
             mock_cost.return_value = 0.0125
             mock_to_thread.return_value = None
 
@@ -218,7 +217,6 @@ class TestCreditDeductionForAnthropicModels:
             patch("src.services.credit_handler.calculate_cost_async") as mock_cost,
             patch("src.services.credit_handler.asyncio.to_thread") as mock_to_thread,
         ):
-
             mock_cost.return_value = 0.0525
             mock_to_thread.return_value = None
 
@@ -282,7 +280,6 @@ class TestTrialUserCreditHandling:
             patch("src.db.trials.track_trial_usage", return_value=None),
             patch("src.services.credit_handler.asyncio.to_thread") as mock_to_thread,
         ):
-
             # Make to_thread call the function directly
             async def call_func(func, *args, **kwargs):
                 return func(*args, **kwargs)
@@ -345,7 +342,6 @@ class TestTrialOverrideForPaidUsers:
             patch("src.services.credit_handler.calculate_cost_async") as mock_cost,
             patch("src.services.credit_handler.asyncio.to_thread") as mock_to_thread,
         ):
-
             mock_cost.return_value = 0.05
 
             async def call_func(func, *args, **kwargs):

--- a/tests/integration/test_stripe_webhook_metadata.py
+++ b/tests/integration/test_stripe_webhook_metadata.py
@@ -42,7 +42,6 @@ class TestCheckoutSessionMetadata:
             patch("stripe.checkout.Session.create") as mock_create_session,
             patch("src.services.payments.update_payment_status") as mock_update,
         ):
-
             # Setup mocks
             mock_get_user.return_value = {"id": 1, "email": "test@example.com"}
             mock_create_payment.return_value = {"id": 100, "user_id": 1}
@@ -85,7 +84,6 @@ class TestCheckoutSessionMetadata:
             patch("stripe.checkout.Session.create") as mock_create_session,
             patch("src.services.payments.update_payment_status"),
         ):
-
             mock_get_user.return_value = {"id": 1, "email": "test@example.com"}
             mock_create_payment.return_value = {"id": 100, "user_id": 1}
 
@@ -126,7 +124,6 @@ class TestWebhookMetadataHandling:
             patch("src.services.payments.update_payment_status") as mock_update,
             patch("stripe.Webhook.construct_event") as mock_construct,
         ):
-
             mock_is_processed.return_value = False
 
             # Create a webhook event with credits_cents in metadata
@@ -170,7 +167,6 @@ class TestWebhookMetadataHandling:
             patch("src.services.payments.update_payment_status"),
             patch("stripe.Webhook.construct_event") as mock_construct,
         ):
-
             mock_is_processed.return_value = False
 
             # Create webhook event with old 'credits' field (backward compatibility)
@@ -215,7 +211,6 @@ class TestWebhookMetadataHandling:
             patch("src.services.payments.add_credits_to_user") as mock_add_credits,
             patch("stripe.Webhook.construct_event") as mock_construct,
         ):
-
             mock_is_processed.return_value = False
             mock_get_payment.return_value = None  # Simulate payment not found
             mock_add_credits.side_effect = Exception("Database error")

--- a/tests/routes/test_image_audio_markup.py
+++ b/tests/routes/test_image_audio_markup.py
@@ -17,11 +17,13 @@ MARKUP = 2.0  # use a distinctive factor so markup application is unambiguous
 # get_image_cost — markup + 4-tuple arity
 # --------------------------------------------------------------------------
 
+
 def test_image_config_path_applies_markup_and_returns_4_tuple():
     # Tier 1: manual_pricing.json hit. Previously returned a 3-tuple (a bug,
     # since callers unpack 4). Now must return 4 values, markup applied.
-    with patch("src.routes.images.Config.PRICING_MARKUP", MARKUP), patch(
-        "src.routes.images.get_image_pricing", return_value=(0.04, False)
+    with (
+        patch("src.routes.images.Config.PRICING_MARKUP", MARKUP),
+        patch("src.routes.images.get_image_pricing", return_value=(0.04, False)),
     ):
         result = get_image_cost("deepinfra", "some-model", num_images=2)
         assert len(result) == 4
@@ -34,8 +36,9 @@ def test_image_config_path_applies_markup_and_returns_4_tuple():
 
 def test_image_fallback_path_applies_markup():
     # Tier 2+: hardcoded fallback (get_image_pricing returns None).
-    with patch("src.routes.images.Config.PRICING_MARKUP", MARKUP), patch(
-        "src.routes.images.get_image_pricing", return_value=None
+    with (
+        patch("src.routes.images.Config.PRICING_MARKUP", MARKUP),
+        patch("src.routes.images.get_image_pricing", return_value=None),
     ):
         total, per_image, is_fallback, res_mult = get_image_cost(
             "fal", "flux-pro", num_images=1
@@ -46,8 +49,9 @@ def test_image_fallback_path_applies_markup():
 
 
 def test_image_unknown_provider_applies_markup():
-    with patch("src.routes.images.Config.PRICING_MARKUP", MARKUP), patch(
-        "src.routes.images.get_image_pricing", return_value=None
+    with (
+        patch("src.routes.images.Config.PRICING_MARKUP", MARKUP),
+        patch("src.routes.images.get_image_pricing", return_value=None),
     ):
         total, per_image, is_fallback, _ = get_image_cost("nobody", "x", num_images=1)
         # UNKNOWN_PROVIDER_DEFAULT_COST = 0.05
@@ -58,6 +62,7 @@ def test_image_unknown_provider_applies_markup():
 # --------------------------------------------------------------------------
 # get_audio_cost — markup
 # --------------------------------------------------------------------------
+
 
 def test_audio_known_model_applies_markup():
     with patch("src.routes.audio.Config.PRICING_MARKUP", MARKUP):

--- a/tests/security/test_vibe_audit_hardening.py
+++ b/tests/security/test_vibe_audit_hardening.py
@@ -13,7 +13,6 @@ import types
 import pytest
 from fastapi import HTTPException
 
-
 # --------------------------------------------------------------------------- #
 # 1. Per-API-key rate-limit guard                                             #
 # --------------------------------------------------------------------------- #

--- a/tests/services/test_byok.py
+++ b/tests/services/test_byok.py
@@ -10,8 +10,8 @@ from cryptography.fernet import Fernet
 
 from src.services.byok import byok_routing_fee, resolve_provider_key
 
-
 # --- routing fee -----------------------------------------------------------
+
 
 def test_fee_disabled_by_default(monkeypatch):
     monkeypatch.delenv("BYOK_ROUTING_FEE_RATE", raising=False)
@@ -40,6 +40,7 @@ def test_fee_malformed_falls_back_to_zero(monkeypatch):
 
 
 # --- key resolution priority ----------------------------------------------
+
 
 def test_byok_key_preferred_over_platform(monkeypatch):
     monkeypatch.setattr(
@@ -76,6 +77,7 @@ def test_anonymous_user_uses_platform_key(monkeypatch):
 
 
 # --- crypto round-trip (BYOK requires REVERSIBLE encryption) ---------------
+
 
 def test_encrypt_decrypt_round_trip(monkeypatch):
     key = Fernet.generate_key().decode()

--- a/tests/services/test_byok_wiring.py
+++ b/tests/services/test_byok_wiring.py
@@ -85,10 +85,10 @@ def test_resolve_byok_key_never_raises(monkeypatch):
 @pytest.mark.parametrize(
     "is_byok,rate,cost,expected",
     [
-        (False, "0.05", 1.0, 1.0),   # not BYOK → full cost
-        (True, "0.0", 1.0, 0.0),     # BYOK, 0% fee → free routing
-        (True, "0.05", 1.0, 0.05),   # BYOK, 5% fee
-        (True, "0.10", 2.0, 0.20),   # BYOK, 10% fee
+        (False, "0.05", 1.0, 1.0),  # not BYOK → full cost
+        (True, "0.0", 1.0, 0.0),  # BYOK, 0% fee → free routing
+        (True, "0.05", 1.0, 0.05),  # BYOK, 5% fee
+        (True, "0.10", 2.0, 0.20),  # BYOK, 10% fee
     ],
 )
 def test_apply_byok_fee(monkeypatch, is_byok, rate, cost, expected):
@@ -138,8 +138,8 @@ def _install_recording_provider(monkeypatch):
 
 
 def test_call_provider_binds_customer_key_during_call(monkeypatch):
-    from src.config import Config
     import src.db.user_provider_keys as upk
+    from src.config import Config
 
     monkeypatch.setattr(Config, "BYOK_ENABLED", True)
     monkeypatch.setattr(upk, "get_decrypted_provider_key", lambda uid, slug: "sk-byok-live")
@@ -158,8 +158,8 @@ def test_call_provider_binds_customer_key_during_call(monkeypatch):
 
 
 def test_call_provider_no_key_is_not_byok(monkeypatch):
-    from src.config import Config
     import src.db.user_provider_keys as upk
+    from src.config import Config
 
     monkeypatch.setattr(Config, "BYOK_ENABLED", True)
     monkeypatch.setattr(upk, "get_decrypted_provider_key", lambda uid, slug: None)  # user has none
@@ -174,8 +174,8 @@ def test_call_provider_no_key_is_not_byok(monkeypatch):
 
 
 def test_call_provider_flag_off_ignores_stored_key(monkeypatch):
-    from src.config import Config
     import src.db.user_provider_keys as upk
+    from src.config import Config
 
     monkeypatch.setattr(Config, "BYOK_ENABLED", False)  # master switch off
     # Even though the user HAS a key, it must not be used.
@@ -193,8 +193,8 @@ def test_call_provider_flag_off_ignores_stored_key(monkeypatch):
 def test_call_provider_failure_leaves_is_byok_false_and_unbinds(monkeypatch):
     from fastapi import HTTPException
 
-    from src.config import Config
     import src.db.user_provider_keys as upk
+    from src.config import Config
 
     monkeypatch.setattr(Config, "BYOK_ENABLED", True)
     monkeypatch.setattr(upk, "get_decrypted_provider_key", lambda uid, slug: "sk-byok-live")
@@ -220,8 +220,8 @@ async def test_call_provider_stream_binds_at_creation_not_across_yields(monkeypa
     """Streaming: the key must be live when the stream is CREATED, but cleared
     before any chunk is yielded — a ContextVar.set() left active across an async-
     generator yield would leak into the caller's context."""
-    from src.config import Config
     import src.db.user_provider_keys as upk
+    from src.config import Config
 
     monkeypatch.setattr(Config, "BYOK_ENABLED", True)
     monkeypatch.setattr(upk, "get_decrypted_provider_key", lambda uid, slug: "sk-byok-stream")

--- a/tests/services/test_context_assembly_bridge.py
+++ b/tests/services/test_context_assembly_bridge.py
@@ -8,10 +8,10 @@ from src.services.context_assembly_bridge import (
     split_messages,
 )
 
-
 # --------------------------------------------------------------------------- #
 # split_messages
 # --------------------------------------------------------------------------- #
+
 
 def test_split_separates_system_from_turns():
     msgs = [
@@ -52,6 +52,7 @@ def test_split_flattens_multimodal_system_content():
 # apply_context_budget
 # --------------------------------------------------------------------------- #
 
+
 def test_empty_messages_passthrough():
     assert apply_context_budget([]) == []
 
@@ -71,9 +72,9 @@ def test_ample_budget_no_memory_preserves_turn_order():
 
 def test_tight_budget_drops_oldest_turns():
     msgs = [
-        {"role": "user", "content": "x" * 400},   # ~100 tokens
-        {"role": "user", "content": "y" * 400},   # ~100 tokens
-        {"role": "user", "content": "z" * 40},    # ~10 tokens (newest)
+        {"role": "user", "content": "x" * 400},  # ~100 tokens
+        {"role": "user", "content": "y" * 400},  # ~100 tokens
+        {"role": "user", "content": "z" * 40},  # ~10 tokens (newest)
     ]
     out = apply_context_budget(msgs, token_budget=60, memory_items=[])
     contents = [m["content"] for m in out]

--- a/tests/services/test_failover_pricing.py
+++ b/tests/services/test_failover_pricing.py
@@ -17,17 +17,13 @@ def _split(total):
 
 
 def test_no_provider_model_id_returns_base():
-    with patch(
-        "src.handlers.chat_handler.calculate_cost_split", return_value=_split(1.0)
-    ) as base:
+    with patch("src.handlers.chat_handler.calculate_cost_split", return_value=_split(1.0)) as base:
         assert _loss_proof_cost_split("openai/gpt-4o", None, 100, 50) == _split(1.0)
         base.assert_called_once()
 
 
 def test_served_equals_requested_returns_base():
-    with patch(
-        "src.handlers.chat_handler.calculate_cost_split", return_value=_split(1.0)
-    ):
+    with patch("src.handlers.chat_handler.calculate_cost_split", return_value=_split(1.0)):
         # provider_model_id identical to requested → no second lookup, base cost
         assert _loss_proof_cost_split("openai/gpt-4o", "openai/gpt-4o", 10, 10) == _split(1.0)
 
@@ -37,9 +33,12 @@ def test_pricier_served_provider_is_billed():
     def fake_split(model_id, p, c):
         return _split(0.20) if model_id == "req/model" else _split(0.50)
 
-    with patch("src.handlers.chat_handler.calculate_cost_split", side_effect=fake_split), patch(
-        "src.handlers.chat_handler.get_model_pricing",
-        return_value={"prompt": 0.000001, "completion": 0.000002, "source": "database"},
+    with (
+        patch("src.handlers.chat_handler.calculate_cost_split", side_effect=fake_split),
+        patch(
+            "src.handlers.chat_handler.get_model_pricing",
+            return_value={"prompt": 0.000001, "completion": 0.000002, "source": "database"},
+        ),
     ):
         total, _, _ = _loss_proof_cost_split("req/model", "served/model", 100, 50)
         assert total == 0.50  # billed the higher served cost — no loss
@@ -51,9 +50,12 @@ def test_cheaper_served_provider_keeps_advertised_rate():
     def fake_split(model_id, p, c):
         return _split(0.50) if model_id == "req/model" else _split(0.20)
 
-    with patch("src.handlers.chat_handler.calculate_cost_split", side_effect=fake_split), patch(
-        "src.handlers.chat_handler.get_model_pricing",
-        return_value={"prompt": 0.000001, "completion": 0.000002, "source": "database"},
+    with (
+        patch("src.handlers.chat_handler.calculate_cost_split", side_effect=fake_split),
+        patch(
+            "src.handlers.chat_handler.get_model_pricing",
+            return_value={"prompt": 0.000001, "completion": 0.000002, "source": "database"},
+        ),
     ):
         total, _, _ = _loss_proof_cost_split("req/model", "served/model", 100, 50)
         assert total == 0.50  # advertised rate retained
@@ -64,9 +66,12 @@ def test_default_source_served_pricing_ignored():
     def fake_split(model_id, p, c):
         return _split(0.20) if model_id == "req/model" else _split(9.99)
 
-    with patch("src.handlers.chat_handler.calculate_cost_split", side_effect=fake_split), patch(
-        "src.handlers.chat_handler.get_model_pricing",
-        return_value={"prompt": 0.00002, "completion": 0.00002, "source": "default"},
+    with (
+        patch("src.handlers.chat_handler.calculate_cost_split", side_effect=fake_split),
+        patch(
+            "src.handlers.chat_handler.get_model_pricing",
+            return_value={"prompt": 0.00002, "completion": 0.00002, "source": "default"},
+        ),
     ):
         total, _, _ = _loss_proof_cost_split("req/model", "served/model", 100, 50)
         assert total == 0.20  # default-sourced served price ignored
@@ -76,9 +81,12 @@ def test_zero_served_pricing_ignored():
     def fake_split(model_id, p, c):
         return _split(0.20) if model_id == "req/model" else _split(0.0)
 
-    with patch("src.handlers.chat_handler.calculate_cost_split", side_effect=fake_split), patch(
-        "src.handlers.chat_handler.get_model_pricing",
-        return_value={"prompt": 0.0, "completion": 0.0, "source": "database"},
+    with (
+        patch("src.handlers.chat_handler.calculate_cost_split", side_effect=fake_split),
+        patch(
+            "src.handlers.chat_handler.get_model_pricing",
+            return_value={"prompt": 0.0, "completion": 0.0, "source": "database"},
+        ),
     ):
         total, _, _ = _loss_proof_cost_split("req/model", "served/model", 100, 50)
         assert total == 0.20  # zero served price ignored
@@ -90,9 +98,12 @@ def test_served_lookup_exception_falls_back_to_base():
             raise ValueError("high-value model missing pricing")
         return _split(0.20)
 
-    with patch("src.handlers.chat_handler.calculate_cost_split", side_effect=fake_split), patch(
-        "src.handlers.chat_handler.get_model_pricing",
-        return_value={"prompt": 0.000001, "completion": 0.000002, "source": "database"},
+    with (
+        patch("src.handlers.chat_handler.calculate_cost_split", side_effect=fake_split),
+        patch(
+            "src.handlers.chat_handler.get_model_pricing",
+            return_value={"prompt": 0.000001, "completion": 0.000002, "source": "database"},
+        ),
     ):
         total, _, _ = _loss_proof_cost_split("req/model", "served/model", 100, 50)
         assert total == 0.20  # safe fallback to requested-model cost

--- a/tests/services/test_ledger_reconciliation.py
+++ b/tests/services/test_ledger_reconciliation.py
@@ -23,19 +23,44 @@ def _settled(ref, user_id, allowance, purchased):
     total = Decimal(str(allowance)) + Decimal(str(purchased))
     rows = []
     if Decimal(str(allowance)) > 0:
-        rows.append({"ref": ref, "user_id": user_id, "account": ALLOWANCE,
-                     "debit": str(allowance), "credit": "0", "state": "settled"})
+        rows.append(
+            {
+                "ref": ref,
+                "user_id": user_id,
+                "account": ALLOWANCE,
+                "debit": str(allowance),
+                "credit": "0",
+                "state": "settled",
+            }
+        )
     if Decimal(str(purchased)) > 0:
-        rows.append({"ref": ref, "user_id": user_id, "account": PURCHASED,
-                     "debit": str(purchased), "credit": "0", "state": "settled"})
-    rows.append({"ref": ref, "user_id": user_id, "account": REVENUE,
-                 "debit": "0", "credit": str(total), "state": "settled"})
+        rows.append(
+            {
+                "ref": ref,
+                "user_id": user_id,
+                "account": PURCHASED,
+                "debit": str(purchased),
+                "credit": "0",
+                "state": "settled",
+            }
+        )
+    rows.append(
+        {
+            "ref": ref,
+            "user_id": user_id,
+            "account": REVENUE,
+            "debit": "0",
+            "credit": str(total),
+            "state": "settled",
+        }
+    )
     return rows
 
 
 # --------------------------------------------------------------------------- #
 # summarize_ledger
 # --------------------------------------------------------------------------- #
+
 
 def test_summarize_ledger_empty_is_clean():
     s = summarize_ledger([])
@@ -47,8 +72,11 @@ def test_summarize_ledger_empty_is_clean():
 
 
 def test_summarize_ledger_aggregates_revenue_per_user():
-    rows = _settled("r1", 1, "0.02", "0.01") + _settled("r2", 1, "0.05", "0") \
+    rows = (
+        _settled("r1", 1, "0.02", "0.01")
+        + _settled("r2", 1, "0.05", "0")
         + _settled("r3", 2, "0", "0.10")
+    )
     s = summarize_ledger(rows)
     assert s.ref_count == 3
     assert s.revenue_by_user[1] == Decimal("0.08")  # 0.03 + 0.05
@@ -81,6 +109,7 @@ def test_summarize_ledger_handles_none_and_string_decimals():
 # --------------------------------------------------------------------------- #
 # summarize_usage
 # --------------------------------------------------------------------------- #
+
 
 def test_summarize_usage_aggregates_cost_per_user():
     rows = [
@@ -122,6 +151,7 @@ def test_summarize_usage_excludes_admin_user_ids():
 # reconcile
 # --------------------------------------------------------------------------- #
 
+
 def test_reconcile_perfect_match_is_ok():
     ledger = summarize_ledger(_settled("r1", 1, "0.03", "0") + _settled("r2", 2, "0.10", "0"))
     usage = summarize_usage([{"user_id": 1, "cost": "0.03"}, {"user_id": 2, "cost": "0.10"}])
@@ -155,11 +185,13 @@ def test_reconcile_within_tolerance_passes():
 
 
 def test_reconcile_unbalanced_ref_makes_report_not_ok():
-    ledger = summarize_ledger([
-        {"ref": "bad", "user_id": 1, "account": ALLOWANCE, "debit": "0.05", "credit": "0"},
-        {"ref": "bad", "user_id": 1, "account": REVENUE, "debit": "0", "credit": "0.05"},
-        {"ref": "bad", "user_id": 1, "account": PURCHASED, "debit": "0.01", "credit": "0"},
-    ])  # debits 0.06 != credit 0.05
+    ledger = summarize_ledger(
+        [
+            {"ref": "bad", "user_id": 1, "account": ALLOWANCE, "debit": "0.05", "credit": "0"},
+            {"ref": "bad", "user_id": 1, "account": REVENUE, "debit": "0", "credit": "0.05"},
+            {"ref": "bad", "user_id": 1, "account": PURCHASED, "debit": "0.01", "credit": "0"},
+        ]
+    )  # debits 0.06 != credit 0.05
     usage = summarize_usage([{"user_id": 1, "cost": "0.05"}])
     report = reconcile(ledger, usage)
     # revenue side matches, but the ref is internally unbalanced → not ok
@@ -186,13 +218,17 @@ def test_reconcile_empty_both_sides_is_ok():
 
 def test_reconcile_per_user_sorted_worst_first():
     ledger = summarize_ledger(
-        _settled("a", 1, "0.10", "0") + _settled("b", 2, "0.10", "0") + _settled("c", 3, "0.10", "0")
+        _settled("a", 1, "0.10", "0")
+        + _settled("b", 2, "0.10", "0")
+        + _settled("c", 3, "0.10", "0")
     )
-    usage = summarize_usage([
-        {"user_id": 1, "cost": "0.10"},   # drift 0
-        {"user_id": 2, "cost": "0.02"},   # drift 0.08
-        {"user_id": 3, "cost": "0.07"},   # drift 0.03
-    ])
+    usage = summarize_usage(
+        [
+            {"user_id": 1, "cost": "0.10"},  # drift 0
+            {"user_id": 2, "cost": "0.02"},  # drift 0.08
+            {"user_id": 3, "cost": "0.07"},  # drift 0.03
+        ]
+    )
     report = reconcile(ledger, usage)
     drifts = [u.drift for u in report.per_user]
     assert drifts == [Decimal("0.08"), Decimal("0.03"), Decimal("0")]
@@ -201,8 +237,9 @@ def test_reconcile_per_user_sorted_worst_first():
 def test_reconcile_rows_one_call_path():
     ledger_rows = _settled("r1", 1, "0.03", "0")
     usage_rows = [{"user_id": 1, "cost": "0.03"}, {"user_id": 99, "cost": "0.50"}]
-    report = reconcile_rows(usage_rows=usage_rows, ledger_rows=ledger_rows,
-                            exclude_user_ids=frozenset({99}))
+    report = reconcile_rows(
+        usage_rows=usage_rows, ledger_rows=ledger_rows, exclude_user_ids=frozenset({99})
+    )
     assert report.ok
     assert report.total_drift == Decimal("0")
 
@@ -276,7 +313,9 @@ def test_reconcile_window_mocked(monkeypatch):
     fake_mod.get_supabase_client = lambda: _Client(store)
     monkeypatch.setitem(sys.modules, "src.config.supabase_config", fake_mod)
 
-    report, admin_count = lr.reconcile_window("2026-01-01T00:00:00+00:00", "2030-01-01T00:00:00+00:00")
+    report, admin_count = lr.reconcile_window(
+        "2026-01-01T00:00:00+00:00", "2030-01-01T00:00:00+00:00"
+    )
     assert admin_count == 1
     assert report.ok
     assert report.total_drift == Decimal("0")

--- a/tests/services/test_memory_extraction.py
+++ b/tests/services/test_memory_extraction.py
@@ -18,6 +18,7 @@ def _user(text):
 # extract_candidate_facts (pure)
 # --------------------------------------------------------------------------- #
 
+
 def test_extracts_name():
     facts = me.extract_candidate_facts([_user("Hello, my name is Ada Lovelace.")])
     contents = [c for c, _, _ in facts]
@@ -56,7 +57,10 @@ def test_caps_candidates():
 
 
 def test_handles_multimodal_content():
-    msg = {"role": "user", "content": [{"type": "text", "text": "my name is Grace"}, {"type": "image"}]}
+    msg = {
+        "role": "user",
+        "content": [{"type": "text", "text": "my name is Grace"}, {"type": "image"}],
+    }
     facts = me.extract_candidate_facts([msg])
     assert any("Grace" in c for c, _, _ in facts)
 
@@ -68,6 +72,7 @@ def test_empty_messages():
 # --------------------------------------------------------------------------- #
 # capture_user_memory (I/O, mocked store)
 # --------------------------------------------------------------------------- #
+
 
 def _patch_store(monkeypatch, existing):
     store = {"rows": list(existing)}

--- a/tests/services/test_model_categorizer.py
+++ b/tests/services/test_model_categorizer.py
@@ -67,9 +67,7 @@ def test_context_tags():
 # --------------------------------------------------------------------------- #
 def test_cheapest_blended_price():
     # gpt-4o-mini-ish: $0.15 in / $0.60 out per 1M => per-token 0.15e-6 / 0.60e-6
-    cheap = ModelSignals(
-        input_price_per_token=0.15e-6, output_price_per_token=0.60e-6
-    )
+    cheap = ModelSignals(input_price_per_token=0.15e-6, output_price_per_token=0.60e-6)
     # blended = (0.15*0.25 + 0.60*0.75) = 0.4875 $/1M <= 0.50
     assert "cheapest" in compute_categories(cheap)
 
@@ -82,9 +80,7 @@ def test_cheapest_blended_price():
 
 
 def test_free_model_is_cheapest_and_free():
-    sig = ModelSignals(
-        is_free=True, input_price_per_token=0.0, output_price_per_token=0.0
-    )
+    sig = ModelSignals(is_free=True, input_price_per_token=0.0, output_price_per_token=0.0)
     tags = compute_categories(sig)
     assert "free" in tags and "cheapest" in tags
 
@@ -158,12 +154,8 @@ def test_custom_threshold_via_rules():
         CategoryRule("largest", "context_length", "gte", 1_000_000),
         CategoryRule("budget", "quality_band", "band", 0, 70),
     ]
-    assert "largest" not in compute_categories(
-        ModelSignals(context_length=200_000), rules
-    )
-    assert "largest" in compute_categories(
-        ModelSignals(context_length=1_000_000), rules
-    )
+    assert "largest" not in compute_categories(ModelSignals(context_length=200_000), rules)
+    assert "largest" in compute_categories(ModelSignals(context_length=1_000_000), rules)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/services/test_model_offers_projection.py
+++ b/tests/services/test_model_offers_projection.py
@@ -37,6 +37,7 @@ def _model(**kw):
 # normalized_cost_per_1k — self-calibrating units
 # --------------------------------------------------------------------------- #
 
+
 def test_per_token_price_normalized_to_per_1k():
     # 5e-7 per token → $0.50/1M → per-1k = 0.0005
     assert normalized_cost_per_1k("0.0000005") == pytest.approx(0.0005)
@@ -58,6 +59,7 @@ def test_none_and_zero_and_garbage_return_none():
 # --------------------------------------------------------------------------- #
 # build_offer_rows
 # --------------------------------------------------------------------------- #
+
 
 def test_basic_offer_built():
     rows = build_offer_rows([_model()], PROVIDERS)

--- a/tests/services/test_payment_processing.py
+++ b/tests/services/test_payment_processing.py
@@ -1442,19 +1442,23 @@ class TestFirstTopupBonus:
         session.currency = "usd"
         return session
 
-    def _mock_user_client(self, mock_get_supabase, *, has_made_first_purchase, referred_by_code=None):
+    def _mock_user_client(
+        self, mock_get_supabase, *, has_made_first_purchase, referred_by_code=None
+    ):
         mock_client = MagicMock()
         mock_get_supabase.return_value = mock_client
-        mock_client.table.return_value.select.return_value.eq.return_value.execute.return_value = Mock(
-            data=[
-                {
-                    "id": 1,
-                    "subscription_status": "trial",
-                    "tier": "basic",
-                    "has_made_first_purchase": has_made_first_purchase,
-                    "referred_by_code": referred_by_code,
-                }
-            ]
+        mock_client.table.return_value.select.return_value.eq.return_value.execute.return_value = (
+            Mock(
+                data=[
+                    {
+                        "id": 1,
+                        "subscription_status": "trial",
+                        "tier": "basic",
+                        "has_made_first_purchase": has_made_first_purchase,
+                        "referred_by_code": referred_by_code,
+                    }
+                ]
+            )
         )
         return mock_client
 

--- a/tests/services/test_price_refresh.py
+++ b/tests/services/test_price_refresh.py
@@ -31,8 +31,8 @@ def _patch_common(monkeypatch, fetch_functions, update_mock):
     is sufficient. We also patch get_provider_format to a stable per-token value
     so normalization is deterministic in tests.
     """
-    import src.services.model_catalog_sync as mcs
     import src.db.models_catalog_db as mdb
+    import src.services.model_catalog_sync as mcs
 
     monkeypatch.setattr(mcs, "PROVIDER_FETCH_FUNCTIONS", fetch_functions, raising=True)
     monkeypatch.setattr(
@@ -59,7 +59,10 @@ class TestRefreshAllPrices:
 
         fetch = MagicMock(
             return_value=[
-                {"id": "vendor/model-a", "pricing": {"prompt": "0.000002", "completion": "0.000004"}}
+                {
+                    "id": "vendor/model-a",
+                    "pricing": {"prompt": "0.000002", "completion": "0.000004"},
+                }
             ]
         )
         # Stored price differs (prompt was 0.000001)
@@ -99,7 +102,10 @@ class TestRefreshAllPrices:
 
         fetch = MagicMock(
             return_value=[
-                {"id": "vendor/model-a", "pricing": {"prompt": "0.0000010", "completion": "0.000004"}}
+                {
+                    "id": "vendor/model-a",
+                    "pricing": {"prompt": "0.0000010", "completion": "0.000004"},
+                }
             ]
         )
         monkeypatch.setattr(
@@ -129,7 +135,10 @@ class TestRefreshAllPrices:
 
         fetch = MagicMock(
             return_value=[
-                {"id": "vendor/brand-new", "pricing": {"prompt": "0.000002", "completion": "0.000004"}}
+                {
+                    "id": "vendor/brand-new",
+                    "pricing": {"prompt": "0.000002", "completion": "0.000004"},
+                }
             ]
         )
         # DB has no matching model
@@ -154,7 +163,10 @@ class TestRefreshAllPrices:
 
         good_fetch = MagicMock(
             return_value=[
-                {"id": "vendor/model-a", "pricing": {"prompt": "0.000002", "completion": "0.000004"}}
+                {
+                    "id": "vendor/model-a",
+                    "pricing": {"prompt": "0.000002", "completion": "0.000004"},
+                }
             ]
         )
 
@@ -202,7 +214,10 @@ class TestRefreshAllPrices:
 
         fetch = MagicMock(
             return_value=[
-                {"id": "vendor/model-a", "pricing": {"prompt": "0.000002", "completion": "0.000004"}}
+                {
+                    "id": "vendor/model-a",
+                    "pricing": {"prompt": "0.000002", "completion": "0.000004"},
+                }
             ]
         )
         monkeypatch.setattr(
@@ -228,9 +243,7 @@ class TestRefreshAllPrices:
         import src.services.cache.model_catalog_cache as catalog_cache
 
         invalidate_spy = MagicMock()
-        monkeypatch.setattr(
-            catalog_cache, "invalidate_full_catalog", invalidate_spy, raising=True
-        )
+        monkeypatch.setattr(catalog_cache, "invalidate_full_catalog", invalidate_spy, raising=True)
 
         result = price_refresh.refresh_all_prices(dry_run=False)
 
@@ -244,7 +257,10 @@ class TestRefreshAllPrices:
 
         fetch = MagicMock(
             return_value=[
-                {"id": "vendor/model-a", "pricing": {"prompt": "0.000002", "completion": "0.000004"}}
+                {
+                    "id": "vendor/model-a",
+                    "pricing": {"prompt": "0.000002", "completion": "0.000004"},
+                }
             ]
         )
         monkeypatch.setattr(

--- a/tests/services/test_rebuild_full_catalog.py
+++ b/tests/services/test_rebuild_full_catalog.py
@@ -100,7 +100,6 @@ class TestRebuildFullCatalogFromProviders:
             ),
             patch("src.services.local_memory_cache.set_local_catalog") as mock_set_local,
         ):
-
             from src.services.model_catalog_cache import rebuild_full_catalog_from_providers
 
             result = rebuild_full_catalog_from_providers()
@@ -130,7 +129,6 @@ class TestRebuildFullCatalogFromProviders:
             ),
             patch("src.services.local_memory_cache.set_local_catalog"),
         ):
-
             from src.services.model_catalog_cache import rebuild_full_catalog_from_providers
 
             result = rebuild_full_catalog_from_providers()
@@ -155,7 +153,6 @@ class TestRebuildFullCatalogFromProviders:
             ),
             patch("src.services.local_memory_cache.set_local_catalog"),
         ):
-
             from src.services.model_catalog_cache import rebuild_full_catalog_from_providers
 
             result = rebuild_full_catalog_from_providers()
@@ -173,7 +170,6 @@ class TestRebuildFullCatalogFromProviders:
                 "src.services.model_catalog_cache.get_model_catalog_cache", return_value=MagicMock()
             ),
         ):
-
             from src.services.model_catalog_cache import rebuild_full_catalog_from_providers
 
             result = rebuild_full_catalog_from_providers()
@@ -202,7 +198,6 @@ class TestRebuildFullCatalogFromProviders:
             ),
             patch("src.services.local_memory_cache.set_local_catalog"),
         ):
-
             from src.services.model_catalog_cache import rebuild_full_catalog_from_providers
 
             result = rebuild_full_catalog_from_providers()
@@ -230,7 +225,6 @@ class TestRebuildFullCatalogFromProviders:
             ),
             patch("src.services.local_memory_cache.set_local_catalog"),
         ):
-
             from src.services.model_catalog_cache import rebuild_full_catalog_from_providers
 
             result = rebuild_full_catalog_from_providers()
@@ -257,7 +251,6 @@ class TestRebuildFullCatalogFromProviders:
             ),
             patch("src.services.local_memory_cache.set_local_catalog"),
         ):
-
             from src.services.model_catalog_cache import rebuild_full_catalog_from_providers
 
             result = rebuild_full_catalog_from_providers()
@@ -282,7 +275,6 @@ class TestRebuildIntegrationWithGetCachedFullCatalog:
             patch("src.services.local_memory_cache.set_local_catalog"),
             patch("src.services.local_memory_cache.get_local_catalog", return_value=(None, False)),
         ):
-
             from src.services.model_catalog_cache import get_cached_full_catalog
 
             result = get_cached_full_catalog()
@@ -305,7 +297,6 @@ class TestRebuildIntegrationWithGetCachedFullCatalog:
                 return_value=_make_models("openai", 5),
             ) as mock_rebuild,
         ):
-
             from src.services.model_catalog_cache import get_cached_full_catalog
 
             result = get_cached_full_catalog()

--- a/tests/services/test_smart_router_bridge.py
+++ b/tests/services/test_smart_router_bridge.py
@@ -25,6 +25,7 @@ def _offer(canonical_id, slug, upstream_cost, p95=100.0, quality=0.5):
 # reorder_chain_by_ranking — pure permutation, never drops/adds
 # --------------------------------------------------------------------------- #
 
+
 def test_reorder_puts_ranked_first_preserves_rest():
     chain = ["a", "b", "c", "d"]
     ranked = ["c", "a"]
@@ -52,6 +53,7 @@ def test_reorder_empty_ranking_is_identity():
 # --------------------------------------------------------------------------- #
 # reorder_provider_chain — full bridge with injected offers
 # --------------------------------------------------------------------------- #
+
 
 def test_no_reorder_when_chain_too_short():
     assert reorder_provider_chain("m", ["only"], offers=[_offer("m", "only", 0.01)]) == ["only"]
@@ -82,9 +84,9 @@ def test_providers_without_offers_kept_at_tail():
     chain = ["no_offer", "cheap", "mid"]
     offers = [_offer("m", "cheap", 0.01), _offer("m", "mid", 0.05)]
     out = reorder_provider_chain("m", chain, policy="cost", offers=offers)
-    assert out[0] == "cheap"      # ranked first
-    assert out[1] == "mid"        # ranked second
-    assert out[2] == "no_offer"   # unranked → tail
+    assert out[0] == "cheap"  # ranked first
+    assert out[1] == "mid"  # ranked second
+    assert out[2] == "no_offer"  # unranked → tail
     assert sorted(out) == sorted(chain)
 
 

--- a/tests/services/test_stripe_basil_api_compat.py
+++ b/tests/services/test_stripe_basil_api_compat.py
@@ -47,6 +47,7 @@ class _AttrObj:
 # _get_subscription_period_end / _get_subscription_period_start
 # --------------------------------------------------------------------------
 
+
 def test_period_end_legacy_top_level(stripe_service):
     sub = {"current_period_end": 1234567890, "items": {"data": []}}
     assert stripe_service._get_subscription_period_end(sub) == 1234567890
@@ -85,8 +86,11 @@ def test_period_start_legacy_top_level(stripe_service):
 # _get_invoice_subscription_id
 # --------------------------------------------------------------------------
 
+
 def test_invoice_subscription_legacy_string(stripe_service):
-    assert stripe_service._get_invoice_subscription_id({"subscription": "sub_legacy"}) == "sub_legacy"
+    assert (
+        stripe_service._get_invoice_subscription_id({"subscription": "sub_legacy"}) == "sub_legacy"
+    )
 
 
 def test_invoice_subscription_legacy_object(stripe_service):
@@ -103,11 +107,7 @@ def test_invoice_subscription_basil_parent(stripe_service):
 def test_invoice_subscription_basil_lines(stripe_service):
     # Basil fallback: subscription under a line item's parent details.
     inv = {
-        "lines": {
-            "data": [
-                {"parent": {"subscription_item_details": {"subscription": "sub_line"}}}
-            ]
-        }
+        "lines": {"data": [{"parent": {"subscription_item_details": {"subscription": "sub_line"}}}]}
     }
     assert stripe_service._get_invoice_subscription_id(inv) == "sub_line"
 
@@ -122,15 +122,20 @@ def test_invoice_subscription_none_for_one_time(stripe_service):
 # _handle_checkout_completed: subscription-mode guard (#4)
 # --------------------------------------------------------------------------
 
+
 def test_checkout_completed_skips_subscription_mode(stripe_service):
     """A mode=subscription checkout must NOT be credited as a one-time top-up."""
     session = {"id": "cs_test_sub", "mode": "subscription", "metadata": {"user_id": "3"}}
 
-    with patch.object(
-        stripe_service, "_hydrate_checkout_session_metadata", return_value=(session, {"user_id": "3"})
-    ), patch("src.db.users.add_credits_to_user") as add_credits, patch(
-        "src.services.billing.payments.add_credits_to_user", MagicMock()
-    ) as add_credits2:
+    with (
+        patch.object(
+            stripe_service,
+            "_hydrate_checkout_session_metadata",
+            return_value=(session, {"user_id": "3"}),
+        ),
+        patch("src.db.users.add_credits_to_user") as add_credits,
+        patch("src.services.billing.payments.add_credits_to_user", MagicMock()) as add_credits2,
+    ):
         result = stripe_service._handle_checkout_completed(session)
 
     # Handler returns without granting any credits.
@@ -146,8 +151,11 @@ def test_checkout_completed_payment_mode_not_skipped(stripe_service):
     # Force an early, identifiable failure *after* the guard so we can assert the
     # guard did not short-circuit a payment-mode session.
     sentinel = RuntimeError("proceeded past subscription guard")
-    with patch.object(
-        stripe_service, "_hydrate_checkout_session_metadata", return_value=(session, {})
-    ), patch.object(stripe_service, "_coerce_to_int", side_effect=sentinel):
+    with (
+        patch.object(
+            stripe_service, "_hydrate_checkout_session_metadata", return_value=(session, {})
+        ),
+        patch.object(stripe_service, "_coerce_to_int", side_effect=sentinel),
+    ):
         with pytest.raises(RuntimeError, match="proceeded past subscription guard"):
             stripe_service._handle_checkout_completed(session)

--- a/tests/services/test_transform_pricing_raw.py
+++ b/tests/services/test_transform_pricing_raw.py
@@ -22,9 +22,7 @@ def _transform(model):
         "src.services.model_catalog_sync.get_provider_format",
         return_value=PricingFormat.PER_TOKEN,
     ):
-        return transform_normalized_model_to_db_schema(
-            model, provider_id=1, provider_slug="vendor"
-        )
+        return transform_normalized_model_to_db_schema(model, provider_id=1, provider_slug="vendor")
 
 
 def test_pricing_raw_is_persisted():
@@ -44,9 +42,7 @@ def test_pricing_raw_is_persisted():
 def test_unknown_pricing_fields_are_omitted():
     # Only prompt provided -> completion/image/request (None) must NOT appear,
     # so a known price is never overwritten with a guessed zero downstream.
-    result = _transform(
-        {"id": "vendor/model-y", "name": "Y", "pricing": {"prompt": "0.000001"}}
-    )
+    result = _transform({"id": "vendor/model-y", "name": "Y", "pricing": {"prompt": "0.000001"}})
     pricing_raw = result["metadata"]["pricing_raw"]
     assert "prompt" in pricing_raw
     assert "completion" not in pricing_raw

--- a/tests/services/test_user_memory_store.py
+++ b/tests/services/test_user_memory_store.py
@@ -87,7 +87,10 @@ def test_add_then_get(client):
     um.add_memory(7, "likes Python", salience=0.9)
     um.add_memory(7, "prefers metric units", salience=0.4)
     items = um.get_memories(7, use_cache=False)
-    assert [i["content"] for i in items] == ["likes Python", "prefers metric units"]  # salience desc
+    assert [i["content"] for i in items] == [
+        "likes Python",
+        "prefers metric units",
+    ]  # salience desc
 
 
 def test_get_scoped_to_user(client):

--- a/tests/services/test_zero_price_gating.py
+++ b/tests/services/test_zero_price_gating.py
@@ -10,9 +10,10 @@ Two coordinated changes are covered:
 All lookups are mocked — no DB.
 """
 
+from unittest.mock import patch
+
 import pytest
 from fastapi import HTTPException
-from unittest.mock import patch
 
 from src.security.inference_gates import enforce_model_pricing_gate
 from src.services.pricing.pricing import model_has_pricing
@@ -25,6 +26,7 @@ def _pricing(prompt, completion, source="database", found=True):
 # --------------------------------------------------------------------------
 # model_has_pricing — zero-price rejection
 # --------------------------------------------------------------------------
+
 
 def test_rejects_zero_priced_row():
     with patch("src.services.pricing.pricing.get_model_pricing", return_value=_pricing(0.0, 0.0)):
@@ -60,22 +62,27 @@ def test_rejects_default_source():
 # enforce_model_pricing_gate — free-model exemption
 # --------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_gate_exempts_free_model_even_when_unpriced():
     # A free model (is_free=True) with NO real pricing must still be allowed
     # through — and model_has_pricing must not even be consulted.
-    with patch("src.security.inference_gates.Config.REQUIRE_MODEL_PRICING", True), patch(
-        "src.services.cache.model_capabilities_cache.is_free_model", return_value=True
-    ), patch("src.services.pricing.model_has_pricing", return_value=False) as mhp:
+    with (
+        patch("src.security.inference_gates.Config.REQUIRE_MODEL_PRICING", True),
+        patch("src.services.cache.model_capabilities_cache.is_free_model", return_value=True),
+        patch("src.services.pricing.model_has_pricing", return_value=False) as mhp,
+    ):
         await enforce_model_pricing_gate("provider/free-model")  # no raise
         mhp.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_gate_rejects_paid_unpriced_model():
-    with patch("src.security.inference_gates.Config.REQUIRE_MODEL_PRICING", True), patch(
-        "src.services.cache.model_capabilities_cache.is_free_model", return_value=False
-    ), patch("src.services.pricing.model_has_pricing", return_value=False):
+    with (
+        patch("src.security.inference_gates.Config.REQUIRE_MODEL_PRICING", True),
+        patch("src.services.cache.model_capabilities_cache.is_free_model", return_value=False),
+        patch("src.services.pricing.model_has_pricing", return_value=False),
+    ):
         with pytest.raises(HTTPException) as exc:
             await enforce_model_pricing_gate("provider/paid-model")
         assert exc.value.status_code == 400
@@ -83,9 +90,11 @@ async def test_gate_rejects_paid_unpriced_model():
 
 @pytest.mark.asyncio
 async def test_gate_allows_paid_priced_model():
-    with patch("src.security.inference_gates.Config.REQUIRE_MODEL_PRICING", True), patch(
-        "src.services.cache.model_capabilities_cache.is_free_model", return_value=False
-    ), patch("src.services.pricing.model_has_pricing", return_value=True):
+    with (
+        patch("src.security.inference_gates.Config.REQUIRE_MODEL_PRICING", True),
+        patch("src.services.cache.model_capabilities_cache.is_free_model", return_value=False),
+        patch("src.services.pricing.model_has_pricing", return_value=True),
+    ):
         await enforce_model_pricing_gate("provider/paid-model")  # no raise
 
 


### PR DESCRIPTION
## Summary

The `Run Linters` CI job (`ruff check src/`) has been failing on `main` with 13 pre-existing findings, unrelated to any feature work. This clears them so the job goes green.

All changes are **behavior-preserving**:
- Drop unused imports: `main.py` (`asyncio`), `services/models.py` (`urljoin`), `pricing/pricing_lookup.py` (`json`, `Path`), `db/client.py` (2), `db/users.py` (`TRIAL_DURATION_DAYS`), `handlers/chat_handler.py` (`calculate_cost`).
- Remove 3 dead-code `*_cents` locals in `get_user_profile` (they were assigned but never read — the profile uses the `_val` values).
- Rewrite one `dict(...)` call as a literal (`C408`).

`ruff check src/` now passes clean; `py_compile` OK on all touched files. No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)