### PR TITLE
fix(catalog): sci-notation pricing + opt-in stale-model purge

### DIFF
--- a/src/db/models_catalog_db.py
+++ b/src/db/models_catalog_db.py
@@ -363,9 +363,10 @@ def process_stale_models(
     provider_id: int,
     seen_provider_model_ids: set[str],
     deactivation_threshold: int = 3,
+    purge_after_days: int | None = None,
 ) -> dict[str, Any]:
     """
-    Track and deactivate models that are no longer listed by a provider.
+    Track, deactivate, and optionally purge models no longer listed by a provider.
 
     After a successful provider sync, call this with the set of model IDs
     that were returned by the provider API.  Models in the DB for this
@@ -373,25 +374,34 @@ def process_stale_models(
     incremented.  Once the count reaches the threshold, they are
     soft-deactivated (is_active = false).
 
+    Soft-deactivated rows otherwise live forever, so the `models` table only
+    grows.  When ``purge_after_days`` is set, any already-deactivated model
+    that has not been seen from its provider for longer than that many days is
+    hard-deleted, keeping the table light.  Active models are never purged.
+
     Args:
         provider_id: The provider's database ID.
         seen_provider_model_ids: Set of provider_model_id values returned
             by the provider API in this sync cycle.
         deactivation_threshold: Number of consecutive misses before
             deactivation (default: 3).
+        purge_after_days: If set (>0), hard-delete deactivated models whose
+            last_seen_in_provider_at is older than this cutoff. ``None`` or 0
+            disables purging (default) — deletion is irreversible, so it is
+            opt-in.
 
     Returns:
-        Dict with counts: reset, incremented, deactivated.
+        Dict with counts: reset, incremented, deactivated, purged.
     """
     from datetime import UTC, datetime
 
     supabase = get_client_for_query(read_only=False)
     now = datetime.now(UTC).isoformat()
-    result = {"reset": 0, "incremented": 0, "deactivated": 0}
+    result = {"reset": 0, "incremented": 0, "deactivated": 0, "purged": 0}
+    page_size = SUPABASE_PAGE_SIZE
 
     # Fetch all active models for this provider
     all_active: list[dict] = []
-    page_size = SUPABASE_PAGE_SIZE
     offset = 0
     while True:
         batch = (
@@ -408,6 +418,9 @@ def process_stale_models(
         offset += page_size
 
     if not all_active:
+        # No active models to reclassify, but there may still be long-dead
+        # rows to purge for this provider, so fall through to the purge step.
+        _purge_stale_deactivated_models(supabase, provider_id, purge_after_days, page_size, result)
         return result
 
     # Split into seen vs unseen
@@ -474,7 +487,61 @@ def process_stale_models(
             f"(missing for {deactivation_threshold}+ consecutive syncs)"
         )
 
+    # Hard-purge long-deactivated rows to keep the table light (opt-in).
+    _purge_stale_deactivated_models(supabase, provider_id, purge_after_days, page_size, result)
+
     return result
+
+
+def _purge_stale_deactivated_models(
+    supabase: Any,
+    provider_id: int,
+    purge_after_days: int | None,
+    page_size: int,
+    result: dict[str, Any],
+) -> None:
+    """Hard-delete deactivated models unseen for longer than the cutoff.
+
+    Only touches rows that are already ``is_active = false`` AND whose
+    ``last_seen_in_provider_at`` predates the cutoff, so an active or
+    recently-seen model can never be deleted. No-op when purging is disabled.
+    Increments ``result["purged"]`` with the number of rows removed.
+    """
+    if not purge_after_days or purge_after_days <= 0:
+        return
+
+    from datetime import UTC, datetime, timedelta
+
+    cutoff = (datetime.now(UTC) - timedelta(days=purge_after_days)).isoformat()
+
+    stale_ids: list[int] = []
+    offset = 0
+    while True:
+        batch = (
+            supabase.table("models")
+            .select("id")
+            .eq("provider_id", provider_id)
+            .eq("is_active", False)
+            .lt("last_seen_in_provider_at", cutoff)
+            .range(offset, offset + page_size - 1)
+            .execute()
+        ).data or []
+        stale_ids.extend(row["id"] for row in batch)
+        if len(batch) < page_size:
+            break
+        offset += page_size
+
+    if not stale_ids:
+        return
+
+    for i in range(0, len(stale_ids), 500):
+        chunk = stale_ids[i : i + 500]
+        supabase.table("models").delete().in_("id", chunk).execute()
+    result["purged"] = len(stale_ids)
+    logger.info(
+        f"Purged {len(stale_ids)} long-deactivated models for provider_id={provider_id} "
+        f"(deactivated & unseen for {purge_after_days}+ days)"
+    )
 
 
 def update_model_health(

--- a/src/services/model_catalog_sync.py
+++ b/src/services/model_catalog_sync.py
@@ -108,8 +108,20 @@ def safe_decimal(value: Any) -> Decimal | None:
         if isinstance(value, (int, float)):
             return Decimal(str(value))
         if isinstance(value, str):
-            # Remove any non-numeric characters except decimal point and minus
-            cleaned = "".join(c for c in value if c.isdigit() or c in ".-")
+            s = value.strip()
+            if not s:
+                return None
+            # Parse directly first — Decimal natively handles scientific
+            # notation (e.g. "5e-07"), which many provider APIs emit for
+            # per-token prices. The char-stripping fallback below would
+            # otherwise drop the "e" and corrupt the value.
+            try:
+                return Decimal(s)
+            except ArithmeticError:
+                pass
+            # Fallback for currency-formatted strings ("$0.5", "1,234"):
+            # keep digits, decimal point, sign, and exponent notation.
+            cleaned = "".join(c for c in s if c.isdigit() or c in ".-+eE")
             if cleaned:
                 return Decimal(cleaned)
         return None
@@ -872,18 +884,30 @@ def sync_provider_models(
 
                 seen_ids = {m["provider_model_id"] for m in db_models if m.get("provider_model_id")}
 
+                # Optional hard-purge of long-deactivated rows to keep the
+                # models table light. Disabled by default (deletion is
+                # irreversible); set MODEL_STALE_PURGE_AFTER_DAYS to enable.
+                try:
+                    import os
+
+                    purge_after_days = int(os.getenv("MODEL_STALE_PURGE_AFTER_DAYS", "0")) or None
+                except ValueError:
+                    purge_after_days = None
+
                 if pre_sync_active_count > 0 and len(seen_ids) >= pre_sync_active_count * 0.5:
                     stale_result = process_stale_models(
                         provider_id=provider["id"],
                         seen_provider_model_ids=seen_ids,
                         deactivation_threshold=3,
+                        purge_after_days=purge_after_days,
                     )
-                    if stale_result.get("deactivated", 0) > 0:
+                    if stale_result.get("deactivated", 0) > 0 or stale_result.get("purged", 0) > 0:
                         logger.warning(
                             f"[{provider_slug.upper()}] Stale model cleanup | "
                             f"Reset: {stale_result['reset']} | "
                             f"Incremented: {stale_result['incremented']} | "
-                            f"Deactivated: {stale_result['deactivated']}"
+                            f"Deactivated: {stale_result['deactivated']} | "
+                            f"Purged: {stale_result.get('purged', 0)}"
                         )
                     else:
                         logger.info(

--- a/tests/db/test_process_stale_models_purge.py
+++ b/tests/db/test_process_stale_models_purge.py
@@ -1,0 +1,137 @@
+"""Tests for the hard-purge path in process_stale_models.
+
+The stale-model flow soft-deactivates models a provider stops listing, but
+without a purge those rows live forever and the `models` table only grows.
+`purge_after_days` hard-deletes models that are BOTH already deactivated
+(is_active=False) AND unseen for longer than the cutoff — keeping the table
+light without ever touching an active model.
+
+These are pure unit tests: the Supabase client is replaced with a tiny fake
+that records the fluent chain (select/eq/lt/in_/range/delete/execute) so we can
+assert exactly which rows get deleted.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+
+class FakeQuery:
+    """Records a fluent PostgREST-style chain and returns canned rows.
+
+    `select` chains resolve to `self._rows`; `delete` chains record deleted ids
+    on the parent client. Filters are captured but not applied — each test
+    hands the fake exactly the rows the corresponding query should return.
+    """
+
+    def __init__(self, client, rows, mode="select"):
+        self._client = client
+        self._rows = rows
+        self._mode = mode
+        self._in_ids = None
+
+    def select(self, *a, **k):
+        return self
+
+    def delete(self, *a, **k):
+        return FakeQuery(self._client, self._rows, mode="delete")
+
+    def update(self, *a, **k):
+        return FakeQuery(self._client, self._rows, mode="update")
+
+    def eq(self, *a, **k):
+        return self
+
+    def lt(self, *a, **k):
+        return self
+
+    def in_(self, _col, ids):
+        self._in_ids = list(ids)
+        return self
+
+    def range(self, *a, **k):
+        return self
+
+    def execute(self):
+        if self._mode == "delete":
+            self._client.deleted_ids.extend(self._in_ids or [])
+        return type("Resp", (), {"data": self._rows})()
+
+
+class FakeClient:
+    """Serves a scripted list of row-batches, one per `.table()` call.
+
+    process_stale_models issues its queries in a fixed order; we enqueue the
+    rows each should return. Any `.delete()` records ids on `deleted_ids`.
+    """
+
+    def __init__(self, batches):
+        self._batches = list(batches)
+        self.deleted_ids: list[int] = []
+        self._i = 0
+
+    def table(self, _name):
+        rows = self._batches[self._i] if self._i < len(self._batches) else []
+        self._i += 1
+        return FakeQuery(self, rows)
+
+
+@pytest.fixture
+def sb():
+    """Presence bypasses the autouse DB-skip in tests/conftest.py — these are
+    pure unit tests with the Supabase client fully faked."""
+    return None
+
+
+def _run(batches, **kwargs):
+    from unittest.mock import patch
+
+    fake = FakeClient(batches)
+    with patch("src.db.models_catalog_db.get_client_for_query", return_value=fake):
+        from src.db.models_catalog_db import process_stale_models
+
+        result = process_stale_models(provider_id=7, seen_provider_model_ids=set(), **kwargs)
+    return result, fake
+
+
+def test_purge_disabled_by_default_never_deletes(sb):
+    """With no purge_after_days, no delete is issued (backward compatible)."""
+    # One active model, unseen → deactivated; no purge query runs.
+    active = [{"id": 1, "provider_model_id": "gone", "consecutive_missing_count": 2}]
+    result, fake = _run([active])
+    assert result["deactivated"] == 1
+    assert result.get("purged", 0) == 0
+    assert fake.deleted_ids == []
+
+
+def test_purge_deletes_long_deactivated_models(sb):
+    """Deactivated + unseen past the cutoff → hard-deleted."""
+    old = (datetime.now(UTC) - timedelta(days=45)).isoformat()
+    active_batch = []  # no active models this sync
+    purge_batch = [
+        {"id": 10, "last_seen_in_provider_at": old},
+        {"id": 11, "last_seen_in_provider_at": old},
+    ]
+    # batches: [fetch active] then [fetch purge-eligible inactive]
+    result, fake = _run([active_batch, purge_batch], purge_after_days=30)
+    assert result["purged"] == 2
+    assert sorted(fake.deleted_ids) == [10, 11]
+
+
+def test_purge_runs_even_when_no_active_models(sb):
+    """Providers with only dead rows must still get purged."""
+    purge_batch = [{"id": 99, "last_seen_in_provider_at": "2020-01-01T00:00:00+00:00"}]
+    result, fake = _run([[], purge_batch], purge_after_days=30)
+    assert result["purged"] == 1
+    assert fake.deleted_ids == [99]
+
+
+def test_purge_nothing_eligible(sb):
+    """Cutoff set but no row past it → no delete."""
+    result, fake = _run([[], []], purge_after_days=30)
+    assert result["purged"] == 0
+    assert fake.deleted_ids == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/services/test_transform_pricing_raw.py
+++ b/tests/services/test_transform_pricing_raw.py
@@ -13,8 +13,39 @@ unnormalized and the assertions are deterministic (no DB/registry dependency).
 from decimal import Decimal
 from unittest.mock import patch
 
-from src.services.model_catalog_sync import transform_normalized_model_to_db_schema
+from src.services.model_catalog_sync import (
+    safe_decimal,
+    transform_normalized_model_to_db_schema,
+)
 from src.utils.pricing_normalization import PricingFormat
+
+
+def test_safe_decimal_parses_scientific_notation():
+    # Many provider APIs (deepinfra, groq, cerebras, featherless, ...) emit
+    # per-token prices as scientific-notation strings. These must parse, not
+    # get silently nulled — a null price makes the model unservable.
+    assert safe_decimal("5e-07") == Decimal("5e-07")
+    assert safe_decimal("2.9999999999999997e-06") == Decimal("2.9999999999999997e-06")
+    assert safe_decimal("0.0000005") == Decimal("5e-07")
+    assert safe_decimal("$0.5") == Decimal("0.5")
+    assert safe_decimal("1,234.5") == Decimal("1234.5")
+    assert safe_decimal("free") is None
+    assert safe_decimal("") is None
+    assert safe_decimal(None) is None
+
+
+def test_scientific_notation_pricing_lands_in_pricing_raw():
+    result = _transform(
+        {
+            "id": "vendor/sci-model",
+            "name": "Sci Model",
+            "pricing": {"prompt": "5e-07", "completion": "3e-06"},
+        }
+    )
+    assert result is not None
+    pricing_raw = result["metadata"]["pricing_raw"]
+    assert Decimal(pricing_raw["prompt"]) == Decimal("5e-07")
+    assert Decimal(pricing_raw["completion"]) == Decimal("3e-06")
 
 
 def _transform(model):


### PR DESCRIPTION
## Summary
Two catalog-cleanup fixes surfaced while auditing the model DB for stale data.

**1. Scientific-notation pricing (`36f87a78`)** — `safe_decimal()` char-stripped price strings, dropping the `e` in sci-notation values (e.g. `5e-07`) that many provider APIs emit for per-token prices. This nulled/corrupted the price and made the model unservable. Now parses via `Decimal()` first (handles sci-notation natively), falling back to char-strip only for currency-formatted strings. Unblocks margin providers (deepinfra/groq/cerebras/featherless/chutes).

**2. Opt-in stale-model hard-purge (`8ca4b797`)** — `process_stale_models()` only soft-deactivated models a provider stopped listing, so dead rows lived forever and the `models` table only grew. Added `_purge_stale_deactivated_models` + `purge_after_days`: hard-deletes rows already `is_active=false` **and** `last_seen_in_provider_at` older than the cutoff. Active/recently-seen models are never touched. Wired via env `MODEL_STALE_PURGE_AFTER_DAYS` (**default 0 = disabled**; deletion is irreversible, so opt-in).

## Audit context (staging)
Catalog is already clean: 0 stale/malformed models, `model_id` column already dropped, 0 orphaned/duplicate pricing rows. The three pricing sources (`model_pricing` = sell price, `model_provider_offers` = upstream cost/routing, `metadata.pricing_raw` = raw snapshot) are distinct layers, **not** redundant — deliberately left intact.

## Tests
- `tests/services/test_transform_pricing_raw.py` — sci-notation parse + lands in `pricing_raw`
- `tests/db/test_process_stale_models_purge.py` — 4 purge cases (disabled default, deletes long-dead, runs with no active models, nothing-eligible)

## Deploy note
To activate purging in prod, set `MODEL_STALE_PURGE_AFTER_DAYS` (e.g. `30`) in the deploy env. Default off = no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model cleanup now supports optional hard-purging of long-deactivated entries, with tracking for how many items were purged.
  * Pricing values now handle scientific-notation formats more reliably.

* **Bug Fixes**
  * Stale model cleanup continues to run even when no active models are found, helping remove old inactive rows.
  * Pricing data is now parsed correctly from a wider range of provider string formats.

* **Tests**
  * Added coverage for hard-purge behavior and scientific-notation pricing parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->