### PR TITLE
fix(routing): normalize per-provider price units so cost router picks direct providers

### DIFF
--- a/src/services/model_offers_projection.py
+++ b/src/services/model_offers_projection.py
@@ -87,6 +87,26 @@ def cost_per_1k_from_model(m: dict) -> float | None:
     return normalized_cost_per_1k(m.get("pricing_original_prompt"))
 
 
+# Plausible per-token USD input price for a PAID model: ~$0.001/1M .. $1000/1M.
+# Anything outside almost certainly means a unit/ingestion error (or a stale
+# cached price). Such an offer must NOT win cost-routing — a near-zero price
+# would both mis-route and undercharge billing — so it is dropped from the
+# projection. In per-1k terms the band is [1e-6, 1.0].
+_MIN_PLAUSIBLE_COST_PER_1K = 1e-6
+_MAX_PLAUSIBLE_COST_PER_1K = 1.0
+
+
+def is_plausible_cost_per_1k(cost_per_1k: float | None) -> bool:
+    """True when a per-1k upstream cost is inside the sane pricing band.
+
+    ``None`` (unpriced) is not plausible here — callers handle free/unpriced
+    models separately before this check.
+    """
+    if cost_per_1k is None:
+        return False
+    return _MIN_PLAUSIBLE_COST_PER_1K <= cost_per_1k <= _MAX_PLAUSIBLE_COST_PER_1K
+
+
 def _quality_from_success_rate(success_rate) -> float:
     """Map a success_rate (0..1 or 0..100) to a 0..1 quality prior; 0.5 if unknown."""
     if success_rate is None or str(success_rate).lower() == "none":
@@ -129,6 +149,7 @@ def build_offer_rows(
     from src.services.model_canonicalization import offer_group_key
 
     best: dict[tuple, dict] = {}
+    dropped_implausible = 0
     for m in models:
         if not m.get("is_active", True):
             continue
@@ -154,6 +175,11 @@ def build_offer_rows(
         cost = cost_per_1k_from_model(m)
         if cost is None:
             continue
+        if not is_plausible_cost_per_1k(cost):
+            # Garbage/stale price (unit error, cache staleness). Excluding it keeps
+            # the cost router honest instead of letting a fake-cheap offer win.
+            dropped_implausible += 1
+            continue
 
         key = (group_key, slug)
         offer = {
@@ -170,6 +196,14 @@ def build_offer_rows(
         if existing is None or offer["upstream_cost"] < existing["upstream_cost"]:
             best[key] = offer
 
+    if dropped_implausible:
+        logger.warning(
+            "Dropped %d offer(s) with implausible upstream price "
+            "(outside [%s, %s] per 1k) — likely a unit/ingestion error or stale cache",
+            dropped_implausible,
+            _MIN_PLAUSIBLE_COST_PER_1K,
+            _MAX_PLAUSIBLE_COST_PER_1K,
+        )
     return list(best.values())
 
 

--- a/src/services/providers/deepinfra_client.py
+++ b/src/services/providers/deepinfra_client.py
@@ -150,16 +150,18 @@ def normalize_deepinfra_model(deepinfra_model: dict) -> dict:
     }
 
     # Extract token-based pricing (text-generation, embeddings, etc.)
-    # DeepInfra returns pricing in cents per token, convert to dollars per token
+    # DeepInfra returns cents PER TOKEN. Emit dollars-per-1M-tokens ($/1M) so the
+    # catalog transform's single per_1m division reaches true per-token — matching
+    # near/novita/together. $/1M = cents_per_token / 100 * 1e6 = cents_per_token * 1e4.
+    # See tests/services/test_provider_price_units.py.
     if "cents_per_input_token" in pricing_info or "cents_per_output_token" in pricing_info:
         cents_input = pricing_info.get("cents_per_input_token", 0)
         cents_output = pricing_info.get("cents_per_output_token", 0)
 
-        # Convert cents to dollars per token
         if cents_input:
-            pricing["prompt"] = str(cents_input / 100)
+            pricing["prompt"] = str(cents_input * 10_000)
         if cents_output:
-            pricing["completion"] = str(cents_output / 100)
+            pricing["completion"] = str(cents_output * 10_000)
 
     # Extract image unit pricing (text-to-image models)
     elif pricing_info.get("type") == "image_units" or "cents_per_image_unit" in pricing_info:

--- a/src/services/providers/near_client.py
+++ b/src/services/providers/near_client.py
@@ -183,39 +183,32 @@ def normalize_near_model(near_model: dict) -> dict:
         "internal_reasoning": None,
     }
 
-    # Extract pricing from Near AI API response
-    # FIXED: Near AI provides pricing as inputCostPerToken and outputCostPerToken with amount and scale
-    # Scale is in powers of 10 (e.g., -9 means 10^-9 = per token)
-    # Database stores per-token pricing, so just use amount × 10^scale
-    input_cost = near_model.get("inputCostPerToken", {})
-    output_cost = near_model.get("outputCostPerToken", {})
+    # Extract pricing from the Near AI API response and emit dollars-per-1M-tokens
+    # ($/1M). The catalog transform then applies the provider's per_1m format once
+    # (/1e6) to reach true per-token — see tests/services/test_provider_price_units.py.
+    #
+    # Near's `pricing` dict carries the per-1M price in `input`/`output` and the same
+    # value per-token in `prompt`/`completion`. Prefer the explicit per-1M fields;
+    # otherwise scale the per-token values up by 1e6 so the unit is consistent.
+    pricing_info = near_model.get("pricing", {}) or {}
 
-    if input_cost and isinstance(input_cost, dict):
-        input_amount = input_cost.get("amount", 0)
-        input_scale = input_cost.get("scale", -9)  # Default scale is -9 (per token)
-        # Per-token price = amount × 10^scale
-        if input_amount > 0:
-            pricing["prompt"] = str(input_amount * (10**input_scale))
+    def _to_per_million(per_million, per_token):
+        if per_million is not None:
+            try:
+                return str(float(per_million))
+            except (TypeError, ValueError):
+                return None
+        if per_token is not None:
+            try:
+                return str(float(per_token) * 1_000_000)
+            except (TypeError, ValueError):
+                return None
+        return None
 
-    if output_cost and isinstance(output_cost, dict):
-        output_amount = output_cost.get("amount", 0)
-        output_scale = output_cost.get("scale", -9)  # Default scale is -9 (per token)
-        # Per-token price = amount × 10^scale
-        if output_amount > 0:
-            pricing["completion"] = str(output_amount * (10**output_scale))
-
-    # Fallback to old pricing format for backward compatibility
-    if not pricing["prompt"] and not pricing["completion"]:
-        pricing_info = near_model.get("pricing", {})
-        if pricing_info:
-            pricing["prompt"] = (
-                str(pricing_info.get("prompt")) if pricing_info.get("prompt") is not None else None
-            )
-            pricing["completion"] = (
-                str(pricing_info.get("completion"))
-                if pricing_info.get("completion") is not None
-                else None
-            )
+    pricing["prompt"] = _to_per_million(pricing_info.get("input"), pricing_info.get("prompt"))
+    pricing["completion"] = _to_per_million(
+        pricing_info.get("output"), pricing_info.get("completion")
+    )
 
     architecture = {
         "modality": metadata.get("modality", MODALITY_TEXT_TO_TEXT),

--- a/src/services/providers/novita_client.py
+++ b/src/services/providers/novita_client.py
@@ -269,7 +269,7 @@ def _normalize_novita_model(model: Any) -> dict[str, Any] | None:
         "description": description,
         "context_length": context_length,
         "architecture": normalized_architecture,
-        "pricing": _normalize_pricing(payload.get("pricing")),
+        "pricing": _normalize_pricing(payload),
         "per_request_limits": payload.get("limits") or payload.get("rate_limits"),
         "supported_parameters": _extract_supported_parameters(payload),
         "default_parameters": payload.get("default_parameters") or {},
@@ -284,8 +284,16 @@ def _normalize_novita_model(model: Any) -> dict[str, Any] | None:
     return normalized
 
 
-def _normalize_pricing(pricing: dict[str, Any] | None) -> dict[str, str | None]:
-    pricing = pricing or {}
+# Novita reports `input_token_price_per_m` in units of 1e-4 USD per 1M tokens
+# (e.g. 14000 == $1.40 / 1M), so dividing by this factor yields dollars-per-1M.
+# Verified against Together's $/1M for glm-5.2 / minimax-m3 / kimi-k2.7.
+_NOVITA_PRICE_PER_M_SCALE = 10_000
+
+
+def _normalize_pricing(payload: dict[str, Any] | None) -> dict[str, str | None]:
+    payload = payload or {}
+    # Legacy shape carried a nested `pricing` dict; current API is top-level.
+    legacy = payload.get("pricing") if isinstance(payload.get("pricing"), dict) else {}
 
     def _stringify(value: Any) -> str | None:
         if value is None:
@@ -295,26 +303,26 @@ def _normalize_pricing(pricing: dict[str, Any] | None) -> dict[str, str | None]:
         except Exception:  # pragma: no cover - defensive
             return None
 
-    prompt = (
-        pricing.get("prompt")
-        or pricing.get("input")
-        or pricing.get("prompt_price")
-        or pricing.get("prompt_tokens")
-    )
-    completion = (
-        pricing.get("completion")
-        or pricing.get("output")
-        or pricing.get("completion_price")
-        or pricing.get("completion_tokens")
-    )
+    def _per_million(raw_per_m, legacy_key) -> str | None:
+        # Emit dollars-per-1M so the catalog transform's single per_1m division
+        # reaches true per-token. See tests/services/test_provider_price_units.py.
+        if raw_per_m is not None:
+            try:
+                return str(float(raw_per_m) / _NOVITA_PRICE_PER_M_SCALE)
+            except (TypeError, ValueError):
+                return None
+        return _stringify(legacy.get(legacy_key))
+
+    prompt = _per_million(payload.get("input_token_price_per_m"), "prompt")
+    completion = _per_million(payload.get("output_token_price_per_m"), "completion")
 
     return {
-        "prompt": _stringify(prompt),
-        "completion": _stringify(completion),
-        "request": _stringify(pricing.get("request")),
-        "image": _stringify(pricing.get("image")),
-        "web_search": _stringify(pricing.get("web_search")),
-        "internal_reasoning": _stringify(pricing.get("internal_reasoning")),
+        "prompt": prompt,
+        "completion": completion,
+        "request": _stringify(legacy.get("request")),
+        "image": _stringify(legacy.get("image")),
+        "web_search": _stringify(legacy.get("web_search")),
+        "internal_reasoning": _stringify(legacy.get("internal_reasoning")),
     }
 
 

--- a/tests/services/test_provider_price_units.py
+++ b/tests/services/test_provider_price_units.py
@@ -117,13 +117,19 @@ def test_build_offer_rows_drops_implausible_priced_offer():
     providers = {1: {"slug": "near"}, 2: {"slug": "openrouter"}}
     models = [
         {  # garbage near-zero price -> must be dropped
-            "id": "1", "provider_id": 1, "provider_model_id": "anthropic/claude-sonnet-4-6",
-            "modality": "text->text", "is_active": True,
+            "id": "1",
+            "provider_id": 1,
+            "provider_model_id": "anthropic/claude-sonnet-4-6",
+            "modality": "text->text",
+            "is_active": True,
             "model_pricing": {"price_per_input_token": 3e-12},
         },
         {  # sane openrouter price -> kept
-            "id": "2", "provider_id": 2, "provider_model_id": "anthropic/claude-sonnet-4-6",
-            "modality": "text->text", "is_active": True,
+            "id": "2",
+            "provider_id": 2,
+            "provider_model_id": "anthropic/claude-sonnet-4-6",
+            "modality": "text->text",
+            "is_active": True,
             "model_pricing": {"price_per_input_token": 3e-6},
         },
     ]

--- a/tests/services/test_provider_price_units.py
+++ b/tests/services/test_provider_price_units.py
@@ -1,0 +1,132 @@
+"""Provider price-unit normalization contract tests.
+
+The cost router compares ``model_provider_offers.upstream_cost`` across providers,
+so every provider's ingested price MUST end up in the same unit. The pipeline is:
+
+    provider client normalize_*()  ->  emits dollars-per-1M-tokens ($/1M)
+    transform_normalized_model_to_db_schema()  ->  applies get_provider_format()
+                                                    (per_1m => / 1e6) once
+    => metadata.pricing_raw.prompt is true dollars-per-TOKEN
+
+near / novita / deepinfra previously each emitted a different unit (per-token,
+a raw dict, or a bogus amount*10^scale), so the single ``per_1m`` division in
+transform produced values off by 1e2-1e6 and the router always picked OpenRouter.
+
+These tests pin the client contract ($/1M) so the shared transform stays correct.
+"""
+
+from decimal import Decimal
+
+from src.services.providers.deepinfra_client import normalize_deepinfra_model
+from src.services.providers.near_client import normalize_near_model
+from src.services.providers.novita_client import _normalize_pricing
+
+
+def _prompt(pricing: dict) -> float:
+    return float(pricing["prompt"])
+
+
+# --- NEAR -------------------------------------------------------------------
+# Real Near API shape: pricing dict carries per-1M in `input`/`output` and the
+# same value per-token in `prompt`/`completion`. Client must emit $/1M.
+def test_near_emits_dollars_per_million_from_input_field():
+    m = {
+        "id": "anthropic/claude-haiku-4-5",
+        "name": "Claude Haiku",
+        "pricing": {"input": 1.0, "output": 5.0, "prompt": "0.000001", "completion": "0.000005"},
+    }
+    out = normalize_near_model(m)
+    assert _prompt(out["pricing"]) == 1.0  # $1 / 1M input
+    assert float(out["pricing"]["completion"]) == 5.0
+
+
+def test_near_falls_back_to_per_token_times_million():
+    # Only the per-token `prompt` is present -> scale up to $/1M.
+    m = {"id": "x/y", "name": "y", "pricing": {"prompt": "0.000003"}}
+    out = normalize_near_model(m)
+    assert _prompt(out["pricing"]) == 3.0  # 0.000003 * 1e6
+
+
+# --- NOVITA -----------------------------------------------------------------
+# Real Novita API: top-level input_token_price_per_m in units of 1e-4 USD/1M,
+# so $/1M = value / 10000 (verified vs Together across glm/minimax/kimi).
+def test_novita_converts_price_per_m_to_dollars_per_million():
+    out = _normalize_pricing({"input_token_price_per_m": 14000, "output_token_price_per_m": 28000})
+    assert _prompt(out) == 1.4
+    assert float(out["completion"]) == 2.8
+
+
+def test_novita_zero_price_is_free():
+    out = _normalize_pricing({"input_token_price_per_m": 0, "output_token_price_per_m": 0})
+    assert out["prompt"] in (None, "0", "0.0")
+
+
+# --- DEEPINFRA --------------------------------------------------------------
+# Real DeepInfra API: cents_per_input_token (cents PER TOKEN) -> $/1M = *1e4.
+def test_deepinfra_emits_dollars_per_million():
+    m = {
+        "model_name": "anthropic/claude-haiku-4-5",
+        "type": "text-generation",
+        "pricing": {"cents_per_input_token": 0.0001, "cents_per_output_token": 0.0005},
+    }
+    out = normalize_deepinfra_model(m)
+    assert _prompt(out["pricing"]) == 1.0  # 0.0001 cents/tok -> $1/1M
+    assert float(out["pricing"]["completion"]) == 5.0
+
+
+# --- END TO END: client + transform => per-token ----------------------------
+def test_pipeline_produces_consistent_per_token_across_providers():
+    from src.services.model_catalog_sync import transform_normalized_model_to_db_schema as T
+
+    def _final(model, slug):
+        row = T(model, 999, slug)
+        raw = (row.get("metadata") or {}).get("pricing_raw") or {}
+        return Decimal(str(raw.get("prompt")))
+
+    near = normalize_near_model(
+        {"id": "anthropic/claude-haiku-4-5", "name": "h", "pricing": {"input": 1.0, "output": 5.0}}
+    )
+    dinf = normalize_deepinfra_model(
+        {
+            "model_name": "anthropic/claude-haiku-4-5",
+            "type": "text-generation",
+            "pricing": {"cents_per_input_token": 0.0001, "cents_per_output_token": 0.0005},
+        }
+    )
+    # near & deepinfra are per_1m in the providers table, so transform divides by 1e6.
+    # $1/1M == 1e-6 per token; both providers must agree within rounding.
+    assert _final(near, "near") == Decimal("0.000001")
+    assert _final(dinf, "deepinfra") == Decimal("0.000001")
+
+
+# --- SANITY GUARD: garbage prices never win routing -------------------------
+def test_implausible_prices_rejected_and_sane_kept():
+    from src.services.model_offers_projection import is_plausible_cost_per_1k
+
+    # Sane band (per-1k): $0.001/1M == 1e-6 .. $1000/1M == 1.0
+    assert is_plausible_cost_per_1k(5e-5) is True  # a normal cheap model
+    assert is_plausible_cost_per_1k(0.003) is True  # claude-sonnet input
+    assert is_plausible_cost_per_1k(None) is False  # unpriced
+    assert is_plausible_cost_per_1k(3e-9) is False  # near-zero stale/unit-error price
+    assert is_plausible_cost_per_1k(170.0) is False  # per-1M written as per-token
+
+
+def test_build_offer_rows_drops_implausible_priced_offer():
+    from src.services.model_offers_projection import build_offer_rows
+
+    providers = {1: {"slug": "near"}, 2: {"slug": "openrouter"}}
+    models = [
+        {  # garbage near-zero price -> must be dropped
+            "id": "1", "provider_id": 1, "provider_model_id": "anthropic/claude-sonnet-4-6",
+            "modality": "text->text", "is_active": True,
+            "model_pricing": {"price_per_input_token": 3e-12},
+        },
+        {  # sane openrouter price -> kept
+            "id": "2", "provider_id": 2, "provider_model_id": "anthropic/claude-sonnet-4-6",
+            "modality": "text->text", "is_active": True,
+            "model_pricing": {"price_per_input_token": 3e-6},
+        },
+    ]
+    rows = build_offer_rows(models, providers)
+    slugs = {r["provider_slug"] for r in rows}
+    assert slugs == {"openrouter"}  # near's garbage offer excluded from routing


### PR DESCRIPTION
## Problem
The OpenRouter-style cost router ranked every **direct** provider as the most expensive option and routed everything to **OpenRouter** — the opposite of the "OpenRouter = fallback, direct supply = primary" goal.

The router logic (`smart_router.py`) was correct. The bug was **price ingestion**: three provider clients emitted prices in the wrong unit, so the catalog transform's single `per_1m` ÷1e6 produced values off by 1e2–1e6.

| provider | client emitted | final per-token | |
|---|---|---|---|
| together / openrouter | correct | ~1e-7 | ✅ |
| **near** | `1e12` (read a nonexistent `inputCostPerToken` field) | `1e6` | ❌ |
| **novita** | `None` (read a nonexistent nested `pricing` dict) | `None` | ❌ |
| **deepinfra** | per-token → transform double-normalized | `~1e-12` | ❌ |

## Fix
Each client now emits the same **dollars-per-1M** contract Together/OpenRouter already use, so the existing per-provider ÷1e6 lands on true per-token. **No DB/schema changes** (near/novita/deepinfra are already `per_1m` in the providers table):

- **near**: read `pricing.input`/`.output` ($/1M); fall back to per-token ×1e6. Removed the bogus `inputCostPerToken` path.
- **novita**: read top-level `input_token_price_per_m` / 10000 → $/1M.
- **deepinfra**: `cents_per_input_token × 1e4` → $/1M.

**Defense-in-depth:** `is_plausible_cost_per_1k` band `[1e-6, 1.0]` per-1k ($0.001–$1000/1M) in `model_offers_projection.build_offer_rows`. Offers with a garbage/stale/near-zero price are dropped from routing (logged, not silent) so they can neither win cost-routing nor undercharge billing.

## Verification (staging)
- Cross-provider prices now **agree** (kimi-k2.7: novita 9.5e-7 ≈ deepinfra 7.4e-7 ≈ together 9.5e-7).
- Re-synced prices + re-projected offers → guard dropped 63 garbage offers, **0** below-floor prices remain.
- **Direct provider is cheapest in 81/131** multi-provider groups (was ~0).
- `reorder_provider_chain` confirmed picking deepinfra/together/near over OpenRouter for real models.
- **110 routing/pricing tests pass**, zero regressions. Black + ruff clean.

## Follow-ups (not in this PR)
- Prod has the same bug (shared sync code) → run price-refresh + offers re-projection after deploy.
- The provider-catalog cache can hold stale broken prices → bust on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pricing from multiple providers is now normalized more consistently, improving cost comparisons across model offers.

* **Bug Fixes**
  * Fixed pricing conversion for several provider integrations so model costs are calculated more accurately.
  * Removed obviously invalid offer pricing from routing results, reducing chances of seeing misleading low-cost options.

* **Tests**
  * Added coverage for provider price normalization and invalid pricing rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->