### PR TITLE
fix(security): require admin auth on providers_management; stop leaking Stripe error text

### DIFF
--- a/src/routes/providers_management.py
+++ b/src/routes/providers_management.py
@@ -5,7 +5,7 @@ Handles CRUD operations for AI model providers
 
 import logging
 
-from fastapi import APIRouter, HTTPException, Path, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 
 from src.db.models_catalog_db import get_models_stats
 from src.db.providers_db import (
@@ -29,12 +29,14 @@ from src.schemas.providers import (
     ProviderStats,
     ProviderUpdate,
 )
+from src.security.deps import require_admin_or_env_key
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/providers",
     tags=["Providers Management"],
+    dependencies=[Depends(require_admin_or_env_key)],
 )
 
 

--- a/src/services/billing/payments.py
+++ b/src/services/billing/payments.py
@@ -1739,11 +1739,18 @@ class StripeService:
         except stripe.StripeError as e:
             logger.error(f"Stripe error creating subscription checkout: {e}")
             # Client-fixable Stripe errors (HTTP 4xx) — e.g. an invalid/unknown price_id, or a
-            # test/live mode mismatch — should surface as a 400 with the real reason, not a
-            # generic 500. Genuine Stripe outages (5xx/network) stay as 500.
+            # test/live mode mismatch — should surface as a 400, not a generic 500. The raw
+            # Stripe error text is logged above for debugging, but is NOT included in the
+            # ValueError message: it flows into HTTPException(400).detail verbatim (the
+            # global handler in error_handlers.py only sanitizes 500/404, not 400), which
+            # would otherwise leak internal Stripe error details to the client.
+            # Genuine Stripe outages (5xx/network) stay as 500 (already sanitized).
             http_status = getattr(e, "http_status", None)
             if http_status and 400 <= http_status < 500:
-                raise ValueError(f"Stripe rejected the checkout request: {str(e)}") from e
+                raise ValueError(
+                    "Your subscription request couldn't be processed. "
+                    "Please check your payment details and try again."
+                ) from e
             raise Exception(f"Payment processing error: {str(e)}") from e
 
         except Exception as e:


### PR DESCRIPTION
## Summary
Two audit-confirmed backend bugs, verified not to be false alarms before implementing. (A third suspected issue, duplicate-signup returning 400 instead of 409, was audited and found to be a false alarm for the actual product — the frontend never calls `/auth/register` at all, it's Privy-only — so no change was made for that one.)

- **Security: `providers_management.py` had no auth dependency at all.** Every route (list/create/update/delete/activate/deactivate providers) was reachable by an anonymous, unauthenticated caller — including `DELETE /providers/{id}`, which hard-deletes a provider **and cascade-deletes all its associated catalog models**. Fixed by adding `dependencies=[Depends(require_admin_or_env_key)]` to the router, mirroring the exact pattern already used by `model_sync.py`. This is a live production exposure — recommend deploying promptly. Note: the frontend's read-only `ProviderAPI` calls will now need an admin-flagged user's API key to succeed (previously succeeded for any authenticated user); the one frontend page that calls it isn't linked from any nav/menu today, so practical impact there is low.
- **`/subscription-checkout` leaked raw Stripe error text on 400s.** Investigated a broader claim that `payments.py` leaks `str(e)` widely — that turned out to be mostly a false alarm, since a global exception handler already sanitizes all 500/404 errors app-wide. The one real gap: a deliberately-raised `ValueError` wrapping a raw Stripe rejection message reached the client verbatim on this one 400 path. Fixed at the single raise site with a generic, safe message (the real error is still logged server-side); deliberately did *not* apply a blanket fix to `error_handlers.py`'s 400 branch, since 93 other legitimate validation-error sites across the codebase rely on echoing their (safe) detail text verbatim — a blanket change would have broken those.

## Test plan
- [x] Full `pytest` suite diffed against `main`: 94 vs 73 failures — investigated the delta, all 21 extra failures were in one file (`test_bug_fix_generator.py`, unrelated to either change — imports `tenacity`, which wasn't installed in the local dev venv until this session) that passes 32/32 in isolation; confirmed pure test-order flakiness, not a regression from either change.
- [x] `ast.parse` sanity check on both changed files.
- [x] Relevant existing tests for the changed areas pass (provider/CM ecosystem tests, payment/subscription tests) with no regressions.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>