### PR TITLE
fix: permanent free-model 429s, provider error leakage, and paid-model access for users with credits

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -239,6 +239,18 @@ class Config:
         ).split(",")
         if s.strip()
     }
+    # Subset of blocked statuses that block regardless of balance (abuse states).
+    # For the remaining blocked statuses (payment lapses like canceled/past_due),
+    # users who still hold prepaid purchased credits may keep spending them —
+    # purchased credits are retained on cancellation and were already paid for.
+    HARD_BLOCKED_SUBSCRIPTION_STATUSES = {
+        s.strip().lower()
+        for s in os.environ.get(
+            "HARD_BLOCKED_SUBSCRIPTION_STATUSES",
+            "bot,suspended",
+        ).split(",")
+        if s.strip()
+    }
 
     # Supabase Configuration
     SUPABASE_URL = os.environ.get("SUPABASE_URL")

--- a/src/db/users.py
+++ b/src/db/users.py
@@ -310,6 +310,63 @@ def _schedule_background_migration(client, user: dict[str, Any], api_key: str) -
     thread.start()
 
 
+def _migrate_legacy_credit_balance(client, user: dict[str, Any]) -> None:
+    """Persist a legacy ``users.credits`` balance into the tiered balance fields.
+
+    Older accounts hold their balance in the legacy ``credits`` column. The
+    inference credit gates and the atomic deduction RPC only look at
+    ``subscription_allowance`` / ``purchased_credits``, so without this
+    migration those users are blocked with 402 "Insufficient credits" while
+    their dashboard (get_user_profile, which applies a read-time fallback)
+    still shows a positive balance.
+
+    The guarded update (``credits`` must still equal the value we read) makes
+    concurrent migrations safe: only one writer matches the WHERE clause, so
+    the balance can never be duplicated. On success the passed-in user dict is
+    updated in place so this request already sees the spendable balance.
+    """
+    try:
+        allowance = float(user.get("subscription_allowance") or 0)
+        purchased = float(user.get("purchased_credits") or 0)
+        legacy_raw = user.get("credits")
+        legacy = float(legacy_raw or 0)
+        if legacy <= 0 or allowance != 0 or purchased != 0:
+            return
+
+        # Same target selection as the get_user_profile display fallback
+        if user.get("tier") in ("pro", "max") and user.get("subscription_status") == "active":
+            target_field = "subscription_allowance"
+        else:
+            target_field = "purchased_credits"
+
+        with track_database_query(table="users", operation="update"):
+            result = (
+                client.table("users")
+                .update({target_field: legacy, "credits": 0})
+                .eq("id", user["id"])
+                .eq("credits", legacy_raw)
+                .execute()
+            )
+
+        if result.data:
+            user[target_field] = legacy
+            user["credits"] = 0
+            logger.info(
+                "Migrated legacy credits balance for user %s: %.6f -> %s",
+                sanitize_for_logging(str(user["id"])),
+                legacy,
+                target_field,
+            )
+    except Exception as e:
+        # Best-effort: on failure the user keeps the pre-migration view and
+        # the migration is retried on the next uncached lookup.
+        logger.error(
+            "Failed to migrate legacy credits for user %s: %s",
+            sanitize_for_logging(str(user.get("id"))),
+            sanitize_for_logging(str(e)),
+        )
+
+
 def _get_user_uncached(api_key: str) -> dict[str, Any] | None:
     """Internal function: Get user by API key from database (no caching)
 
@@ -349,6 +406,7 @@ def _get_user_uncached(api_key: str) -> dict[str, Any] | None:
                     user["scope_permissions"] = key_data.get("scope_permissions")
                     user["is_primary"] = key_data.get("is_primary", False)
                     user["api_key"] = api_key  # ensure api_key is always in user dict
+                    _migrate_legacy_credit_balance(client, user)
                     return user
             except (DatabaseResultError, KeyError) as e:
                 logger.warning(
@@ -380,6 +438,7 @@ def _get_user_uncached(api_key: str) -> dict[str, Any] | None:
                 # Mark the user as having an unmigrated temporary key
                 user["_has_temporary_key"] = True
                 # Allow auth to proceed - temporary keys work fine
+                _migrate_legacy_credit_balance(client, user)
                 return user
 
             # PERF: Allow legacy key auth immediately, migrate in background
@@ -393,6 +452,7 @@ def _get_user_uncached(api_key: str) -> dict[str, Any] | None:
             _schedule_background_migration(client, user, api_key)
 
             # Return user immediately - don't wait for migration
+            _migrate_legacy_credit_balance(client, user)
             return user
 
         return None

--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -368,6 +368,14 @@ async def chat_completions(
     # Initialize performance tracker
     tracker = PerformanceTracker(endpoint="/v1/chat/completions")
 
+    # Bound before the try so the exception handlers below can always
+    # reference them, even for failures during auth/validation.
+    rate_limit_mgr = None
+    # True while this request holds a concurrency slot taken by the rate-limit
+    # pre-check. Must be released on EVERY exit path — a leaked slot
+    # permanently 429s the key ("Concurrency limit exceeded") until restart.
+    concurrency_slot_held = False
+
     try:
         # === 1) User + plan/trial prechecks (OPTIMIZED: parallelized DB calls) ===
         with tracker.stage("auth_validation"):
@@ -568,6 +576,7 @@ async def chat_completions(
                     reason=rl_pre.reason,
                     rate_limit_headers=get_rate_limit_headers(rl_pre),
                 )
+            concurrency_slot_held = should_release_concurrency
 
         # Credit check (only for authenticated non-trial users)
         # Uses cost-based pre-check instead of simple balance > 0
@@ -923,7 +932,16 @@ async def chat_completions(
                         mask_key(api_key),
                         exc,
                     )
-                rl_final = await rate_limit_mgr.check_rate_limit(api_key, tokens_used=total_tokens)
+                concurrency_slot_held = False
+                # Accounting-only check: records the tokens actually used but
+                # must NOT take another concurrency slot or count a second
+                # request — the pre-check already admitted this request.
+                rl_final = await rate_limit_mgr.check_rate_limit(
+                    api_key,
+                    tokens_used=total_tokens,
+                    acquire_concurrency=False,
+                    count_request=False,
+                )
                 if not rl_final.allowed:
                     await _to_thread(
                         create_rate_limit_alert,
@@ -1099,6 +1117,15 @@ async def chat_completions(
         return JSONResponse(content=processed, headers=headers)
 
     except HTTPException as http_exc:
+        # Release the concurrency slot taken by the rate-limit pre-check;
+        # otherwise every failed request leaks a slot until the key is
+        # permanently "Concurrency limit exceeded".
+        if concurrency_slot_held and rate_limit_mgr:
+            try:
+                await rate_limit_mgr.release_concurrency(api_key)
+            except Exception as release_exc:
+                logger.debug("Failed to release concurrency on error: %s", release_exc)
+
         # Save failed request for HTTPException errors (rate limits, auth errors, etc.)
         await save_failed_request(
             _to_thread=_to_thread,
@@ -1121,6 +1148,14 @@ async def chat_completions(
             f"[{request_id}] Unhandled server error: {type(e).__name__}",
             extra={"request_id": request_id, "error_type": type(e).__name__},
         )
+
+        # Release the concurrency slot taken by the rate-limit pre-check (see
+        # the HTTPException handler above).
+        if concurrency_slot_held and rate_limit_mgr:
+            try:
+                await rate_limit_mgr.release_concurrency(api_key)
+            except Exception as release_exc:
+                logger.debug("Failed to release concurrency on error: %s", release_exc)
 
         # Save failed request for unexpected errors
         await save_failed_request(

--- a/src/routes/chat_dispatch.py
+++ b/src/routes/chat_dispatch.py
@@ -96,6 +96,22 @@ async def dispatch_streaming(
         # iteration (not just setup) can be caught and the next provider tried,
         # but only before the first content chunk has been sent to the client.
         async def _auth_stream_with_failover():
+            try:
+                async for _chunk in _auth_stream_attempts():
+                    yield _chunk
+            finally:
+                # Release the concurrency slot taken by the route's rate-limit
+                # pre-check. Streaming responses outlive chat_completions(), so
+                # the route can't release it — without this every streamed
+                # request leaked a slot until the key was permanently
+                # "Concurrency limit exceeded".
+                if rate_limit_mgr and rl_pre is not None and not (trial or {}).get("is_trial"):
+                    try:
+                        await rate_limit_mgr.release_concurrency(api_key)
+                    except Exception as _release_exc:
+                        logger.debug("Failed to release stream concurrency: %s", _release_exc)
+
+        async def _auth_stream_attempts():
             _adapter = OpenAIChatAdapter()
             last_exc = None
 

--- a/src/routes/chat_streaming.py
+++ b/src/routes/chat_streaming.py
@@ -477,15 +477,35 @@ async def stream_generator(
             or "503" in error_str
             or "502" in error_str
         ):
-            error_message = f"Provider temporarily unavailable: {str(e)[:200]}"
+            # Generic client message — the raw error is logged above and
+            # captured to Sentry below; never surfaced to the end user.
+            error_message = (
+                "The model provider is temporarily unavailable. Please try again in a moment."
+            )
             error_type = "provider_error"
+            try:
+                from src.utils.sentry_context import capture_provider_error
+
+                capture_provider_error(
+                    e,
+                    provider=provider,
+                    model=model,
+                    request_id=request_id,
+                    endpoint="/v1/chat/completions",
+                    extra_context={"error_category": "stream_provider_error"},
+                )
+            except Exception:
+                logger.debug("Failed to capture stream provider error", exc_info=True)
         # Check for timeout errors
         elif "timeout" in error_str or "timed out" in error_str:
             error_message = "Request timed out. The model may be overloaded. Please try again."
             error_type = "timeout_error"
         # Check for model not found errors
         elif "not found" in error_str or "404" in error_str:
-            error_message = f"Model or resource not found: {str(e)[:200]}"
+            error_message = (
+                f"Model '{model}' was not found or is currently unavailable. "
+                "Please check the model ID or try another model."
+            )
             error_type = "not_found_error"
         # For other errors, include a sanitized version of the error message
         else:

--- a/src/routes/images.py
+++ b/src/routes/images.py
@@ -536,7 +536,24 @@ async def generate_images(
                     error_message=str(e)[:500],
                 )
 
-            raise HTTPException(status_code=500, detail=f"Image generation failed: {str(e)}") from e
+            # Capture full details in telemetry; never expose internals to the client
+            try:
+                from src.utils.sentry_context import capture_provider_error
+
+                capture_provider_error(
+                    e,
+                    provider=actual_provider or "unknown",
+                    model=model,
+                    endpoint="/v1/images/generations",
+                    extra_context={"error_category": "image_generation_error"},
+                )
+            except Exception:
+                logger.debug("Failed to capture image generation error", exc_info=True)
+
+            raise HTTPException(
+                status_code=500,
+                detail="Image generation failed due to an internal error. Please try again.",
+            ) from e
 
         finally:
             # Clean up executor
@@ -545,5 +562,5 @@ async def generate_images(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Unexpected error in image generation endpoint: {e}")
-        raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}") from e
+        logger.error(f"Unexpected error in image generation endpoint: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from e

--- a/src/security/inference_gates.py
+++ b/src/security/inference_gates.py
@@ -107,6 +107,26 @@ def enforce_subscription_status_gate(
         return
     sub_status = str(raw).strip().lower()
     if sub_status in Config.BLOCKED_SUBSCRIPTION_STATUSES:
+        # Payment-lapse statuses (canceled, past_due, ...) must not lock out
+        # prepaid balances: purchased credits are retained on cancellation and
+        # were already paid for. Only hard-blocked abuse statuses (bot,
+        # suspended) block regardless of balance.
+        if sub_status not in Config.HARD_BLOCKED_SUBSCRIPTION_STATUSES:
+            purchased = float(user.get("purchased_credits") or 0)
+            legacy = float(user.get("credits") or 0)
+            allowance = float(user.get("subscription_allowance") or 0)
+            has_prepaid_balance = purchased > 0 or (
+                allowance == 0 and purchased == 0 and legacy > 0
+            )
+            if has_prepaid_balance:
+                logger.info(
+                    "Allowing request from lapsed-subscription user with prepaid credits "
+                    "(request_id=%s, user_id=%s, subscription_status=%s)",
+                    request_id,
+                    user.get("id"),
+                    sub_status,
+                )
+                return
         logger.warning(
             "Blocking request (request_id=%s, user_id=%s, subscription_status=%s)",
             request_id,

--- a/src/services/provider_failover.py
+++ b/src/services/provider_failover.py
@@ -404,6 +404,30 @@ def filter_by_circuit_breaker(
         return provider_chain
 
 
+def _upstream_rate_limit_exception(
+    provider: str, model: str, retry_after: str | int | None
+) -> HTTPException:
+    """Build the client-facing 429 for an UPSTREAM provider rate limit.
+
+    Free-tier models (locked to a single provider) hit shared upstream limits
+    frequently; the message and X-RateLimit-Scope header make clear this is
+    model congestion, not the caller exceeding their own gateway limits.
+    """
+    headers = {
+        "Retry-After": str(retry_after) if retry_after else "30",
+        "X-RateLimit-Scope": "upstream",
+    }
+    return HTTPException(
+        status_code=429,
+        detail=(
+            f"The model '{model}' is temporarily rate limited upstream due to high demand. "
+            "This is congestion at the model provider, not your account limit. "
+            "Please retry shortly."
+        ),
+        headers=headers,
+    )
+
+
 def map_provider_error(
     provider: str,
     model: str,
@@ -411,12 +435,47 @@ def map_provider_error(
 ) -> HTTPException:
     """
     Map upstream exceptions to HTTPException responses.
-    Keeps existing status/detail semantics while allowing centralized handling.
+
+    All client-visible details are sanitized (no raw provider response bodies,
+    URLs, or key ids); the raw error is logged server-side and captured to
+    Sentry for retryable/upstream failures so the team is alerted instead of
+    end users seeing internals.
     """
-    # Log all upstream errors for debugging
+    http_exc = _map_provider_error_impl(provider, model, exc)
+
+    # Alert telemetry for upstream failures. HTTPExceptions are deliberately
+    # skipped by AutoSentryMiddleware, so without this capture provider
+    # outages/rate-limits/budget exhaustion never reach Sentry.
+    if not isinstance(exc, HTTPException) and (
+        http_exc.status_code in (402, 429) or http_exc.status_code >= 500
+    ):
+        try:
+            from src.utils.sentry_context import capture_provider_error
+
+            capture_provider_error(
+                exc,
+                provider=provider,
+                model=model,
+                extra_context={
+                    "mapped_status": http_exc.status_code,
+                    "error_category": "upstream_provider_error",
+                },
+            )
+        except Exception:  # noqa: BLE001 - telemetry must never break error mapping
+            logger.debug("Failed to capture provider error to Sentry", exc_info=True)
+
+    return http_exc
+
+
+def _map_provider_error_impl(
+    provider: str,
+    model: str,
+    exc: Exception,
+) -> HTTPException:
+    # Log all upstream errors for debugging (full detail stays server-side)
     logger.warning(
         f"Provider error: provider={provider}, model={model}, "
-        f"error_type={type(exc).__name__}, error={str(exc)[:200]}"
+        f"error_type={type(exc).__name__}, error={str(exc)[:500]}"
     )
 
     if isinstance(exc, HTTPException):
@@ -467,8 +526,11 @@ def map_provider_error(
                 detail=f"{provider} returned no response candidates. Trying alternative providers.",
             )
 
-        # Other ValueErrors are treated as bad requests
-        return HTTPException(status_code=400, detail=str(exc))
+        # Other ValueErrors are treated as bad requests (sanitized: never leak
+        # raw URLs/tokens embedded in upstream error text)
+        return HTTPException(
+            status_code=400, detail=sanitize_provider_error_for_user(error_msg, max_length=300)
+        )
 
     # OpenAI SDK exceptions (used for OpenRouter and other compatible providers)
     # Check APITimeoutError before APIConnectionError as it may be a subclass
@@ -493,11 +555,7 @@ def map_provider_error(
                 retry_after = exc.response.headers.get("retry-after")
             if retry_after is None and isinstance(getattr(exc, "body", None), dict):
                 retry_after = exc.body.get("retry_after")
-            if retry_after:
-                headers = {"Retry-After": str(retry_after)}
-            return HTTPException(
-                status_code=429, detail="Upstream rate limit exceeded", headers=headers
-            )
+            return _upstream_rate_limit_exception(provider, model, retry_after)
 
         auth_error_classes = tuple(
             err for err in (AuthenticationError, PermissionDeniedError) if err is not None
@@ -510,17 +568,26 @@ def map_provider_error(
             detail = f"Model {model} not found or unavailable on {provider}"
             status = 404
         elif BadRequestError and isinstance(exc, BadRequestError):
-            # Extract actual error message from BadRequestError
+            # Extract actual error message from BadRequestError. The raw
+            # response body is logged server-side only — provider bodies can
+            # embed key ids, internal URLs, and infra details.
             error_msg = getattr(exc, "message", None) or str(exc)
             try:
-                # Try to get response body if available
                 if hasattr(exc, "response") and exc.response:
                     response_text = getattr(exc.response, "text", None)
                     if response_text:
-                        error_msg = f"{error_msg} | Response: {response_text[:200]}"
+                        logger.warning(
+                            "OpenAI BadRequestError response body (provider=%s, model=%s): %s",
+                            provider,
+                            model,
+                            response_text[:500],
+                        )
             except Exception as log_exc:
                 logger.debug("Failed to extract OpenAI BadRequestError response body: %r", log_exc)
-            detail = f"Provider '{provider}' rejected request for model '{model}': {error_msg}"
+            detail = (
+                f"Provider '{provider}' rejected request for model '{model}': "
+                f"{sanitize_provider_error_for_user(error_msg, max_length=300)}"
+            )
             status = 400
         elif status == 403:
             detail = f"{provider} authentication error"
@@ -534,12 +601,21 @@ def map_provider_error(
         if detail == "Upstream error":
             error_msg = getattr(exc, "message", None) or str(exc)
             # Include provider and model in error message for better error tracking
-            detail = f"Provider '{provider}' error for model '{model}': {error_msg}"
+            detail = (
+                f"Provider '{provider}' error for model '{model}': "
+                f"{sanitize_provider_error_for_user(error_msg, max_length=300)}"
+            )
 
         return HTTPException(status_code=status, detail=detail, headers=headers)
 
     if OpenAIError and isinstance(exc, OpenAIError):
-        return HTTPException(status_code=502, detail=str(exc))
+        return HTTPException(
+            status_code=502,
+            detail=(
+                f"Provider '{provider}' error for model '{model}': "
+                f"{sanitize_provider_error_for_user(str(exc), max_length=300)}"
+            ),
+        )
 
     # Cerebras SDK exceptions (similar structure to OpenAI SDK but separate classes)
     if CerebrasAPIConnectionError and isinstance(exc, CerebrasAPIConnectionError):
@@ -560,11 +636,7 @@ def map_provider_error(
                 retry_after = exc.response.headers.get("retry-after")
             if retry_after is None and isinstance(getattr(exc, "body", None), dict):
                 retry_after = exc.body.get("retry_after")
-            if retry_after:
-                headers = {"Retry-After": str(retry_after)}
-            return HTTPException(
-                status_code=429, detail="Upstream rate limit exceeded", headers=headers
-            )
+            return _upstream_rate_limit_exception(provider, model, retry_after)
 
         cerebras_auth_error_classes = tuple(
             err
@@ -579,19 +651,28 @@ def map_provider_error(
             detail = f"Model {model} not found or unavailable on {provider}"
             status = 404
         elif CerebrasBadRequestError and isinstance(exc, CerebrasBadRequestError):
-            # Extract actual error message from BadRequestError
+            # Extract actual error message from BadRequestError. The raw
+            # response body is logged server-side only — provider bodies can
+            # embed key ids, internal URLs, and infra details.
             error_msg = getattr(exc, "message", None) or str(exc)
             try:
-                # Try to get response body if available
                 if hasattr(exc, "response") and exc.response:
                     response_text = getattr(exc.response, "text", None)
                     if response_text:
-                        error_msg = f"{error_msg} | Response: {response_text[:200]}"
+                        logger.warning(
+                            "Cerebras BadRequestError response body (provider=%s, model=%s): %s",
+                            provider,
+                            model,
+                            response_text[:500],
+                        )
             except Exception as log_exc:
                 logger.debug(
                     "Failed to extract Cerebras BadRequestError response body: %r", log_exc
                 )
-            detail = f"Provider '{provider}' rejected request for model '{model}': {error_msg}"
+            detail = (
+                f"Provider '{provider}' rejected request for model '{model}': "
+                f"{sanitize_provider_error_for_user(error_msg, max_length=300)}"
+            )
             status = 400
         elif status == 403:
             detail = f"{provider} authentication error"
@@ -605,7 +686,10 @@ def map_provider_error(
         if detail == "Upstream error":
             error_msg = getattr(exc, "message", None) or str(exc)
             # Include provider and model in error message for better error tracking
-            detail = f"Provider '{provider}' error for model '{model}': {error_msg}"
+            detail = (
+                f"Provider '{provider}' error for model '{model}': "
+                f"{sanitize_provider_error_for_user(error_msg, max_length=300)}"
+            )
 
         return HTTPException(status_code=status, detail=detail, headers=headers)
 
@@ -617,10 +701,7 @@ def map_provider_error(
         retry_after = exc.response.headers.get("retry-after")
 
         if status == 429:
-            headers = {"Retry-After": retry_after} if retry_after else None
-            return HTTPException(
-                status_code=429, detail="Upstream rate limit exceeded", headers=headers
-            )
+            return _upstream_rate_limit_exception(provider, model, retry_after)
         if status in (401, 403):
             return HTTPException(status_code=500, detail=f"{provider} authentication error")
         if status == 404:
@@ -629,13 +710,24 @@ def map_provider_error(
                 detail=f"Model {model} not found or unavailable on {provider}",
             )
         if 400 <= status < 500:
-            # Extract error details from response
+            # Client-visible detail carries only a sanitized summary; the raw
+            # response body is logged server-side for debugging.
             error_detail = (
                 f"Provider '{provider}' rejected request for model '{model}' (HTTP {status})"
             )
             try:
-                response_body = exc.response.text[:500] if exc.response.text else "No response body"
-                error_detail += f" | Response: {response_body}"
+                response_body = exc.response.text[:500] if exc.response.text else ""
+                if response_body:
+                    logger.warning(
+                        "Upstream 4xx response body (provider=%s, model=%s, status=%s): %s",
+                        provider,
+                        model,
+                        status,
+                        response_body,
+                    )
+                    error_detail += (
+                        f": {sanitize_provider_error_for_user(response_body, max_length=200)}"
+                    )
             except Exception as log_exc:
                 logger.debug("Failed to extract httpx response body: %r", log_exc)
             return HTTPException(status_code=400, detail=error_detail)
@@ -661,14 +753,7 @@ def map_provider_error(
         parsed_status == 429 or "rate limit" in msg.lower() or "too many requests" in msg.lower()
     )
     if is_rate_limited:
-        return HTTPException(
-            status_code=429,
-            detail=(
-                f"Provider '{provider}' rate limit exceeded for model '{model}'. "
-                "Please retry shortly."
-            ),
-            headers={"Retry-After": "30"},
-        )
+        return _upstream_rate_limit_exception(provider, model, None)
     if parsed_status == 404:
         return HTTPException(
             status_code=404, detail=f"Model {model} not found or unavailable on {provider}"

--- a/src/services/rate_limiting.py
+++ b/src/services/rate_limiting.py
@@ -115,6 +115,7 @@ class SlidingWindowRateLimiter:
         self.fallback_manager = get_fallback_rate_limit_manager()
         self.concurrent_requests = defaultdict(int)
         self.burst_tokens = {}
+        self.burst_last_refill = {}
         self.local_cache = {}
         self.redis_client = redis_client
 
@@ -123,8 +124,22 @@ class SlidingWindowRateLimiter:
         api_key: str,
         config: RateLimitConfig,
         tokens_used: int = 0,
+        *,
+        acquire_concurrency: bool = True,
+        count_request: bool = True,
     ) -> RateLimitResult:
-        """Check rate limit using fallback system"""
+        """Check rate limit using fallback system.
+
+        Args:
+            acquire_concurrency: When True (default), an allowed result takes a
+                concurrency slot that the caller MUST release via
+                release_concurrent_request(). Pass False for post-request
+                accounting checks that must not take a slot.
+            count_request: When True (default), an allowed result consumes a
+                burst token and counts one request in the sliding windows.
+                Pass False for post-request token accounting so a single user
+                request is not counted twice.
+        """
         try:
             # Check concurrency limit first
             concurrency_check = await self._check_concurrency_limit(api_key, config)
@@ -144,7 +159,7 @@ class SlidingWindowRateLimiter:
                 return result
 
             # Check burst limit
-            burst_check = await self._check_burst_limit(api_key, config)
+            burst_check = await self._check_burst_limit(api_key, config, consume=count_request)
             if not burst_check["allowed"]:
                 result = RateLimitResult(
                     allowed=False,
@@ -161,7 +176,9 @@ class SlidingWindowRateLimiter:
                 return result
 
             # Check sliding window limits
-            window_check = await self._check_sliding_window(api_key, config, tokens_used)
+            window_check = await self._check_sliding_window(
+                api_key, config, tokens_used, count_request=count_request
+            )
             if not window_check["allowed"]:
                 result = RateLimitResult(
                     allowed=False,
@@ -179,8 +196,12 @@ class SlidingWindowRateLimiter:
                 return result
 
             # All checks passed - request is allowed
-            # Increment concurrency counter BEFORE returning
-            await self.increment_concurrent_requests(api_key)
+            # Increment concurrency counter BEFORE returning. The caller is
+            # responsible for releasing this slot on EVERY exit path (success,
+            # error, and stream completion) — a leaked slot permanently
+            # rate-limits the key until the worker restarts.
+            if acquire_concurrency:
+                await self.increment_concurrent_requests(api_key)
 
             # Build result from our own sliding window check data
             limit_result = RateLimitResult(
@@ -244,8 +265,13 @@ class SlidingWindowRateLimiter:
             "limit": config.concurrency_limit,
         }
 
-    async def _check_burst_limit(self, api_key: str, config: RateLimitConfig) -> dict[str, Any]:
+    async def _check_burst_limit(
+        self, api_key: str, config: RateLimitConfig, consume: bool = True
+    ) -> dict[str, Any]:
         """Check burst limit using token bucket algorithm
+
+        When consume=False, only reports the current bucket state without
+        taking a token (used for post-request accounting checks).
 
         FIX (2026-02-06): Removed invalid `await` on sync Redis pipeline operations.
         Pipeline commands queue up and execute together - they don't return awaitables.
@@ -276,6 +302,14 @@ class SlidingWindowRateLimiter:
             current_tokens = min(config.burst_limit, current_tokens + tokens_to_add)
 
             if current_tokens >= 1:
+                if not consume:
+                    return {
+                        "allowed": True,
+                        "remaining": int(current_tokens),
+                        "current": int(current_tokens),
+                        "limit": config.burst_limit,
+                    }
+
                 # Consume one token
                 def _consume_token():
                     with tag_wrapper({"cache_layer": "rate_limit", "cache_op": "write"}):
@@ -306,8 +340,20 @@ class SlidingWindowRateLimiter:
             if api_key not in self.burst_tokens:
                 self.burst_tokens[api_key] = config.burst_limit
 
+            # Refill tokens based on time passed (same policy as the Redis
+            # path). Without this the local bucket only ever drains, so every
+            # key ends up permanently "Burst limit exceeded" after burst_limit
+            # lifetime requests on a long-lived worker.
+            last_refill = self.burst_last_refill.get(api_key, now)
+            tokens_to_add = (now - last_refill) * (config.burst_limit / 60)
+            self.burst_tokens[api_key] = min(
+                config.burst_limit, self.burst_tokens[api_key] + tokens_to_add
+            )
+            self.burst_last_refill[api_key] = now
+
             if self.burst_tokens[api_key] >= 1:
-                self.burst_tokens[api_key] -= 1
+                if consume:
+                    self.burst_tokens[api_key] -= 1
                 return {
                     "allowed": True,
                     "remaining": int(self.burst_tokens[api_key]),
@@ -324,21 +370,25 @@ class SlidingWindowRateLimiter:
                 }
 
     async def _check_sliding_window(
-        self, api_key: str, config: RateLimitConfig, tokens_used: int
+        self, api_key: str, config: RateLimitConfig, tokens_used: int, count_request: bool = True
     ) -> dict[str, Any]:
-        """Check sliding window rate limits"""
+        """Check sliding window rate limits.
+
+        When count_request=False, tokens_used is still recorded but no request
+        is counted (post-request token accounting).
+        """
         now = datetime.now(UTC)
         window_start = now - timedelta(seconds=config.window_size_seconds)
 
         if self.redis_client:
             # Use Redis for distributed rate limiting
             return await self._check_redis_sliding_window(
-                api_key, config, tokens_used, now, window_start
+                api_key, config, tokens_used, now, window_start, count_request=count_request
             )
         else:
             # Fallback to local cache
             return await self._check_local_sliding_window(
-                api_key, config, tokens_used, now, window_start
+                api_key, config, tokens_used, now, window_start, count_request=count_request
             )
 
     async def _check_redis_sliding_window(
@@ -348,6 +398,7 @@ class SlidingWindowRateLimiter:
         tokens_used: int,
         now: datetime,
         window_start: datetime,
+        count_request: bool = True,
     ) -> dict[str, Any]:
         """Check sliding window using Redis
 
@@ -450,11 +501,12 @@ class SlidingWindowRateLimiter:
         def _update_counters():
             with tag_wrapper({"cache_layer": "rate_limit", "cache_op": "write"}):
                 pipe = self.redis_client.pipeline()
-                pipe.incr(f"{minute_key}:requests")
+                if count_request:
+                    pipe.incr(f"{minute_key}:requests")
+                    pipe.incr(f"{hour_key}:requests")
+                    pipe.incr(f"{day_key}:requests")
                 pipe.incrby(f"{minute_key}:tokens", tokens_used)
-                pipe.incr(f"{hour_key}:requests")
                 pipe.incrby(f"{hour_key}:tokens", tokens_used)
-                pipe.incr(f"{day_key}:requests")
                 pipe.incrby(f"{day_key}:tokens", tokens_used)
 
                 # Set expiration times
@@ -482,6 +534,7 @@ class SlidingWindowRateLimiter:
         tokens_used: int,
         now: datetime,
         window_start: datetime,
+        count_request: bool = True,
     ) -> dict[str, Any]:
         """Check sliding window using local cache (fallback)"""
         if api_key not in self.local_cache:
@@ -521,8 +574,11 @@ class SlidingWindowRateLimiter:
                 "reason": "Minute token limit exceeded",
             }
 
-        # Record this request
-        cache["requests"].append(now)
+        # Record this request (tokens are always recorded; the request itself
+        # only when count_request is set, so post-request accounting does not
+        # double-count a single user request)
+        if count_request:
+            cache["requests"].append(now)
         cache["tokens"].append((now, tokens_used))
 
         return {
@@ -608,7 +664,13 @@ class RateLimitManager:
         pass
 
     async def check_rate_limit(
-        self, api_key: str, tokens_used: int = 0, request_type: str = "api"
+        self,
+        api_key: str,
+        tokens_used: int = 0,
+        request_type: str = "api",
+        *,
+        acquire_concurrency: bool = True,
+        count_request: bool = True,
     ) -> RateLimitResult:
         """Check rate limit for a specific API key (OPTIMIZED: with short-lived caching)
 
@@ -625,7 +687,12 @@ class RateLimitManager:
         now = time.time()
         cache_key = f"{api_key}:{tokens_used}"
 
-        if cache_key in self._result_cache:
+        # Only full-consumption checks participate in the result cache: a
+        # cached "allowed" for an accounting-only check must not skip a real
+        # admission check (and vice versa).
+        use_result_cache = acquire_concurrency and count_request
+
+        if use_result_cache and cache_key in self._result_cache:
             cached_result, cached_time = self._result_cache[cache_key]
             if now - cached_time < self._cache_ttl:
                 logger.debug(
@@ -683,7 +750,13 @@ class RateLimitManager:
         severe_config = await self._get_severe_rate_limit_config_with_user(user)
         if severe_config is not None:
             # Apply severe rate limiting for suspicious accounts
-            result = await self.rate_limiter.check_rate_limit(api_key, severe_config, tokens_used)
+            result = await self.rate_limiter.check_rate_limit(
+                api_key,
+                severe_config,
+                tokens_used,
+                acquire_concurrency=acquire_concurrency,
+                count_request=count_request,
+            )
             if not result.allowed:
                 logger.warning(
                     f"Severe rate limit exceeded for suspicious account {api_key[:10]}...: {result.reason}"
@@ -692,10 +765,16 @@ class RateLimitManager:
 
         # Cache miss - do actual check
         config = await self.get_key_config(api_key)
-        result = await self.rate_limiter.check_rate_limit(api_key, config, tokens_used)
+        result = await self.rate_limiter.check_rate_limit(
+            api_key,
+            config,
+            tokens_used,
+            acquire_concurrency=acquire_concurrency,
+            count_request=count_request,
+        )
 
         # Cache the result if allowed (only cache successful checks)
-        if result.allowed:
+        if use_result_cache and result.allowed:
             self._result_cache[cache_key] = (result, now)
             # Clean up old cache entries (keep cache size bounded)
             if len(self._result_cache) > 1000:

--- a/src/utils/rate_limit_guard.py
+++ b/src/utils/rate_limit_guard.py
@@ -55,7 +55,14 @@ async def enforce_request_rate_limit(
         return None
 
     try:
-        result = await manager.check_rate_limit(api_key, tokens_used=tokens_used)
+        # acquire_concurrency=False: this guard has no release hook, so taking
+        # a concurrency slot here would leak it permanently (the per-key
+        # counter is shared with /v1/chat/completions — leaked slots
+        # eventually 429 every request from the key until worker restart).
+        # Requests-per-window and burst limits are still fully enforced.
+        result = await manager.check_rate_limit(
+            api_key, tokens_used=tokens_used, acquire_concurrency=False
+        )
     except Exception as exc:  # pragma: no cover - defensive; manager already fails open
         logger.warning("Rate limit check errored; allowing request (fail-open): %s", exc)
         return None

--- a/tests/billing/test_legacy_credit_migration.py
+++ b/tests/billing/test_legacy_credit_migration.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+Tests for the legacy `users.credits` balance migration.
+
+Older accounts hold their balance in the legacy `credits` column, which the
+inference credit gates and atomic deduction RPC cannot see — those users were
+blocked with 402 "Insufficient credits" while their dashboard showed a
+positive balance. `_migrate_legacy_credit_balance` persists the legacy value
+into the tiered fields (subscription_allowance / purchased_credits).
+"""
+
+from unittest.mock import Mock
+
+from src.db.users import _migrate_legacy_credit_balance
+
+
+def _mock_client(update_returns_rows: bool = True):
+    client = Mock()
+    table_mock = Mock()
+    client.table.return_value = table_mock
+    table_mock.update.return_value = table_mock
+    table_mock.eq.return_value = table_mock
+    table_mock.execute.return_value = Mock(data=[{"id": 1}] if update_returns_rows else [])
+    return client, table_mock
+
+
+def test_migrates_legacy_credits_to_purchased_for_basic_user():
+    client, table_mock = _mock_client()
+    user = {
+        "id": 1,
+        "tier": "basic",
+        "subscription_status": None,
+        "credits": 12.5,
+        "subscription_allowance": 0,
+        "purchased_credits": 0,
+    }
+
+    _migrate_legacy_credit_balance(client, user)
+
+    table_mock.update.assert_called_once_with({"purchased_credits": 12.5, "credits": 0})
+    # Guarded update: id + credits unchanged since read
+    eq_calls = {call.args for call in table_mock.eq.call_args_list}
+    assert ("id", 1) in eq_calls
+    assert ("credits", 12.5) in eq_calls
+    # In-memory user reflects the migration for this request
+    assert user["purchased_credits"] == 12.5
+    assert user["credits"] == 0
+
+
+def test_migrates_legacy_credits_to_allowance_for_active_pro_user():
+    client, table_mock = _mock_client()
+    user = {
+        "id": 2,
+        "tier": "pro",
+        "subscription_status": "active",
+        "credits": 30.0,
+        "subscription_allowance": 0,
+        "purchased_credits": 0,
+    }
+
+    _migrate_legacy_credit_balance(client, user)
+
+    table_mock.update.assert_called_once_with({"subscription_allowance": 30.0, "credits": 0})
+    assert user["subscription_allowance"] == 30.0
+    assert user["credits"] == 0
+
+
+def test_no_migration_when_tiered_balance_exists():
+    client, table_mock = _mock_client()
+    user = {
+        "id": 3,
+        "tier": "basic",
+        "credits": 10.0,
+        "subscription_allowance": 0,
+        "purchased_credits": 5.0,
+    }
+
+    _migrate_legacy_credit_balance(client, user)
+
+    table_mock.update.assert_not_called()
+    assert user["purchased_credits"] == 5.0
+    assert user["credits"] == 10.0
+
+
+def test_no_migration_when_no_legacy_credits():
+    client, table_mock = _mock_client()
+    user = {
+        "id": 4,
+        "tier": "basic",
+        "credits": 0,
+        "subscription_allowance": 0,
+        "purchased_credits": 0,
+    }
+
+    _migrate_legacy_credit_balance(client, user)
+
+    table_mock.update.assert_not_called()
+
+
+def test_lost_migration_race_keeps_unmigrated_view():
+    """When the guarded update matches no rows (another request already
+    migrated), the in-memory user must NOT be granted the balance again."""
+    client, table_mock = _mock_client(update_returns_rows=False)
+    user = {
+        "id": 5,
+        "tier": "basic",
+        "subscription_status": None,
+        "credits": 12.5,
+        "subscription_allowance": 0,
+        "purchased_credits": 0,
+    }
+
+    _migrate_legacy_credit_balance(client, user)
+
+    assert user["purchased_credits"] == 0
+    assert user["credits"] == 12.5
+
+
+def test_migration_failure_is_non_fatal():
+    client = Mock()
+    client.table.side_effect = RuntimeError("db down")
+    user = {
+        "id": 6,
+        "tier": "basic",
+        "credits": 12.5,
+        "subscription_allowance": 0,
+        "purchased_credits": 0,
+    }
+
+    # Must not raise — auth path continues with the un-migrated view
+    _migrate_legacy_credit_balance(client, user)
+    assert user["credits"] == 12.5

--- a/tests/security/test_subscription_status_gate.py
+++ b/tests/security/test_subscription_status_gate.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""
+Tests for enforce_subscription_status_gate.
+
+Payment-lapse statuses (canceled, past_due, ...) must not lock out prepaid
+purchased credits — those are retained on cancellation and were already paid
+for. Hard-blocked abuse statuses (bot, suspended) block regardless of balance.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from src.security.inference_gates import enforce_subscription_status_gate
+
+
+def test_active_user_passes():
+    enforce_subscription_status_gate({"id": 1, "subscription_status": "active"})
+
+
+def test_none_user_and_missing_status_pass():
+    enforce_subscription_status_gate(None)
+    enforce_subscription_status_gate({"id": 1})
+
+
+def test_canceled_user_without_balance_is_blocked():
+    user = {
+        "id": 2,
+        "subscription_status": "canceled",
+        "purchased_credits": 0,
+        "subscription_allowance": 0,
+        "credits": 0,
+    }
+    with pytest.raises(HTTPException) as exc_info:
+        enforce_subscription_status_gate(user)
+    assert exc_info.value.status_code == 403
+
+
+def test_canceled_user_with_purchased_credits_is_allowed():
+    user = {
+        "id": 3,
+        "subscription_status": "canceled",
+        "purchased_credits": 4.20,
+        "subscription_allowance": 0,
+        "credits": 0,
+    }
+    enforce_subscription_status_gate(user)
+
+
+def test_past_due_user_with_purchased_credits_is_allowed():
+    user = {
+        "id": 4,
+        "subscription_status": "past_due",
+        "purchased_credits": 1.0,
+    }
+    enforce_subscription_status_gate(user)
+
+
+def test_canceled_user_with_only_legacy_credits_is_allowed():
+    user = {
+        "id": 5,
+        "subscription_status": "canceled",
+        "purchased_credits": 0,
+        "subscription_allowance": 0,
+        "credits": 9.99,
+    }
+    enforce_subscription_status_gate(user)
+
+
+@pytest.mark.parametrize("status", ["bot", "suspended"])
+def test_hard_blocked_statuses_block_even_with_credits(status):
+    user = {
+        "id": 6,
+        "subscription_status": status,
+        "purchased_credits": 100.0,
+        "credits": 100.0,
+    }
+    with pytest.raises(HTTPException) as exc_info:
+        enforce_subscription_status_gate(user)
+    assert exc_info.value.status_code == 403

--- a/tests/security/test_vibe_audit_hardening.py
+++ b/tests/security/test_vibe_audit_hardening.py
@@ -52,7 +52,10 @@ async def test_guard_allows_under_limit(monkeypatch):
     monkeypatch.delenv("DISABLE_RATE_LIMITING", raising=False)
 
     class _Mgr:
-        async def check_rate_limit(self, api_key, tokens_used=0):
+        async def check_rate_limit(self, api_key, tokens_used=0, **kwargs):
+            # The guard must not take a concurrency slot: it has no release
+            # hook, so an acquired slot would leak permanently.
+            assert kwargs.get("acquire_concurrency") is False
             return _Result(allowed=True)
 
     monkeypatch.setattr(rate_limit_guard, "get_rate_limit_manager", lambda: _Mgr())
@@ -66,7 +69,7 @@ async def test_guard_raises_429_over_limit(monkeypatch):
     monkeypatch.delenv("DISABLE_RATE_LIMITING", raising=False)
 
     class _Mgr:
-        async def check_rate_limit(self, api_key, tokens_used=0):
+        async def check_rate_limit(self, api_key, tokens_used=0, **kwargs):
             return _Result(allowed=False, reason="Rate limit exceeded", retry_after=42)
 
     monkeypatch.setattr(rate_limit_guard, "get_rate_limit_manager", lambda: _Mgr())

--- a/tests/services/test_rate_limiting.py
+++ b/tests/services/test_rate_limiting.py
@@ -112,10 +112,7 @@ async def test_check_rate_limit_happy_path_local(monkeypatch, mod, fake_fallback
 
 @pytest.mark.anyio
 async def test_concurrency_limit_exceeded(mod, fake_fallback):
-    """Test concurrency limit - currently disabled in source code (see rate_limiting.py lines 94-104)"""
-    pytest.skip(
-        "Concurrency limiting temporarily disabled - see rate_limiting.py _check_concurrency_limit()"
-    )
+    """Concurrency limit blocks when all slots are held."""
     limiter = mod.SlidingWindowRateLimiter(redis_client=None)
     cfg = mod.RateLimitConfig(
         concurrency_limit=1, burst_limit=50, requests_per_minute=60, tokens_per_minute=10000
@@ -128,6 +125,72 @@ async def test_concurrency_limit_exceeded(mod, fake_fallback):
     assert res.allowed is False
     assert "Concurrency" in res.reason
     assert res.retry_after == 60
+
+
+@pytest.mark.anyio
+async def test_allowed_check_takes_concurrency_slot_and_release_frees_it(mod, fake_fallback):
+    """An allowed check takes a slot; release_concurrent_request frees it."""
+    limiter = mod.SlidingWindowRateLimiter(redis_client=None)
+    cfg = mod.RateLimitConfig(
+        concurrency_limit=1, burst_limit=50, requests_per_minute=60, tokens_per_minute=10000
+    )
+
+    res1 = await limiter.check_rate_limit("keyD", cfg, tokens_used=0)
+    assert res1.allowed is True
+    assert limiter.concurrent_requests["keyD"] == 1
+
+    # Slot is held -> second concurrent request is blocked
+    res2 = await limiter.check_rate_limit("keyD", cfg, tokens_used=0)
+    assert res2.allowed is False
+    assert "Concurrency" in res2.reason
+
+    # Releasing frees the slot again
+    await limiter.release_concurrent_request("keyD")
+    assert limiter.concurrent_requests["keyD"] == 0
+    res3 = await limiter.check_rate_limit("keyD", cfg, tokens_used=0)
+    assert res3.allowed is True
+
+
+@pytest.mark.anyio
+async def test_accounting_only_check_does_not_consume(mod, fake_fallback):
+    """acquire_concurrency=False / count_request=False must not take a slot,
+    consume a burst token, or count a second request (used by the post-request
+    token accounting check in chat.py)."""
+    limiter = mod.SlidingWindowRateLimiter(redis_client=None)
+    cfg = mod.RateLimitConfig(
+        concurrency_limit=1, burst_limit=50, requests_per_minute=60, tokens_per_minute=10000
+    )
+
+    res = await limiter.check_rate_limit(
+        "keyE", cfg, tokens_used=123, acquire_concurrency=False, count_request=False
+    )
+    assert res.allowed is True
+    # No concurrency slot taken
+    assert limiter.concurrent_requests.get("keyE", 0) == 0
+    # No request counted in the sliding window
+    assert len(limiter.local_cache["keyE"]["requests"]) == 0
+    # But the tokens ARE recorded
+    assert sum(amount for _, amount in limiter.local_cache["keyE"]["tokens"]) == 123
+
+
+@pytest.mark.anyio
+async def test_local_burst_bucket_refills_over_time(mod, fake_fallback, monkeypatch):
+    """The local (no-Redis) burst bucket must refill over time; before the fix
+    it only ever drained, permanently 429ing every key on a long-lived worker."""
+    limiter = mod.SlidingWindowRateLimiter(redis_client=None)
+    cfg = mod.RateLimitConfig(
+        concurrency_limit=10, burst_limit=60, requests_per_minute=1000, tokens_per_minute=100000
+    )
+
+    # Drain the bucket completely
+    limiter.burst_tokens["keyF"] = 0
+    limiter.burst_last_refill["keyF"] = 1000.0
+
+    # 30 seconds later, half the bucket (30 tokens at 60/min) has refilled
+    monkeypatch.setattr(mod.time, "time", lambda: 1030.0)
+    burst = await limiter._check_burst_limit("keyF", cfg)
+    assert burst["allowed"] is True
+    assert burst["remaining"] >= 28  # ~30 refilled minus the one consumed
 
 
 # -------------------- Burst limit (local path) --------------------


### PR DESCRIPTION
Fixes three user-reported production issues: free models constantly returning rate-limit errors, raw provider error internals showing up in the frontend, and users with credits being blocked from paid models.

## 1. Rate limiting — per-key limiter state only ever got stricter (`cc9cbe7`)

- **Leaked concurrency slots**: every admitted request took a concurrency slot, but only the successful non-streaming chat path released it. Streamed chats, failed requests, and the images/audio/payments guard (which has no release hook at all) each leaked a slot; at 50 leaked slots the key was permanently `429 "Concurrency limit exceeded"` until worker restart. Slots are now released on all route error paths and when the authenticated stream generator finishes; the expensive-endpoint guard no longer acquires one.
- **Local burst bucket never refilled**: without Redis (which is how `get_rate_limit_manager()` always runs) the token bucket only drained, so every key became permanently "Burst limit exceeded" after `burst_limit` lifetime requests. It now refills over time, matching the Redis path.
- **Double counting**: the post-request accounting check consumed a second request, second burst token, and a second (never-released) concurrency slot per request. New `acquire_concurrency` / `count_request` flags let it record tokens only.
- Upstream provider 429s (common on `:free` models, which are provider-locked and share account-wide limits) are now clearly labeled as provider congestion — not the caller's account limit — with `Retry-After` always set and a new `X-RateLimit-Scope: upstream` header so clients can tell the two apart.
- Un-skips the stale concurrency test and adds regression tests for slot release, accounting-only checks, and burst refill.

## 2. Error responses — sanitize for users, alert telemetry (`e801b58`)

- `map_provider_error` embedded raw `str(exc)` and upstream response bodies (which can contain key ids, dashboard URLs, infra details) into client-visible details on the anonymous and streaming paths. Every branch now goes through `sanitize_provider_error_for_user`; raw bodies are logged server-side only.
- `AutoSentryMiddleware` deliberately skips `HTTPException`, so none of these provider failures ever reached Sentry. Upstream failures mapped to 402/429/5xx are now captured via `capture_provider_error`.
- Streaming SSE error chunks no longer embed raw exception text; stream provider failures are captured to Sentry.
- `/v1/images/generations` 500s no longer include raw exception text.

## 3. Billing — users with credits couldn't use paid models (`b667656`)

- Balances in the legacy `users.credits` column were counted by the dashboard (display-only fallback in `get_user_profile`) but invisible to the chat credit gates **and** the atomic deduction RPC — those users saw a balance and got 402 on every paid request. `get_user()` now persists the legacy balance into the tiered fields on first lookup via a guarded compare-and-swap update (concurrent requests cannot duplicate the balance), making it visible to the gates and actually spendable/deductible.
- `enforce_subscription_status_gate` 403'd all blocked statuses uniformly, locking canceled/past_due users out of purchased credits that are deliberately retained on cancellation. Payment-lapse statuses now pass when a prepaid balance exists; abuse statuses stay hard-blocked (`bot`, `suspended`, configurable via new `HARD_BLOCKED_SUBSCRIPTION_STATUSES` env var).

## Testing

- 18 new regression tests (`tests/services/test_rate_limiting.py`, `tests/billing/test_legacy_credit_migration.py`, `tests/security/test_subscription_status_gate.py`).
- ~1,750 tests across services/handlers/routes/billing/security/conceptual-model pass locally; remaining failures verified identical on unmodified main (env-dependent DB access + pre-existing cross-suite pollution).
- Black + ruff clean with CI flags on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWiZ1xkKrs4xrWarK5AmX5

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWiZ1xkKrs4xrWarK5AmX5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscription access now distinguishes hard-blocked statuses from payment-lapse statuses, allowing eligible users with prepaid credits to continue.
  * Legacy credit balances are automatically transferred to the appropriate spendable credit balance during sign-in.

* **Bug Fixes**
  * Improved rate-limit tracking prevents stuck concurrency limits and repeated rate-limit errors.
  * Streaming requests now release rate-limit capacity correctly.
  * Provider and image-generation errors now show clearer, safer messages without exposing internal details.
  * Upstream rate-limit responses now include standardized retry guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->