### PR TITLE
fix(routing): authenticated non-streaming chat completions now fail over across provider_chain

### DIFF
--- a/src/routes/chat_dispatch.py
+++ b/src/routes/chat_dispatch.py
@@ -386,111 +386,137 @@ async def dispatch_non_streaming(
     processed = None
     last_http_exc = None
 
-    # Use unified handler for authenticated non-streaming requests
+    # Use unified handler for authenticated non-streaming requests, with failover
+    # across provider_chain — mirrors dispatch_streaming's _auth_stream_with_failover
+    # loop below. Previously this attempted exactly one provider (the stale,
+    # pre-smart-router `provider` value) with no failover at all.
     if not is_anonymous:
-        try:
-            logger.info(
-                f"[Unified Handler] Processing authenticated non-streaming request for model {original_model}"
+        if not provider_chain:
+            raise HTTPException(
+                status_code=502,
+                detail={"error": {"message": f"No providers available for model {original_model}"}},
             )
-
-            # Convert external OpenAI format to internal format
-            adapter = OpenAIChatAdapter()
-            internal_request = adapter.to_internal_request(
-                {"messages": messages, "model": original_model, "stream": False, **optional}
-            )
-            # Pass the detected provider so the handler doesn't have to re-detect
-            internal_request.provider = provider
-
-            # Create unified handler with user context (pass request for disconnect detection)
-            handler = ChatInferenceHandler(api_key, background_tasks, request=request)
-
-            # Wrap with AITracer for gen_ai.* telemetry + track duration for Prometheus
-            inference_start = time.time()
-            async with AITracer.trace_inference(
-                provider="openrouter",  # Will be updated after response
-                model=original_model,
-                request_type=AIRequestType.CHAT_COMPLETION,
-                operation_name=f"unified_handler/{original_model}",
-            ) as trace_ctx:
-                # Process request through unified pipeline
-                internal_response = await handler.process(internal_request)
-
-                # Convert internal response back to OpenAI format
-                processed = adapter.from_internal_response(internal_response)
-
-                # Extract values for postprocessing
-                provider = internal_response.provider_used or "openrouter"
-                model = internal_response.model or original_model
-
-                # Set trace attributes with actual values from response
-                usage = processed.get("usage", {}) or {}
-                input_tokens = usage.get("prompt_tokens", 0)
-                output_tokens = usage.get("completion_tokens", 0)
-                trace_ctx.set_token_usage(
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    total_tokens=usage.get("total_tokens", 0),
+        for idx, attempt_provider in enumerate(provider_chain):
+            is_last = idx == len(provider_chain) - 1
+            try:
+                logger.info(
+                    f"[Unified Handler] Processing authenticated non-streaming request for model "
+                    f"{original_model} (provider={attempt_provider}, attempt {idx + 1}/{len(provider_chain)})"
                 )
-                trace_ctx.set_response_model(
-                    response_model=model,
-                    finish_reason=(
-                        processed.get("choices", [{}])[0].get("finish_reason")
-                        if processed.get("choices")
-                        else None
-                    ),
-                    response_id=processed.get("id"),
+
+                # Convert external OpenAI format to internal format
+                adapter = OpenAIChatAdapter()
+                internal_request = adapter.to_internal_request(
+                    {"messages": messages, "model": original_model, "stream": False, **optional}
                 )
-                if optional:
-                    trace_ctx.set_model_parameters(
-                        temperature=optional.get("temperature"),
-                        max_tokens=optional.get("max_tokens"),
-                        top_p=optional.get("top_p"),
-                        frequency_penalty=optional.get("frequency_penalty"),
-                        presence_penalty=optional.get("presence_penalty"),
+                # Set the provider for this attempt
+                internal_request.provider = attempt_provider
+
+                # Create unified handler with user context (pass request for disconnect detection)
+                handler = ChatInferenceHandler(api_key, background_tasks, request=request)
+
+                # Wrap with AITracer for gen_ai.* telemetry + track duration for Prometheus
+                inference_start = time.time()
+                async with AITracer.trace_inference(
+                    provider=attempt_provider,
+                    model=original_model,
+                    request_type=AIRequestType.CHAT_COMPLETION,
+                    operation_name=f"unified_handler/{original_model}",
+                ) as trace_ctx:
+                    # Process request through unified pipeline
+                    internal_response = await handler.process(internal_request)
+
+                    # Convert internal response back to OpenAI format
+                    processed = adapter.from_internal_response(internal_response)
+
+                    # Extract values for postprocessing
+                    provider = internal_response.provider_used or attempt_provider
+                    model = internal_response.model or original_model
+
+                    # Set trace attributes with actual values from response
+                    usage = processed.get("usage", {}) or {}
+                    input_tokens = usage.get("prompt_tokens", 0)
+                    output_tokens = usage.get("completion_tokens", 0)
+                    trace_ctx.set_token_usage(
+                        input_tokens=input_tokens,
+                        output_tokens=output_tokens,
+                        total_tokens=usage.get("total_tokens", 0),
                     )
-                if user:
-                    trace_ctx.set_user_info(
-                        user_id=str(user.get("id")),
-                        tier="trial" if trial.get("is_trial") else "paid",
+                    trace_ctx.set_response_model(
+                        response_model=model,
+                        finish_reason=(
+                            processed.get("choices", [{}])[0].get("finish_reason")
+                            if processed.get("choices")
+                            else None
+                        ),
+                        response_id=processed.get("id"),
+                    )
+                    if optional:
+                        trace_ctx.set_model_parameters(
+                            temperature=optional.get("temperature"),
+                            max_tokens=optional.get("max_tokens"),
+                            top_p=optional.get("top_p"),
+                            frequency_penalty=optional.get("frequency_penalty"),
+                            presence_penalty=optional.get("presence_penalty"),
+                        )
+                    if user:
+                        trace_ctx.set_user_info(
+                            user_id=str(user.get("id")),
+                            tier="trial" if trial.get("is_trial") else "paid",
+                        )
+
+                # Record Prometheus metrics for model popularity tracking
+                inference_duration = time.time() - inference_start
+                exemplar = get_trace_exemplar()
+                model_inference_requests.labels(
+                    provider=provider, model=model, status="success"
+                ).inc(1, exemplar=exemplar)
+                model_inference_duration.labels(provider=provider, model=model).observe(
+                    inference_duration, exemplar=exemplar
+                )
+                if input_tokens > 0:
+                    tokens_used.labels(provider=provider, model=model, token_type="input").inc(
+                        input_tokens, exemplar=exemplar
+                    )
+                if output_tokens > 0:
+                    tokens_used.labels(provider=provider, model=model, token_type="output").inc(
+                        output_tokens, exemplar=exemplar
                     )
 
-            # Record Prometheus metrics for model popularity tracking
-            inference_duration = time.time() - inference_start
-            exemplar = get_trace_exemplar()
-            model_inference_requests.labels(provider=provider, model=model, status="success").inc(
-                1, exemplar=exemplar
-            )
-            model_inference_duration.labels(provider=provider, model=model).observe(
-                inference_duration, exemplar=exemplar
-            )
-            if input_tokens > 0:
-                tokens_used.labels(provider=provider, model=model, token_type="input").inc(
-                    input_tokens, exemplar=exemplar
+                logger.info(
+                    f"[Unified Handler] Successfully processed request: provider={provider}, model={model}"
                 )
-            if output_tokens > 0:
-                tokens_used.labels(provider=provider, model=model, token_type="output").inc(
-                    output_tokens, exemplar=exemplar
+                last_http_exc = None
+                break  # success — stop the failover loop
+
+            except Exception as exc:
+                # Record error metric for model popularity tracking
+                model_inference_requests.labels(
+                    provider=attempt_provider, model=original_model, status="error"
+                ).inc(1, exemplar=get_trace_exemplar())
+
+                http_exc = (
+                    exc
+                    if isinstance(exc, HTTPException)
+                    else map_provider_error(attempt_provider, original_model, exc)
                 )
 
-            logger.info(
-                f"[Unified Handler] Successfully processed request: provider={provider}, model={model}"
-            )
+                if not is_last and should_failover(http_exc):
+                    logger.warning(
+                        f"[Unified Handler] Provider '{attempt_provider}' failed "
+                        f"(HTTP {http_exc.status_code}) for model {original_model}, "
+                        f"failing over ({idx + 1}/{len(provider_chain)})"
+                    )
+                    last_http_exc = http_exc
+                    processed = None
+                    continue
 
-        except Exception as exc:
-            # Record error metric for model popularity tracking
-            error_provider = provider if "provider" in locals() else "openrouter"
-            error_model = model if "model" in locals() else original_model
-            model_inference_requests.labels(
-                provider=error_provider, model=error_model, status="error"
-            ).inc(1, exemplar=get_trace_exemplar())
-
-            # Map any errors to HTTPException
-            logger.error(f"[Unified Handler] Error: {type(exc).__name__}: {exc}", exc_info=True)
-            if isinstance(exc, HTTPException):
-                raise
-            # Map provider-specific errors (map_provider_error imported at module level)
-            http_exc = map_provider_error(error_provider, error_model, exc)
-            raise http_exc
+                logger.error(
+                    f"[Unified Handler] Provider '{attempt_provider}' failed for model "
+                    f"{original_model}: {type(exc).__name__}: {exc}",
+                    exc_info=True,
+                )
+                raise http_exc
     else:
         # Anonymous users: keep existing provider routing logic
         for idx, attempt_provider in enumerate(provider_chain):

--- a/tests/routes/test_chat_dispatch_non_streaming_failover.py
+++ b/tests/routes/test_chat_dispatch_non_streaming_failover.py
@@ -29,20 +29,20 @@ def _make_response(provider_used: str, model: str) -> InternalChatResponse:
 
 
 def _kwargs(**overrides):
-    base = dict(
-        is_anonymous=False,
-        provider_chain=["deepinfra", "openrouter"],
-        messages=[{"role": "user", "content": "hi"}],
-        original_model="allenai/Olmo-3.1-32B-Instruct",
-        optional={},
-        model="allenai/Olmo-3.1-32B-Instruct",
-        provider="openrouter",  # stale pre-routing value — must NOT be trusted anymore
-        api_key="test-key",
-        background_tasks=BackgroundTasks(),
-        request=None,
-        user={"id": 1},
-        trial={"is_trial": False},
-    )
+    base = {
+        "is_anonymous": False,
+        "provider_chain": ["deepinfra", "openrouter"],
+        "messages": [{"role": "user", "content": "hi"}],
+        "original_model": "allenai/Olmo-3.1-32B-Instruct",
+        "optional": {},
+        "model": "allenai/Olmo-3.1-32B-Instruct",
+        "provider": "openrouter",  # stale pre-routing value — must NOT be trusted anymore
+        "api_key": "test-key",
+        "background_tasks": BackgroundTasks(),
+        "request": None,
+        "user": {"id": 1},
+        "trial": {"is_trial": False},
+    }
     base.update(overrides)
     return base
 

--- a/tests/routes/test_chat_dispatch_non_streaming_failover.py
+++ b/tests/routes/test_chat_dispatch_non_streaming_failover.py
@@ -1,0 +1,117 @@
+"""Regression tests: authenticated non-streaming dispatch must fail over across
+provider_chain, matching dispatch_streaming's behavior. Previously it attempted
+exactly one provider (the stale, pre-smart-router `provider` value) and never
+consulted provider_chain at all.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+
+from src.handlers.chat_handler import ChatInferenceHandler
+from src.routes.chat_dispatch import dispatch_non_streaming
+from src.schemas.internal.chat import InternalChatResponse, InternalUsage
+
+
+def _make_response(provider_used: str, model: str) -> InternalChatResponse:
+    return InternalChatResponse(
+        id="resp-1",
+        model=model,
+        content="OK",
+        usage=InternalUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        finish_reason="stop",
+        provider_used=provider_used,
+        cost_usd=0.0,
+        input_cost_usd=0.0,
+        output_cost_usd=0.0,
+    )
+
+
+def _kwargs(**overrides):
+    base = dict(
+        is_anonymous=False,
+        provider_chain=["deepinfra", "openrouter"],
+        messages=[{"role": "user", "content": "hi"}],
+        original_model="allenai/Olmo-3.1-32B-Instruct",
+        optional={},
+        model="allenai/Olmo-3.1-32B-Instruct",
+        provider="openrouter",  # stale pre-routing value — must NOT be trusted anymore
+        api_key="test-key",
+        background_tasks=BackgroundTasks(),
+        request=None,
+        user={"id": 1},
+        trial={"is_trial": False},
+    )
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_fails_over_to_next_provider_on_failover_eligible_error():
+    """First provider raises a 401 (failover-eligible) -> second provider serves it."""
+    calls = []
+
+    async def fake_process(self, internal_request):
+        calls.append(internal_request.provider)
+        if internal_request.provider == "deepinfra":
+            raise HTTPException(status_code=401, detail="dead key")
+        return _make_response("openrouter", internal_request.model)
+
+    with patch.object(ChatInferenceHandler, "process", new=fake_process):
+        processed, provider, model = await dispatch_non_streaming(**_kwargs())
+
+    assert calls == ["deepinfra", "openrouter"]
+    assert provider == "openrouter"
+    assert processed["choices"][0]["message"]["content"] == "OK"
+
+
+@pytest.mark.asyncio
+async def test_succeeds_on_first_provider_without_trying_others():
+    calls = []
+
+    async def fake_process(self, internal_request):
+        calls.append(internal_request.provider)
+        return _make_response("deepinfra", internal_request.model)
+
+    with patch.object(ChatInferenceHandler, "process", new=fake_process):
+        processed, provider, model = await dispatch_non_streaming(**_kwargs())
+
+    assert calls == ["deepinfra"]
+    assert provider == "deepinfra"
+
+
+@pytest.mark.asyncio
+async def test_raises_after_exhausting_all_providers():
+    async def fake_process(self, internal_request):
+        raise HTTPException(status_code=401, detail="dead key")
+
+    with patch.object(ChatInferenceHandler, "process", new=fake_process):
+        with pytest.raises(HTTPException) as exc_info:
+            await dispatch_non_streaming(**_kwargs())
+
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_does_not_fail_over_on_non_failover_eligible_error():
+    """A 400 (bad request) must not trigger failover to the next provider."""
+    calls = []
+
+    async def fake_process(self, internal_request):
+        calls.append(internal_request.provider)
+        raise HTTPException(status_code=400, detail="bad request")
+
+    with patch.object(ChatInferenceHandler, "process", new=fake_process):
+        with pytest.raises(HTTPException) as exc_info:
+            await dispatch_non_streaming(**_kwargs())
+
+    assert calls == ["deepinfra"]
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_raises_502_when_provider_chain_is_empty():
+    with pytest.raises(HTTPException) as exc_info:
+        await dispatch_non_streaming(**_kwargs(provider_chain=[]))
+    assert exc_info.value.status_code == 502


### PR DESCRIPTION
## Summary
- `dispatch_non_streaming`'s authenticated branch called `ChatInferenceHandler.process()` exactly once with the stale pre-smart-router `provider` value, completely ignoring `provider_chain` — unlike `dispatch_streaming`'s already-correct failover loop right above it in the same file.
- In practice this meant the P3 cost-based routing work (smart router, canonicalization, price-unit fixes) never actually took effect for authenticated non-streaming requests — the majority of chat traffic. Every default-routed request went straight to OpenRouter with zero failover, regardless of what the smart router ranked as cheapest.
- Fix mirrors the existing streaming failover-loop pattern verbatim (same file, ~80 lines away).

## Test plan
- [x] New regression tests in `tests/routes/test_chat_dispatch_non_streaming_failover.py`: fails over on failover-eligible errors, succeeds on first try without extra attempts, raises after exhausting the chain, does NOT fail over on non-retryable errors (400), raises cleanly on an empty chain.
- [x] Existing `tests/routes/test_chat_client_ip_regression.py`, `tests/billing/test_billing_integrity.py`, `tests/services/test_provider_price_units.py` — all pass, no regressions.
- [x] Live-verified against staging: a DeepInfra-catalog model that previously 502'd via a dead OpenRouter key now returns 200 and routes to `deepinfra` directly (`gateway_usage.provider: "deepinfra"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved non-streaming chat reliability by automatically trying the next configured provider when an eligible provider failure occurs.
  * Ensured the response reflects the provider that successfully handled the request.
  * Preserved immediate error reporting for non-retryable failures.
  * Added a clear error response when no providers are available.

* **Tests**
  * Added coverage for successful requests, provider failover, exhausted provider chains, and non-retryable errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->