### PR TITLE
feat(ranking): source /ranking/models from real Gatewayz usage

### DIFF
--- a/src/db/ranking.py
+++ b/src/db/ranking.py
@@ -5,6 +5,21 @@ from src.config.supabase_config import get_supabase_client
 
 logger = logging.getLogger(__name__)
 
+# (time_period label, get_trending_models time_range) — the label values are a
+# public contract with the frontend (gatewayz-frontend reads these exact
+# strings: "Top today", "Top this week", "Top this month", "Trending").
+_TIME_BUCKETS: list[tuple[str, str]] = [
+    ("Trending", "1h"),
+    ("Top today", "24h"),
+    ("Top this week", "7d"),
+    ("Top this month", "30d"),
+]
+
+# Below this many real-usage rows for a bucket, fall back to the scraped
+# snapshot for that bucket so the page never renders empty while traffic is
+# still low. Logged (not silent) so it's obvious when this can be removed.
+_MIN_REAL_ROWS = 5
+
 
 def get_all_latest_models(
     limit: int | None = None, offset: int | None = None
@@ -52,6 +67,160 @@ def get_all_latest_models(
     except Exception as e:
         logger.error(f"Failed to get latest models: {e}")
         raise RuntimeError(f"Failed to get latest models: {e}") from e
+
+
+def _get_latest_models_for_bucket(time_period: str) -> list[dict[str, Any]]:
+    """Scraped-snapshot rows for one time_period bucket (fallback source)."""
+    try:
+        client = get_supabase_client()
+        result = (
+            client.table("latest_models")
+            .select("*")
+            .eq("time_period", time_period)
+            .order("rank", desc=False)
+            .execute()
+        )
+        return result.data or []
+    except Exception as e:
+        logger.error(f"Failed to get latest_models for bucket {time_period!r}: {e}")
+        return []
+
+
+def _format_tokens(total_tokens: int) -> str:
+    """Human-readable token count, e.g. 4650000000000 -> '4.65T tokens'."""
+    value = float(total_tokens or 0)
+    for threshold, suffix in ((1e12, "T"), (1e9, "B"), (1e6, "M"), (1e3, "K")):
+        if value >= threshold:
+            return f"{value / threshold:.2f}{suffix} tokens"
+    return f"{int(value)} tokens"
+
+
+def _derive_author(model_id: str) -> str:
+    if model_id and "/" in model_id:
+        return model_id.split("/", 1)[0]
+    return "Gatewayz"
+
+
+def _derive_model_url(model_id: str, provider_slug: str | None) -> str:
+    """Mirrors gatewayz-frontend's src/lib/utils.ts:getModelUrl path convention."""
+    if not model_id:
+        return "/models"
+    if ":" in model_id:
+        provider, name = model_id.split(":", 1)
+        return f"/models/{provider.lower()}/{name}"
+    if "/" in model_id:
+        return f"/models/{model_id}"
+    return f"/models/{(provider_slug or 'gatewayz').lower()}/{model_id}"
+
+
+def _build_catalog_index() -> dict[str, dict[str, Any]]:
+    """model id (and lowercased id) -> catalog row, for enriching usage stats."""
+    from src.services.models import get_cached_models
+
+    try:
+        catalog = get_cached_models("all") or []
+    except Exception as e:
+        logger.warning(f"Ranking: catalog fetch failed, enrichment will be partial: {e}")
+        catalog = []
+
+    index: dict[str, dict[str, Any]] = {}
+    for entry in catalog:
+        model_id = entry.get("id")
+        if not model_id:
+            continue
+        index[model_id] = entry
+        index.setdefault(model_id.lower(), entry)
+    return index
+
+
+def _usage_row_to_ranking_row(
+    stats: dict[str, Any], rank: int, time_period: str, catalog_index: dict[str, dict[str, Any]]
+) -> dict[str, Any]:
+    model_id = stats.get("model") or ""
+    catalog_entry = catalog_index.get(model_id) or catalog_index.get(model_id.lower()) or {}
+
+    author = _derive_author(model_id)
+    provider_slug = (
+        catalog_entry.get("provider_slug") or stats.get("gateway") or stats.get("provider")
+    )
+    model_name = catalog_entry.get("name") or model_id
+
+    return {
+        "rank": rank,
+        "model_name": model_name,
+        "author": author,
+        "tokens": _format_tokens(stats.get("total_tokens", 0)),
+        # No prior-window baseline is computed in this version — report flat
+        # rather than fabricate a trend delta.
+        "trend_percentage": "0%",
+        "trend_direction": "flat",
+        "trend_icon": "•",
+        "trend_color": "gray",
+        "model_url": _derive_model_url(model_id, provider_slug),
+        "author_url": f"/organizations/{author}",
+        "time_period": time_period,
+        "id": model_id,
+        "provider_slug": provider_slug,
+        "context_length": catalog_entry.get("context_length"),
+        "pricing": catalog_entry.get("pricing"),
+        "description": catalog_entry.get("description"),
+        "logo_url": generate_logo_url_from_author(author),
+        "requests": stats.get("requests", 0),
+        "unique_users": stats.get("unique_users", 0),
+        "source": "usage",
+    }
+
+
+def get_ranking_models_from_usage(
+    limit: int | None = None, offset: int | None = None
+) -> list[dict[str, Any]]:
+    """Ranking rows sourced from real Gatewayz usage (activity_log), enriched
+    from the model catalog, in the same shape as the legacy scraped
+    latest_models rows the frontend already consumes.
+
+    Falls back to the scraped snapshot per-bucket when a bucket doesn't yet
+    have enough real usage rows (traffic is still ramping up post-pivot).
+    """
+    from src.db.gateway_analytics import get_trending_models
+
+    catalog_index = _build_catalog_index()
+    rows: list[dict[str, Any]] = []
+
+    for time_period, time_range in _TIME_BUCKETS:
+        try:
+            usage_stats = get_trending_models(
+                gateway="all", time_range=time_range, limit=20, sort_by="requests"
+            )
+        except Exception as e:
+            logger.warning(f"Ranking: usage query failed for bucket {time_period!r}: {e}")
+            usage_stats = []
+
+        if len(usage_stats) < _MIN_REAL_ROWS:
+            logger.info(
+                f"Ranking: bucket {time_period!r} has only {len(usage_stats)} real usage rows "
+                f"(< {_MIN_REAL_ROWS}); falling back to scraped snapshot for this bucket"
+            )
+            rows.extend(_get_latest_models_for_bucket(time_period))
+            continue
+
+        rows.extend(
+            _usage_row_to_ranking_row(stats, idx + 1, time_period, catalog_index)
+            for idx, stats in enumerate(usage_stats)
+        )
+
+    # Backfill logo URLs for any row missing one (scraped rows fall through here too).
+    for row in rows:
+        if not row.get("logo_url"):
+            logo_url = generate_logo_url_from_author(row.get("author", ""))
+            if logo_url:
+                row["logo_url"] = logo_url
+
+    if offset:
+        rows = rows[offset:]
+    if limit:
+        rows = rows[:limit]
+
+    return rows
 
 
 def generate_logo_url_from_author(author: str) -> str:

--- a/src/routes/ranking.py
+++ b/src/routes/ranking.py
@@ -2,7 +2,7 @@ import logging
 
 from fastapi import APIRouter, HTTPException, Query
 
-from src.db.ranking import get_all_latest_apps, get_all_latest_models
+from src.db.ranking import get_all_latest_apps, get_ranking_models_from_usage
 
 # Initialize logging
 logger = logging.getLogger(__name__)
@@ -15,11 +15,12 @@ async def get_ranking_models(
     limit: int | None = Query(None, description="Limit number of results"),
     offset: int | None = Query(0, description="Offset for pagination"),
 ):
-    """Get all models from latest_models table for ranking page with logo URLs"""
+    """Get ranking models sourced from real Gatewayz usage, falling back to the
+    scraped snapshot per time-period bucket while traffic is still low."""
     try:
         # Get models with pagination support
-        models = get_all_latest_models(limit=limit, offset=offset)
-        logger.info(f"Retrieved {len(models)} models from latest_models table")
+        models = get_ranking_models_from_usage(limit=limit, offset=offset)
+        logger.info(f"Retrieved {len(models)} ranking models")
 
         return {
             "success": True,

--- a/tests/db/test_ranking.py
+++ b/tests/db/test_ranking.py
@@ -23,3 +23,117 @@ class TestRanking:
         from src.db import ranking
 
         assert hasattr(ranking, "__name__")
+
+
+class TestFormatTokens:
+    def test_formats_trillions(self):
+        from src.db.ranking import _format_tokens
+
+        assert _format_tokens(4_650_000_000_000) == "4.65T tokens"
+
+    def test_formats_small_counts_without_suffix(self):
+        from src.db.ranking import _format_tokens
+
+        assert _format_tokens(42) == "42 tokens"
+
+    def test_handles_none(self):
+        from src.db.ranking import _format_tokens
+
+        assert _format_tokens(None) == "0 tokens"
+
+
+class TestDeriveModelUrl:
+    def test_org_slash_model_form(self):
+        from src.db.ranking import _derive_model_url
+
+        assert _derive_model_url("openai/gpt-5.1", "openai") == "/models/openai/gpt-5.1"
+
+    def test_colon_provider_form(self):
+        from src.db.ranking import _derive_model_url
+
+        assert _derive_model_url("aimo:model-name", None) == "/models/aimo/model-name"
+
+    def test_bare_model_id_uses_provider_slug(self):
+        from src.db.ranking import _derive_model_url
+
+        assert _derive_model_url("gemma-4-31b", "cerebras") == "/models/cerebras/gemma-4-31b"
+
+
+class TestGetRankingModelsFromUsage:
+    """get_ranking_models_from_usage: real-usage rows enriched from the catalog,
+    with a per-bucket fallback to the scraped snapshot when usage is sparse."""
+
+    @patch("src.db.ranking._get_latest_models_for_bucket")
+    @patch("src.db.gateway_analytics.get_trending_models")
+    @patch("src.services.models.get_cached_models")
+    def test_enriches_usage_rows_from_catalog_when_above_floor(
+        self, mock_catalog, mock_trending, mock_fallback
+    ):
+        from src.db.ranking import _MIN_REAL_ROWS, get_ranking_models_from_usage
+
+        mock_catalog.return_value = [
+            {
+                "id": "openai/gpt-5.1",
+                "name": "GPT-5.1",
+                "provider_slug": "openai",
+                "context_length": 128000,
+                "pricing": {"prompt": "1e-06", "completion": "2e-06"},
+            }
+        ]
+        usage_rows = [
+            {
+                "model": "openai/gpt-5.1",
+                "provider": "openai",
+                "gateway": "openai",
+                "requests": 100,
+                "total_tokens": 4_650_000_000_000,
+                "unique_users": 12,
+            }
+        ] * _MIN_REAL_ROWS
+        mock_trending.return_value = usage_rows
+
+        rows = get_ranking_models_from_usage(limit=1)
+
+        mock_fallback.assert_not_called()
+        assert rows[0]["model_name"] == "GPT-5.1"
+        assert rows[0]["author"] == "openai"
+        assert rows[0]["provider_slug"] == "openai"
+        assert rows[0]["tokens"] == "4.65T tokens"
+        assert rows[0]["time_period"] == "Trending"
+        assert rows[0]["model_url"] == "/models/openai/gpt-5.1"
+        assert rows[0]["rank"] == 1
+
+    @patch("src.db.ranking._get_latest_models_for_bucket")
+    @patch("src.db.gateway_analytics.get_trending_models")
+    @patch("src.services.models.get_cached_models")
+    def test_falls_back_to_scraped_snapshot_below_floor(
+        self, mock_catalog, mock_trending, mock_fallback
+    ):
+        from src.db.ranking import get_ranking_models_from_usage
+
+        mock_catalog.return_value = []
+        mock_trending.return_value = []  # every bucket is below the floor
+        mock_fallback.return_value = [{"model_name": "Scraped Model", "rank": 1}]
+
+        rows = get_ranking_models_from_usage()
+
+        # 4 time buckets, each falling back
+        assert mock_fallback.call_count == 4
+        assert all(r["model_name"] == "Scraped Model" for r in rows)
+
+    @patch("src.db.ranking._get_latest_models_for_bucket")
+    @patch("src.db.gateway_analytics.get_trending_models")
+    @patch("src.services.models.get_cached_models")
+    def test_unknown_model_still_produces_a_row(self, mock_catalog, mock_trending, mock_fallback):
+        """A model with usage but no catalog entry shouldn't be dropped."""
+        from src.db.ranking import _MIN_REAL_ROWS, get_ranking_models_from_usage
+
+        mock_catalog.return_value = []
+        mock_trending.return_value = [
+            {"model": "some/untracked-model", "requests": 1, "total_tokens": 10}
+        ] * _MIN_REAL_ROWS
+
+        rows = get_ranking_models_from_usage(limit=1)
+
+        assert rows[0]["model_name"] == "some/untracked-model"
+        assert rows[0]["author"] == "some"


### PR DESCRIPTION
## Summary
- `/ranking/models` served the `latest_models` table — a stale scraped snapshot of OpenRouter's own leaderboard (`model_url` pointed at openrouter.ai, `scraped_at` from April) — despite Gatewayz already having real usage data in `activity_log` via `get_trending_models()`.
- The frontend (`gatewayz-frontend`: `page.tsx`, `organizations/[name]/page.tsx`, `start/api/page.tsx`, `developers/page.tsx`, `onboarding/page.tsx`) is tightly coupled to the exact row shape and `time_period` bucket values (`"Top today"`, `"Top this week"`, `"Top this month"`, `"Trending"`) — a same-repo-only swap to the real endpoint's shape would break all 5 pages.
- New `get_ranking_models_from_usage()` (`src/db/ranking.py`) computes each bucket from real usage, enriches from the model catalog (name, pricing, context_length, provider_slug), and formats into the same shape the frontend already consumes. Falls back to the scraped snapshot **per bucket** when real usage is below a floor (5 rows) so pages don't render empty while traffic ramps up post-pivot — logged, not silent.
- No fabricated trend data: `trend_percentage`/`trend_direction` default to `"0%"`/`"flat"` since no prior-window baseline is computed in this version.

## Test plan
- [x] New unit tests in `tests/db/test_ranking.py` (formatting, URL derivation, enrichment, per-bucket fallback, unknown-model handling) — 11/11 pass.
- [x] Live-verified against staging: `/ranking/models` now returns real usage-sourced rows enriched from the catalog, with correct per-bucket fallback logging when a bucket is below the floor.
- [x] `black`/`ruff`/`isort` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)