### PR TITLE
Admin panel observability: persist failed requests, status/is_free filters, provider auth alerting

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -395,6 +395,11 @@ class Config:
     ADMIN_EMAIL = os.environ.get("ADMIN_EMAIL")
     GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
 
+    # Ops Alerting Configuration
+    # Destination for provider-auth-failure alerts (src/services/provider_alerting.py).
+    # Unset (default) means alerting is a no-op — see startup.py warning.
+    OPS_ALERT_EMAIL: str | None = os.environ.get("OPS_ALERT_EMAIL")
+
     # Admin Credit Grant Safety Controls
     # Maximum single credit grant amount in dollars (default $1000)
     ADMIN_MAX_CREDIT_GRANT: float = float(os.environ.get("ADMIN_MAX_CREDIT_GRANT", "1000"))

--- a/src/db/chat_completion_requests_enhanced.py
+++ b/src/db/chat_completion_requests_enhanced.py
@@ -66,11 +66,20 @@ def save_chat_completion_request_with_cost(
             model_id = get_model_id_by_name(model_name, provider_name)
 
         if model_id is None:
-            logger.warning(
-                f"Skipping chat completion request save: model not found in database "
-                f"(model_name={model_name}, provider={provider_name})"
-            )
-            return None
+            if status == "failed":
+                # Persist failed requests even when the model can't be resolved —
+                # these are exactly the failures worth surfacing (e.g. a dead
+                # provider key or a model removed from the catalog).
+                logger.warning(
+                    f"Saving failed chat completion request with unresolved model "
+                    f"(model_name={model_name}, provider={provider_name})"
+                )
+            else:
+                logger.warning(
+                    f"Skipping chat completion request save: model not found in database "
+                    f"(model_name={model_name}, provider={provider_name})"
+                )
+                return None
 
         # Prepare the data with cost fields
         request_data = {
@@ -96,6 +105,11 @@ def save_chat_completion_request_with_cost(
             request_data["api_key_id"] = api_key_id
         if metadata:
             request_data["metadata"] = metadata
+        if model_id is None and status == "failed":
+            request_data["metadata"] = {
+                **(request_data.get("metadata") or {}),
+                "unresolved_model_name": model_name,
+            }
 
         # Insert into database
         result = client.table("chat_completion_requests").insert(request_data).execute()

--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -2502,6 +2502,7 @@ async def get_model_usage_analytics(
     page: int = Query(1, ge=1, description="Page number (starts at 1)"),
     limit: int = Query(50, ge=1, le=500, description="Items per page (max 500)"),
     model_name: str = Query(None, description="Search by model name (partial match)"),
+    is_free: bool | None = Query(None, description="Filter by free-tier flag (true/false)"),
     sort_by: str = Query(
         "total_cost_usd", description="Sort by field (total_cost_usd, successful_requests, etc.)"
     ),
@@ -2522,6 +2523,7 @@ async def get_model_usage_analytics(
     Supports:
     - Pagination: ?page=1&limit=50
     - Search: ?model_name=gpt (partial match, case-insensitive)
+    - Filtering: ?is_free=true (free-tier only) or ?is_free=false (paid only)
     - Sorting: ?sort_by=total_cost_usd&sort_order=desc
     """
     try:
@@ -2539,6 +2541,9 @@ async def get_model_usage_analytics(
         if model_name:
             # Use ilike for case-insensitive partial match
             query = query.ilike("model_name", f"%{model_name}%")
+
+        if is_free is not None:
+            query = query.eq("is_free", is_free)
 
         # Validate sort_by field (prevent SQL injection)
         valid_sort_fields = [

--- a/src/routes/monitoring.py
+++ b/src/routes/monitoring.py
@@ -1165,6 +1165,9 @@ async def get_chat_completion_requests(
     model_id: int | None = Query(None, description="Filter by model ID"),
     provider_id: int | None = Query(None, description="Filter by provider ID"),
     model_name: str | None = Query(None, description="Filter by model name (contains)"),
+    status: str | None = Query(
+        None, description="Filter by request status (completed, failed, partial)"
+    ),
     start_date: str | None = Query(
         None, description="Filter by start date (ISO format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)"
     ),
@@ -1240,6 +1243,9 @@ async def get_chat_completion_requests(
             # Use ilike for case-insensitive partial matching
             query = query.ilike("models.model_name", f"%{model_name}%")
 
+        if status is not None:
+            query = query.eq("status", status)
+
         if start_date is not None:
             query = query.gte("created_at", start_date)
 
@@ -1259,6 +1265,8 @@ async def get_chat_completion_requests(
 
         if model_id is not None:
             count_query = count_query.eq("model_id", model_id)
+        if status is not None:
+            count_query = count_query.eq("status", status)
 
         # Note: Filtering by provider_id or model_name requires joins,
         # so we'll use the result length as an approximation for now
@@ -1278,6 +1286,7 @@ async def get_chat_completion_requests(
                     "model_id": model_id,
                     "provider_id": provider_id,
                     "model_name": model_name,
+                    "status": status,
                     "start_date": start_date,
                     "end_date": end_date,
                 },

--- a/src/services/provider_alerting.py
+++ b/src/services/provider_alerting.py
@@ -1,0 +1,63 @@
+"""Rate-limited operational alerting for provider-level failures.
+
+Reuses NotificationService's existing Resend email integration — this is
+NOT the user-facing notification system (src/schemas/notification.py
+NotificationType enum), it's a separate ops channel to OPS_ALERT_EMAIL.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from src.config import Config
+from src.services.notification import NotificationService
+
+logger = logging.getLogger(__name__)
+
+_ALERT_COOLDOWN_SECONDS = 15 * 60
+
+# provider name -> last alert unix timestamp. In-process only (per-instance);
+# acceptable because the goal is "don't spam", not exactly-once delivery.
+_last_alert_sent_at: dict[str, float] = {}
+
+
+def alert_provider_auth_failure(provider: str, model: str, error_detail: str) -> None:
+    """Send an ops email when a provider rejects our credentials.
+
+    Rate-limited to one email per provider per 15 minutes. No-op if
+    OPS_ALERT_EMAIL is not configured.
+    """
+    if not Config.OPS_ALERT_EMAIL:
+        return
+
+    now = time.time()
+    last_sent = _last_alert_sent_at.get(provider)
+    if last_sent is not None and (now - last_sent) < _ALERT_COOLDOWN_SECONDS:
+        logger.debug(
+            "Suppressing duplicate provider auth alert for %s (last sent %.0fs ago)",
+            provider,
+            now - last_sent,
+        )
+        return
+
+    try:
+        service = NotificationService()
+        sent = service.send_email_notification(
+            to_email=Config.OPS_ALERT_EMAIL,
+            subject=f"[Gatewayz] {provider} authentication failure",
+            html_content=(
+                f"<p>Provider <b>{provider}</b> rejected a request for model "
+                f"<b>{model}</b>:</p><pre>{error_detail}</pre>"
+                f"<p>This usually means the provider's API key was rotated/revoked. "
+                f"Check Railway env vars for the corresponding key.</p>"
+            ),
+            text_content=(
+                f"Provider {provider} rejected a request for model {model}: {error_detail}\n"
+                f"This usually means the provider's API key was rotated/revoked."
+            ),
+        )
+        if sent:
+            _last_alert_sent_at[provider] = now
+    except Exception as e:  # noqa: BLE001 - alerting must never break the request path
+        logger.error("Failed to send provider auth failure alert: %s", e)

--- a/src/services/provider_alerting.py
+++ b/src/services/provider_alerting.py
@@ -7,6 +7,7 @@ NotificationType enum), it's a separate ops channel to OPS_ALERT_EMAIL.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 
@@ -41,23 +42,37 @@ def alert_provider_auth_failure(provider: str, model: str, error_detail: str) ->
         )
         return
 
+    def _send() -> None:
+        try:
+            service = NotificationService()
+            sent = service.send_email_notification(
+                to_email=Config.OPS_ALERT_EMAIL,
+                subject=f"[Gatewayz] {provider} authentication failure",
+                html_content=(
+                    f"<p>Provider <b>{provider}</b> rejected a request for model "
+                    f"<b>{model}</b>:</p><pre>{error_detail}</pre>"
+                    f"<p>This usually means the provider's API key was rotated/revoked. "
+                    f"Check Railway env vars for the corresponding key.</p>"
+                ),
+                text_content=(
+                    f"Provider {provider} rejected a request for model {model}: {error_detail}\n"
+                    f"This usually means the provider's API key was rotated/revoked."
+                ),
+            )
+            if sent:
+                _last_alert_sent_at[provider] = now
+        except Exception as e:  # noqa: BLE001 - alerting must never break the request path
+            logger.error("Failed to send provider auth failure alert: %s", e)
+
+    # NotificationService.send_email_notification() makes a synchronous,
+    # un-timed HTTP call to Resend. This function is reached from the async
+    # request-handling path (dispatch_streaming -> map_provider_error), so
+    # run the blocking send in a worker thread instead of stalling the event
+    # loop for every concurrent request during an auth-failure storm. Falls
+    # back to an inline (blocking) send when there's no running event loop
+    # (e.g. sync callers/tests) so the alert is still attempted.
     try:
-        service = NotificationService()
-        sent = service.send_email_notification(
-            to_email=Config.OPS_ALERT_EMAIL,
-            subject=f"[Gatewayz] {provider} authentication failure",
-            html_content=(
-                f"<p>Provider <b>{provider}</b> rejected a request for model "
-                f"<b>{model}</b>:</p><pre>{error_detail}</pre>"
-                f"<p>This usually means the provider's API key was rotated/revoked. "
-                f"Check Railway env vars for the corresponding key.</p>"
-            ),
-            text_content=(
-                f"Provider {provider} rejected a request for model {model}: {error_detail}\n"
-                f"This usually means the provider's API key was rotated/revoked."
-            ),
-        )
-        if sent:
-            _last_alert_sent_at[provider] = now
-    except Exception as e:  # noqa: BLE001 - alerting must never break the request path
-        logger.error("Failed to send provider auth failure alert: %s", e)
+        asyncio.get_running_loop()
+        asyncio.create_task(asyncio.to_thread(_send))
+    except RuntimeError:
+        _send()

--- a/src/services/provider_failover.py
+++ b/src/services/provider_failover.py
@@ -7,6 +7,7 @@ import re
 import httpx
 from fastapi import HTTPException
 
+from src.services.provider_alerting import alert_provider_auth_failure
 from src.utils.error_messages import (
     is_provider_budget_error,
     sanitize_provider_error_for_user,
@@ -564,6 +565,7 @@ def _map_provider_error_impl(
             detail = f"{provider} authentication error"
             # Always map auth errors to 401 for consistency
             status = 401
+            alert_provider_auth_failure(provider, model, str(exc)[:500])
         elif NotFoundError and isinstance(exc, NotFoundError):
             detail = f"Model {model} not found or unavailable on {provider}"
             status = 404

--- a/src/services/startup.py
+++ b/src/services/startup.py
@@ -675,6 +675,18 @@ async def lifespan(app):
     except Exception:
         pass
 
+    # Warn if ops alert email is missing (don't fail startup)
+    try:
+        from src.config import Config as _Config3
+
+        if not _Config3.OPS_ALERT_EMAIL:
+            logger.warning(
+                "  [WARN] OPS_ALERT_EMAIL is not set. "
+                "Provider auth-failure alerting will be a no-op."
+            )
+    except Exception:
+        pass
+
     # Initialize Traceloop SDK (OpenLLMetry) for LLM auto-instrumentation
     # Must run after OTel but before any LLM SDK calls
     try:

--- a/supabase/migrations/20260715000000_add_is_free_to_model_usage_analytics_view.sql
+++ b/supabase/migrations/20260715000000_add_is_free_to_model_usage_analytics_view.sql
@@ -1,0 +1,186 @@
+-- ============================================================================
+-- Add is_free to Model Usage Analytics View
+-- ============================================================================
+-- Migration: 20260715000000
+-- Description: Adds models.is_free to the model_usage_analytics view so
+--              free-tier usage (and failure rates) can be segmented from
+--              paid usage in admin tooling.
+--
+-- Reconstruction note: the view's SELECT/FROM/JOIN/WHERE/GROUP BY/HAVING/
+-- ORDER BY below are copied verbatim from
+-- 20260212000001_fix_analytics_view_pricing_from_metadata.sql, which is the
+-- last migration in this repo's history that redefines the view body (grep
+-- across supabase/migrations/ for "model_usage_analytics" confirms no later
+-- migration issues DROP VIEW / CREATE VIEW / CREATE OR REPLACE VIEW with an
+-- explicit new column list for it). 20260527000001_full_security_hardening.sql
+-- runs later and rebuilds the view via
+-- `CREATE OR REPLACE VIEW ... AS <pg_get_viewdef(...)>` — i.e. it copies
+-- whatever column list already existed rather than changing it — but adds
+-- `WITH (security_invoker = true)` and revokes anon/authenticated SELECT
+-- grants (leaving only service_role). Both properties are preserved below.
+-- Only `m.is_free` (added by 20260401000005_add_model_capability_columns.sql,
+-- NOT NULL DEFAULT false) is new here, added to the SELECT list and GROUP BY.
+--
+-- Confidence: high for the column list/joins/predicates (directly copied from
+-- the last defining migration); this was NOT verified against a live/staging
+-- database — no DATABASE_URL/Supabase credentials were available in this
+-- sandbox. Re-run `pg_get_viewdef('model_usage_analytics'::regclass)` against
+-- the real database before/after applying to confirm an exact match.
+-- ============================================================================
+
+DROP VIEW IF EXISTS "public"."model_usage_analytics";
+
+CREATE VIEW "public"."model_usage_analytics" WITH (security_invoker = true) AS
+SELECT
+    -- Model identification
+    m.id as model_id,
+    m.model_name,
+    m.provider_model_id,
+    p.name as provider_name,
+    p.slug as provider_slug,
+    m.is_free,
+
+    -- Request counts
+    COUNT(ccr.id) as successful_requests,
+
+    -- Token usage breakdown
+    COALESCE(SUM(ccr.input_tokens), 0) as total_input_tokens,
+    COALESCE(SUM(ccr.output_tokens), 0) as total_output_tokens,
+    COALESCE(SUM(ccr.input_tokens + ccr.output_tokens), 0) as total_tokens,
+
+    -- Average token usage per request
+    ROUND(AVG(ccr.input_tokens), 2) as avg_input_tokens_per_request,
+    ROUND(AVG(ccr.output_tokens), 2) as avg_output_tokens_per_request,
+
+    -- Pricing (per 1M tokens for display)
+    -- Priority: model_pricing table > metadata.pricing_raw > 0
+    -- model_pricing stores per-token, metadata.pricing_raw stores per-token
+    -- Multiply by 1,000,000 for per-1M display
+    COALESCE(
+        mp.price_per_input_token * 1000000,
+        CAST(m.metadata->'pricing_raw'->>'prompt' AS NUMERIC) * 1000000,
+        0
+    ) as input_token_price_per_1m,
+    COALESCE(
+        mp.price_per_output_token * 1000000,
+        CAST(m.metadata->'pricing_raw'->>'completion' AS NUMERIC) * 1000000,
+        0
+    ) as output_token_price_per_1m,
+
+    -- Per-token pricing (raw, for cost calculations below)
+    -- Used in cost formulas via the resolved per-token price
+    COALESCE(
+        mp.price_per_input_token,
+        CAST(m.metadata->'pricing_raw'->>'prompt' AS NUMERIC),
+        0
+    ) as input_token_price,
+    COALESCE(
+        mp.price_per_output_token,
+        CAST(m.metadata->'pricing_raw'->>'completion' AS NUMERIC),
+        0
+    ) as output_token_price,
+
+    -- Cost calculations (in USD)
+    ROUND(
+        CAST(
+            (COALESCE(SUM(ccr.input_tokens), 0) * COALESCE(
+                mp.price_per_input_token,
+                CAST(m.metadata->'pricing_raw'->>'prompt' AS NUMERIC),
+                0
+            )) +
+            (COALESCE(SUM(ccr.output_tokens), 0) * COALESCE(
+                mp.price_per_output_token,
+                CAST(m.metadata->'pricing_raw'->>'completion' AS NUMERIC),
+                0
+            ))
+            AS NUMERIC
+        ),
+        6
+    ) as total_cost_usd,
+
+    -- Cost breakdown
+    ROUND(
+        CAST(COALESCE(SUM(ccr.input_tokens), 0) * COALESCE(
+            mp.price_per_input_token,
+            CAST(m.metadata->'pricing_raw'->>'prompt' AS NUMERIC),
+            0
+        ) AS NUMERIC),
+        6
+    ) as input_cost_usd,
+    ROUND(
+        CAST(COALESCE(SUM(ccr.output_tokens), 0) * COALESCE(
+            mp.price_per_output_token,
+            CAST(m.metadata->'pricing_raw'->>'completion' AS NUMERIC),
+            0
+        ) AS NUMERIC),
+        6
+    ) as output_cost_usd,
+
+    -- Average cost per request
+    ROUND(
+        CAST(
+            (COALESCE(SUM(ccr.input_tokens), 0) * COALESCE(
+                mp.price_per_input_token,
+                CAST(m.metadata->'pricing_raw'->>'prompt' AS NUMERIC),
+                0
+            )) +
+            (COALESCE(SUM(ccr.output_tokens), 0) * COALESCE(
+                mp.price_per_output_token,
+                CAST(m.metadata->'pricing_raw'->>'completion' AS NUMERIC),
+                0
+            ))
+            AS NUMERIC
+        ) / NULLIF(COUNT(ccr.id), 0),
+        6
+    ) as avg_cost_per_request_usd,
+
+    -- Performance metrics
+    ROUND(AVG(ccr.processing_time_ms), 2) as avg_processing_time_ms,
+
+    -- Model metadata
+    m.context_length,
+    m.modality,
+    m.health_status,
+    m.is_active,
+
+    -- Pricing metadata
+    mp.pricing_type,
+    mp.pricing_source,
+
+    -- Time tracking
+    MIN(ccr.created_at) as first_request_at,
+    MAX(ccr.created_at) as last_request_at
+
+FROM "public"."models" m
+INNER JOIN "public"."providers" p ON m.provider_id = p.id
+INNER JOIN "public"."chat_completion_requests" ccr ON m.id = ccr.model_id
+LEFT JOIN "public"."model_pricing" mp ON m.id = mp.model_id
+WHERE ccr.status = 'completed'
+GROUP BY
+    m.id,
+    m.model_name,
+    m.provider_model_id,
+    m.metadata,
+    m.context_length,
+    m.modality,
+    m.health_status,
+    m.is_active,
+    m.is_free,
+    p.name,
+    p.slug,
+    mp.price_per_input_token,
+    mp.price_per_output_token,
+    mp.pricing_type,
+    mp.pricing_source
+HAVING COUNT(ccr.id) > 0
+ORDER BY successful_requests DESC, total_cost_usd DESC;
+
+-- Add comment
+COMMENT ON VIEW "public"."model_usage_analytics" IS
+    'Model usage analytics with pricing from model_pricing table OR metadata.pricing_raw fallback. '
+    'Includes is_free (added 2026-07-15) to segment free-tier from paid usage.';
+
+-- Grants: match the current hardened state (20260527000001_full_security_hardening.sql
+-- revoked anon/authenticated SELECT on this view; only service_role should read it).
+REVOKE ALL ON "public"."model_usage_analytics" FROM anon, authenticated;
+GRANT SELECT ON "public"."model_usage_analytics" TO service_role;

--- a/tests/db/test_chat_completion_requests_enhanced.py
+++ b/tests/db/test_chat_completion_requests_enhanced.py
@@ -1,0 +1,68 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.db.chat_completion_requests_enhanced import save_chat_completion_request_with_cost
+
+
+@pytest.fixture
+def sb(monkeypatch):
+    """In-memory Supabase stub to prevent database connection"""
+    return MagicMock()
+
+
+@patch("src.db.chat_completion_requests_enhanced.get_model_id_by_name", return_value=None)
+@patch("src.db.chat_completion_requests_enhanced.get_supabase_client")
+def test_failed_request_persisted_even_when_model_unresolved(mock_get_client, mock_get_model_id, sb):
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+    mock_client.table.return_value.insert.return_value.execute.return_value.data = [
+        {"id": 1, "request_id": "req-123", "model_id": None, "status": "failed"}
+    ]
+
+    result = save_chat_completion_request_with_cost(
+        request_id="req-123",
+        model_name="some/unresolvable-model",
+        input_tokens=10,
+        output_tokens=0,
+        processing_time_ms=50,
+        cost_usd=0.0,
+        input_cost_usd=0.0,
+        output_cost_usd=0.0,
+        pricing_source="error",
+        status="failed",
+        error_message="401 User not found",
+        provider_name="openrouter",
+    )
+
+    assert result is not None
+    assert result["request_id"] == "req-123"
+    inserted_payload = mock_client.table.return_value.insert.call_args[0][0]
+    assert inserted_payload["model_id"] is None
+    assert inserted_payload["metadata"]["unresolved_model_name"] == "some/unresolvable-model"
+    assert inserted_payload["status"] == "failed"
+
+
+@patch("src.db.chat_completion_requests_enhanced.get_model_id_by_name", return_value=None)
+@patch("src.db.chat_completion_requests_enhanced.get_supabase_client")
+def test_non_failed_request_skipped_when_model_unresolved(mock_get_client, mock_get_model_id, sb):
+    """Verify that non-failed requests still return None (unchanged behavior)"""
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    result = save_chat_completion_request_with_cost(
+        request_id="req-456",
+        model_name="some/unresolvable-model",
+        input_tokens=10,
+        output_tokens=5,
+        processing_time_ms=100,
+        cost_usd=0.01,
+        input_cost_usd=0.005,
+        output_cost_usd=0.005,
+        pricing_source="calculated",
+        status="completed",
+        provider_name="openrouter",
+    )
+
+    assert result is None
+    mock_client.table.return_value.insert.assert_not_called()

--- a/tests/db/test_chat_completion_requests_enhanced.py
+++ b/tests/db/test_chat_completion_requests_enhanced.py
@@ -13,7 +13,9 @@ def sb(monkeypatch):
 
 @patch("src.db.chat_completion_requests_enhanced.get_model_id_by_name", return_value=None)
 @patch("src.db.chat_completion_requests_enhanced.get_supabase_client")
-def test_failed_request_persisted_even_when_model_unresolved(mock_get_client, mock_get_model_id, sb):
+def test_failed_request_persisted_even_when_model_unresolved(
+    mock_get_client, mock_get_model_id, sb
+):
     mock_client = MagicMock()
     mock_get_client.return_value = mock_client
     mock_client.table.return_value.insert.return_value.execute.return_value.data = [

--- a/tests/routes/test_admin_model_usage_analytics.py
+++ b/tests/routes/test_admin_model_usage_analytics.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from src.main import app
+from src.security.deps import require_admin
+
+client = TestClient(app)
+app.dependency_overrides[require_admin] = lambda: {"id": 1, "email": "admin@test.com"}
+
+
+@patch("src.db.client.get_db")
+def test_model_usage_analytics_is_free_filter_applies_eq(mock_get_db):
+    mock_client = MagicMock()
+    mock_get_db.return_value = mock_client
+    query_mock = mock_client.table.return_value.select.return_value
+    query_mock.eq.return_value = query_mock
+    query_mock.ilike.return_value = query_mock
+    query_mock.order.return_value = query_mock
+    query_mock.range.return_value = query_mock
+    query_mock.execute.return_value.data = []
+    query_mock.execute.return_value.count = 0
+
+    response = client.get("/admin/model-usage-analytics?is_free=true")
+
+    assert response.status_code == 200
+    query_mock.eq.assert_any_call("is_free", True)

--- a/tests/routes/test_monitoring_chat_requests.py
+++ b/tests/routes/test_monitoring_chat_requests.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from src.main import app
+
+client = TestClient(app)
+
+
+@patch("src.db.client.get_db")
+def test_chat_requests_status_filter_applies_eq(mock_get_db):
+    mock_client = MagicMock()
+    mock_get_db.return_value = mock_client
+    query_mock = mock_client.table.return_value.select.return_value
+    query_mock.eq.return_value = query_mock
+    query_mock.ilike.return_value = query_mock
+    query_mock.gte.return_value = query_mock
+    query_mock.lte.return_value = query_mock
+    query_mock.order.return_value = query_mock
+    query_mock.range.return_value = query_mock
+    query_mock.execute.return_value.data = []
+    mock_client.table.return_value.select.return_value.execute.return_value.count = 0
+
+    response = client.get("/api/monitoring/chat-requests?status=failed")
+
+    assert response.status_code == 200
+    query_mock.eq.assert_any_call("status", "failed")

--- a/tests/services/test_provider_alerting.py
+++ b/tests/services/test_provider_alerting.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from src.services.provider_alerting import alert_provider_auth_failure, _last_alert_sent_at
+from src.services.provider_alerting import _last_alert_sent_at, alert_provider_auth_failure
 
 
 @patch("src.services.provider_alerting.NotificationService")

--- a/tests/services/test_provider_alerting.py
+++ b/tests/services/test_provider_alerting.py
@@ -1,0 +1,45 @@
+import time
+from unittest.mock import patch
+
+from src.services.provider_alerting import alert_provider_auth_failure, _last_alert_sent_at
+
+
+@patch("src.services.provider_alerting.NotificationService")
+@patch("src.services.provider_alerting.Config")
+def test_alert_sent_when_ops_email_configured(mock_config, mock_notification_service_cls):
+    mock_config.OPS_ALERT_EMAIL = "ops@gatewayz.ai"
+    mock_service = mock_notification_service_cls.return_value
+    mock_service.send_email_notification.return_value = True
+    _last_alert_sent_at.clear()
+
+    alert_provider_auth_failure("openrouter", "tencent/hy3:free", "401 User not found")
+
+    mock_service.send_email_notification.assert_called_once()
+    call_kwargs = mock_service.send_email_notification.call_args.kwargs
+    assert call_kwargs["to_email"] == "ops@gatewayz.ai"
+    assert "openrouter" in call_kwargs["subject"]
+
+
+@patch("src.services.provider_alerting.NotificationService")
+@patch("src.services.provider_alerting.Config")
+def test_alert_rate_limited_within_15_minutes(mock_config, mock_notification_service_cls):
+    mock_config.OPS_ALERT_EMAIL = "ops@gatewayz.ai"
+    mock_service = mock_notification_service_cls.return_value
+    _last_alert_sent_at.clear()
+
+    alert_provider_auth_failure("openrouter", "model-a", "401")
+    alert_provider_auth_failure("openrouter", "model-b", "401")  # same provider, immediately after
+
+    assert mock_service.send_email_notification.call_count == 1
+
+
+@patch("src.services.provider_alerting.NotificationService")
+@patch("src.services.provider_alerting.Config")
+def test_no_alert_when_ops_email_unset(mock_config, mock_notification_service_cls):
+    mock_config.OPS_ALERT_EMAIL = None
+    mock_service = mock_notification_service_cls.return_value
+    _last_alert_sent_at.clear()
+
+    alert_provider_auth_failure("openrouter", "model-a", "401")
+
+    mock_service.send_email_notification.assert_not_called()

--- a/tests/services/test_provider_alerting.py
+++ b/tests/services/test_provider_alerting.py
@@ -1,5 +1,8 @@
+import asyncio
 import time
 from unittest.mock import patch
+
+import pytest
 
 from src.services.provider_alerting import alert_provider_auth_failure, _last_alert_sent_at
 
@@ -43,3 +46,52 @@ def test_no_alert_when_ops_email_unset(mock_config, mock_notification_service_cl
     alert_provider_auth_failure("openrouter", "model-a", "401")
 
     mock_service.send_email_notification.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("src.services.provider_alerting.NotificationService")
+@patch("src.services.provider_alerting.Config")
+async def test_alert_does_not_block_event_loop(mock_config, mock_notification_service_cls):
+    """The Resend send must be offloaded to a thread, not run inline on the
+    event loop — otherwise a hung/slow Resend call stalls every concurrent
+    request during a provider auth-failure storm."""
+    mock_config.OPS_ALERT_EMAIL = "ops@gatewayz.ai"
+    mock_service = mock_notification_service_cls.return_value
+
+    def _slow_send(**kwargs):
+        time.sleep(0.2)
+        return True
+
+    mock_service.send_email_notification.side_effect = _slow_send
+    _last_alert_sent_at.clear()
+
+    start = time.monotonic()
+    alert_provider_auth_failure("openrouter", "tencent/hy3:free", "401 User not found")
+    elapsed = time.monotonic() - start
+
+    # Must return immediately without blocking on the slow Resend call.
+    assert elapsed < 0.1
+    mock_service.send_email_notification.assert_not_called()
+
+    # Let the offloaded background thread task run to completion.
+    await asyncio.sleep(0.3)
+
+    mock_service.send_email_notification.assert_called_once()
+    assert _last_alert_sent_at["openrouter"] > 0
+
+
+@patch("src.services.provider_alerting.NotificationService")
+@patch("src.services.provider_alerting.Config")
+def test_alert_sent_inline_without_running_event_loop(mock_config, mock_notification_service_cls):
+    """When called from a plain synchronous context (no running event loop),
+    the alert must still be sent — falling back to an inline send rather than
+    silently dropping it."""
+    mock_config.OPS_ALERT_EMAIL = "ops@gatewayz.ai"
+    mock_service = mock_notification_service_cls.return_value
+    mock_service.send_email_notification.return_value = True
+    _last_alert_sent_at.clear()
+
+    alert_provider_auth_failure("openrouter", "tencent/hy3:free", "401 User not found")
+
+    mock_service.send_email_notification.assert_called_once()
+    assert _last_alert_sent_at["openrouter"] > 0

--- a/tests/services/test_provider_failover.py
+++ b/tests/services/test_provider_failover.py
@@ -752,6 +752,20 @@ class TestMapProviderErrorOpenAI:
         assert mapped.status_code == 401
         assert "authentication" in mapped.detail.lower()
 
+    @patch("src.services.provider_failover.alert_provider_auth_failure")
+    def test_auth_error_triggers_alert(self, mock_alert):
+        """Test AuthenticationError fires the ops alert hook"""
+        response = Mock()
+        response.status_code = 401
+        error = AuthenticationError("Invalid API key", response=response, body=None)
+        error.status_code = 401
+        map_provider_error("openrouter", "gpt-4", error)
+
+        mock_alert.assert_called_once()
+        call_args = mock_alert.call_args.args
+        assert call_args[0] == "openrouter"
+        assert call_args[1] == "gpt-4"
+
     def test_map_not_found_error(self):
         """Test NotFoundError indicates model not available"""
         response = Mock()


### PR DESCRIPTION
## Summary
Closes the 4 backend observability gaps found while investigating the OpenRouter-key-dead incident (2026-07-15): no backend error feed, no free-model segmentation, no alerting on provider failures.

- **Persist failed requests with unresolved model_id** — `save_chat_completion_request_with_cost()` no longer silently drops failed requests when the model can't be resolved by name; stores `model_id=NULL` + original name in metadata.
- **`status` filter on `GET /api/monitoring/chat-requests`** — supports `?status=failed` to isolate failures.
- **`is_free` on model usage analytics** — new migration adds `is_free` to the `model_usage_analytics` view + `?is_free=` filter on `GET /admin/model-usage-analytics`.
- **Provider auth-failure alerting** — new `src/services/provider_alerting.py`: rate-limited (1 email/provider/15min) ops email via existing `NotificationService`/Resend when a provider rejects our API key, wired into `provider_failover.py`'s auth-error classification path, plus a startup-time warning if `OPS_ALERT_EMAIL` is unset. The alert send is offloaded off the event loop (`asyncio.to_thread`) so a slow/hung Resend call can't stall concurrent requests.

## Known open items (flagged during review, not blocking but need a human before/around deploy)
- **`is_free` migration is unverified against a live database** — reconstructed from migration history (`20260212000001` + `20260527000001`), not run against staging. Run `pg_get_viewdef('model_usage_analytics'::regclass)` and diff before/after applying.
- **`OPS_ALERT_EMAIL` needs to be set in Railway** — `railway variables --set "OPS_ALERT_EMAIL=<ops-inbox>@gatewayz.ai" --environment production --service api` (needs a real inbox address, not guessed).
- A second, parallel Cerebras auth-error branch (`provider_failover.py:648`) was intentionally left unwired (out of scope per the plan) — a dead Cerebras key won't trigger an alert. Worth a fast-follow.

## Test plan
- [x] Full `pytest tests/` — 2690 passed, 4 pre-existing failures unrelated to this branch (confirmed via `git diff --stat` — none of the failing test files were touched here)
- [x] New/changed tests for all 4 tasks pass with TDD RED→GREEN evidence in commit history
- [x] Whole-branch review (opus) — approved with the event-loop-blocking fix applied and re-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added operational email alerts for provider authentication failures, with rate limiting.
  * Added free-tier filtering to model usage analytics.
  * Added status filtering to chat request monitoring.
* **Bug Fixes**
  * Failed chat requests are now retained even when model details can’t be resolved, preserving the unresolved model name for diagnostics.
* **Tests**
  * Added/expanded test coverage for alerting behavior, failover alert triggering, admin analytics filtering, monitoring status filtering, and failed-request persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->