### PR TITLE
fix(ci): strip markdown backticks when parsing supabase migration list output

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -99,7 +99,7 @@ jobs:
           # Detect drift: lines where REMOTE has a version but LOCAL is empty
           # Format: "   LOCAL          | REMOTE         | TIME"
           DRIFT=$(awk -F'|' '{
-            gsub(/[ \t]/, "", $1); gsub(/[ \t]/, "", $2);
+            gsub(/[ \t`]/, "", $1); gsub(/[ \t`]/, "", $2);
             if ($2 ~ /^[0-9]{14}$/ && $1 !~ /^[0-9]{14}$/) print $2
           }' migration-status.txt || true)
 
@@ -114,7 +114,7 @@ jobs:
 
           # Check for pending local-only migrations
           PENDING=$(awk -F'|' '{
-            gsub(/[ \t]/, "", $1); gsub(/[ \t]/, "", $2);
+            gsub(/[ \t`]/, "", $1); gsub(/[ \t`]/, "", $2);
             if ($1 ~ /^[0-9]{14}$/ && $2 !~ /^[0-9]{14}$/) print $1
           }' migration-status.txt || true)
 


### PR DESCRIPTION
## Summary
The \`supabase-migrations.yml\` drift/pending-detection logic silently reports "no pending migrations" even when a migration has never been applied to the remote database, because the Supabase CLI now wraps \`migration list\` table cells in backticks and the awk scripts only stripped spaces/tabs — so every cell fails the \`^[0-9]{14}$\` regex.

Found this while confirming PR #2163's \`20260715000000_add_is_free_to_model_usage_analytics_view\` migration was actually applied after merge — the workflow ran "successfully" but the Remote column was still empty for that migration both before and after the "sync" step.

## Fix
Strip backticks alongside spaces/tabs in both the DRIFT and PENDING awk parsers.

## Test plan
- [x] Reproduced the bug locally against real CI output (`` `20260715000000` | ` ` | ... ``) — old gsub pattern never matched, new one does
- [ ] After merge, re-run `Supabase Migrations` via `workflow_dispatch` and confirm the `is_free` migration now shows a populated Remote column

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration status detection by correctly handling backtick characters in migration identifiers.
  * Reduced the risk of incorrect drift or pending-migration results, helping automated migration actions run only when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->