### PR TITLE
fix(ci): green main-only CI shards after MVP refactor

### DIFF
--- a/docs/CONCEPTUAL_MODEL.md
+++ b/docs/CONCEPTUAL_MODEL.md
@@ -183,7 +183,7 @@ When a provider fails, the request automatically retries with the next provider 
 Primary (Fireworks) ──FAIL──► OpenRouter ──FAIL──► Together ──SUCCESS──► Response
 ```
 
-- **14-provider failover chain** ordered by reliability
+- **9-provider failover chain** ordered by reliability (HuggingFace removed in the MVP refactor)
 - **Triggers on**: 401, 402 (provider out of credits), 403, 404, 502, 503, 504
 - **Does not trigger on**: 400 (user error), 429 (rate limit — retry with backoff instead)
 - **Circuit breakers** per provider: after 5 consecutive failures, the provider is temporarily removed from the chain. Auto-recovers after 1 minute (60 seconds) of cool-down.

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -6,23 +6,20 @@ Consolidates all configuration-related modules.
 # Re-export main Config class for backward compatibility
 from src.config.config import Config
 
+# Re-export Supabase configuration
 # Re-export database configuration
 from src.config.supabase_config import (
     DatabaseConfig,
     close_db_connections,
+    get_client,
     get_db_config,
     get_db_connection,
-    is_db_available,
-    test_db_connection,
-)
-
-# Re-export Supabase configuration
-from src.config.supabase_config import (
-    get_client,
     get_initialization_status,
     get_supabase_client,
     init_db,
+    is_db_available,
     test_connection,
+    test_db_connection,
 )
 
 # Re-export Redis configuration (if needed)

--- a/src/db/chat_completion_requests.py
+++ b/src/db/chat_completion_requests.py
@@ -1356,6 +1356,7 @@ def get_models_with_min_one_per_provider(
 # MVP Task 17 — moved verbatim; imports already present at module top).
 # ============================================================================
 
+
 def save_chat_completion_request_with_cost(
     request_id: str,
     model_name: str,

--- a/src/enhanced_notification_service.py
+++ b/src/enhanced_notification_service.py
@@ -478,5 +478,6 @@ The {self.app_name} Team
             logger.error(f"Error details: {str(e)}", exc_info=True)
             return False
 
+
 # Global enhanced notification service instance
 enhanced_notification_service = EnhancedNotificationService()

--- a/src/handlers/provider_registry.py
+++ b/src/handlers/provider_registry.py
@@ -155,6 +155,7 @@ def _safe_adapter_routing(slug: str) -> ProviderRouting:
             "stream": make_error_raiser("stream"),
         }
 
+
 # ---------------------------------------------------------------------------
 # Load all providers and build PROVIDER_ROUTING
 # ---------------------------------------------------------------------------

--- a/src/routes/catalog.py
+++ b/src/routes/catalog.py
@@ -2757,4 +2757,3 @@ def _extract_availability_comparison(
     for item in models_data:
         availability[item["gateway"]] = True
     return availability
-

--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -32,6 +32,7 @@ from src.utils.errors import APIExceptions
 from src.utils.performance_tracker import PerformanceTracker
 from src.utils.rate_limit_headers import get_rate_limit_headers
 
+
 # Traceloop integration removed; keep call sites as a no-op.
 def set_traceloop_properties(**kwargs):
     pass

--- a/src/routes/model_sync.py
+++ b/src/routes/model_sync.py
@@ -49,6 +49,7 @@ async def _full_provider_and_model_sync(dry_run: bool = False) -> dict:
         "models": model_result,
     }
 
+
 router = APIRouter(
     prefix="/admin/model-sync",
     tags=["Admin - Model Sync"],

--- a/src/services/model_catalog_sync.py
+++ b/src/services/model_catalog_sync.py
@@ -14,11 +14,6 @@ from src.db.providers_db import (
     create_provider,
     get_provider_by_slug,
 )
-from src.utils.pricing_normalization import (
-    PricingFormat,
-    get_provider_format,
-    normalize_to_per_token,
-)
 from src.services.providers.alibaba_cloud_client import fetch_models_from_alibaba
 from src.services.providers.anthropic_client import fetch_models_from_anthropic
 from src.services.providers.cerebras_client import fetch_models_from_cerebras
@@ -37,6 +32,11 @@ from src.services.providers.together_catalog import fetch_models_from_together
 from src.services.providers.xai_client import fetch_models_from_xai
 from src.services.providers.xiaomi_catalog import fetch_models_from_xiaomi
 from src.services.providers.zai_catalog import fetch_models_from_zai
+from src.utils.pricing_normalization import (
+    PricingFormat,
+    get_provider_format,
+    normalize_to_per_token,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/services/monitoring/provider_credit_monitor.py
+++ b/src/services/monitoring/provider_credit_monitor.py
@@ -60,8 +60,6 @@ def _get_monitored_402_providers() -> set[str]:
 MONITORED_402_PROVIDERS = _FALLBACK_402_PROVIDERS
 
 
-
-
 def _parse_openrouter_balance(data: dict) -> float | None:
     return data.get("data", {}).get("limit_remaining")
 
@@ -194,8 +192,10 @@ async def check_provider_balance(provider: str) -> dict[str, Any]:
         }
         _credit_balance_cache[provider] = result
 
-        log = logger.error if status == "critical" else (
-            logger.warning if status == "warning" else logger.info
+        log = (
+            logger.error
+            if status == "critical"
+            else (logger.warning if status == "warning" else logger.info)
         )
         log(f"{provider} credit balance {status.upper()}: {balance:.2f} {api['currency']}")
         return result

--- a/src/services/monitoring/provider_credit_monitor.py
+++ b/src/services/monitoring/provider_credit_monitor.py
@@ -323,7 +323,7 @@ async def check_all_provider_credits() -> dict[str, dict[str, Any]]:
     balances = await asyncio.gather(
         *(check_provider_balance(p) for p in api_providers), return_exceptions=True
     )
-    for provider, result in zip(api_providers, balances):
+    for provider, result in zip(api_providers, balances, strict=False):
         if isinstance(result, Exception):
             results[provider] = {
                 "provider": provider,

--- a/src/services/providers.py
+++ b/src/services/providers.py
@@ -336,5 +336,3 @@ def fetch_models_from_novita():
     from src.services.providers.novita_client import fetch_models_from_novita as _fetch
 
     return _fetch()
-
-

--- a/src/services/providers/adapter_configs.py
+++ b/src/services/providers/adapter_configs.py
@@ -73,9 +73,7 @@ ADAPTER_CONFIGS: dict[str, ProviderConfig] = {
         api_key_env="GROQ_API_KEY",
         display_name="Groq",
         client_factory=get_groq_pooled_client,
-        quirks=Quirks(
-            circuit_breaker=_STANDARD_CIRCUIT_CONFIG, sentry=True, timing=True
-        ),
+        quirks=Quirks(circuit_breaker=_STANDARD_CIRCUIT_CONFIG, sentry=True, timing=True),
     ),
     "zai": ProviderConfig(
         slug="zai",

--- a/src/services/providers/deepinfra_catalog.py
+++ b/src/services/providers/deepinfra_catalog.py
@@ -23,6 +23,7 @@ MODALITY_TEXT_TO_TEXT = "text->text"
 MODALITY_TEXT_TO_IMAGE = "text->image"
 MODALITY_TEXT_TO_AUDIO = "text->audio"
 
+
 def normalize_deepinfra_model(deepinfra_model: dict) -> dict:
     """Normalize DeepInfra model to our schema"""
     from src.services.pricing_lookup import enrich_model_with_pricing

--- a/src/services/providers/deepseek_catalog.py
+++ b/src/services/providers/deepseek_catalog.py
@@ -33,9 +33,7 @@ def normalize_deepseek_model(deepseek_model: dict) -> dict | None:
     slug = f"deepseek/{provider_model_id}"
     provider_slug = "deepseek"
 
-    display_name = clean_model_name(
-        provider_model_id.replace("-", " ").replace("_", " ").title()
-    )
+    display_name = clean_model_name(provider_model_id.replace("-", " ").replace("_", " ").title())
     owned_by = deepseek_model.get("owned_by", "deepseek")
     description = f"DeepSeek model {provider_model_id}, provided by {owned_by}."
 

--- a/src/services/providers/fireworks_catalog.py
+++ b/src/services/providers/fireworks_catalog.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 # Modality constants
 MODALITY_TEXT_TO_TEXT = "text->text"
 
+
 def normalize_fireworks_model(fireworks_model: dict) -> dict:
     """Normalize Fireworks catalog entries to resemble OpenRouter model shape"""
     from src.services.pricing_lookup import enrich_model_with_pricing

--- a/src/services/providers/groq_catalog.py
+++ b/src/services/providers/groq_catalog.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 # Modality constants
 MODALITY_TEXT_TO_TEXT = "text->text"
 
+
 def normalize_groq_model(groq_model: dict) -> dict:
     """Normalize Groq catalog entries to resemble OpenRouter model shape"""
     from src.services.pricing_lookup import enrich_model_with_pricing

--- a/src/services/providers/minimax_catalog.py
+++ b/src/services/providers/minimax_catalog.py
@@ -33,9 +33,7 @@ def normalize_minimax_model(minimax_model: dict) -> dict | None:
     slug = f"minimax/{provider_model_id}"
     provider_slug = "minimax"
 
-    display_name = clean_model_name(
-        provider_model_id.replace("-", " ").replace("_", " ").title()
-    )
+    display_name = clean_model_name(provider_model_id.replace("-", " ").replace("_", " ").title())
     owned_by = minimax_model.get("owned_by", "minimax")
     description = f"MiniMax model {provider_model_id}, provided by {owned_by}."
 

--- a/src/services/providers/moonshot_catalog.py
+++ b/src/services/providers/moonshot_catalog.py
@@ -33,9 +33,7 @@ def normalize_moonshot_model(moonshot_model: dict) -> dict | None:
     slug = f"moonshot/{provider_model_id}"
     provider_slug = "moonshot"
 
-    display_name = clean_model_name(
-        provider_model_id.replace("-", " ").replace("_", " ").title()
-    )
+    display_name = clean_model_name(provider_model_id.replace("-", " ").replace("_", " ").title())
     owned_by = moonshot_model.get("owned_by", "moonshot")
     description = f"Moonshot AI (Kimi) model {provider_model_id}, provided by {owned_by}."
 

--- a/src/services/providers/openai_compat.py
+++ b/src/services/providers/openai_compat.py
@@ -110,9 +110,7 @@ class OpenAICompatAdapter:
 
             mode = "stream" if stream else "non_stream"
             with ProviderTimingContext(self.cfg.slug, resolved, mode):
-                return client.chat.completions.create(
-                    model=resolved, messages=messages, **kwargs
-                )
+                return client.chat.completions.create(model=resolved, messages=messages, **kwargs)
         return client.chat.completions.create(model=resolved, messages=messages, **kwargs)
 
     def _capture(
@@ -143,18 +141,14 @@ class OpenAICompatAdapter:
         except CircuitBreakerError as e:
             logger.warning(f"{self.name} circuit breaker OPEN: {e.message}")
             if self.quirks.sentry:
-                self._capture(
-                    e, model, endpoint, {"circuit_breaker_state": e.state.value}
-                )
+                self._capture(e, model, endpoint, {"circuit_breaker_state": e.state.value})
             raise
         except Exception as e:
             try:
                 logger.error(f"{self.name} request failed for model '{model}': {e}")
                 logger.error(f"Error type: {type(e).__name__}")
                 if hasattr(e, "response"):
-                    logger.error(
-                        f"Response status: {getattr(e.response, 'status_code', 'N/A')}"
-                    )
+                    logger.error(f"Response status: {getattr(e.response, 'status_code', 'N/A')}")
             except UnicodeEncodeError:
                 logger.error(f"{self.name} request failed (encoding error in logging)")
             if self.quirks.sentry:
@@ -167,9 +161,7 @@ class OpenAICompatAdapter:
         """Non-streaming chat completion (old make_<slug>_request_openai)."""
         return self._call(messages, model, stream=False, **params)
 
-    def stream(
-        self, messages: list[dict[str, Any]], model: str, **params: Any
-    ) -> Iterator[Any]:
+    def stream(self, messages: list[dict[str, Any]], model: str, **params: Any) -> Iterator[Any]:
         """Streaming chat completion; the SDK stream (and its SSE chunks) is
         returned unmodified (old make_<slug>_request_openai_stream)."""
         return self._call(messages, model, stream=True, **params)

--- a/src/services/providers/together_catalog.py
+++ b/src/services/providers/together_catalog.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 # Modality constants
 MODALITY_TEXT_TO_TEXT = "text->text"
 
+
 def normalize_together_model(together_model: dict) -> dict:
     """Normalize Together catalog entries to resemble OpenRouter model shape"""
     from src.services.pricing_lookup import enrich_model_with_pricing

--- a/src/services/providers/xiaomi_catalog.py
+++ b/src/services/providers/xiaomi_catalog.py
@@ -34,9 +34,7 @@ def normalize_xiaomi_model(xiaomi_model: dict) -> dict | None:
     slug = f"xiaomi/{provider_model_id}"
     provider_slug = "xiaomi"
 
-    display_name = clean_model_name(
-        provider_model_id.replace("-", " ").replace("_", " ").title()
-    )
+    display_name = clean_model_name(provider_model_id.replace("-", " ").replace("_", " ").title())
     owned_by = xiaomi_model.get("owned_by", "xiaomi")
     description = f"Xiaomi MiMo model {provider_model_id}, provided by {owned_by}."
 

--- a/src/utils/errors.py
+++ b/src/utils/errors.py
@@ -14,8 +14,6 @@ Public surface (re-exported verbatim for importers):
   - ``ErrorCode``/``ErrorCategory`` enums and their helper functions
 """
 
-
-
 # ============================================================================
 # Merged from error_codes.py
 # ============================================================================
@@ -401,7 +399,6 @@ Usage:
 """
 
 import re
-
 
 # User-facing, friendly message for provider account/key budget exhaustion (e.g. an
 # OpenRouter key hitting its weekly spend limit). Never expose the upstream key/URL.

--- a/src/utils/errors.py
+++ b/src/utils/errors.py
@@ -1268,8 +1268,8 @@ class APIExceptions:
         Returns:
             HTTPException with detailed error response
         """
-        from src.utils.errors import DetailedErrorFactory
         from src.utils.error_handlers import create_error_response_dict
+        from src.utils.errors import DetailedErrorFactory
 
         error = DetailedErrorFactory.model_not_found(
             model_id=model_id,
@@ -1302,8 +1302,8 @@ class APIExceptions:
         Returns:
             HTTPException with detailed error response
         """
-        from src.utils.errors import DetailedErrorFactory
         from src.utils.error_handlers import create_error_response_dict
+        from src.utils.errors import DetailedErrorFactory
 
         error = DetailedErrorFactory.insufficient_credits(
             current_credits=current_credits,
@@ -1358,8 +1358,8 @@ class APIExceptions:
             ...     input_tokens=100
             ... )
         """
-        from src.utils.errors import DetailedErrorFactory
         from src.utils.error_handlers import create_error_response_dict
+        from src.utils.errors import DetailedErrorFactory
 
         error = DetailedErrorFactory.insufficient_credits_for_reservation(
             current_credits=current_credits,
@@ -1394,8 +1394,8 @@ class APIExceptions:
         Returns:
             HTTPException with detailed error response
         """
-        from src.utils.errors import DetailedErrorFactory
         from src.utils.error_handlers import create_error_response_dict
+        from src.utils.errors import DetailedErrorFactory
 
         error = DetailedErrorFactory.invalid_api_key(
             reason=reason,
@@ -1431,8 +1431,8 @@ class APIExceptions:
         Returns:
             HTTPException with detailed error response
         """
-        from src.utils.errors import DetailedErrorFactory
         from src.utils.error_handlers import create_error_response_dict
+        from src.utils.errors import DetailedErrorFactory
 
         error = DetailedErrorFactory.rate_limit_exceeded(
             limit_type=limit_type,
@@ -1470,8 +1470,8 @@ class APIExceptions:
         Returns:
             HTTPException with detailed error response
         """
-        from src.utils.errors import DetailedErrorFactory
         from src.utils.error_handlers import create_error_response_dict
+        from src.utils.errors import DetailedErrorFactory
 
         error = DetailedErrorFactory.provider_error(
             provider=provider,
@@ -1513,8 +1513,8 @@ class APIExceptions:
         Returns:
             HTTPException with detailed error response
         """
-        from src.utils.errors import DetailedErrorFactory
         from src.utils.error_handlers import create_error_response_dict
+        from src.utils.errors import DetailedErrorFactory
 
         error = DetailedErrorFactory.invalid_parameter(
             parameter_name=parameter_name,

--- a/src/utils/security_validators.py
+++ b/src/utils/security_validators.py
@@ -880,4 +880,3 @@ def sanitize_for_logging(value: str) -> str:
         value = str(value)
     # Replace newlines and carriage returns with spaces to prevent log injection
     return value.replace("\n", " ").replace("\r", " ").replace("\x00", "")
-

--- a/tests/conceptual_model/test_cm05_provider_failover.py
+++ b/tests/conceptual_model/test_cm05_provider_failover.py
@@ -86,11 +86,15 @@ class TestFailoverChain:
     """CM 5.1 - Failover chain configuration and status-code triggers."""
 
     @pytest.mark.cm_verified
-    def test_failover_chain_has_10_providers(self):
-        """CM-5.1.1: build_provider_failover_chain produces a chain with 10 providers."""
+    def test_failover_chain_has_9_providers(self):
+        """CM-5.1.1: build_provider_failover_chain produces a chain with 9 providers.
+
+        HuggingFace was removed from the roster in the MVP refactor (its client
+        was deleted), taking the chain from 10 down to 9 providers.
+        """
         with _all_providers_enabled():
             chain = build_provider_failover_chain("openrouter")
-        assert len(chain) == 10
+        assert len(chain) == 9
 
     @pytest.mark.cm_verified
     def test_failover_chain_ordered_by_reliability(self):
@@ -103,7 +107,6 @@ class TestFailoverChain:
             "anthropic",
             "google-vertex",
             "cerebras",
-            "huggingface",
             "featherless",
             "alibaba",
             "fireworks",

--- a/tests/conceptual_model/test_cm07_plans_trials.py
+++ b/tests/conceptual_model/test_cm07_plans_trials.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+
 # ---------------------------------------------------------------------------
 # CM-7.8  Plan tiers exist: Trial, Dev, Team, Enterprise
 # ---------------------------------------------------------------------------

--- a/tests/conceptual_model/test_cm16_webhooks_events.py
+++ b/tests/conceptual_model/test_cm16_webhooks_events.py
@@ -44,7 +44,17 @@ class TestCM1601WebhookPayloadHmacSigned:
 # ---------------------------------------------------------------------------
 # CM-16.2  credits.low event triggered
 # ---------------------------------------------------------------------------
-@pytest.mark.cm_verified
+# GAP: The MVP refactor (commit 8fa2e773 "refactor(mvp): remove notifications")
+# deleted src/services/notification.py entirely, including NotificationService
+# and check_low_balance_alert / LowBalanceAlert. The surviving
+# EnhancedNotificationService only handles welcome / password-reset / plan-upgrade
+# / api-key emails — it has no low-balance alerting equivalent. The spec still
+# lists the credits.low event, so this is a documented code-vs-spec gap.
+@pytest.mark.cm_gap
+@pytest.mark.xfail(
+    reason="Low-balance alerting removed in MVP refactor (8fa2e773); no surviving equivalent",
+    raises=(ModuleNotFoundError, ImportError),
+)
 class TestCM1602WebhookCreditsLowEventTriggered:
     def test_webhook_credits_low_event_triggered(self):
         """check_low_balance_alert returns a LowBalanceAlert when the user's
@@ -129,7 +139,14 @@ class TestCM1602WebhookCreditsLowEventTriggered:
 # ---------------------------------------------------------------------------
 # CM-16.3  credits.depleted event triggered
 # ---------------------------------------------------------------------------
-@pytest.mark.cm_verified
+# GAP: Same removal as CM-16.2 — check_low_balance_alert no longer exists after
+# the MVP notifications purge. Spec still lists credits.depleted, so this is a
+# documented code-vs-spec gap rather than a regression.
+@pytest.mark.cm_gap
+@pytest.mark.xfail(
+    reason="Low-balance alerting removed in MVP refactor (8fa2e773); no surviving equivalent",
+    raises=(ModuleNotFoundError, ImportError),
+)
 class TestCM1603WebhookCreditsDepletedEventTriggered:
     def test_webhook_credits_depleted_event_triggered(self):
         """The low balance alert fires when credits are 0 (depleted),

--- a/tests/conceptual_model/test_cm18_provider_ecosystem.py
+++ b/tests/conceptual_model/test_cm18_provider_ecosystem.py
@@ -71,8 +71,7 @@ class TestCM1802EachProviderHasClientModule:
                 failed.append((provider, str(e)))
 
         assert len(failed) == 0, (
-            f"All key providers must have a client module or adapter entry. "
-            f"Failed: {failed}"
+            f"All key providers must have a client module or adapter entry. " f"Failed: {failed}"
         )
         assert len(imported) == len(key_providers)
 
@@ -101,9 +100,9 @@ class TestCM1803ProviderClientImplementsRequiredInterface:
         for provider in key_providers:
             if provider in ADAPTERS:
                 adapter = ADAPTERS[provider]
-                assert callable(adapter.request) and callable(adapter.stream), (
-                    f"{provider} adapter must expose request/stream callables"
-                )
+                assert callable(adapter.request) and callable(
+                    adapter.stream
+                ), f"{provider} adapter must expose request/stream callables"
                 continue
 
             module = importlib.import_module(f"src.services.{provider}_client")

--- a/tests/config/test_supabase_config.py
+++ b/tests/config/test_supabase_config.py
@@ -487,7 +487,7 @@ class TestGlobalFunctions:
 
     def test_get_db_config_singleton(self):
         """Test get_db_config returns singleton"""
-        from src.config import db_config
+        from src.config import supabase_config as db_config
 
         # Reset global
         db_config._db_config = None
@@ -501,7 +501,7 @@ class TestGlobalFunctions:
     @patch("src.config.supabase_config.pool")
     def test_get_db_connection(self, mock_pool):
         """Test get_db_connection helper"""
-        from src.config import db_config
+        from src.config import supabase_config as db_config
 
         mock_conn = Mock()
         mock_pool_instance = Mock()
@@ -519,7 +519,7 @@ class TestGlobalFunctions:
     @patch("src.config.supabase_config.pool")
     def test_test_db_connection(self, mock_pool):
         """Test test_db_connection helper"""
-        from src.config import db_config
+        from src.config import supabase_config as db_config
 
         mock_cursor = Mock()
         mock_cursor.fetchone = Mock(return_value=(1,))
@@ -538,7 +538,7 @@ class TestGlobalFunctions:
 
     def test_close_db_connections(self):
         """Test close_db_connections helper"""
-        from src.config import db_config
+        from src.config import supabase_config as db_config
 
         # Reset global
         db_config._db_config = None
@@ -548,7 +548,7 @@ class TestGlobalFunctions:
 
     def test_is_db_available(self):
         """Test is_db_available helper"""
-        from src.config import db_config
+        from src.config import supabase_config as db_config
 
         # Reset global
         db_config._db_config = None

--- a/tests/security/test_admin_auth_coverage.py
+++ b/tests/security/test_admin_auth_coverage.py
@@ -168,7 +168,6 @@ def test_bandit_false_positives_suppressed():
     project_root = Path(__file__).parent.parent.parent
     checks = [
         ("src/routes/admin.py", "nosec B324"),
-        ("src/routes/health_timeline.py", "nosec B324"),
     ]
     for filepath, nosec_tag in checks:
         source = (project_root / filepath).read_text()

--- a/tests/services/providers/test_openai_compat.py
+++ b/tests/services/providers/test_openai_compat.py
@@ -123,9 +123,7 @@ class TestRequestClientConstruction:
     def test_extra_headers_passed_as_default_headers(self, fake_key):
         adapter = make_adapter(_fake_cfg(extra_headers={"X-Custom": "yes"}))
         with patch("src.services.providers.openai_compat.OpenAI") as mock_openai:
-            mock_openai.return_value.chat.completions.create.return_value = (
-                _mock_openai_response()
-            )
+            mock_openai.return_value.chat.completions.create.return_value = _mock_openai_response()
             adapter.request(MESSAGES, "test-model")
             assert mock_openai.call_args[1]["default_headers"] == {"X-Custom": "yes"}
 
@@ -186,9 +184,7 @@ class TestRequestClientConstruction:
     def test_request_propagates_provider_error(self, fake_key):
         adapter = make_adapter(_fake_cfg())
         with patch("src.services.providers.openai_compat.OpenAI") as mock_openai:
-            mock_openai.return_value.chat.completions.create.side_effect = Exception(
-                "API Error"
-            )
+            mock_openai.return_value.chat.completions.create.side_effect = Exception("API Error")
             with pytest.raises(Exception, match="API Error"):
                 adapter.request(MESSAGES, "test-model")
 
@@ -216,9 +212,7 @@ class TestStream:
     def test_stream_propagates_error(self, fake_key):
         adapter = make_adapter(_fake_cfg())
         with patch("src.services.providers.openai_compat.OpenAI") as mock_openai:
-            mock_openai.return_value.chat.completions.create.side_effect = Exception(
-                "Stream Error"
-            )
+            mock_openai.return_value.chat.completions.create.side_effect = Exception("Stream Error")
             with pytest.raises(Exception, match="Stream Error"):
                 adapter.stream(MESSAGES, "test-model")
 
@@ -265,9 +259,7 @@ class TestProcess:
 
 class TestQuirks:
     def _cb_cfg(self):
-        return _fake_cfg(
-            quirks=Quirks(circuit_breaker=CircuitBreakerConfig(), sentry=True)
-        )
+        return _fake_cfg(quirks=Quirks(circuit_breaker=CircuitBreakerConfig(), sentry=True))
 
     def test_circuit_breaker_wraps_call(self, fake_key):
         adapter = make_adapter(self._cb_cfg())
@@ -293,27 +285,19 @@ class TestQuirks:
             "src.services.providers.openai_compat.get_circuit_breaker",
             return_value=breaker,
         ):
-            with patch(
-                "src.utils.sentry_context.capture_provider_error"
-            ) as mock_capture:
+            with patch("src.utils.sentry_context.capture_provider_error") as mock_capture:
                 with pytest.raises(CircuitBreakerError):
                     adapter.request(MESSAGES, "test-model")
 
         mock_capture.assert_called_once()
         assert mock_capture.call_args[1]["provider"] == "fakeprov"
-        assert mock_capture.call_args[1]["extra_context"] == {
-            "circuit_breaker_state": "open"
-        }
+        assert mock_capture.call_args[1]["extra_context"] == {"circuit_breaker_state": "open"}
 
     def test_sentry_captures_generic_error(self, fake_key):
         adapter = make_adapter(_fake_cfg(quirks=Quirks(sentry=True)))
         with patch("src.services.providers.openai_compat.OpenAI") as mock_openai:
-            mock_openai.return_value.chat.completions.create.side_effect = Exception(
-                "boom"
-            )
-            with patch(
-                "src.utils.sentry_context.capture_provider_error"
-            ) as mock_capture:
+            mock_openai.return_value.chat.completions.create.side_effect = Exception("boom")
+            with patch("src.utils.sentry_context.capture_provider_error") as mock_capture:
                 with pytest.raises(Exception, match="boom"):
                     adapter.request(MESSAGES, "test-model")
 
@@ -324,12 +308,8 @@ class TestQuirks:
     def test_no_sentry_capture_without_quirk(self, fake_key):
         adapter = make_adapter(_fake_cfg())
         with patch("src.services.providers.openai_compat.OpenAI") as mock_openai:
-            mock_openai.return_value.chat.completions.create.side_effect = Exception(
-                "boom"
-            )
-            with patch(
-                "src.utils.sentry_context.capture_provider_error"
-            ) as mock_capture:
+            mock_openai.return_value.chat.completions.create.side_effect = Exception("boom")
+            with patch("src.utils.sentry_context.capture_provider_error") as mock_capture:
                 with pytest.raises(Exception, match="boom"):
                     adapter.request(MESSAGES, "test-model")
 
@@ -338,9 +318,7 @@ class TestQuirks:
     def test_timing_context_used_when_enabled(self, fake_key):
         adapter = make_adapter(_fake_cfg(quirks=Quirks(timing=True)))
         with patch("src.services.providers.openai_compat.OpenAI") as mock_openai:
-            mock_openai.return_value.chat.completions.create.return_value = (
-                _mock_openai_response()
-            )
+            mock_openai.return_value.chat.completions.create.return_value = _mock_openai_response()
             with patch("src.utils.provider_timing.ProviderTimingContext") as mock_ctx:
                 adapter.request(MESSAGES, "test-model")
 
@@ -480,9 +458,7 @@ class TestConsolidatedProviderParity:
         mock_client = Mock()
         mock_client.chat.completions.create.return_value = _mock_openai_response()
 
-        with patch.object(
-            OpenAICompatAdapter, "_get_client", return_value=mock_client
-        ):
+        with patch.object(OpenAICompatAdapter, "_get_client", return_value=mock_client):
             response = adapter.request(MESSAGES, "test-model")
 
         assert response is not None
@@ -493,9 +469,7 @@ class TestConsolidatedProviderParity:
         mock_client = Mock()
         mock_client.chat.completions.create.side_effect = Exception("API Error")
 
-        with patch.object(
-            OpenAICompatAdapter, "_get_client", return_value=mock_client
-        ):
+        with patch.object(OpenAICompatAdapter, "_get_client", return_value=mock_client):
             with pytest.raises(Exception, match="API Error"):
                 adapter.request(MESSAGES, "test-model")
 
@@ -505,9 +479,7 @@ class TestConsolidatedProviderParity:
         sentinel = Mock(name="stream")
         mock_client.chat.completions.create.return_value = sentinel
 
-        with patch.object(
-            OpenAICompatAdapter, "_get_client", return_value=mock_client
-        ):
+        with patch.object(OpenAICompatAdapter, "_get_client", return_value=mock_client):
             result = adapter.stream(MESSAGES, "test-model")
 
         assert result is sentinel
@@ -518,9 +490,7 @@ class TestConsolidatedProviderParity:
         mock_client = Mock()
         mock_client.chat.completions.create.side_effect = Exception("Stream Error")
 
-        with patch.object(
-            OpenAICompatAdapter, "_get_client", return_value=mock_client
-        ):
+        with patch.object(OpenAICompatAdapter, "_get_client", return_value=mock_client):
             with pytest.raises(Exception, match="Stream Error"):
                 adapter.stream(MESSAGES, "test-model")
 

--- a/tests/services/providers/test_tier2_adapters.py
+++ b/tests/services/providers/test_tier2_adapters.py
@@ -160,9 +160,7 @@ class TestTier2RequestTargeting:
         adapter = self._adapter(slug)
 
         with patch("src.services.providers.openai_compat.OpenAI") as mock_openai:
-            mock_openai.return_value.chat.completions.create.return_value = (
-                _mock_openai_response()
-            )
+            mock_openai.return_value.chat.completions.create.return_value = _mock_openai_response()
             adapter.request(MESSAGES, "test-model")
 
             kwargs = mock_openai.call_args[1]

--- a/tests/services/test_error_monitor_loki.py
+++ b/tests/services/test_error_monitor_loki.py
@@ -8,14 +8,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.services.error_monitor import ErrorMonitor
+from src.services.monitoring.error_monitor import ErrorMonitor
 
 
 class TestLokiErrorLogging:
     """Test Loki error logging behavior."""
 
     @pytest.mark.asyncio
-    @patch("src.services.error_monitor.httpx.AsyncClient")
+    @patch("src.services.monitoring.error_monitor.httpx.AsyncClient")
     async def test_loki_empty_error_not_logged(self, mock_httpx_client):
         """Test that empty Loki errors are suppressed and not logged at ERROR level."""
         monitor = ErrorMonitor()
@@ -29,7 +29,7 @@ class TestLokiErrorLogging:
         # Simulate an empty error
         mock_session.get.side_effect = Exception("")
 
-        with patch("src.services.error_monitor.logger") as mock_logger:
+        with patch("src.services.monitoring.error_monitor.logger") as mock_logger:
             errors = await monitor.fetch_recent_errors(hours=1, limit=100)
 
             # Should return empty list
@@ -42,7 +42,7 @@ class TestLokiErrorLogging:
             mock_logger.debug.assert_called_once_with("Loki fetch returned empty/no response")
 
     @pytest.mark.asyncio
-    @patch("src.services.error_monitor.httpx.AsyncClient")
+    @patch("src.services.monitoring.error_monitor.httpx.AsyncClient")
     async def test_loki_none_error_not_logged(self, mock_httpx_client):
         """Test that 'None' string errors from Loki are suppressed."""
         monitor = ErrorMonitor()
@@ -55,7 +55,7 @@ class TestLokiErrorLogging:
         # Simulate a "None" error
         mock_session.get.side_effect = Exception("None")
 
-        with patch("src.services.error_monitor.logger") as mock_logger:
+        with patch("src.services.monitoring.error_monitor.logger") as mock_logger:
             errors = await monitor.fetch_recent_errors(hours=1, limit=100)
 
             assert errors == []
@@ -63,7 +63,7 @@ class TestLokiErrorLogging:
             mock_logger.debug.assert_called()
 
     @pytest.mark.asyncio
-    @patch("src.services.error_monitor.httpx.AsyncClient")
+    @patch("src.services.monitoring.error_monitor.httpx.AsyncClient")
     async def test_loki_real_error_still_logged(self, mock_httpx_client):
         """Test that real Loki errors are still logged at ERROR level."""
         monitor = ErrorMonitor()
@@ -77,7 +77,7 @@ class TestLokiErrorLogging:
         real_error = Exception("Connection timeout to Loki server")
         mock_session.get.side_effect = real_error
 
-        with patch("src.services.error_monitor.logger") as mock_logger:
+        with patch("src.services.monitoring.error_monitor.logger") as mock_logger:
             errors = await monitor.fetch_recent_errors(hours=1, limit=100)
 
             assert errors == []
@@ -88,7 +88,7 @@ class TestLokiErrorLogging:
             assert "Connection timeout to Loki server" in error_call_args
 
     @pytest.mark.asyncio
-    @patch("src.services.error_monitor.httpx.AsyncClient")
+    @patch("src.services.monitoring.error_monitor.httpx.AsyncClient")
     async def test_loki_successful_fetch(self, mock_httpx_client):
         """Test that successful Loki fetches work correctly."""
         monitor = ErrorMonitor()
@@ -114,7 +114,7 @@ class TestLokiErrorLogging:
         }
         mock_session.get.return_value = mock_response
 
-        with patch("src.services.error_monitor.logger") as mock_logger:
+        with patch("src.services.monitoring.error_monitor.logger") as mock_logger:
             errors = await monitor.fetch_recent_errors(hours=1, limit=100)
 
             # Should return errors
@@ -127,7 +127,7 @@ class TestLokiErrorLogging:
             mock_logger.debug.assert_not_called()
 
     @pytest.mark.asyncio
-    @patch("src.services.error_monitor.httpx.AsyncClient")
+    @patch("src.services.monitoring.error_monitor.httpx.AsyncClient")
     async def test_loki_disabled_no_error(self, mock_httpx_client):
         """Test that disabled Loki doesn't trigger errors."""
         monitor = ErrorMonitor()
@@ -135,7 +135,7 @@ class TestLokiErrorLogging:
         # Loki disabled
         monitor.loki_enabled = False
 
-        with patch("src.services.error_monitor.logger") as mock_logger:
+        with patch("src.services.monitoring.error_monitor.logger") as mock_logger:
             errors = await monitor.fetch_recent_errors(hours=1, limit=100)
 
             # Should return empty list
@@ -148,7 +148,7 @@ class TestLokiErrorLogging:
             mock_logger.error.assert_not_called()
 
     @pytest.mark.asyncio
-    @patch("src.services.error_monitor.httpx.AsyncClient")
+    @patch("src.services.monitoring.error_monitor.httpx.AsyncClient")
     async def test_loki_whitespace_error_suppressed(self, mock_httpx_client):
         """Test that whitespace-only errors are suppressed."""
         monitor = ErrorMonitor()
@@ -161,7 +161,7 @@ class TestLokiErrorLogging:
         # Simulate a whitespace error
         mock_session.get.side_effect = Exception("   \n\t  ")
 
-        with patch("src.services.error_monitor.logger") as mock_logger:
+        with patch("src.services.monitoring.error_monitor.logger") as mock_logger:
             errors = await monitor.fetch_recent_errors(hours=1, limit=100)
 
             assert errors == []


### PR DESCRIPTION
## Summary

The MVP refactor (−37k LOC, #2165) merged into `main` and turned the full push-to-main CI matrix red. Several CI shards run **only on push-to-main** (not on PR check suites), so they carried stale tests encoding pre-refactor reality. This repairs all of them.

## Per-item cause → fix

| # | Failure | Root cause | Verdict | Fix |
|---|---------|-----------|---------|-----|
| 1 | Ruff **B905** at `provider_credit_monitor.py:326` | `zip()` without `strict=` (new lint under refactor) | code lint | Added `strict=False` (lists same-length by construction) |
| 2 | `test_bandit_false_positives_suppressed` — `FileNotFoundError` | `src/routes/health_timeline.py` deleted in refactor | **stale test** | Removed the deleted-file entry from the `checks` list (only `admin.py` remains, still carries `nosec B324`) |
| 3 | `test_cm05_provider_failover` — expected 10-provider chain incl. huggingface | HF client deleted; chain is now 9 | **stale test** | Updated count 10→9, dropped `huggingface` from expected order; updated `docs/CONCEPTUAL_MODEL.md` "14-provider" → "9-provider" (spec+code must move together) |
| 4 | `test_error_monitor_loki` — 5× "Expected 'debug' to be called" | Refactor moved `error_monitor` into `src/services/monitoring/` subpackage; the `src/services/__init__.py` shim creates a **duplicate module object**, so `patch("src.services.error_monitor.logger")` patched the shim while the code runs under `src.services.monitoring.error_monitor` with its own live logger | **stale test** (no code regression — behavior is correct; CI log's `Error fetching from Loki: Connection timeout` was the *real* logger firing because the mock never bound) | Repointed all import/patch targets to `src.services.monitoring.error_monitor` |
| 5 | `test_cm16_webhooks_events` — 3× credits_low/credits_depleted | `src/services/notification.py` (with `NotificationService.check_low_balance_alert` / `LowBalanceAlert`) deleted in refactor `8fa2e773` ("remove notifications"); surviving `EnhancedNotificationService` has no low-balance equivalent | **stale test** (deleted functionality, not flakiness) | Marked CM-16.2 / CM-16.3 classes `@pytest.mark.cm_gap` + `xfail(raises=ImportError)` per the CM suite convention, with comments citing the removal commit. Spec still lists the events, so the gap is documented rather than deleted |

**Net:** 1 code lint fix, 4 stale-test repairs. No production-code regressions found.

## Verification (local)

- `pytest tests/conceptual_model/test_cm05_provider_failover.py tests/conceptual_model/test_cm16_webhooks_events.py tests/security/test_admin_auth_coverage.py tests/services/test_error_monitor_loki.py` → **34 passed, 5 xfailed**
- `ruff check src/` → **All checks passed!**
- `python -c "import src.main"` → **exit 0** (35 routes loaded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)