### PR TITLE
fix(catalog): route order — /models/search shadowed by /models/{developer_name}

### DIFF
--- a/src/routes/catalog.py
+++ b/src/routes/catalog.py
@@ -2383,21 +2383,6 @@ async def get_specific_model_api_legacy(
     )
 
 
-@router.get("/models/{developer_name}", tags=["models"])
-async def get_developer_models_api(
-    developer_name: str,
-    limit: int = Query(100, ge=1, le=1000, description=DESC_LIMIT_NUMBER_OF_RESULTS),
-    offset: int | None = Query(0, description=DESC_OFFSET_FOR_PAGINATION),
-    gateway: str | None = Query("all", description="Gateway: 'openrouter' or 'all'"),
-):
-    return await get_developer_models(
-        developer_name=developer_name,
-        limit=limit,
-        offset=offset,
-        gateway=gateway,
-    )
-
-
 @router.get("/models/search", tags=["models"])
 async def search_models(
     q: str | None = Query(
@@ -2629,6 +2614,21 @@ async def search_models(
     except Exception as e:
         logger.error(f"Failed to search models: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to search models: {str(e)}")
+
+
+@router.get("/models/{developer_name}", tags=["models"])
+async def get_developer_models_api(
+    developer_name: str,
+    limit: int = Query(100, ge=1, le=1000, description=DESC_LIMIT_NUMBER_OF_RESULTS),
+    offset: int | None = Query(0, description=DESC_OFFSET_FOR_PAGINATION),
+    gateway: str | None = Query("all", description="Gateway: 'openrouter' or 'all'"),
+):
+    return await get_developer_models(
+        developer_name=developer_name,
+        limit=limit,
+        offset=offset,
+        gateway=gateway,
+    )
 
 
 # Helper functions for model comparison

--- a/tests/routes/test_catalog_search_route_order.py
+++ b/tests/routes/test_catalog_search_route_order.py
@@ -69,9 +69,9 @@ class TestModelsSearchRouteOrder:
             "/models/unique",
             "/models/search",
         ):
-            assert paths.index(static_path) < developer_idx, (
-                f"{static_path} must be registered before /models/{{developer_name}}"
-            )
+            assert (
+                paths.index(static_path) < developer_idx
+            ), f"{static_path} must be registered before /models/{{developer_name}}"
 
     def test_models_search_endpoint_returns_search_handler_shape(self):
         """End-to-end proof via the real router mount order: GET

--- a/tests/routes/test_catalog_search_route_order.py
+++ b/tests/routes/test_catalog_search_route_order.py
@@ -1,0 +1,102 @@
+"""Regression tests: /v1/models/search must not be shadowed by the dynamic
+/models/{developer_name} catch-all route.
+
+Bug: FastAPI/Starlette matches routes in registration order. When the static
+`/models/search` route is registered *after* the dynamic
+`/models/{developer_name}` route, a request to `GET /v1/models/search?q=...`
+gets captured by the developer-catch-all handler (with developer_name="search")
+instead of the dedicated search handler — silently returning the wrong (empty)
+response shape.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import src.routes.catalog as catalog
+
+MOCK_MODELS = [
+    {
+        "id": "openai/gpt-4-turbo",
+        "name": "GPT-4 Turbo",
+        "description": "OpenAI flagship model",
+        "provider": "openai",
+        "provider_slug": "openai",
+        "context_length": 128000,
+        "pricing": {"prompt": 0.01, "completion": 0.03},
+    }
+]
+
+
+def _make_client() -> TestClient:
+    """Build a minimal app that mounts the real catalog router the same way
+    src/main.py does (v1 router with '/v1' prefix), so route registration
+    order is exactly what production sees."""
+    app = FastAPI()
+    app.include_router(catalog.router, prefix="/v1")
+    return TestClient(app)
+
+
+class TestModelsSearchRouteOrder:
+    def test_search_route_registered_before_developer_catchall(self):
+        """Static /models/search must appear before the dynamic
+        /models/{developer_name} catch-all in the router's route list —
+        otherwise Starlette will match 'search' as a developer_name."""
+        paths = [r.path for r in catalog.router.routes if hasattr(r, "path")]
+
+        search_idx = paths.index("/models/search")
+        developer_idx = paths.index("/models/{developer_name}")
+
+        assert search_idx < developer_idx, (
+            "/models/search is registered AFTER /models/{developer_name}; "
+            "requests to /models/search will be shadowed by the developer "
+            "catch-all route."
+        )
+
+    def test_other_static_models_routes_precede_developer_catchall(self):
+        """/models/trending, /models/low-latency, /models/unique, and
+        /models/by-category/{category} are also static-ish siblings of the
+        dynamic catch-all and must stay registered ahead of it."""
+        paths = [r.path for r in catalog.router.routes if hasattr(r, "path")]
+        developer_idx = paths.index("/models/{developer_name}")
+
+        for static_path in (
+            "/models/by-category/{category}",
+            "/models/trending",
+            "/models/low-latency",
+            "/models/unique",
+            "/models/search",
+        ):
+            assert paths.index(static_path) < developer_idx, (
+                f"{static_path} must be registered before /models/{{developer_name}}"
+            )
+
+    def test_models_search_endpoint_returns_search_handler_shape(self):
+        """End-to-end proof via the real router mount order: GET
+        /v1/models/search?q=gpt must hit search_models (success/data/meta
+        shape), never get_developer_models_api (developer/models/total shape)."""
+        client = _make_client()
+
+        with (
+            patch("src.routes.catalog.get_cached_models", return_value=MOCK_MODELS),
+            patch(
+                "src.services.cache.catalog_response_cache.get_redis_client",
+                return_value=None,
+            ),
+        ):
+            resp = client.get("/v1/models/search", params={"q": "gpt"})
+
+        assert resp.status_code == 200
+        body = resp.json()
+
+        # search_models() response shape
+        assert body.get("success") is True
+        assert "data" in body
+        assert "meta" in body
+        assert body["meta"]["filters_applied"]["query"] == "gpt"
+
+        # Must NOT be the get_developer_models_api() shadowed shape, which
+        # has a "developer" key and no "success"/"meta" keys.
+        assert "developer" not in body


### PR DESCRIPTION
## Symptom
Live curl against `/v1/models/search?q=...` always returned the empty developer-catch-all shape (`{"developer": "search", "models": [], "total": 0, ...}`) instead of search results.

## Root cause
In `src/routes/catalog.py`, `@router.get("/models/search")` was registered *after* `@router.get("/models/{developer_name}")`. FastAPI/Starlette matches routes in registration order, so any request to `/models/search` was captured by the dynamic catch-all with `developer_name="search"`, which found no models matching developer "search" and returned an empty (but 200 OK) response — silently shadowing the real search endpoint.

## Fix
Moved the `/models/search` route definition (decorator + handler) above `/models/{developer_name}` so the static path wins the match.

Checked all other static `/models/*` routes for the same hazard:
- `/models/by-category/{category}`, `/models/trending`, `/models/low-latency`, `/models/unique` were already registered ahead of the `{developer_name}` catch-all — no shadowing there.
- `/models/{provider_name}/{model_name:path}` (two-segment) routes are unaffected since Starlette segment-counts differ from the single-segment `{developer_name}`.

## Test
Added `tests/routes/test_catalog_search_route_order.py`:
- `test_search_route_registered_before_developer_catchall` — asserts route registration order directly.
- `test_other_static_models_routes_precede_developer_catchall` — guards the other static siblings against regressing the same way.
- `test_models_search_endpoint_returns_search_handler_shape` — end-to-end `TestClient` proof: mounts the real router the same way `main.py` does, mocks `get_cached_models`, hits `GET /v1/models/search?q=gpt`, and asserts the `success`/`data`/`meta` search shape (not the `developer`/`models` shadowed shape).

RED (pre-fix, original route order): all 3 new tests fail — the functional test's response body was literally `{"developer": "search", "models": [], ...}`.
GREEN (post-fix): all 3 pass.

## Verification
- `python3 -c "from src.main import create_app; create_app()"` boots cleanly (35 routes loaded).
- `pytest -o addopts="" tests/routes -q --timeout=120 -x` → 95 passed, 2 xpassed, no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)