### PR TITLE
fix(pricing): restore manual_pricing.json loader so closed providers (OpenAI/Anthropic) get priced

### DIFF
--- a/src/services/pricing/pricing_lookup.py
+++ b/src/services/pricing/pricing_lookup.py
@@ -16,12 +16,17 @@ If you add a new pricing source, use normalize_pricing_dict() with the correct
 PricingFormat constant before returning values from this module.
 """
 
+import json
 import logging
 import threading
 import time
+from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+# Manual pricing seed: src/data/manual_pricing.json (this file is src/services/pricing/).
+_MANUAL_PRICING_PATH = Path(__file__).resolve().parents[2] / "data" / "manual_pricing.json"
 
 
 def validate_pricing_value(value: Any, field: str, model_id: str = "") -> str:
@@ -94,13 +99,47 @@ _openrouter_pricing_index: dict[str, dict] | None = None
 
 
 def load_manual_pricing() -> dict[str, Any]:
-    """Manual pricing file fallback is removed.
+    """Load the manual pricing seed from ``src/data/manual_pricing.json``.
 
-    All pricing now comes from the database (models_catalog via model sync).
-    This stub is kept so existing callers continue to work — they all handle
-    the empty-dict return gracefully (return None / skip to next tier).
+    This is the tier-3 fallback in :func:`get_model_pricing` for providers whose
+    upstream ``/models`` API returns no pricing (e.g. OpenAI, Anthropic). Without
+    it, those models sync with ``None`` pricing and get filtered out of the served
+    catalog (and blocked at the inference gate). Model keys are lowercased at load
+    time so lookups are O(1) and case-insensitive. Result is cached in-memory for
+    ``PRICING_CACHE_TTL``; thread-safe. On any read/parse error, caches and returns
+    an empty dict so callers degrade gracefully to the next tier.
     """
-    return {}
+    global _pricing_cache, _pricing_cache_timestamp
+
+    now = time.monotonic()
+    with _pricing_cache_lock:
+        if (
+            _pricing_cache is not None
+            and _pricing_cache_timestamp is not None
+            and (now - _pricing_cache_timestamp) < PRICING_CACHE_TTL
+        ):
+            return _pricing_cache
+
+        try:
+            with open(_MANUAL_PRICING_PATH, encoding="utf-8") as f:
+                raw = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.error(f"Failed to load manual pricing from {_MANUAL_PRICING_PATH}: {e}")
+            _pricing_cache = {}
+            _pricing_cache_timestamp = now
+            return _pricing_cache
+
+        normalized: dict[str, Any] = {}
+        for gateway, models in raw.items():
+            gw = str(gateway).lower()
+            if isinstance(models, dict):
+                normalized[gw] = {str(k).lower(): v for k, v in models.items()}
+            else:
+                normalized[gw] = models
+
+        _pricing_cache = normalized
+        _pricing_cache_timestamp = now
+        return _pricing_cache
 
 
 def get_model_pricing(gateway: str, model_id: str) -> dict[str, str] | None:

--- a/tests/services/test_manual_pricing_loader.py
+++ b/tests/services/test_manual_pricing_loader.py
@@ -1,0 +1,31 @@
+"""Manual pricing loader must actually load the JSON seed so closed providers
+(OpenAI/Anthropic) get pricing during model sync instead of None."""
+
+import src.services.pricing.pricing_lookup as pl
+
+
+def _reset_cache():
+    pl._pricing_cache = None
+    pl._pricing_cache_timestamp = None
+
+
+def test_load_manual_pricing_is_not_empty():
+    _reset_cache()
+    data = pl.load_manual_pricing()
+    assert isinstance(data, dict) and data, "manual pricing must load real entries, not {}"
+    assert "openai" in data and "anthropic" in data
+
+
+def test_openai_and_anthropic_chat_models_priced():
+    _reset_cache()
+    p = pl.get_model_pricing("openai", "openai/gpt-4o")
+    assert p and float(p["prompt"]) > 0 and float(p["completion"]) > 0
+    a = pl.get_model_pricing("anthropic", "anthropic/claude-sonnet-4")
+    assert a and float(a["prompt"]) > 0 and float(a["completion"]) > 0
+
+
+def test_pricing_is_per_token_scale():
+    """gpt-4o is ~$2.5 / 1M input tokens => ~2.5e-6 per token (sanity vs 1e6 unit errors)."""
+    _reset_cache()
+    p = pl.get_model_pricing("openai", "openai/gpt-4o")
+    assert 1e-7 < float(p["prompt"]) < 1e-4


### PR DESCRIPTION
## Problem
Prod router narrowed to `openai,anthropic,xai`. After setting keys + syncing, the catalog served **only xai** (4 models). openai (104) + anthropic (5) synced with `None` pricing → filtered out of the served catalog and blocked at the inference gate.

## Root cause
`load_manual_pricing()` was stubbed to `return {}` ("all pricing comes from the DB now"). But OpenAI/Anthropic `/models` APIs return **no pricing**, and nothing else seeds it. xic survives only because `xai_client` hardcodes pricing.

## Fix
Restore the tier-3 fallback: load `src/data/manual_pricing.json` (already in the repo; covers gpt-4o / claude-*), lowercase keys, thread-safe cached with TTL. Values normalize to correct per-token scale (gpt-4o $2.5/$10 per-1M).

## Tests
- New `tests/services/test_manual_pricing_loader.py` (3): loader non-empty, openai/anthropic chat models priced, per-token sanity.
- Existing pricing suite: 29 passed, 5 skipped, 0 failures.

## Post-merge
Redeploy → `POST /admin/model-sync/all?providers=openai&providers=anthropic&providers=xai` → verify catalog + a live completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Manual pricing data now loads correctly instead of returning empty results.
  * Pricing lookups support case-insensitive gateway and model names.
  * Pricing data is cached for faster, thread-safe access and refreshes automatically.
  * Loading errors are handled gracefully without disrupting the application.

* **Tests**
  * Added coverage for provider pricing, model pricing, and valid per-token values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->