### PR TITLE
fix(pricing): stop double-normalizing enriched per-token pricing at sync

### DIFF
--- a/src/services/model_catalog_sync.py
+++ b/src/services/model_catalog_sync.py
@@ -770,8 +770,7 @@ def sync_provider_models(
         if not normalized_models:
             total_duration = time.time() - start_time
             logger.warning(
-                f"[{provider_slug.upper()}] No models returned | "
-                f"Duration: {total_duration:.2f}s"
+                f"[{provider_slug.upper()}] No models returned | Duration: {total_duration:.2f}s"
             )
             return {
                 "success": True,
@@ -1064,12 +1063,12 @@ def sync_all_providers(
                     f"Skipping {len(skip_set)} providers from sync: {', '.join(sorted(skip_set))}"
                 )
 
-        logger.info(f"\n{'='*80}")
+        logger.info(f"\n{'=' * 80}")
         logger.info(f"{'STARTING PROVIDER SYNC':^80}")
-        logger.info(f"{'='*80}")
+        logger.info(f"{'=' * 80}")
         logger.info(f"Providers to sync: {len(providers_to_sync)}")
         logger.info(f"Dry run mode: {dry_run}")
-        logger.info(f"{'='*80}\n")
+        logger.info(f"{'=' * 80}\n")
 
         results = []
         total_fetched = 0
@@ -1082,7 +1081,7 @@ def sync_all_providers(
 
         for i, provider_slug in enumerate(providers_to_sync, 1):
             logger.info(
-                f"\n{'='*80}\n[{i}/{len(providers_to_sync)}] Syncing: {provider_slug.upper()}\n{'='*80}"
+                f"\n{'=' * 80}\n[{i}/{len(providers_to_sync)}] Syncing: {provider_slug.upper()}\n{'=' * 80}"
             )
             result = sync_provider_models(provider_slug, dry_run=dry_run, batch_mode=True)
             results.append(result)
@@ -1138,9 +1137,9 @@ def sync_all_providers(
         success_rate = (success_count / len(results) * 100) if results else 0
 
         # Print comprehensive dashboard
-        logger.info(f"\n{'='*80}")
+        logger.info(f"\n{'=' * 80}")
         logger.info(f"{'SYNC SUMMARY DASHBOARD':^80}")
-        logger.info(f"{'='*80}\n")
+        logger.info(f"{'=' * 80}\n")
 
         # Overall Statistics
         logger.info(f"{'OVERALL STATISTICS':-<80}")
@@ -1154,13 +1153,13 @@ def sync_all_providers(
         logger.info(f"{'MODEL STATISTICS':-<80}")
         logger.info(f"{'Total Fetched':<40} {total_fetched:>20}")
         logger.info(
-            f"{'Total Transformed':<40} {total_transformed:>20} ({total_transformed/max(total_fetched,1)*100:>6.1f}%)"
+            f"{'Total Transformed':<40} {total_transformed:>20} ({total_transformed / max(total_fetched, 1) * 100:>6.1f}%)"
         )
         logger.info(
-            f"{'Total Skipped':<40} {total_skipped:>20} ({total_skipped/max(total_fetched,1)*100:>6.1f}%)"
+            f"{'Total Skipped':<40} {total_skipped:>20} ({total_skipped / max(total_fetched, 1) * 100:>6.1f}%)"
         )
         logger.info(
-            f"{'Total Synced':<40} {total_synced:>20} ({total_synced/max(total_transformed,1)*100:>6.1f}%)\n"
+            f"{'Total Synced':<40} {total_synced:>20} ({total_synced / max(total_transformed, 1) * 100:>6.1f}%)\n"
         )
 
         # Performance Metrics
@@ -1199,7 +1198,7 @@ def sync_all_providers(
                 logger.error(f"{i}. {error['provider']:<25} {error['error']}")
             logger.info("")
 
-        logger.info(f"{'='*80}\n")
+        logger.info(f"{'=' * 80}\n")
 
         return {
             "success": success,

--- a/src/services/model_catalog_sync.py
+++ b/src/services/model_catalog_sync.py
@@ -369,9 +369,22 @@ def transform_normalized_model_to_db_schema(
         # Normalize pricing to per-token if the provider uses a different format
         # (e.g., per-1M for NEAR, DeepInfra, etc.)
         # This prevents storing inflated values in metadata.pricing_raw
+        #
+        # CRITICAL (North Star §4.2 unit-error landmine): pricing produced by
+        # enrichment — tier "manual" (get_model_pricing), "database", or
+        # "cross_reference" (OpenRouter) — is ALREADY per-token. Only inline
+        # provider pricing (e.g. xai's hardcoded per-1M "5"/"15", which sets no
+        # pricing_source) still needs normalization here. Re-normalizing enriched
+        # pricing divides by the provider factor a SECOND time (per-1M => 1e-12),
+        # silently making every closed-provider model ~1e6x too cheap.
         source_gateway = normalized_model.get("source_gateway", provider_slug)
+        already_per_token = normalized_model.get("pricing_source") in (
+            "manual",
+            "database",
+            "cross_reference",
+        )
         provider_format = get_provider_format(source_gateway)
-        if provider_format != PricingFormat.PER_TOKEN:
+        if not already_per_token and provider_format != PricingFormat.PER_TOKEN:
             for field in ("prompt", "completion", "image", "request"):
                 if pricing[field] is not None and pricing[field] != Decimal("0"):
                     normalized_val = normalize_to_per_token(pricing[field], provider_format)

--- a/tests/services/test_pricing_double_normalize.py
+++ b/tests/services/test_pricing_double_normalize.py
@@ -1,0 +1,45 @@
+"""Sync must not re-normalize pricing that enrichment already returned per-token.
+
+North Star §4.2 unit-error landmine: enriched pricing (pricing_source in
+manual/database/cross_reference) is already per-token; only inline raw provider
+pricing (e.g. xai per-1M, no pricing_source) should be normalized here.
+"""
+
+from decimal import Decimal
+
+from src.services.model_catalog_sync import transform_normalized_model_to_db_schema
+
+
+def _pricing_raw(model):
+    rec = transform_normalized_model_to_db_schema(model, provider_id=1, provider_slug=model["provider_slug"])
+    assert rec is not None
+    return rec["metadata"]["pricing_raw"]
+
+
+def test_enriched_per_token_pricing_is_not_renormalized():
+    # openai: enrichment produced per-token 2.5e-6; must survive unchanged.
+    model = {
+        "id": "openai/gpt-4o",
+        "provider_model_id": "gpt-4o",
+        "provider_slug": "openai",
+        "source_gateway": "openai",
+        "pricing_source": "database",
+        "pricing": {"prompt": "2.5e-06", "completion": "1e-05", "request": "0", "image": "0"},
+    }
+    pr = _pricing_raw(model)
+    assert Decimal(pr["prompt"]) == Decimal("2.5e-06"), pr
+    assert Decimal(pr["completion"]) == Decimal("1e-05"), pr
+
+
+def test_inline_per_1m_pricing_is_normalized_once():
+    # xai: hardcoded raw per-1M "5"/"15", no pricing_source -> normalize to per-token.
+    model = {
+        "id": "grok-2",
+        "provider_model_id": "grok-2",
+        "provider_slug": "xai",
+        "source_gateway": "xai",
+        "pricing": {"prompt": "5", "completion": "15", "request": "0", "image": "0"},
+    }
+    pr = _pricing_raw(model)
+    assert Decimal(pr["prompt"]) == Decimal("0.000005"), pr
+    assert Decimal(pr["completion"]) == Decimal("0.000015"), pr

--- a/tests/services/test_pricing_double_normalize.py
+++ b/tests/services/test_pricing_double_normalize.py
@@ -11,7 +11,9 @@ from src.services.model_catalog_sync import transform_normalized_model_to_db_sch
 
 
 def _pricing_raw(model):
-    rec = transform_normalized_model_to_db_schema(model, provider_id=1, provider_slug=model["provider_slug"])
+    rec = transform_normalized_model_to_db_schema(
+        model, provider_id=1, provider_slug=model["provider_slug"]
+    )
     assert rec is not None
     return rec["metadata"]["pricing_raw"]
 


### PR DESCRIPTION
## Problem
After restoring the manual pricing loader (#2172), openai/anthropic models synced but priced ~1e6 too cheap (gpt-3.5-turbo served at `5E-13`, should be `5E-7`). xai was correct.

## Root cause
`transform_normalized_model_to_db_schema` normalizes pricing per-1M→per-token for every non-PER_TOKEN provider. But enriched pricing (`pricing_source` = manual/database/cross_reference) is **already** per-token — so it got divided by 1e6 a second time. xai is fine because it inlines raw per-1M and sets no `pricing_source` (normalized once).

## Fix
Skip normalization when `pricing_source` marks enriched (already-per-token) pricing; still normalize inline raw provider pricing.

## Tests
New `tests/services/test_pricing_double_normalize.py`: enriched per-token preserved; inline per-1M normalized once. Sync/pricing suite: 39 passed, 0 failures.

## Post-merge
Deploy → flush the corrupted prod pricing → resync openai/anthropic/xai → verify per-token values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)