### PR TITLE
fix(chat): default sampling params to None so they aren't injected into upstream

### DIFF
--- a/src/schemas/proxy.py
+++ b/src/schemas/proxy.py
@@ -96,13 +96,13 @@ class ProxyRequest(BaseModel):
         description="The maximum number of tokens that can be generated in the chat completion",
     )
     temperature: float | None = Field(
-        default=1.0,
+        default=None,
         ge=0.0,
         le=2.0,
         description="Sampling temperature between 0 and 2. Higher values make output more random",
     )
     top_p: float | None = Field(
-        default=1.0,
+        default=None,
         ge=0.0,
         le=1.0,
         description="Nucleus sampling: consider tokens with top_p probability mass",
@@ -119,13 +119,13 @@ class ProxyRequest(BaseModel):
 
     # Penalty parameters
     frequency_penalty: float | None = Field(
-        default=0.0,
+        default=None,
         ge=-2.0,
         le=2.0,
         description="Penalize new tokens based on their existing frequency in the text",
     )
     presence_penalty: float | None = Field(
-        default=0.0,
+        default=None,
         ge=-2.0,
         le=2.0,
         description="Penalize new tokens based on whether they appear in the text so far",

--- a/tests/schemas/test_sampling_param_defaults.py
+++ b/tests/schemas/test_sampling_param_defaults.py
@@ -1,0 +1,28 @@
+"""Sampling params must default to None so the gateway only forwards them when the
+caller explicitly sets them. Injecting temperature/top_p/penalties breaks newer
+provider models (claude-sonnet-5 rejects top_p; grok-3 rejects presence_penalty)."""
+
+from src.schemas.proxy import ProxyRequest
+
+
+def test_sampling_params_default_to_none():
+    req = ProxyRequest(model="x", messages=[{"role": "user", "content": "hi"}])
+    assert req.temperature is None
+    assert req.top_p is None
+    assert req.frequency_penalty is None
+    assert req.presence_penalty is None
+
+
+def test_explicit_sampling_params_preserved():
+    req = ProxyRequest(
+        model="x",
+        messages=[{"role": "user", "content": "hi"}],
+        temperature=0.5,
+        top_p=0.9,
+        presence_penalty=0.2,
+        frequency_penalty=0.1,
+    )
+    assert req.temperature == 0.5
+    assert req.top_p == 0.9
+    assert req.presence_penalty == 0.2
+    assert req.frequency_penalty == 0.1


### PR DESCRIPTION
## Problem
With prod narrowed to openai/anthropic/xai, real completions worked for openai but anthropic + xai newer models 400'd:
- claude-sonnet-5: `top_p is deprecated` / `temperature and top_p cannot both be specified`
- grok-3: `presence_penalty not supported`

## Root cause
`ProxyRequest` defaulted `temperature=1.0, top_p=1.0, frequency_penalty=0.0, presence_penalty=0.0`, so `chat_dispatch` forwarded them on every request even when the caller omitted them. Newer models reject these.

## Fix
Default the four sampling params to `None`; they're only forwarded when explicitly provided. Models that accept them (gpt-4o) are unchanged — the provider applies its own default.

## Tests
New `tests/schemas/test_sampling_param_defaults.py` (defaults None; explicit values preserved). Proxy/chat schema suite: 60 passed.

## Verified after deploy
Real completions on gpt-4o-mini (openai), claude-sonnet-5 (anthropic), grok (xai).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sampling and penalty parameters are now omitted unless explicitly provided, preventing unintended default values from being forwarded.
  - Explicitly configured sampling values continue to be preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->