### PR TITLE
fix(routing): strip moonshot/ prefix before Moonshot API (unbreaks Kimi completions)

### DIFF
--- a/src/services/providers/adapter_configs.py
+++ b/src/services/providers/adapter_configs.py
@@ -96,6 +96,9 @@ ADAPTER_CONFIGS: dict[str, ProviderConfig] = {
         base_url="https://api.moonshot.ai/v1",
         api_key_env="MOONSHOT_API_KEY",
         display_name="Moonshot AI",
+        # Catalog stores ids as "moonshot/kimi-k2.6"; Moonshot's API expects the
+        # bare id ("kimi-k2.6"). Strip the slug prefix before the upstream call.
+        model_prefix="moonshot/",
     ),
     "minimax": ProviderConfig(
         slug="minimax",

--- a/tests/services/test_moonshot_model_prefix.py
+++ b/tests/services/test_moonshot_model_prefix.py
@@ -1,0 +1,15 @@
+"""Moonshot's catalog ids carry a "moonshot/" prefix but its API wants the bare
+id — the adapter must strip it, else every Kimi call 404s."""
+
+from src.services.providers.adapter_configs import ADAPTERS
+
+
+def test_moonshot_strips_slug_prefix():
+    a = ADAPTERS["moonshot"]
+    assert a._resolve_model("moonshot/kimi-k2.6") == "kimi-k2.6"
+    assert a._resolve_model("moonshot/kimi-k3") == "kimi-k3"
+
+
+def test_moonshot_leaves_bare_ids_untouched():
+    a = ADAPTERS["moonshot"]
+    assert a._resolve_model("kimi-k3") == "kimi-k3"


### PR DESCRIPTION
Kimi requests reached the moonshot adapter (after #2176) but 404'd because the catalog id 'moonshot/kimi-k2.6' was sent to Moonshot's API, which expects 'kimi-k2.6'. Set model_prefix='moonshot/' so the adapter strips it. Test included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)