### PR TITLE
chore(api): stop advertising the removed prompt-router (/routers, /gateways)

### DIFF
--- a/docs/superpowers/plans/2026-07-21-task-router-rebuild.md
+++ b/docs/superpowers/plans/2026-07-21-task-router-rebuild.md
@@ -1,0 +1,104 @@
+# Task-Based Router — Rebuild Plan
+
+**Status:** Design / plan. The prompt-router engine was deleted in the MVP refactor
+(commit `e94e095c`, ~3.2k LOC). Its `/routers` + `/gateways` advertising was removed
+in #2179. This plan rebuilds it as *real* task-based routing.
+
+**North Star note:** §4.3 currently specifies only provider-selection + latency routing
+for an **explicit** model. Task→model auto-selection is a new product capability and
+needs a `north-star:` amendment before shipping. The profit invariant is preserved:
+task routing sits *above* the provider router; provider cost/health/latency arbitrage
+is unchanged.
+
+---
+
+## 1. Goal
+
+One router API. A caller sends `model: "router:<mode>"` (or `router:code:<mode>`) and the
+system: (1) classifies the task, (2) selects the best model for `(task, mode)` from the
+live roster, (3) hands the resolved model to the **existing** provider failover chain
+(cost → health → latency) which streams + bills. Everything downstream is reused.
+
+Response echoes the routed model id (`"model": "openai/gpt-4o-mini"`) for transparency.
+
+## 2. Architecture — 3 stages
+
+```
+request (messages, model="router:general:balanced")
+  → [1] classify task      (heuristics; optional small-model classifier for ambiguous)
+  → [2] select model       (task + mode → category tags + benchmarks + health → model id)
+  → [3] provider dispatch   (EXISTING build_provider_failover_chain → stream → meter → settle)
+```
+
+**Stage 1 — Task classification.** Infer task type + requirements from the messages:
+`general chat | code | reasoning | long-context | vision`. Signals: prompt length,
+fenced code / language keywords, presence of tools/images, explicit hints. MUST be fast
+(North Star <50ms hot-path budget) → heuristics first; an optional cheap-model classifier
+only for genuinely ambiguous inputs, behind a flag.
+
+**Stage 2 — Model selection.** For `(task, mode)`, rank the live roster:
+- `balanced` — weighted quality/cost/latency
+- `quality` — best benchmark/quality for the task
+- `cost` — cheapest capable model
+- `latency` — fastest (speed-tier hosts, `:fast`)
+- code modes: `price | quality | agentic` (agentic = premium multi-step models)
+Inputs: model **category tags** (cheapest/fastest/largest/best-for-code), benchmark
+scores (code), context length, modality, current health. Selection is pure + testable
+(given a catalog snapshot → deterministic model id).
+
+**Stage 3 — Dispatch.** Resolve selected model → `build_provider_failover_chain` (already
+live) → stream/meter/settle. No new billing or provider code.
+
+## 3. Building blocks
+
+| Block | State | Action |
+|---|---|---|
+| Model **category tags** (cheapest/fastest/largest/best-for-code) | built on branch `feat/model-categorization`, **unmerged** | rebase onto current main + merge (Phase 0) |
+| Provider failover chain (stage 3) | **live** | reuse as-is |
+| Code benchmark data (old code-router was benchmark-based) | removed with the engine | re-source or start with a curated table |
+| `/routers` + `/gateways` advertising | emptied (#2179) | re-populate once functional (Phase 4) |
+
+## 4. Data model
+
+- **Model metadata** (catalog `models.metadata`): `category_tags[]`, `benchmark_scores{}`,
+  `context_length`, `modality`, `latency_tier`. Tags come from the categorization branch.
+- **Router policy** (config or small `router_policies` table): `mode → {weights, candidate
+  filter}`. Keep it data-driven so tuning a mode is not a code change.
+
+## 5. API surface (one router API)
+
+- `POST /v1/chat/completions` with `model: "router:general:<mode>"` or `"router:code:<mode>"`
+  (bare `router:general` = default mode). Keep the `gatewayz-*` aliases for back-compat.
+- A read endpoint (`GET /routers`) re-advertises modes **only once they resolve**.
+- Reject unknown modes with a clear 400 (not the current silent "no pricing" failure).
+
+## 6. Phases
+
+- **Phase 0 — tags.** Rebase + merge `feat/model-categorization`; verify tags populate on sync.
+- **Phase 1 — general router.** Heuristic classifier + rule-based selection for
+  `router:general:<mode>` over the live roster. Pure selection unit-tested against catalog
+  fixtures. Wire into `resolve_model_routing` (currently a rejecting stub).
+- **Phase 2 — code router.** `router:code:<mode>` with a curated benchmark table +
+  `agentic` premium tier.
+- **Phase 3 — smarter classification (optional).** Cheap-model classifier for ambiguous
+  inputs, behind a flag + latency guard; learn from usage stats.
+- **Phase 4 — re-advertise.** Re-populate `/routers` + `/gateways`; frontend wires the modes.
+
+## 7. Invariants & risks
+
+- **Latency:** default path must classify + select without an LLM call (heuristics) to stay
+  in the <50ms hot-path budget. LLM classification is opt-in only.
+- **Safety:** misclassification → wrong model. Mitigate: default to `balanced`/cheapest-capable,
+  always honor an explicit model id (bypass router), echo the routed model back.
+- **Transparency:** always return the concrete model used + let users pin.
+- **Profit:** provider arbitrage (stage 3) is untouched; task routing only chooses the model.
+- **North Star:** ship the `north-star:` §4.3 amendment (task→model selection) before Phase 1
+  merges to prod.
+
+## 8. Success criteria
+
+- `router:general:cost` picks the cheapest capable model; `:quality` the best; `:latency` a
+  speed-tier host — verified on catalog fixtures + live smoke tests.
+- Routed model id is returned; explicit models still bypass the router.
+- p50 added latency for the router path < 50ms over a direct explicit-model call.
+- `/routers` advertises only modes that actually resolve.

--- a/src/routes/catalog.py
+++ b/src/routes/catalog.py
@@ -175,108 +175,10 @@ async def get_intelligent_routers():
     - use_cases: Recommended use cases
     """
     try:
-        routers = [
-            {
-                "id": "general",
-                "name": "General Router",
-                "description": "Intelligent routing for general-purpose tasks",
-                "modes": [
-                    {
-                        "value": "balanced",
-                        "label": "Balanced",
-                        "description": "Balance quality, cost, and latency",
-                    },
-                    {
-                        "value": "quality",
-                        "label": "Quality",
-                        "description": "Optimize for response quality",
-                    },
-                    {
-                        "value": "cost",
-                        "label": "Cost",
-                        "description": "Optimize for lowest cost",
-                    },
-                    {
-                        "value": "latency",
-                        "label": "Latency",
-                        "description": "Optimize for fastest response",
-                    },
-                ],
-                "syntax": {
-                    "primary": "router:general:<mode>",
-                    "examples": [
-                        "router:general",
-                        "router:general:quality",
-                        "router:general:cost",
-                        "router:general:latency",
-                    ],
-                    "aliases": [
-                        "gatewayz-general",
-                        "gatewayz-general-quality",
-                        "gatewayz-general-cost",
-                        "gatewayz-general-latency",
-                    ],
-                },
-                "use_cases": [
-                    "creative writing",
-                    "summarization",
-                    "Q&A",
-                    "general chat",
-                    "data analysis",
-                ],
-            },
-            {
-                "id": "code",
-                "name": "Code Router",
-                "description": "Code-optimized routing with benchmark-based model selection",
-                "powered_by": "Gatewayz",
-                "modes": [
-                    {
-                        "value": "auto",
-                        "label": "Auto",
-                        "description": "Automatically select best model for task",
-                    },
-                    {
-                        "value": "price",
-                        "label": "Price",
-                        "description": "Optimize for lowest cost",
-                    },
-                    {
-                        "value": "quality",
-                        "label": "Quality",
-                        "description": "Optimize for highest quality",
-                    },
-                    {
-                        "value": "agentic",
-                        "label": "Agentic",
-                        "description": "Premium models for complex multi-step tasks",
-                    },
-                ],
-                "syntax": {
-                    "primary": "router:code:<mode>",
-                    "examples": [
-                        "router:code",
-                        "router:code:price",
-                        "router:code:quality",
-                        "router:code:agentic",
-                    ],
-                    "aliases": [
-                        "gatewayz-code",
-                        "gatewayz-code-price",
-                        "gatewayz-code-quality",
-                        "gatewayz-code-agentic",
-                    ],
-                },
-                "use_cases": [
-                    "code generation",
-                    "debugging",
-                    "refactoring",
-                    "code review",
-                    "architecture design",
-                ],
-            },
-        ]
-
+        # Prompt-router engine removed in the MVP refactor (commit e94e095c). The
+        # router:* / gatewayz-* aliases no longer resolve, so advertise nothing
+        # until task-based routing is rebuilt (see the rebuild plan).
+        routers: list[dict] = []
         return {
             "data": routers,
             "total": len(routers),
@@ -343,65 +245,11 @@ async def get_gateways():
         # Sort by priority (fast first), then by name
         gateways.sort(key=lambda g: (0 if g["priority"] == "fast" else 1, g["name"]))
 
-        # Add intelligent routers section
-        routers = [
-            {
-                "id": "general",
-                "name": "General Router",
-                "description": "Intelligent routing for general-purpose tasks",
-                "modes": ["balanced", "quality", "cost", "latency"],
-                "syntax": {
-                    "primary": "router:general:<mode>",
-                    "examples": [
-                        "router:general",
-                        "router:general:quality",
-                        "router:general:cost",
-                        "router:general:latency",
-                    ],
-                    "aliases": [
-                        "gatewayz-general",
-                        "gatewayz-general-quality",
-                        "gatewayz-general-cost",
-                        "gatewayz-general-latency",
-                    ],
-                },
-                "use_cases": [
-                    "creative writing",
-                    "summarization",
-                    "Q&A",
-                    "general chat",
-                    "data analysis",
-                ],
-            },
-            {
-                "id": "code",
-                "name": "Code Router",
-                "description": "Code-optimized routing with benchmark-based model selection",
-                "modes": ["auto", "price", "quality", "agentic"],
-                "syntax": {
-                    "primary": "router:code:<mode>",
-                    "examples": [
-                        "router:code",
-                        "router:code:price",
-                        "router:code:quality",
-                        "router:code:agentic",
-                    ],
-                    "aliases": [
-                        "gatewayz-code",
-                        "gatewayz-code-price",
-                        "gatewayz-code-quality",
-                        "gatewayz-code-agentic",
-                    ],
-                },
-                "use_cases": [
-                    "code generation",
-                    "debugging",
-                    "refactoring",
-                    "code review",
-                    "architecture design",
-                ],
-            },
-        ]
+        # Intelligent routers: the prompt-router engine was removed in the MVP
+        # refactor (commit e94e095c, ~3.2k LOC), so advertising router:* / gatewayz-*
+        # aliases here was misleading — every one 404s at inference. Return an empty
+        # list until task-based routing is rebuilt (see the rebuild plan).
+        routers: list[dict] = []
 
         return {
             "data": gateways,
@@ -1607,7 +1455,7 @@ async def get_trending_models_endpoint(
 
 @router.get("/gateways/summary", tags=["statistics"])
 async def get_all_gateways_summary_endpoint(
-    time_range: str = Query("24h", description=DESC_TIME_RANGE_ALL)
+    time_range: str = Query("24h", description=DESC_TIME_RANGE_ALL),
 ):
     """
     Get summary statistics for all gateways


### PR DESCRIPTION
The prompt-router engine was removed in the MVP refactor (e94e095c). `/routers` and `/gateways` still advertised `router:*`/`gatewayz-*` aliases with full syntax, but every one 404s at inference (verified on prod). Return empty router lists until task-based routing is rebuilt (plan incoming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated catalog responses to remove outdated intelligent-routing aliases.
  * The routers and gateways endpoints now return only currently available routing information.
  * Preserved the existing gateway summary time-range behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->