### PR TITLE
chore(billing): disable subscriptions — credits-only (per North Star)

### DIFF
--- a/src/routes/payments.py
+++ b/src/routes/payments.py
@@ -628,34 +628,10 @@ async def create_subscription_checkout(
         "status": "open"
     }
     """
-    try:
-        user_id = current_user["id"]
-        logger.info(
-            f"Creating subscription checkout for user {user_id}, price_id: {request.price_id}, product_id: {request.product_id}"
-        )
-
-        session = stripe_service.create_subscription_checkout(user_id=user_id, request=request)
-
-        logger.info(
-            f"Subscription checkout session created for user {user_id}: {session.session_id}"
-        )
-
-        return {
-            "session_id": session.session_id,
-            "url": session.url,
-            "customer_id": session.customer_id,
-            "status": session.status,
-        }
-
-    except ValueError as e:
-        logger.error(f"Validation error creating subscription checkout: {e}", exc_info=True)
-        raise HTTPException(status_code=400, detail=str(e))
-
-    except Exception as e:
-        logger.error(f"Error creating subscription checkout: {e}", exc_info=True)
-        raise HTTPException(
-            status_code=500, detail=f"Failed to create subscription checkout: {str(e)}"
-        )
+    raise HTTPException(
+        status_code=410,
+        detail="Subscriptions have been discontinued. Please use credit top-ups instead.",
+    )
 
 
 # ==================== Subscription Management ====================
@@ -684,36 +660,10 @@ async def get_current_subscription(
         "price_id": "price_xxxxx"
     }
     """
-    try:
-        user_id = current_user["id"]
-        subscription = stripe_service.get_current_subscription(user_id)
-
-        return {
-            "has_subscription": subscription.has_subscription,
-            "subscription_id": subscription.subscription_id,
-            "status": subscription.status,
-            "tier": subscription.tier,
-            "current_period_start": (
-                subscription.current_period_start.isoformat()
-                if subscription.current_period_start
-                else None
-            ),
-            "current_period_end": (
-                subscription.current_period_end.isoformat()
-                if subscription.current_period_end
-                else None
-            ),
-            "cancel_at_period_end": subscription.cancel_at_period_end,
-            "canceled_at": (
-                subscription.canceled_at.isoformat() if subscription.canceled_at else None
-            ),
-            "product_id": subscription.product_id,
-            "price_id": subscription.price_id,
-        }
-
-    except Exception as e:
-        logger.error(f"Error getting subscription: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Failed to get subscription: {str(e)}")
+    raise HTTPException(
+        status_code=410,
+        detail="Subscriptions have been discontinued. Please use credit top-ups instead.",
+    )
 
 
 @router.post("/subscription/upgrade", response_model=dict[str, Any])
@@ -749,31 +699,10 @@ async def upgrade_subscription(
         "message": "Successfully upgraded to max tier"
     }
     """
-    try:
-        user_id = current_user["id"]
-        logger.info(
-            f"Upgrading subscription for user {user_id} to product {request.new_product_id}"
-        )
-
-        result = stripe_service.upgrade_subscription(user_id=user_id, request=request)
-
-        return {
-            "success": result.success,
-            "subscription_id": result.subscription_id,
-            "status": result.status,
-            "current_tier": result.current_tier,
-            "message": result.message,
-            "effective_date": result.effective_date.isoformat() if result.effective_date else None,
-            "proration_amount": result.proration_amount,
-        }
-
-    except ValueError as e:
-        logger.error(f"Validation error upgrading subscription: {e}", exc_info=True)
-        raise HTTPException(status_code=400, detail=str(e))
-
-    except Exception as e:
-        logger.error(f"Error upgrading subscription: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Failed to upgrade subscription: {str(e)}")
+    raise HTTPException(
+        status_code=410,
+        detail="Subscriptions have been discontinued. Please use credit top-ups instead.",
+    )
 
 
 @router.post("/subscription/downgrade", response_model=dict[str, Any])
@@ -809,31 +738,10 @@ async def downgrade_subscription(
         "message": "Successfully downgraded to pro tier. Credit applied for unused time."
     }
     """
-    try:
-        user_id = current_user["id"]
-        logger.info(
-            f"Downgrading subscription for user {user_id} to product {request.new_product_id}"
-        )
-
-        result = stripe_service.downgrade_subscription(user_id=user_id, request=request)
-
-        return {
-            "success": result.success,
-            "subscription_id": result.subscription_id,
-            "status": result.status,
-            "current_tier": result.current_tier,
-            "message": result.message,
-            "effective_date": result.effective_date.isoformat() if result.effective_date else None,
-            "proration_amount": result.proration_amount,
-        }
-
-    except ValueError as e:
-        logger.error(f"Validation error downgrading subscription: {e}", exc_info=True)
-        raise HTTPException(status_code=400, detail=str(e))
-
-    except Exception as e:
-        logger.error(f"Error downgrading subscription: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Failed to downgrade subscription: {str(e)}")
+    raise HTTPException(
+        status_code=410,
+        detail="Subscriptions have been discontinued. Please use credit top-ups instead.",
+    )
 
 
 @router.post("/subscription/cancel", response_model=dict[str, Any])
@@ -870,28 +778,7 @@ async def cancel_subscription(
         "effective_date": "2024-02-01T00:00:00Z"
     }
     """
-    try:
-        user_id = current_user["id"]
-        logger.info(
-            f"Canceling subscription for user {user_id} "
-            f"(cancel_at_period_end: {request.cancel_at_period_end})"
-        )
-
-        result = stripe_service.cancel_subscription(user_id=user_id, request=request)
-
-        return {
-            "success": result.success,
-            "subscription_id": result.subscription_id,
-            "status": result.status,
-            "current_tier": result.current_tier,
-            "message": result.message,
-            "effective_date": result.effective_date.isoformat() if result.effective_date else None,
-        }
-
-    except ValueError as e:
-        logger.error(f"Validation error canceling subscription: {e}", exc_info=True)
-        raise HTTPException(status_code=400, detail=str(e))
-
-    except Exception as e:
-        logger.error(f"Error canceling subscription: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Failed to cancel subscription: {str(e)}")
+    raise HTTPException(
+        status_code=410,
+        detail="Subscriptions have been discontinued. Please use credit top-ups instead.",
+    )

--- a/src/routes/plans.py
+++ b/src/routes/plans.py
@@ -247,57 +247,8 @@ async def get_trial_status(api_key: str = Depends(get_api_key)):
 
 @router.get("/subscription/plans", tags=["subscription"])
 async def get_subscription_plans():
-    """Get available subscription plans with 4-tier structure"""
-    try:
-        # Get all plans from a database
-        plans = get_all_plans()
-
-        # Enhance plans with additional information
-        enhanced_plans = []
-        for plan in plans:
-            plan_type = plan.get("plan_type", "free")
-            is_pay_as_you_go = plan.get("is_pay_as_you_go", False)
-
-            enhanced_plan = {
-                "id": plan.get("id"),
-                "name": plan.get("name"),
-                "description": plan.get("description"),
-                "plan_type": plan_type,
-                "monthly_price": float(plan.get("price_per_month", 0)),
-                "yearly_price": (
-                    float(plan.get("yearly_price", 0)) if plan.get("yearly_price") else None
-                ),
-                "price_per_token": (
-                    float(plan.get("price_per_token", 0)) if plan.get("price_per_token") else None
-                ),
-                "is_pay_as_you_go": is_pay_as_you_go,
-                "daily_request_limit": plan.get("daily_request_limit", 0),
-                "monthly_request_limit": plan.get("monthly_request_limit", 0),
-                "daily_token_limit": plan.get("daily_token_limit", 0),
-                "monthly_token_limit": plan.get("monthly_token_limit", 0),
-                "max_concurrent_requests": plan.get("max_concurrent_requests", 5),
-                "features": plan.get("features", []),
-                "is_active": plan.get("is_active", True),
-                "trial_eligible": plan_type == "free",  # Only the Free plan is trial eligible
-            }
-            enhanced_plans.append(enhanced_plan)
-
-        # Sort plans by price (Free, Dev, Team, Customize)
-        plan_order = {"free": 0, "dev": 1, "team": 2, "customize": 3}
-        enhanced_plans.sort(key=lambda x: plan_order.get(x["plan_type"], 999))
-
-        return {
-            "success": True,
-            "plans": enhanced_plans,
-            "message": "Subscription plans retrieved successfully",
-            "trial_info": {
-                "trial_days": 3,
-                "trial_credits": 5.0,
-                "trial_tokens": 1000000,  # 1M tokens for trial
-                "trial_requests": 10000,  # 10K requests for trial
-                "trial_plan": "free",
-            },
-        }
-    except Exception as e:
-        logger.error(f"Error getting subscription plans: {e}")
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    """Subscriptions have been discontinued; this endpoint is disabled."""
+    raise HTTPException(
+        status_code=410,
+        detail="Subscriptions have been discontinued. Please use credit top-ups instead.",
+    )

--- a/tests/routes/test_payments_subscription_disabled.py
+++ b/tests/routes/test_payments_subscription_disabled.py
@@ -1,0 +1,69 @@
+"""
+Tests confirming subscription purchase/management endpoints are disabled (HTTP 410).
+
+Per North Star, Gatewayz is a prepaid-credits-only platform. Subscription
+create/upgrade/downgrade/cancel/get-current endpoints must return 410 Gone
+instead of performing any Stripe subscription operation. Credit top-up
+(/api/stripe/checkout-session) is NOT covered here and must remain unaffected.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.routes.payments import get_current_user, router
+
+EXPECTED_DETAIL = "Subscriptions have been discontinued. Please use credit top-ups instead."
+
+
+@pytest.fixture(scope="function")
+def client():
+    app = FastAPI()
+    app.include_router(router)
+
+    async def mock_get_current_user():
+        return {"id": 1, "email": "test@example.com"}
+
+    app.dependency_overrides[get_current_user] = mock_get_current_user
+    return TestClient(app)
+
+
+class TestSubscriptionEndpointsDisabled:
+    def test_subscription_checkout_returns_410(self, client):
+        resp = client.post(
+            "/api/stripe/subscription-checkout",
+            json={
+                "price_id": "price_123",
+                "product_id": "prod_123",
+                "success_url": "https://example.com/success",
+                "cancel_url": "https://example.com/cancel",
+            },
+        )
+        assert resp.status_code == 410
+        assert resp.json()["detail"] == EXPECTED_DETAIL
+
+    def test_get_current_subscription_returns_410(self, client):
+        resp = client.get("/api/stripe/subscription")
+        assert resp.status_code == 410
+        assert resp.json()["detail"] == EXPECTED_DETAIL
+
+    def test_upgrade_subscription_returns_410(self, client):
+        resp = client.post(
+            "/api/stripe/subscription/upgrade",
+            json={"new_price_id": "price_456", "new_product_id": "prod_456"},
+        )
+        assert resp.status_code == 410
+        assert resp.json()["detail"] == EXPECTED_DETAIL
+
+    def test_downgrade_subscription_returns_410(self, client):
+        resp = client.post(
+            "/api/stripe/subscription/downgrade",
+            json={"new_price_id": "price_789", "new_product_id": "prod_789"},
+        )
+        assert resp.status_code == 410
+        assert resp.json()["detail"] == EXPECTED_DETAIL
+
+    def test_cancel_subscription_returns_410(self, client):
+        resp = client.post("/api/stripe/subscription/cancel", json={})
+        assert resp.status_code == 410
+        assert resp.json()["detail"] == EXPECTED_DETAIL

--- a/tests/routes/test_plans.py
+++ b/tests/routes/test_plans.py
@@ -5,6 +5,7 @@ Comprehensive tests for Plans routes
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from src.routes.plans import router
@@ -23,3 +24,21 @@ class TestPlansRoutes:
         import src.routes.plans
 
         assert src.routes.plans is not None
+
+
+class TestSubscriptionPlansDisabled:
+    """Subscriptions are discontinued; /subscription/plans must return 410."""
+
+    @pytest.fixture(scope="function")
+    def client(self):
+        app = FastAPI()
+        app.include_router(router)
+        return TestClient(app)
+
+    def test_subscription_plans_returns_410(self, client):
+        resp = client.get("/subscription/plans")
+        assert resp.status_code == 410
+        assert (
+            resp.json()["detail"]
+            == "Subscriptions have been discontinued. Please use credit top-ups instead."
+        )


### PR DESCRIPTION
North Star is prepaid-credits-only. Disable subscription create/manage flows; keep credit top-ups fully working.

- 6 subscription endpoints now return **410 Gone** with a clear message: 5 in `payments.py` (`/subscription-checkout`, `GET /subscription`, `/subscription/upgrade`, `/subscription/downgrade`, `/subscription/cancel`) + `/subscription/plans` in `plans.py`.
- **Untouched:** credit top-up checkout, Stripe webhook, and all plan/tier/trial/rate-limit endpoints. `StripeService` subscription methods left in place (routes short-circuited) — reversible.

Tests: tests/routes 101 passed + 6 new 410 assertions, 0 regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)