### PR TITLE
feat(billing): nightly pricing-drift monitor (guard against billing below cost)

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -157,9 +157,7 @@ class Config:
         "ENABLE_PRICING_DRIFT_MONITOR", "true"
     ).lower() in {"1", "true", "yes"}
     # Default: once every 1440 minutes (24h) — nightly.
-    PRICING_DRIFT_INTERVAL_MINUTES = int(
-        os.environ.get("PRICING_DRIFT_INTERVAL_MINUTES", "1440")
-    )
+    PRICING_DRIFT_INTERVAL_MINUTES = int(os.environ.get("PRICING_DRIFT_INTERVAL_MINUTES", "1440"))
     # Reject inference requests for models without a row in model_pricing.
     REQUIRE_MODEL_PRICING = os.environ.get("REQUIRE_MODEL_PRICING", "true").lower() in {
         "1",

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -149,6 +149,17 @@ class Config:
     LEDGER_RECONCILIATION_WINDOW_HOURS = int(
         os.environ.get("LEDGER_RECONCILIATION_WINDOW_HOURS", "24")
     )
+    # Nightly pricing-drift monitor: audits active-provider catalog pricing against
+    # current OpenRouter reference pricing so we never bill below provider cost even
+    # with PRICING_MARKUP applied. Read-only: logs at ERROR + captures to Sentry when
+    # drift/unpriced models are found; never mutates prices or models.
+    ENABLE_PRICING_DRIFT_MONITOR = os.environ.get(
+        "ENABLE_PRICING_DRIFT_MONITOR", "true"
+    ).lower() in {"1", "true", "yes"}
+    # Default: once every 1440 minutes (24h) — nightly.
+    PRICING_DRIFT_INTERVAL_MINUTES = int(
+        os.environ.get("PRICING_DRIFT_INTERVAL_MINUTES", "1440")
+    )
     # Reject inference requests for models without a row in model_pricing.
     REQUIRE_MODEL_PRICING = os.environ.get("REQUIRE_MODEL_PRICING", "true").lower() in {
         "1",

--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -2537,6 +2537,35 @@ async def run_pricing_audit(
 
 
 # ============================================================================
+# ADMIN PRICING DRIFT MONITOR - Catch below-cost billing before it leaks margin
+# ============================================================================
+
+
+@router.get("/admin/pricing-drift", tags=["admin"])
+async def run_pricing_drift_audit(
+    admin_user: dict = Depends(require_admin),
+):
+    """
+    Audit active-provider catalog pricing against current OpenRouter reference
+    pricing to catch margin leaks.
+
+    We bill inference at ``catalog_price * Config.PRICING_MARKUP``. If a
+    provider raises its price and our catalog goes stale, we could bill below
+    the provider's real cost even with markup applied. This endpoint flags:
+
+    - ``drift``: models where ``catalog_price * markup`` is still below the
+      current OpenRouter reference price (worst deficit first).
+    - ``unpriced``: active models with no usable catalog price (None/0).
+
+    Read-only: never mutates prices or models. Requires admin authentication.
+    """
+    from src.services.billing.pricing_drift_monitor import audit_pricing_drift
+
+    report = await asyncio.to_thread(audit_pricing_drift)
+    return report
+
+
+# ============================================================================
 # Pricing Sync Scheduler Endpoints - DEPRECATED (Phase 2)
 # ============================================================================
 # These endpoints were removed as part of the pricing sync deprecation (Issue #1062).

--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -2217,9 +2217,7 @@ async def get_chat_requests_summary_admin(
 
         # Create cache key based on filters
         filter_str = f"{model_id}:{provider_id}:{model_name}:{start_date}:{end_date}"
-        filter_hash = hashlib.md5(
-            filter_str.encode()
-        ).hexdigest()  # nosec B324 - MD5 for cache key, not security
+        filter_hash = hashlib.md5(filter_str.encode()).hexdigest()  # nosec B324 - MD5 for cache key, not security
         cache_key = f"chat_summary:filters:{filter_hash}"
 
         redis_client = get_redis_client()
@@ -2268,7 +2266,9 @@ async def get_chat_requests_summary_admin(
         if redis_client:
             try:
                 redis_client.setex(
-                    cache_key, 60, json.dumps(response, default=str)  # 60 second TTL
+                    cache_key,
+                    60,
+                    json.dumps(response, default=str),  # 60 second TTL
                 )
                 logger.info(f"Cached chat summary for filter_hash={filter_hash} (TTL: 60s)")
             except Exception as cache_error:

--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -2217,7 +2217,9 @@ async def get_chat_requests_summary_admin(
 
         # Create cache key based on filters
         filter_str = f"{model_id}:{provider_id}:{model_name}:{start_date}:{end_date}"
-        filter_hash = hashlib.md5(filter_str.encode()).hexdigest()  # nosec B324 - MD5 for cache key, not security
+        filter_hash = hashlib.md5(
+            filter_str.encode()
+        ).hexdigest()  # nosec B324 - MD5 for cache key, not security
         cache_key = f"chat_summary:filters:{filter_hash}"
 
         redis_client = get_redis_client()

--- a/src/services/billing/pricing_drift_monitor.py
+++ b/src/services/billing/pricing_drift_monitor.py
@@ -1,0 +1,232 @@
+"""Nightly pricing-drift monitor — catches margin leaks before they bill.
+
+We charge inference at ``catalog_price * Config.PRICING_MARKUP``. If a
+provider raises its price and our catalog goes stale (sync lag, a provider
+that stopped reporting pricing, a broken cross-reference match, etc.), we
+could end up billing *below* the provider's real cost — a silent margin leak
+that compounds with every request.
+
+This module audits every active model of every active (ENABLED) provider:
+for each model it compares our billed price (catalog price with markup
+applied) against the current OpenRouter reference price for the same
+model. If the billed price is still below the reference even *with* markup
+applied, the model is flagged as DRIFT. Models with no catalog price at all
+(None/0) are flagged as ``unpriced`` — a distinct, often worse, failure mode
+(free inference).
+
+Read-only / side-effect-free: this module only reads pricing data and
+returns a report. It never mutates prices, models, or providers. Callers
+(the admin endpoint, the nightly scheduler) decide what to do with the
+report — alert, page, log — but this module never acts on it.
+
+Reuses the existing pricing infrastructure instead of re-deriving pricing
+logic:
+  - ``src.db.providers_db.get_active_provider_slugs`` — which providers matter
+  - ``src.db.models_catalog_db.get_models_by_provider_slug`` — active models
+    per provider (same query used by the catalog itself)
+  - ``src.services.pricing.pricing_lookup._resolve_pricing_from_db`` — the
+    shared DB pricing resolver used by both display and billing (checks the
+    legacy ``model_pricing`` table, then ``metadata.pricing_raw``)
+  - ``src.services.pricing.pricing_lookup._build_openrouter_pricing_index`` /
+    ``_get_cross_reference_pricing`` — the same OpenRouter-catalog
+    cross-reference (incl. ``OPENROUTER_PROVIDER_ALIASES``) used to price
+    gateway providers during catalog sync
+
+All prices are per-token USD, matching the canonical format used throughout
+the billing pipeline (see the module docstring in ``pricing_lookup.py``).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from src.config.config import Config
+from src.db.models_catalog_db import get_models_by_provider_slug
+from src.db.providers_db import get_active_provider_slugs
+from src.services.pricing.pricing_lookup import (
+    _build_openrouter_pricing_index,
+    _get_cross_reference_pricing,
+    _resolve_pricing_from_db,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _to_float(value: Any) -> float | None:
+    """Best-effort numeric coercion. Returns None for missing/invalid values."""
+    if value is None or value == "":
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    if f != f:  # NaN guard (NaN != NaN)
+        return None
+    return f
+
+
+def _our_catalog_pricing(model_id: str, model_name: str | None) -> dict[str, str] | None:
+    """Mirror pricing_lookup's DB pricing resolution for a single model.
+
+    Delegates entirely to ``_resolve_pricing_from_db`` (the shared resolver
+    also used by the live billing path), trying both the canonical
+    ``provider_model_id`` and the display ``model_name`` as candidates so the
+    lookup matches whichever column pricing was actually keyed on.
+    """
+    candidate_ids = {model_id}
+    if model_name:
+        candidate_ids.add(model_name)
+    return _resolve_pricing_from_db(model_id, candidate_ids=candidate_ids)
+
+
+def _model_identifier(model: dict[str, Any]) -> str | None:
+    """Canonical model id for a catalog row — same field used as model["id"]
+    in every downstream catalog response (see get_all_pricing_batch)."""
+    return model.get("provider_model_id") or model.get("model_name")
+
+
+def audit_pricing_drift() -> dict[str, Any]:
+    """Audit active-provider catalog pricing against OpenRouter reference pricing.
+
+    For every active model of every active (ENABLED) provider, compares our
+    billed price — ``catalog_price * Config.PRICING_MARKUP`` — against the
+    current OpenRouter reference price for the same model (matched via the
+    same base-id + provider-alias cross-reference logic used to price gateway
+    providers during catalog sync). A model is flagged as **drift** when the
+    billed price is still below the reference price on either the input or
+    output side, meaning we would bill below the provider's real cost even
+    after applying our markup. A model with no catalog price at all (None or
+    0 on both sides) is flagged as **unpriced** instead — a distinct failure
+    mode (it would bill nothing) that isn't meaningfully expressed as a
+    "deficit percentage".
+
+    OpenRouter itself is skipped as a comparison target (its own catalog IS
+    the reference; there is nothing to cross-check it against), mirroring
+    ``enrich_model_with_pricing``'s treatment of the openrouter gateway.
+
+    Read-only: makes no writes. Safe to call from an admin endpoint or a
+    scheduled background job.
+
+    Returns:
+        {
+            "checked": int,                 # total active models examined
+            "drift": [                      # worst-first by deficit_pct
+                {
+                    "model_id": str,
+                    "provider": str,
+                    "our_in": float | None,  # our catalog per-token input price
+                    "our_out": float | None, # our catalog per-token output price
+                    "ref_in": float | None,  # OpenRouter reference input price
+                    "ref_out": float | None, # OpenRouter reference output price
+                    "markup": float,
+                    "deficit_pct": float,    # worst-case % below reference cost
+                },
+                ...
+            ],
+            "unpriced": [
+                {"model_id": str, "provider": str, "missing": [str, ...]},
+                ...
+            ],
+            "worst_deficit_pct": float,      # 0.0 if no drift found
+            "ok": bool,                      # True iff no drift AND no unpriced
+        }
+    """
+    markup = Config.PRICING_MARKUP
+    openrouter_index = _build_openrouter_pricing_index()
+
+    checked = 0
+    drift: list[dict[str, Any]] = []
+    unpriced: list[dict[str, Any]] = []
+
+    provider_slugs = get_active_provider_slugs()
+
+    for provider_slug in provider_slugs:
+        try:
+            models = get_models_by_provider_slug(provider_slug, is_active_only=True)
+        except Exception as e:
+            logger.error(
+                f"[pricing-drift] Failed to load active models for provider "
+                f"'{provider_slug}': {e}"
+            )
+            continue
+
+        for model in models:
+            model_id = _model_identifier(model)
+            if not model_id:
+                continue
+            checked += 1
+
+            our_pricing = _our_catalog_pricing(model_id, model.get("model_name"))
+            our_in = _to_float(our_pricing.get("prompt")) if our_pricing else None
+            our_out = _to_float(our_pricing.get("completion")) if our_pricing else None
+
+            in_missing = our_in is None or our_in <= 0
+            out_missing = our_out is None or our_out <= 0
+
+            if in_missing and out_missing:
+                # No usable catalog price at all — would bill $0. Distinct
+                # failure mode from drift (there's no "deficit %" of nothing).
+                unpriced.append(
+                    {
+                        "model_id": model_id,
+                        "provider": provider_slug,
+                        "missing": [
+                            side
+                            for side, missing in (("input", in_missing), ("output", out_missing))
+                            if missing
+                        ],
+                    }
+                )
+                continue
+
+            # OpenRouter's own catalog IS the reference price — nothing to
+            # cross-check it against.
+            if provider_slug.lower() == "openrouter":
+                continue
+
+            ref_pricing = _get_cross_reference_pricing(
+                model_id, openrouter_index, provider=provider_slug
+            )
+            if not ref_pricing:
+                # No reference available (model not on OpenRouter, or index
+                # miss) — can't assess drift for this model.
+                continue
+
+            ref_in = _to_float(ref_pricing.get("prompt"))
+            ref_out = _to_float(ref_pricing.get("completion"))
+
+            deficits: list[float] = []
+            if our_in is not None and ref_in is not None and ref_in > 0:
+                billed_in = our_in * markup
+                if billed_in < ref_in:
+                    deficits.append((ref_in - billed_in) / ref_in * 100)
+            if our_out is not None and ref_out is not None and ref_out > 0:
+                billed_out = our_out * markup
+                if billed_out < ref_out:
+                    deficits.append((ref_out - billed_out) / ref_out * 100)
+
+            if deficits:
+                drift.append(
+                    {
+                        "model_id": model_id,
+                        "provider": provider_slug,
+                        "our_in": our_in,
+                        "our_out": our_out,
+                        "ref_in": ref_in,
+                        "ref_out": ref_out,
+                        "markup": markup,
+                        "deficit_pct": max(deficits),
+                    }
+                )
+
+    drift.sort(key=lambda d: d["deficit_pct"], reverse=True)
+    worst_deficit_pct = drift[0]["deficit_pct"] if drift else 0.0
+
+    return {
+        "checked": checked,
+        "drift": drift,
+        "unpriced": unpriced,
+        "worst_deficit_pct": worst_deficit_pct,
+        "ok": not drift and not unpriced,
+    }

--- a/src/services/billing/pricing_drift_monitor.py
+++ b/src/services/billing/pricing_drift_monitor.py
@@ -141,13 +141,20 @@ def audit_pricing_drift() -> dict[str, Any]:
 
     provider_slugs = get_active_provider_slugs()
 
+    # Only providers that actually route + bill matter for margin. ENABLED_PROVIDERS
+    # gates routing (src/utils/provider_filter.py); a provider active in the DB but
+    # not enabled (e.g. openrouter as dormant fallback) never bills a user, so its
+    # unpriced/underpriced models are noise, not a margin risk. Filter to enabled.
+    enabled = Config.ENABLED_PROVIDERS
+    if enabled:
+        provider_slugs = [s for s in provider_slugs if s in enabled]
+
     for provider_slug in provider_slugs:
         try:
             models = get_models_by_provider_slug(provider_slug, is_active_only=True)
         except Exception as e:
             logger.error(
-                f"[pricing-drift] Failed to load active models for provider "
-                f"'{provider_slug}': {e}"
+                f"[pricing-drift] Failed to load active models for provider '{provider_slug}': {e}"
             )
             continue
 

--- a/src/services/scheduled_sync.py
+++ b/src/services/scheduled_sync.py
@@ -645,3 +645,150 @@ def stop_ledger_reconciliation_scheduler():
         logger.error("❌ Error stopping ledger reconciliation scheduler: %s", e)
     finally:
         _recon_scheduler = None
+
+
+# ============================================================================
+# Nightly pricing-drift monitor — scheduled, read-only. We bill inference at
+# catalog_price * Config.PRICING_MARKUP; if a provider raises its price and our
+# catalog goes stale, we could bill below provider cost even with markup applied.
+# This job audits active-provider catalog pricing against current OpenRouter
+# reference pricing and alerts (log at ERROR + Sentry) on drift. It never mutates
+# prices or models — alert only, exactly like ledger reconciliation above.
+# ============================================================================
+
+_pricing_drift_scheduler: AsyncIOScheduler | None = None
+
+_last_pricing_drift_status: dict[str, Any] = {
+    "last_run_time": None,
+    "last_ok": None,
+    "last_checked": None,
+    "last_drift_count": None,
+    "last_unpriced_count": None,
+    "last_worst_deficit_pct": None,
+    "last_error": None,
+}
+
+
+async def run_scheduled_pricing_drift_audit():
+    """Run the nightly pricing-drift audit and alert on any margin-leak risk.
+
+    Read-only: never mutates prices/models. On drift or unpriced active models,
+    logs at ERROR (alertable via log-based alerting) and captures a Sentry
+    message so it pages independently of log scraping.
+    """
+    from src.services.billing.pricing_drift_monitor import audit_pricing_drift
+
+    now = datetime.now(UTC)
+    _last_pricing_drift_status["last_run_time"] = now
+
+    try:
+        result = await asyncio.to_thread(audit_pricing_drift)
+
+        _last_pricing_drift_status["last_ok"] = result.get("ok")
+        _last_pricing_drift_status["last_checked"] = result.get("checked")
+        _last_pricing_drift_status["last_drift_count"] = len(result.get("drift", []))
+        _last_pricing_drift_status["last_unpriced_count"] = len(result.get("unpriced", []))
+        _last_pricing_drift_status["last_worst_deficit_pct"] = result.get("worst_deficit_pct")
+        _last_pricing_drift_status["last_error"] = None
+
+        if result.get("ok"):
+            logger.info(
+                "✅ Pricing drift audit OK | checked=%s no drift, no unpriced models",
+                result.get("checked", 0),
+            )
+            return
+
+        drift = result.get("drift", [])
+        unpriced = result.get("unpriced", [])
+        logger.error(
+            "❌ Pricing drift audit found billing risk | checked=%s drift=%s "
+            "unpriced=%s worst_deficit_pct=%.2f%% | worst_examples=%s",
+            result.get("checked", 0),
+            len(drift),
+            len(unpriced),
+            result.get("worst_deficit_pct", 0.0),
+            drift[:5],
+        )
+
+        try:
+            import sentry_sdk
+
+            sentry_sdk.capture_message(
+                "Pricing drift detected: catalog price * markup below provider cost "
+                f"for {len(drift)} model(s), {len(unpriced)} unpriced active model(s) "
+                f"(worst deficit {result.get('worst_deficit_pct', 0.0):.2f}%)",
+                level="error",
+            )
+        except Exception as sentry_error:
+            logger.warning("Failed to capture pricing drift to Sentry: %s", sentry_error)
+
+    except Exception as e:
+        _last_pricing_drift_status["last_error"] = str(e)
+        logger.exception("Pricing drift audit EXCEPTION: %s", e)
+
+
+def start_pricing_drift_scheduler():
+    """Start the APScheduler for the nightly pricing-drift monitor (app lifespan)."""
+    global _pricing_drift_scheduler
+
+    if not Config.ENABLE_PRICING_DRIFT_MONITOR:
+        logger.info("Pricing drift monitor DISABLED: ENABLE_PRICING_DRIFT_MONITOR=false")
+        return
+
+    interval_minutes = Config.PRICING_DRIFT_INTERVAL_MINUTES
+    logger.info(
+        "Starting pricing drift monitor scheduler (interval: %s min)", interval_minutes
+    )
+    try:
+        _pricing_drift_scheduler = AsyncIOScheduler()
+        _pricing_drift_scheduler.add_job(
+            run_scheduled_pricing_drift_audit,
+            trigger=IntervalTrigger(minutes=interval_minutes),
+            id="pricing_drift_monitor",
+            name="Pricing Drift Monitor Job",
+            replace_existing=True,
+            max_instances=1,
+            coalesce=True,
+        )
+        _pricing_drift_scheduler.start()
+        logger.info(
+            "✅ Pricing drift monitor scheduler started (next run in %s min)", interval_minutes
+        )
+    except Exception as e:
+        logger.error("❌ Failed to start pricing drift monitor scheduler: %s", e)
+        logger.exception(e)
+
+
+def stop_pricing_drift_scheduler():
+    """Stop the pricing-drift-monitor APScheduler gracefully (called during shutdown)."""
+    global _pricing_drift_scheduler
+
+    if _pricing_drift_scheduler is None:
+        return
+    logger.info("Stopping pricing drift monitor scheduler...")
+    try:
+        _pricing_drift_scheduler.shutdown(wait=True)
+        logger.info("✅ Pricing drift monitor scheduler stopped successfully")
+    except Exception as e:
+        logger.error("❌ Error stopping pricing drift monitor scheduler: %s", e)
+    finally:
+        _pricing_drift_scheduler = None
+
+
+def get_pricing_drift_status() -> dict[str, Any]:
+    """Get the current status of the pricing-drift monitor (for health monitoring)."""
+    return {
+        "enabled": Config.ENABLE_PRICING_DRIFT_MONITOR,
+        "interval_minutes": Config.PRICING_DRIFT_INTERVAL_MINUTES,
+        "last_run_time": (
+            _last_pricing_drift_status["last_run_time"].isoformat()
+            if _last_pricing_drift_status["last_run_time"]
+            else None
+        ),
+        "last_ok": _last_pricing_drift_status["last_ok"],
+        "last_checked": _last_pricing_drift_status["last_checked"],
+        "last_drift_count": _last_pricing_drift_status["last_drift_count"],
+        "last_unpriced_count": _last_pricing_drift_status["last_unpriced_count"],
+        "last_worst_deficit_pct": _last_pricing_drift_status["last_worst_deficit_pct"],
+        "last_error": _last_pricing_drift_status["last_error"],
+    }

--- a/src/services/scheduled_sync.py
+++ b/src/services/scheduled_sync.py
@@ -73,9 +73,7 @@ async def warm_caches_after_sync(changed_providers: list[str]) -> None:
         warm_unique_models_cache_all_variants,
     )
 
-    logger.info(
-        f"Cache warming started after sync " f"(providers with changes: {changed_providers})"
-    )
+    logger.info(f"Cache warming started after sync (providers with changes: {changed_providers})")
 
     # Brief delay to let DB writes propagate
     await asyncio.sleep(2)
@@ -415,8 +413,7 @@ async def run_scheduled_price_refresh():
             _last_price_refresh_status["last_error"] = None
             _last_price_refresh_status["last_prices_updated"] = result.get("prices_updated", 0)
             logger.info(
-                "Price refresh SUCCESSFUL in %.2fs | updated=%s unchanged=%s "
-                "checked=%s failed=%s",
+                "Price refresh SUCCESSFUL in %.2fs | updated=%s unchanged=%s checked=%s failed=%s",
                 duration,
                 result.get("prices_updated", 0),
                 result.get("prices_unchanged", 0),
@@ -736,9 +733,7 @@ def start_pricing_drift_scheduler():
         return
 
     interval_minutes = Config.PRICING_DRIFT_INTERVAL_MINUTES
-    logger.info(
-        "Starting pricing drift monitor scheduler (interval: %s min)", interval_minutes
-    )
+    logger.info("Starting pricing drift monitor scheduler (interval: %s min)", interval_minutes)
     try:
         _pricing_drift_scheduler = AsyncIOScheduler()
         _pricing_drift_scheduler.add_job(

--- a/src/services/startup.py
+++ b/src/services/startup.py
@@ -627,6 +627,17 @@ async def lifespan(app):
         logger.warning(f"Failed to start ledger reconciliation scheduler: {e}")
         # Don't fail startup if reconciliation fails to start
 
+    # Start nightly pricing-drift monitor (read-only; alerts if catalog price *
+    # markup would ever bill below current provider/reference cost)
+    try:
+        from src.services.scheduled_sync import start_pricing_drift_scheduler
+
+        start_pricing_drift_scheduler()
+        logger.info("Pricing drift monitor service initialized")
+    except Exception as e:
+        logger.warning(f"Failed to start pricing drift monitor scheduler: {e}")
+        # Don't fail startup if the drift monitor fails to start
+
     # ---------------------------------------------------------------------------
     # Additional startup work (migrated from @app.on_event("startup"))
     # ---------------------------------------------------------------------------
@@ -733,6 +744,15 @@ async def lifespan(app):
         logger.info("Ledger reconciliation service stopped")
     except Exception as e:
         logger.warning(f"Ledger reconciliation shutdown warning: {e}")
+
+    # Stop nightly pricing-drift monitor
+    try:
+        from src.services.scheduled_sync import stop_pricing_drift_scheduler
+
+        stop_pricing_drift_scheduler()
+        logger.info("Pricing drift monitor service stopped")
+    except Exception as e:
+        logger.warning(f"Pricing drift monitor shutdown warning: {e}")
 
     # Cancel any pending background tasks
     if _background_tasks:

--- a/src/services/startup.py
+++ b/src/services/startup.py
@@ -576,7 +576,7 @@ async def lifespan(app):
                     event_loop_lag_seconds.set(lag)
                     if lag > 0.1:
                         logger.warning(
-                            f"[EVENT LOOP LAG] {lag*1000:.1f}ms — event loop is under pressure"
+                            f"[EVENT LOOP LAG] {lag * 1000:.1f}ms — event loop is under pressure"
                         )
                     await asyncio.sleep(5)  # Check every 5 seconds
             except Exception as e:

--- a/tests/services/test_pricing_drift_monitor.py
+++ b/tests/services/test_pricing_drift_monitor.py
@@ -38,7 +38,9 @@ def _run(
     with (
         patch(f"{MODULE}.Config") as mock_config,
         patch(f"{MODULE}.get_active_provider_slugs", return_value=provider_slugs),
-        patch(f"{MODULE}.get_models_by_provider_slug", side_effect=fake_get_models_by_provider_slug),
+        patch(
+            f"{MODULE}.get_models_by_provider_slug", side_effect=fake_get_models_by_provider_slug
+        ),
         patch(f"{MODULE}._resolve_pricing_from_db", side_effect=fake_resolve_pricing),
         patch(f"{MODULE}._build_openrouter_pricing_index", return_value={"stub": True}),
         patch(f"{MODULE}._get_cross_reference_pricing", side_effect=fake_cross_reference),
@@ -53,12 +55,8 @@ def test_below_cost_model_is_flagged_as_drift():
     report = _run(
         provider_slugs=["featherless"],
         models_by_provider={"featherless": [_model(model_id)]},
-        our_pricing_by_model={
-            model_id: {"prompt": "0.0000009", "completion": "0.0000009"}
-        },
-        ref_pricing_by_model={
-            model_id: {"prompt": "0.000001", "completion": "0.000001"}
-        },
+        our_pricing_by_model={model_id: {"prompt": "0.0000009", "completion": "0.0000009"}},
+        ref_pricing_by_model={model_id: {"prompt": "0.000001", "completion": "0.000001"}},
         markup=1.03,
     )
 
@@ -79,12 +77,8 @@ def test_at_or_above_cost_model_is_not_flagged():
     report = _run(
         provider_slugs=["featherless"],
         models_by_provider={"featherless": [_model(model_id)]},
-        our_pricing_by_model={
-            model_id: {"prompt": "0.000001", "completion": "0.000001"}
-        },
-        ref_pricing_by_model={
-            model_id: {"prompt": "0.000001", "completion": "0.000001"}
-        },
+        our_pricing_by_model={model_id: {"prompt": "0.000001", "completion": "0.000001"}},
+        ref_pricing_by_model={model_id: {"prompt": "0.000001", "completion": "0.000001"}},
         markup=1.03,
     )
 
@@ -102,9 +96,7 @@ def test_unpriced_active_model_is_flagged():
         provider_slugs=["deepinfra"],
         models_by_provider={"deepinfra": [_model(model_id)]},
         our_pricing_by_model={},  # _resolve_pricing_from_db returns None
-        ref_pricing_by_model={
-            model_id: {"prompt": "0.000001", "completion": "0.000001"}
-        },
+        ref_pricing_by_model={model_id: {"prompt": "0.000001", "completion": "0.000001"}},
         markup=1.03,
     )
 
@@ -124,9 +116,7 @@ def test_zero_priced_model_is_flagged_as_unpriced():
         provider_slugs=["deepinfra"],
         models_by_provider={"deepinfra": [_model(model_id)]},
         our_pricing_by_model={model_id: {"prompt": "0", "completion": "0"}},
-        ref_pricing_by_model={
-            model_id: {"prompt": "0.000001", "completion": "0.000001"}
-        },
+        ref_pricing_by_model={model_id: {"prompt": "0.000001", "completion": "0.000001"}},
         markup=1.03,
     )
 
@@ -149,12 +139,8 @@ def test_markup_is_applied_in_drift_threshold():
     report = _run(
         provider_slugs=["featherless"],
         models_by_provider={"featherless": [_model(model_id)]},
-        our_pricing_by_model={
-            model_id: {"prompt": str(our_price), "completion": str(our_price)}
-        },
-        ref_pricing_by_model={
-            model_id: {"prompt": str(ref_price), "completion": str(ref_price)}
-        },
+        our_pricing_by_model={model_id: {"prompt": str(our_price), "completion": str(our_price)}},
+        ref_pricing_by_model={model_id: {"prompt": str(ref_price), "completion": str(ref_price)}},
         markup=markup,
     )
 
@@ -165,12 +151,8 @@ def test_markup_is_applied_in_drift_threshold():
     report_no_markup = _run(
         provider_slugs=["featherless"],
         models_by_provider={"featherless": [_model(model_id)]},
-        our_pricing_by_model={
-            model_id: {"prompt": str(our_price), "completion": str(our_price)}
-        },
-        ref_pricing_by_model={
-            model_id: {"prompt": str(ref_price), "completion": str(ref_price)}
-        },
+        our_pricing_by_model={model_id: {"prompt": str(our_price), "completion": str(our_price)}},
+        ref_pricing_by_model={model_id: {"prompt": str(ref_price), "completion": str(ref_price)}},
         markup=1.0,
     )
     assert not report_no_markup["ok"]
@@ -184,12 +166,8 @@ def test_openrouter_provider_is_never_compared_against_itself():
     report = _run(
         provider_slugs=["openrouter"],
         models_by_provider={"openrouter": [_model(model_id)]},
-        our_pricing_by_model={
-            model_id: {"prompt": "0.0000001", "completion": "0.0000001"}
-        },
-        ref_pricing_by_model={
-            model_id: {"prompt": "0.000001", "completion": "0.000001"}
-        },
+        our_pricing_by_model={model_id: {"prompt": "0.0000001", "completion": "0.0000001"}},
+        ref_pricing_by_model={model_id: {"prompt": "0.000001", "completion": "0.000001"}},
         markup=1.03,
     )
 

--- a/tests/services/test_pricing_drift_monitor.py
+++ b/tests/services/test_pricing_drift_monitor.py
@@ -46,6 +46,9 @@ def _run(
         patch(f"{MODULE}._get_cross_reference_pricing", side_effect=fake_cross_reference),
     ):
         mock_config.PRICING_MARKUP = markup
+        # None = no ENABLED_PROVIDERS filter, so the mocked provider list drives
+        # the population (tests assert against get_active_provider_slugs directly).
+        mock_config.ENABLED_PROVIDERS = None
         return drift_mod.audit_pricing_drift()
 
 

--- a/tests/services/test_pricing_drift_monitor.py
+++ b/tests/services/test_pricing_drift_monitor.py
@@ -1,0 +1,226 @@
+"""Nightly pricing-drift monitor: catches billing below provider cost even with markup.
+
+Mocks the catalog snapshot (get_active_provider_slugs / get_models_by_provider_slug /
+_resolve_pricing_from_db) and the OpenRouter reference lookup
+(_get_cross_reference_pricing) so the test is fast and deterministic — no real DB or
+network calls.
+"""
+
+from unittest.mock import patch
+
+from src.services.billing import pricing_drift_monitor as drift_mod
+
+MODULE = "src.services.billing.pricing_drift_monitor"
+
+
+def _model(provider_model_id: str, model_name: str | None = None) -> dict:
+    return {"provider_model_id": provider_model_id, "model_name": model_name or provider_model_id}
+
+
+def _run(
+    provider_slugs,
+    models_by_provider,
+    our_pricing_by_model,
+    ref_pricing_by_model,
+    markup=1.03,
+):
+    """Wire up mocks and call audit_pricing_drift(), returning the report dict."""
+
+    def fake_get_models_by_provider_slug(provider_slug, is_active_only=True):
+        return models_by_provider.get(provider_slug, [])
+
+    def fake_resolve_pricing(model_id, candidate_ids=None):
+        return our_pricing_by_model.get(model_id)
+
+    def fake_cross_reference(model_id, openrouter_index=None, provider=None):
+        return ref_pricing_by_model.get(model_id)
+
+    with (
+        patch(f"{MODULE}.Config") as mock_config,
+        patch(f"{MODULE}.get_active_provider_slugs", return_value=provider_slugs),
+        patch(f"{MODULE}.get_models_by_provider_slug", side_effect=fake_get_models_by_provider_slug),
+        patch(f"{MODULE}._resolve_pricing_from_db", side_effect=fake_resolve_pricing),
+        patch(f"{MODULE}._build_openrouter_pricing_index", return_value={"stub": True}),
+        patch(f"{MODULE}._get_cross_reference_pricing", side_effect=fake_cross_reference),
+    ):
+        mock_config.PRICING_MARKUP = markup
+        return drift_mod.audit_pricing_drift()
+
+
+def test_below_cost_model_is_flagged_as_drift():
+    """catalog_price * markup still below reference cost => DRIFT."""
+    model_id = "meta-llama/Llama-3-8b"
+    report = _run(
+        provider_slugs=["featherless"],
+        models_by_provider={"featherless": [_model(model_id)]},
+        our_pricing_by_model={
+            model_id: {"prompt": "0.0000009", "completion": "0.0000009"}
+        },
+        ref_pricing_by_model={
+            model_id: {"prompt": "0.000001", "completion": "0.000001"}
+        },
+        markup=1.03,
+    )
+
+    assert report["checked"] == 1
+    assert not report["ok"]
+    assert len(report["drift"]) == 1
+    flagged = report["drift"][0]
+    assert flagged["model_id"] == model_id
+    assert flagged["provider"] == "featherless"
+    assert flagged["deficit_pct"] > 0
+    assert report["worst_deficit_pct"] == flagged["deficit_pct"]
+    assert report["unpriced"] == []
+
+
+def test_at_or_above_cost_model_is_not_flagged():
+    """catalog_price * markup >= reference cost => no drift."""
+    model_id = "meta-llama/Llama-3-70b"
+    report = _run(
+        provider_slugs=["featherless"],
+        models_by_provider={"featherless": [_model(model_id)]},
+        our_pricing_by_model={
+            model_id: {"prompt": "0.000001", "completion": "0.000001"}
+        },
+        ref_pricing_by_model={
+            model_id: {"prompt": "0.000001", "completion": "0.000001"}
+        },
+        markup=1.03,
+    )
+
+    assert report["checked"] == 1
+    assert report["ok"]
+    assert report["drift"] == []
+    assert report["unpriced"] == []
+    assert report["worst_deficit_pct"] == 0.0
+
+
+def test_unpriced_active_model_is_flagged():
+    """Active model with no catalog price (None) => flagged as unpriced, not drift."""
+    model_id = "some-org/unpriced-model"
+    report = _run(
+        provider_slugs=["deepinfra"],
+        models_by_provider={"deepinfra": [_model(model_id)]},
+        our_pricing_by_model={},  # _resolve_pricing_from_db returns None
+        ref_pricing_by_model={
+            model_id: {"prompt": "0.000001", "completion": "0.000001"}
+        },
+        markup=1.03,
+    )
+
+    assert report["checked"] == 1
+    assert not report["ok"]
+    assert report["drift"] == []
+    assert len(report["unpriced"]) == 1
+    assert report["unpriced"][0]["model_id"] == model_id
+    assert report["unpriced"][0]["provider"] == "deepinfra"
+
+
+def test_zero_priced_model_is_flagged_as_unpriced():
+    """Active model priced at exactly 0 on both sides => unpriced, not drift (no
+    deficit % of nothing)."""
+    model_id = "some-org/zero-priced-model"
+    report = _run(
+        provider_slugs=["deepinfra"],
+        models_by_provider={"deepinfra": [_model(model_id)]},
+        our_pricing_by_model={model_id: {"prompt": "0", "completion": "0"}},
+        ref_pricing_by_model={
+            model_id: {"prompt": "0.000001", "completion": "0.000001"}
+        },
+        markup=1.03,
+    )
+
+    assert not report["ok"]
+    assert report["drift"] == []
+    assert len(report["unpriced"]) == 1
+
+
+def test_markup_is_applied_in_drift_threshold():
+    """Without markup, catalog price is below reference; WITH markup applied it
+    clears the reference — must NOT be flagged. Proves markup is actually applied
+    (not just compared raw catalog price to catalog price)."""
+    model_id = "org/markup-saved-model"
+    our_price = 0.98e-6
+    ref_price = 1.0e-6
+    assert our_price < ref_price  # raw catalog price alone would look like drift
+    markup = 1.03
+    assert our_price * markup > ref_price  # but markup clears the reference cost
+
+    report = _run(
+        provider_slugs=["featherless"],
+        models_by_provider={"featherless": [_model(model_id)]},
+        our_pricing_by_model={
+            model_id: {"prompt": str(our_price), "completion": str(our_price)}
+        },
+        ref_pricing_by_model={
+            model_id: {"prompt": str(ref_price), "completion": str(ref_price)}
+        },
+        markup=markup,
+    )
+
+    assert report["ok"]
+    assert report["drift"] == []
+
+    # Sanity: with a lower markup that does NOT clear the reference, it IS flagged.
+    report_no_markup = _run(
+        provider_slugs=["featherless"],
+        models_by_provider={"featherless": [_model(model_id)]},
+        our_pricing_by_model={
+            model_id: {"prompt": str(our_price), "completion": str(our_price)}
+        },
+        ref_pricing_by_model={
+            model_id: {"prompt": str(ref_price), "completion": str(ref_price)}
+        },
+        markup=1.0,
+    )
+    assert not report_no_markup["ok"]
+    assert len(report_no_markup["drift"]) == 1
+
+
+def test_openrouter_provider_is_never_compared_against_itself():
+    """OpenRouter IS the reference catalog — its own models should never be
+    cross-checked (and thus never flagged as drift, regardless of price)."""
+    model_id = "openrouter/some-model"
+    report = _run(
+        provider_slugs=["openrouter"],
+        models_by_provider={"openrouter": [_model(model_id)]},
+        our_pricing_by_model={
+            model_id: {"prompt": "0.0000001", "completion": "0.0000001"}
+        },
+        ref_pricing_by_model={
+            model_id: {"prompt": "0.000001", "completion": "0.000001"}
+        },
+        markup=1.03,
+    )
+
+    assert report["checked"] == 1
+    assert report["ok"]
+    assert report["drift"] == []
+
+
+def test_multiple_providers_sorted_worst_first():
+    """Drift list must be sorted worst deficit first across multiple providers."""
+    model_a = "org/model-a"  # small deficit
+    model_b = "org/model-b"  # large deficit
+
+    report = _run(
+        provider_slugs=["featherless", "deepinfra"],
+        models_by_provider={
+            "featherless": [_model(model_a)],
+            "deepinfra": [_model(model_b)],
+        },
+        our_pricing_by_model={
+            model_a: {"prompt": "0.00000099", "completion": "0.00000099"},  # tiny deficit
+            model_b: {"prompt": "0.0000005", "completion": "0.0000005"},  # huge deficit
+        },
+        ref_pricing_by_model={
+            model_a: {"prompt": "0.000001", "completion": "0.000001"},
+            model_b: {"prompt": "0.000001", "completion": "0.000001"},
+        },
+        markup=1.0,
+    )
+
+    assert len(report["drift"]) == 2
+    assert report["drift"][0]["model_id"] == model_b
+    assert report["drift"][1]["model_id"] == model_a
+    assert report["drift"][0]["deficit_pct"] >= report["drift"][1]["deficit_pct"]


### PR DESCRIPTION
Guards against margin leak: nightly, compares each active model's catalog price to the provider's current market price (OpenRouter reference, reusing the cross-ref infra) and flags any where `our_price × PRICING_MARKUP < provider cost`, plus unpriced active models. Alerts (log ERROR + Sentry), never mutates prices. Adds `GET /admin/pricing-drift` + a nightly scheduler job.

Tests: 7/7 new + 37/37 pricing suite (0 regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a nightly pricing-drift monitor that audits active provider models and reports underpriced (“drift”) and missing-catalog (“unpriced”) items with deficit details and summary counts.
  * Added configurable enablement and run interval for the monitor.
  * Added an admin-only endpoint to run the audit on demand.
* **Bug Fixes**
  * None.
* **Tests**
  * Added tests covering drift/unpriced detection, markup thresholding, provider exclusions, and worst-deficit-first sorting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->