### PR TITLE
fix(catalog): restore North Star catalog coherence

### DIFF
--- a/src/routes/catalog.py
+++ b/src/routes/catalog.py
@@ -48,6 +48,7 @@ from src.services.models import (
 )
 from src.services.prometheus_metrics import set_gateway_model_count
 from src.services.providers import enhance_providers_with_logos_and_sites, get_cached_providers
+from src.utils.provider_filter import get_enabled_providers, is_provider_enabled
 from src.utils.security_validators import sanitize_for_logging
 
 # Initialize logging
@@ -2249,7 +2250,7 @@ async def search_models(
     max_price: float | None = Query(None, description="Maximum price per token (USD)"),
     gateway: str | None = Query(
         "all",
-        description="Gateway filter: openrouter, featherless, deepinfra, chutes, groq, fireworks, together, google-vertex, or all",
+        description="Enabled provider/gateway slug, or all for the configured aggregate catalog",
     ),
     sort_by: str = Query("price", description="Sort by: price, context, popularity, name"),
     order: str = Query("asc", description="Sort order: asc or desc"),
@@ -2265,7 +2266,7 @@ async def search_models(
     **Examples:**
     - Search for cheap models: `?max_price=0.0001&sort_by=price`
     - Find models with large context: `?min_context=100000&sort_by=context&order=desc`
-    - Search by name: `?q=gpt-4&gateway=openrouter`
+    - Search by name: `?q=gpt-4&gateway=openai`
     - Filter by modality: `?modality=image&sort_by=popularity`
     - Filter for private models only: `?is_private=true`
     - Exclude private models: `?is_private=false`
@@ -2276,7 +2277,14 @@ async def search_models(
     - Applied filters
     """
     try:
-        validate_gateway(gateway)
+        gateway_value = (gateway or "all").lower()
+        gateway_value = get_gateway_slug_resolution().get(gateway_value, gateway_value)
+
+        # With an explicit allowlist, ENABLED_PROVIDERS is authoritative even
+        # before a newly configured provider has been bootstrapped into the DB
+        # registry. Without an allowlist, retain registry validation.
+        if gateway_value != "all" and get_enabled_providers() is None:
+            validate_gateway(gateway)
 
         # Validate sort_by; silently fall back to default for backwards compatibility
         valid_search_sort = {"price", "context", "popularity", "name"}
@@ -2287,46 +2295,20 @@ async def search_models(
             )
             sort_by = "price"
 
-        # Get all models from specified gateways
-        all_models = []
-        gateway_value = gateway.lower() if gateway else "all"
+        # Read from the same DB-backed catalog as GET /v1/models. The aggregated
+        # cache is assembled from active DB providers and filtered by
+        # ENABLED_PROVIDERS, so search cannot resurrect legacy provider caches.
+        if gateway_value == "all":
+            all_models = get_cached_models("all") or []
+        elif is_provider_enabled(gateway_value):
+            all_models = get_cached_models(gateway_value) or []
+        else:
+            logger.info("Search skipped disabled provider catalog: %s", gateway_value)
+            all_models = []
 
-        # Fetch from selected gateways
-        if gateway_value in ("openrouter", "all"):
-            openrouter_models = get_cached_models("openrouter") or []
-            all_models.extend(openrouter_models)
-
-        if gateway_value in ("featherless", "all"):
-            featherless_models = get_cached_models("featherless") or []
-            all_models.extend(featherless_models)
-
-        if gateway_value in ("deepinfra", "all"):
-            deepinfra_models = get_cached_models("deepinfra") or []
-            all_models.extend(deepinfra_models)
-
-        if gateway_value in ("chutes", "all"):
-            chutes_models = get_cached_models("chutes") or []
-            all_models.extend(chutes_models)
-
-        if gateway_value in ("groq", "all"):
-            groq_models = get_cached_models("groq") or []
-            all_models.extend(groq_models)
-
-        if gateway_value in ("fireworks", "all"):
-            fireworks_models = get_cached_models("fireworks") or []
-            all_models.extend(fireworks_models)
-
-        if gateway_value in ("together", "all"):
-            together_models = get_cached_models("together") or []
-            all_models.extend(together_models)
-
-        if gateway_value in ("google-vertex", "all"):
-            google_models = get_cached_models("google-vertex") or []
-            all_models.extend(google_models)
-
-        if gateway_value in ("simplismart", "all"):
-            simplismart_models = get_cached_models("simplismart") or []
-            all_models.extend(simplismart_models)
+        # Match the primary catalog's health contract before applying search
+        # filters, counts, sorting, or pagination.
+        all_models = _apply_health_gating(all_models)
 
         # Apply filters
         filtered_models = all_models

--- a/src/services/cache/catalog_response_cache.py
+++ b/src/services/cache/catalog_response_cache.py
@@ -56,14 +56,14 @@ METADATA_CACHE_TTL = 86400  # 24 hours
 # Cache key namespace — prepended to every Redis key to avoid collisions with
 # other services or provider slugs that could otherwise match a bare prefix.
 # Key schema:
-#   gw:catalog:v2:{gateway}:{hash}        - cached catalog API response
+#   gw:catalog:v3:{gateway}:{hash}        - cached catalog API response
 #   gw:catalog:metadata:{gateway}         - cache metadata (stats, timestamps)
 #   gw:catalog:rebuild_lock:{cache_key}   - stampede-protection lock
 CACHE_NAMESPACE = "gw:"
 
 # Cache configuration
 CATALOG_CACHE_TTL = CATALOG_RESPONSE_CACHE_TTL  # backward-compatible alias
-CATALOG_CACHE_PREFIX = f"{CACHE_NAMESPACE}catalog:v2:"  # Version prefix for easy invalidation
+CATALOG_CACHE_PREFIX = f"{CACHE_NAMESPACE}catalog:v3:"  # Version prefix for easy invalidation
 CATALOG_METADATA_KEY = f"{CACHE_NAMESPACE}catalog:metadata"
 
 # Maximum number of entries in the catalog response cache (CM-8.1.4)
@@ -74,7 +74,7 @@ MAX_CATALOG_CACHE_ENTRIES = MAX_CACHE_ENTRIES  # alias
 LRU_ENABLED = True
 LRU_EVICTION_BATCH_SIZE = 100  # Number of entries to evict at once
 CATALOG_CACHE_KEYS_INDEX = (
-    f"{CACHE_NAMESPACE}catalog_cache:keys_index"  # Sorted set for LRU tracking
+    f"{CACHE_NAMESPACE}catalog_cache:v3:keys_index"  # Sorted set for LRU tracking
 )
 
 
@@ -154,8 +154,6 @@ async def get_cached_catalog_response(gateway: str | None, params: dict) -> dict
         if cached_data:
             logger.info(f"✅ Cache HIT: {cache_key}")
             _track_cache_hit(gateway)
-            # Refresh TTL so frequently accessed keys stay warm
-            redis.expire(cache_key, CATALOG_CACHE_TTL)
 
             # Update LRU timestamp on cache hit (CM-8.1.6)
             try:
@@ -284,15 +282,16 @@ def invalidate_catalog_cache(gateway: str | None = None) -> int:
     This should be called after model sync operations to ensure fresh data.
 
     Args:
-        gateway: If specified, only invalidate caches for this gateway.
+        gateway: If specified, invalidate caches for this gateway and the
+                 aggregated ``all`` catalog that contains it.
                  If None, invalidate ALL catalog caches (use with caution).
 
     Returns:
         Number of cache keys deleted
 
     Examples:
-        >>> invalidate_catalog_cache("openrouter")  # Invalidate OpenRouter only
-        15
+        >>> invalidate_catalog_cache("openrouter")  # Invalidate OpenRouter + all
+        30
         >>> invalidate_catalog_cache()  # Invalidate all gateways
         250
 
@@ -308,34 +307,41 @@ def invalidate_catalog_cache(gateway: str | None = None) -> int:
             return 0
 
         if gateway:
-            # Invalidate specific gateway
-            pattern = f"{CATALOG_CACHE_PREFIX}{gateway}:*"
+            # A provider change also changes the aggregated gateway=all response.
+            # Keep the patterns distinct so provider-specific variants and every
+            # pagination/filter variant of the aggregate are removed together.
+            patterns = [f"{CATALOG_CACHE_PREFIX}{gateway}:*"]
+            if gateway != "all":
+                patterns.append(f"{CATALOG_CACHE_PREFIX}all:*")
         else:
-            # Invalidate all catalog caches
-            pattern = f"{CATALOG_CACHE_PREFIX}*"
+            patterns = [f"{CATALOG_CACHE_PREFIX}*"]
 
         # Use SCAN instead of KEYS to avoid blocking Redis
         # SCAN is cursor-based and won't block other operations
         deleted_count = 0
-        cursor = 0
+        for pattern in patterns:
+            cursor = 0
+            while True:
+                cursor, keys = redis.scan(cursor, match=pattern, count=100)
 
-        while True:
-            cursor, keys = redis.scan(cursor, match=pattern, count=100)
+                if keys:
+                    # Batch delete for efficiency
+                    redis.delete(*keys)
+                    # Keep sorted set in sync — remove evicted keys from LRU index
+                    redis.zrem(CATALOG_CACHE_KEYS_INDEX, *keys)
+                    deleted_count += len(keys)
 
-            if keys:
-                # Batch delete for efficiency
-                redis.delete(*keys)
-                # Keep sorted set in sync — remove evicted keys from LRU index
-                redis.zrem(CATALOG_CACHE_KEYS_INDEX, *keys)
-                deleted_count += len(keys)
-
-            if cursor == 0:
-                break
+                if cursor == 0:
+                    break
 
         if deleted_count > 0:
-            logger.info(f"🗑️  Invalidated {deleted_count} cache entries " f"(pattern: {pattern})")
+            logger.info(
+                "🗑️  Invalidated %s cache entries (patterns: %s)",
+                deleted_count,
+                ", ".join(patterns),
+            )
         else:
-            logger.debug(f"No cache entries to invalidate (pattern: {pattern})")
+            logger.debug("No cache entries to invalidate (patterns: %s)", ", ".join(patterns))
 
         return deleted_count
 

--- a/src/services/cache/model_catalog_cache.py
+++ b/src/services/cache/model_catalog_cache.py
@@ -181,7 +181,7 @@ _invalidation_debouncer = InvalidationDebouncer(delay=1.0)
 # overlap a bare prefix like "models:" or "providers:".
 #
 # Key schema:
-#   gw:models:catalog:full          - full aggregated catalog
+#   gw:models:catalog:v2:full       - full aggregated catalog
 #   gw:models:provider:{name}       - per-provider catalog list
 #   gw:models:model:{key}           - individual model metadata
 #   gw:models:pricing:{key}         - pricing data
@@ -216,7 +216,7 @@ class ModelCatalogCache:
 
     # Cache key prefixes — all include CACHE_NAMESPACE ("gw:") to avoid
     # collisions with provider slugs or keys from other services.
-    PREFIX_FULL_CATALOG = f"{CACHE_NAMESPACE}models:catalog:full"
+    PREFIX_FULL_CATALOG = f"{CACHE_NAMESPACE}models:catalog:v2:full"
     PREFIX_PROVIDER = f"{CACHE_NAMESPACE}models:provider"
     PREFIX_MODEL = f"{CACHE_NAMESPACE}models:model"
     PREFIX_PRICING = f"{CACHE_NAMESPACE}models:pricing"
@@ -310,7 +310,6 @@ class ModelCatalogCache:
                 self._stats["hits"] += 1
                 self._record_cache_operation("hit")
                 logger.debug("Cache HIT: Full model catalog")
-                self.redis_client.expire(key, self.TTL_FULL_CATALOG)
                 return _deserialize(cached_data)
             else:
                 self._stats["misses"] += 1
@@ -3149,7 +3148,7 @@ def invalidate_catalog_caches(gateway: str = None) -> dict[str, Any]:
         # L1 — shared response-level keys (always cleared regardless of scope)
         # ------------------------------------------------------------------
         l1_exact_keys = [
-            ModelCatalogCache.PREFIX_FULL_CATALOG,  # gw:models:catalog:full
+            ModelCatalogCache.PREFIX_FULL_CATALOG,  # gw:models:catalog:v2:full
             ModelCatalogCache.PREFIX_STATS,  # gw:models:stats
             ModelCatalogCache.PREFIX_UNIQUE,  # gw:models:unique
         ]

--- a/src/services/model_catalog_sync.py
+++ b/src/services/model_catalog_sync.py
@@ -738,6 +738,25 @@ def sync_provider_models(
                 f"[{provider_slug.upper()}] Provider inactive | "
                 f"Delisted {delisted_count} previously-active model(s)"
             )
+            try:
+                from src.services.model_catalog_cache import (
+                    invalidate_catalog_stats,
+                    invalidate_provider_catalog,
+                    invalidate_unique_models,
+                )
+
+                invalidate_provider_catalog(provider_slug, cascade=not batch_mode)
+                if not batch_mode:
+                    from src.services.cache.catalog_response_cache import invalidate_catalog_cache
+
+                    invalidate_unique_models()
+                    invalidate_catalog_stats()
+                    invalidate_catalog_cache(provider_slug)
+            except Exception as cache_e:
+                logger.warning(
+                    f"[{provider_slug.upper()}] Inactive-provider cache invalidation failed: "
+                    f"{cache_e}"
+                )
             return {
                 "success": True,
                 "provider": provider_slug,
@@ -958,9 +977,12 @@ def sync_provider_models(
                     logger.debug(f"[{provider_slug.upper()}] Cache INVALIDATE (batch, no cascade)")
                 else:
                     # Single-provider sync: full cascade
+                    from src.services.cache.catalog_response_cache import invalidate_catalog_cache
+
                     invalidate_provider_catalog(provider_slug, cascade=True)
                     invalidate_unique_models()
                     invalidate_catalog_stats()
+                    invalidate_catalog_cache(provider_slug)
                     logger.info(f"[{provider_slug.upper()}] Cache INVALIDATE (full cascade)")
 
             except Exception as cache_e:
@@ -1033,28 +1055,36 @@ def sync_all_providers(
         sync_start_time = time.time()
 
         # Get providers to sync
-        from src.utils.provider_filter import is_provider_enabled
+        from src.utils.provider_filter import get_enabled_providers, is_provider_enabled
 
         if provider_slugs:
             # Even explicit slugs must pass the enabled filter
             providers_to_sync = [p for p in provider_slugs if is_provider_enabled(p)]
         else:
-            # Use all active providers with fetch functions, minus skipped ones
+            # ENABLED_PROVIDERS is the routing/catalog source of truth. Starting
+            # from it also bootstraps a newly enabled provider whose DB registry
+            # row does not exist yet; sync_provider_models creates that row.
             skip_set = Config.MODEL_SYNC_SKIP_PROVIDERS
-            try:
-                from src.db.providers_db import get_active_provider_slugs
-                from src.services.gateway_registry import get_gateway_registry
+            enabled_providers = get_enabled_providers()
+            if enabled_providers is not None:
+                all_providers = sorted(enabled_providers)
+            else:
+                try:
+                    from src.db.providers_db import get_active_provider_slugs
+                    from src.services.gateway_registry import get_gateway_registry
 
-                all_providers = get_active_provider_slugs()
-                registry = get_gateway_registry()
-                all_providers = [
-                    s for s in all_providers if registry.get(s, {}).get("has_fetch_function", False)
-                ]
-                if not all_providers:
-                    logger.info("DB returned zero fetchable providers; nothing to sync")
-            except Exception:
-                logger.warning("Failed to load providers from DB; using hardcoded fallback")
-                all_providers = list(PROVIDER_FETCH_FUNCTIONS.keys())
+                    all_providers = get_active_provider_slugs()
+                    registry = get_gateway_registry()
+                    all_providers = [
+                        s
+                        for s in all_providers
+                        if registry.get(s, {}).get("has_fetch_function", False)
+                    ]
+                    if not all_providers:
+                        logger.info("DB returned zero fetchable providers; nothing to sync")
+                except Exception:
+                    logger.warning("Failed to load providers from DB; using hardcoded fallback")
+                    all_providers = list(PROVIDER_FETCH_FUNCTIONS.keys())
             providers_to_sync = [
                 p for p in all_providers if p not in skip_set and is_provider_enabled(p)
             ]
@@ -1075,6 +1105,7 @@ def sync_all_providers(
         total_transformed = 0
         total_skipped = 0
         total_synced = 0
+        total_delisted = 0
         errors = []
 
         import gc
@@ -1091,6 +1122,7 @@ def sync_all_providers(
                 total_transformed += result.get("models_transformed", 0)
                 total_skipped += result.get("models_skipped", 0)
                 total_synced += result.get("models_synced", 0)
+                total_delisted += result.get("models_delisted", 0)
             else:
                 errors.append({"provider": provider_slug, "error": result.get("error")})
 
@@ -1102,8 +1134,9 @@ def sync_all_providers(
 
         # Invalidate global caches ONCE after all providers are done
         # (instead of 35+ times per provider in the loop)
-        if total_synced > 0 and not dry_run:
+        if (total_synced > 0 or total_delisted > 0) and not dry_run:
             try:
+                from src.services.cache.catalog_response_cache import invalidate_catalog_cache
                 from src.services.model_catalog_cache import (
                     invalidate_catalog_stats,
                     invalidate_full_catalog,
@@ -1113,6 +1146,7 @@ def sync_all_providers(
                 invalidate_full_catalog()
                 invalidate_unique_models()
                 invalidate_catalog_stats()
+                invalidate_catalog_cache()
                 logger.info(
                     f"Global caches invalidated once after syncing {len(providers_to_sync)} providers"
                 )
@@ -1210,6 +1244,7 @@ def sync_all_providers(
             "total_models_transformed": total_transformed,
             "total_models_skipped": total_skipped,
             "total_models_synced": total_synced,
+            "total_models_delisted": total_delisted,
             "total_duration": round(total_duration, 2),
             "avg_duration_per_provider": round(avg_duration_per_provider, 2),
             "overall_models_per_sec": round(overall_models_per_sec, 2),

--- a/src/services/startup.py
+++ b/src/services/startup.py
@@ -388,7 +388,7 @@ async def lifespan(app):
                 except Exception as e:
                     logger.warning(f"Provider connection warmup warning: {e}")
 
-                # Phase 5: Warm catalog response cache (Redis catalog:v2:* keys)
+                # Phase 5: Warm catalog response cache (Redis catalog:v3:* keys)
                 # This pre-populates the exact cache hit by GET /v1/models?gateway=all
                 # so the first request after deployment does not incur a cold-cache penalty.
                 # Runs after Phase 2 has already loaded the model catalog into Redis, so no

--- a/tests/routes/test_catalog_search_route_order.py
+++ b/tests/routes/test_catalog_search_route_order.py
@@ -24,6 +24,8 @@ MOCK_MODELS = [
         "description": "OpenAI flagship model",
         "provider": "openai",
         "provider_slug": "openai",
+        "source_gateway": "openai",
+        "health_status": "healthy",
         "context_length": 128000,
         "pricing": {"prompt": 0.01, "completion": 0.03},
     }
@@ -80,7 +82,9 @@ class TestModelsSearchRouteOrder:
         client = _make_client()
 
         with (
-            patch("src.routes.catalog.get_cached_models", return_value=MOCK_MODELS),
+            patch(
+                "src.routes.catalog.get_cached_models", return_value=MOCK_MODELS
+            ) as get_cached_models,
             patch(
                 "src.services.cache.catalog_response_cache.get_redis_client",
                 return_value=None,
@@ -96,7 +100,28 @@ class TestModelsSearchRouteOrder:
         assert "data" in body
         assert "meta" in body
         assert body["meta"]["filters_applied"]["query"] == "gpt"
+        get_cached_models.assert_called_once_with("all")
 
         # Must NOT be the get_developer_models_api() shadowed shape, which
         # has a "developer" key and no "success"/"meta" keys.
         assert "developer" not in body
+
+    def test_models_search_does_not_read_disabled_provider_cache(self):
+        client = _make_client()
+
+        with (
+            patch(
+                "src.routes.catalog.get_enabled_providers",
+                return_value=frozenset({"openai"}),
+            ),
+            patch("src.routes.catalog.is_provider_enabled", return_value=False),
+            patch("src.routes.catalog.get_cached_models") as get_cached_models,
+        ):
+            resp = client.get(
+                "/v1/models/search",
+                params={"q": "command", "gateway": "openrouter"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"] == []
+        get_cached_models.assert_not_called()

--- a/tests/services/cache/test_catalog_response_cache.py
+++ b/tests/services/cache/test_catalog_response_cache.py
@@ -1,0 +1,74 @@
+import json
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from src.services.cache import catalog_response_cache
+from src.services.cache import model_catalog_cache
+
+
+@pytest.mark.asyncio
+async def test_catalog_cache_hit_keeps_original_expiry(monkeypatch):
+    redis = MagicMock()
+    redis.get.return_value = json.dumps({"data": [{"id": "openai/gpt-4o-mini"}]})
+    monkeypatch.setattr(catalog_response_cache, "get_redis_client", lambda: redis)
+
+    result = await catalog_response_cache.get_cached_catalog_response(
+        "all", {"limit": 100, "offset": 0}
+    )
+
+    assert result == {"data": [{"id": "openai/gpt-4o-mini"}]}
+    redis.expire.assert_not_called()
+    redis.zadd.assert_called_once()
+
+
+def test_catalog_cache_uses_fresh_v3_namespace():
+    key = catalog_response_cache.get_catalog_cache_key("all", {"limit": 100, "offset": 0})
+
+    assert key.startswith("gw:catalog:v3:all:")
+
+
+def test_full_catalog_cache_uses_fresh_namespace_and_fixed_expiry(monkeypatch):
+    redis = MagicMock()
+    redis.get.return_value = json.dumps({"data": [{"id": "openai/gpt-4o-mini"}]})
+    monkeypatch.setattr(model_catalog_cache, "get_redis_client", lambda: redis)
+    monkeypatch.setattr(model_catalog_cache, "is_redis_available", lambda: True)
+    cache = model_catalog_cache.ModelCatalogCache()
+
+    result = cache.get_full_catalog()
+
+    assert result == {"data": [{"id": "openai/gpt-4o-mini"}]}
+    redis.get.assert_called_once_with("gw:models:catalog:v2:full")
+    redis.expire.assert_not_called()
+
+
+def test_provider_invalidation_also_clears_aggregated_variants(monkeypatch):
+    redis = MagicMock()
+    redis.scan.side_effect = [
+        (0, [b"gw:catalog:v3:openai:provider-key"]),
+        (0, [b"gw:catalog:v3:all:aggregate-key"]),
+    ]
+    monkeypatch.setattr(catalog_response_cache, "get_redis_client", lambda: redis)
+
+    deleted = catalog_response_cache.invalidate_catalog_cache("openai")
+
+    assert deleted == 2
+    assert redis.scan.call_args_list == [
+        call(0, match="gw:catalog:v3:openai:*", count=100),
+        call(0, match="gw:catalog:v3:all:*", count=100),
+    ]
+    assert redis.delete.call_args_list == [
+        call(b"gw:catalog:v3:openai:provider-key"),
+        call(b"gw:catalog:v3:all:aggregate-key"),
+    ]
+
+
+def test_all_invalidation_scans_once(monkeypatch):
+    redis = MagicMock()
+    redis.scan.return_value = (0, [b"gw:catalog:v3:all:key"])
+    monkeypatch.setattr(catalog_response_cache, "get_redis_client", lambda: redis)
+
+    deleted = catalog_response_cache.invalidate_catalog_cache("all")
+
+    assert deleted == 1
+    redis.scan.assert_called_once_with(0, match="gw:catalog:v3:all:*", count=100)

--- a/tests/services/test_model_catalog_sync_delisting.py
+++ b/tests/services/test_model_catalog_sync_delisting.py
@@ -156,15 +156,98 @@ def test_sync_provider_models_inactive_provider_delists_previously_active_models
             "src.services.model_catalog_sync.deactivate_models_by_provider",
             return_value=3,
         ) as mock_deactivate,
+        patch(
+            "src.services.model_catalog_cache.invalidate_provider_catalog"
+        ) as invalidate_provider,
+        patch("src.services.model_catalog_cache.invalidate_unique_models") as invalidate_unique,
+        patch("src.services.model_catalog_cache.invalidate_catalog_stats") as invalidate_stats,
+        patch(
+            "src.services.cache.catalog_response_cache.invalidate_catalog_cache"
+        ) as invalidate_response,
     ):
         result = sync_provider_models("vendor")
 
     mock_deactivate.assert_called_once_with(42)
+    invalidate_provider.assert_called_once_with("vendor", cascade=True)
+    invalidate_unique.assert_called_once_with()
+    invalidate_stats.assert_called_once_with()
+    invalidate_response.assert_called_once_with("vendor")
     assert result["success"] is True
     assert result["models_delisted"] == 3
     assert result["reason"] == "provider_inactive"
     assert result["models_fetched"] == 0
     assert result["models_synced"] == 0
+
+
+def test_batch_sync_invalidates_all_catalog_layers_after_delisting():
+    inactive_result = {
+        "success": True,
+        "provider": "vendor",
+        "models_fetched": 0,
+        "models_transformed": 0,
+        "models_skipped": 0,
+        "models_synced": 0,
+        "models_delisted": 3,
+    }
+
+    with (
+        patch("src.utils.provider_filter.is_provider_enabled", return_value=True),
+        patch(
+            "src.services.model_catalog_sync.sync_provider_models",
+            return_value=inactive_result,
+        ),
+        patch("src.services.model_catalog_cache.invalidate_full_catalog") as invalidate_full,
+        patch("src.services.model_catalog_cache.invalidate_unique_models") as invalidate_unique,
+        patch("src.services.model_catalog_cache.invalidate_catalog_stats") as invalidate_stats,
+        patch(
+            "src.services.cache.catalog_response_cache.invalidate_catalog_cache"
+        ) as invalidate_response,
+    ):
+        from src.services.model_catalog_sync import sync_all_providers
+
+        result = sync_all_providers(["vendor"])
+
+    invalidate_full.assert_called_once_with()
+    invalidate_unique.assert_called_once_with()
+    invalidate_stats.assert_called_once_with()
+    invalidate_response.assert_called_once_with()
+    assert result["total_models_delisted"] == 3
+
+
+def test_batch_sync_bootstraps_enabled_provider_missing_from_registry():
+    synced_result = {
+        "success": True,
+        "provider": "moonshot",
+        "models_fetched": 1,
+        "models_transformed": 1,
+        "models_skipped": 0,
+        "models_synced": 1,
+        "models_delisted": 0,
+    }
+
+    with (
+        patch(
+            "src.utils.provider_filter.get_enabled_providers",
+            return_value=frozenset({"moonshot"}),
+        ),
+        patch("src.utils.provider_filter.is_provider_enabled", return_value=True),
+        patch(
+            "src.services.model_catalog_sync.sync_provider_models",
+            return_value=synced_result,
+        ) as sync_provider,
+        patch("src.config.config.Config.MODEL_SYNC_SKIP_PROVIDERS", set()),
+        patch("src.services.model_catalog_cache.invalidate_full_catalog"),
+        patch("src.services.model_catalog_cache.invalidate_unique_models"),
+        patch("src.services.model_catalog_cache.invalidate_catalog_stats"),
+        patch("src.services.cache.catalog_response_cache.invalidate_catalog_cache"),
+    ):
+        from src.services.model_catalog_sync import sync_all_providers
+
+        result = sync_all_providers()
+
+    sync_provider.assert_called_once_with("moonshot", dry_run=False, batch_mode=True)
+    assert result["providers_processed"] == 1
+    assert result["total_models_synced"] == 1
 
 
 def test_sync_provider_models_active_provider_does_not_bulk_delist():


### PR DESCRIPTION
## What was done
- make enabled providers the model-sync source of truth
- invalidate provider and aggregate catalog caches together
- stop extending stale catalog cache TTLs
- make model search use the same DB-backed enabled catalog
- bootstrap enabled providers missing from the DB registry

## Files changed
- `src/routes/catalog.py`
- `src/services/cache/catalog_response_cache.py`
- `src/services/cache/model_catalog_cache.py`
- `src/services/model_catalog_sync.py`
- `src/services/startup.py`
- focused catalog/cache/sync tests

## Verification
- 30 focused tests pass
- Ruff and Black checks pass