### PR TITLE
style(tests): satisfy catalog cache import order

### DIFF
--- a/tests/services/cache/test_catalog_response_cache.py
+++ b/tests/services/cache/test_catalog_response_cache.py
@@ -3,8 +3,7 @@ from unittest.mock import MagicMock, call
 
 import pytest
 
-from src.services.cache import catalog_response_cache
-from src.services.cache import model_catalog_cache
+from src.services.cache import catalog_response_cache, model_catalog_cache
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What was done
- apply the repository isort profile to the new catalog response-cache test imports

## Files changed
- `tests/services/cache/test_catalog_response_cache.py`

## Verification
- isort check passes
- Black check passes
- 5 catalog response-cache tests pass

Follow-up to #2182.