### PR TITLE
fix(config): never let an unset ENABLED_PROVIDERS rewrite the provider roster

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -538,11 +538,19 @@ class Config:
     # Enabled providers — only these providers will be loaded, routed to,
     # shown in the catalog, and synced.  Comma-separated slugs using the
     # hyphenated gateway names (e.g. "openrouter,openai,anthropic").
-    # Empty string or unset means ALL providers are enabled.
-    _raw_enabled = os.environ.get("ENABLED_PROVIDERS", "openrouter")
+    # Empty string means ALL providers are enabled.
+    #
+    # Unset is deliberately NOT the same as a value. The roster is a business
+    # decision (North Star §3) and startup rewrites the providers table to match
+    # it, so a missing env var must never stand in for one — defaulting to a
+    # single slug once inverted the whole production roster to the aggregator
+    # that North Star §5 bars as primary supply. ENABLED_PROVIDERS_EXPLICIT
+    # tells startup to leave the DB roster alone instead.
+    _raw_enabled = os.environ.get("ENABLED_PROVIDERS")
+    ENABLED_PROVIDERS_EXPLICIT: bool = _raw_enabled is not None
     ENABLED_PROVIDERS: frozenset[str] | None = (
         frozenset(s.strip() for s in _raw_enabled.split(",") if s.strip())
-        if _raw_enabled.strip()
+        if _raw_enabled and _raw_enabled.strip()
         else None  # None = all providers enabled
     )
 

--- a/src/services/startup.py
+++ b/src/services/startup.py
@@ -216,7 +216,15 @@ async def lifespan(app):
                     "  providers        ENABLED_PROVIDERS is UNSET — leaving the providers "
                     "table untouched. Set it explicitly to manage the roster from config."
                 )
-            elif enabled is not None:
+            elif enabled is None:
+                # Explicitly empty means "no restriction", not "activate all 37
+                # rows" — most have no API key configured. The filter already
+                # lets every provider through; the DB roster stays authoritative.
+                logger.info(
+                    "  providers        ENABLED_PROVIDERS is empty (no restriction) — "
+                    "provider activity left to the DB roster"
+                )
+            else:
                 supabase = get_client_for_query()
                 # Deactivate providers not in ENABLED_PROVIDERS
                 resp = supabase.table("providers").select("slug, is_active").execute()

--- a/src/services/startup.py
+++ b/src/services/startup.py
@@ -204,11 +204,19 @@ async def lifespan(app):
 
         # Sync DB providers table with ENABLED_PROVIDERS env var
         try:
+            from src.config.config import Config
             from src.config.supabase_config import get_client_for_query
             from src.utils.provider_filter import get_enabled_providers, is_provider_enabled
 
             enabled = get_enabled_providers()
-            if enabled is not None:
+            if not Config.ENABLED_PROVIDERS_EXPLICIT:
+                # A dropped env var must not rewrite the roster. Leave the DB as
+                # the last deliberate state and make the omission loud instead.
+                logger.error(
+                    "  providers        ENABLED_PROVIDERS is UNSET — leaving the providers "
+                    "table untouched. Set it explicitly to manage the roster from config."
+                )
+            elif enabled is not None:
                 supabase = get_client_for_query()
                 # Deactivate providers not in ENABLED_PROVIDERS
                 resp = supabase.table("providers").select("slug, is_active").execute()

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -670,3 +670,47 @@ class TestCostRoutingDefaults:
         monkeypatch.setenv("SMART_ROUTER_ENABLED", "false")
         importlib.reload(config)
         assert config.Config.SMART_ROUTER_ENABLED is False
+
+
+class TestEnabledProvidersRoster:
+    """ENABLED_PROVIDERS must distinguish "unset" from "explicitly empty".
+
+    A dropped env var once fell back to a single-slug default and startup
+    rewrote the production providers table to match it, inverting the roster
+    to the aggregator North Star §5 bars as primary supply.
+    """
+
+    def test_unset_enables_all_and_is_not_explicit(self, monkeypatch):
+        import importlib
+
+        from src.config import config
+
+        monkeypatch.delenv("ENABLED_PROVIDERS", raising=False)
+        importlib.reload(config)
+
+        assert config.Config.ENABLED_PROVIDERS is None
+        assert config.Config.ENABLED_PROVIDERS_EXPLICIT is False
+
+    def test_explicit_empty_enables_all_but_is_explicit(self, monkeypatch):
+        import importlib
+
+        from src.config import config
+
+        monkeypatch.setenv("ENABLED_PROVIDERS", "")
+        importlib.reload(config)
+
+        assert config.Config.ENABLED_PROVIDERS is None
+        assert config.Config.ENABLED_PROVIDERS_EXPLICIT is True
+
+    def test_roster_is_parsed_and_marked_explicit(self, monkeypatch):
+        import importlib
+
+        from src.config import config
+
+        monkeypatch.setenv("ENABLED_PROVIDERS", "openai, anthropic ,xai,moonshot")
+        importlib.reload(config)
+
+        assert config.Config.ENABLED_PROVIDERS == frozenset(
+            {"openai", "anthropic", "xai", "moonshot"}
+        )
+        assert config.Config.ENABLED_PROVIDERS_EXPLICIT is True


### PR DESCRIPTION
## What happened

Prod served **OpenRouter only** for four days. Root cause, all on deploy `7655dc48` (Jul 22 19:29 CEST):

1. **17:35:49 UTC** — the container booted without `ENABLED_PROVIDERS` in its env. `config.py` fell back to its hardcoded default `"openrouter"`, and the startup provider sync rewrote the prod `providers` table to match: moonshot → xai → openai → anthropic deactivated, **openrouter activated** — five writes inside one second, in exactly the deactivate-then-activate loop order.
2. **18:25:42 UTC** — a catalog sync ran, saw those four providers inactive, and hit the delisting path from #2182 (`model_catalog_sync.py`, `deactivate_models_by_provider`): all **123 model rows** for openai (104), anthropic (5), xai (10), moonshot (4) flipped to `is_active=false`.

Net effect: a missing env var silently inverted the configured roster into the one aggregator North Star §5 bars as primary supply, then erased the catalog of everything else.

## The fix

**Unset is no longer the same as a value.**

| `ENABLED_PROVIDERS` | Filter | Startup table sync |
|---|---|---|
| unset | no restriction | **skipped**, logged at error level — DB keeps the last deliberate roster |
| `""` | no restriction | skipped (unchanged) — "no restriction" never meant "activate all 37 rows", most have no API key |
| `openai,anthropic,…` | that roster | rewrites the table (unchanged) |

The roster is a business decision (North Star §3) that startup writes to persistent state. A dropped variable must never stand in for one.

The two skip paths are now separate branches with distinct log lines, so the reason a boot left the table alone is visible in the logs.

## Tests

3 new tests in `tests/config/test_config.py` covering unset / explicitly-empty / explicit-roster. 70 tests pass across config, provider-contract, catalog-rebuild and sync-delisting suites. black + ruff clean.

## Recovery already applied to prod

Redeployed `api` (roster restored), re-synced all four providers, and busted the stale `gateway=all` response cache. `GET /models` now returns 47 models — openai 34, xai 7, anthropic 4, moonshot 2, zero OpenRouter.

## Follow-ups (not in this PR)

- OpenRouter's 329 model rows are still `is_active=true` while the provider is inactive — excluded from the served catalog, but incoherent.
- `ENABLE_SCHEDULED_MODEL_SYNC` is unset in prod → defaults to `false`, so nothing re-syncs on a schedule.
- 47 models served vs 60 active in the DB — health gating / non-chat filtering, worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)