### PR TITLE
fix(catalog): stop caching half-written syncs, and revive the unique-models catalog

### DIFF
--- a/src/db/models_catalog_db.py
+++ b/src/db/models_catalog_db.py
@@ -2313,6 +2313,41 @@ def get_all_unique_models_for_catalog(include_inactive: bool = False) -> list[di
             logger.info("No unique models found in database")
             return []
 
+        # Provider lookup for the in-Python join below (see the mappings query).
+        # ~40 rows, one round-trip.
+        #
+        # Restricted to active + ENABLED_PROVIDERS so this catalog agrees with
+        # rebuild_full_catalog_from_providers. Without the filter the unique
+        # view is the one surface that still exposes deactivated providers —
+        # including the aggregator North Star §5 bars as primary supply — while
+        # every other endpoint hides them. Mappings for excluded providers are
+        # dropped by the `if not provider` guard in the grouping loop.
+        providers_by_id: dict[Any, dict[str, Any]] = {}
+        try:
+            from src.utils.provider_filter import is_provider_enabled
+
+            providers_response = (
+                supabase.table("providers").select("id, slug, name").eq("is_active", True).execute()
+            )
+            providers_by_id = {
+                row["id"]: row
+                for row in (providers_response.data or [])
+                if row.get("slug") and is_provider_enabled(row["slug"])
+            }
+        except Exception as provider_e:
+            logger.error(
+                "get_all_unique_models_for_catalog: failed to load providers for join: %s",
+                provider_e,
+            )
+            return []
+
+        if not providers_by_id:
+            logger.warning(
+                "get_all_unique_models_for_catalog: no active enabled providers; "
+                "returning empty unique catalog"
+            )
+            return []
+
         # Note: These two queries are not atomic. Brief inconsistency is possible during model updates.
         # Supabase (PostgREST) does not support multi-statement transactions via the REST API,
         # so unique_models and unique_models_provider are fetched in separate round-trips.
@@ -2337,12 +2372,24 @@ def get_all_unique_models_for_catalog(include_inactive: bool = False) -> list[di
                 )
                 break
 
+            # providers is joined in Python, not embedded. unique_models_provider
+            # has an index on provider_id but no foreign key to providers (see
+            # 20260129000001_create_unique_models_provider_table.sql), so
+            # PostgREST cannot resolve a `providers!inner(...)` embed and answers
+            # PGRST200 — which this function swallowed into an empty list,
+            # silently emptying the unique-models catalog. The provider table is
+            # tiny and already fetched above, so the join is free.
             ump_query = supabase.table("unique_models_provider").select(
-                "unique_model_id, models!inner(id, model_name, provider_model_id, metadata, context_length, health_status, average_response_time_ms, modality, supports_streaming, supports_function_calling, supports_vision, description, is_active), providers!inner(id, slug, name)"
+                "unique_model_id, provider_id, models!inner(id, model_name, provider_model_id, metadata, context_length, health_status, average_response_time_ms, modality, supports_streaming, supports_function_calling, supports_vision, description, is_active)"
             )
 
             if not include_inactive:
                 ump_query = ump_query.eq("models.is_active", True)
+
+            # Push the provider filter into the query instead of discarding rows
+            # after transfer: without it every mapping for every retired provider
+            # is paged over (13k rows, ~10s) just to be dropped in the join.
+            ump_query = ump_query.in_("provider_id", list(providers_by_id.keys()))
 
             ump_query = ump_query.range(ump_offset, ump_offset + page_size - 1)
             ump_response = ump_query.execute()
@@ -2384,7 +2431,12 @@ def get_all_unique_models_for_catalog(include_inactive: bool = False) -> list[di
                 continue
 
             model = ump.get("models", {})
-            provider = ump.get("providers", {})
+            provider = providers_by_id.get(ump.get("provider_id"))
+            if not provider:
+                # Mapping points at a provider row that no longer exists. Skip it
+                # rather than emitting an offer with a null provider — the router
+                # cannot route to it and the catalog would show a blank source.
+                continue
 
             # NOTE: pricing_prompt/pricing_completion/pricing_image/pricing_request
             # and architecture columns were dropped from the models table

--- a/src/services/cache/catalog_sync_guard.py
+++ b/src/services/cache/catalog_sync_guard.py
@@ -1,0 +1,108 @@
+"""Cross-worker guard that keeps catalog caches off a half-written database.
+
+``sync_all_providers`` rewrites the ``models`` table provider by provider. While
+that runs the table is a moving target: a provider's rows may be partly upserted
+and stale rows not yet delisted. Any catalog rebuild during the window — the
+sync's own post-run warm, or an ordinary ``GET /models`` — reads that mid-flight
+state and caches it for the full provider TTL (30 minutes), so a 12-second sync
+can serve a wrong catalog for half an hour.
+
+A process-local flag cannot fix this: Redis is shared across workers, so the
+worker running the sync is rarely the worker answering the request. The marker
+therefore lives in Redis, and every catalog cache *write* consults it. Reads are
+untouched — during a sync callers simply fall through to the database and get
+fresh (if briefly inconsistent) data instead of poisoning the cache for everyone.
+
+The marker always carries a TTL, so a crashed sync expires instead of wedging
+the catalog into permanent no-cache mode.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Redis key holding the marker. Namespaced with the catalog cache keys so the
+# whole catalog surface is greppable under one prefix.
+SYNC_GUARD_KEY = "gw:models:sync:in_progress"
+
+# Safety net for a sync that dies without clearing the marker. Generous relative
+# to a real sync (~12s for the current roster, minutes for a large one) but far
+# below the provider cache TTL it protects.
+SYNC_GUARD_TTL_SECONDS = 900
+
+
+def mark_sync_started(ttl: int = SYNC_GUARD_TTL_SECONDS) -> bool:
+    """Announce that a catalog sync is mutating the database.
+
+    Returns True when the marker was written. A Redis outage returns False and
+    the caller proceeds — degraded to the previous behaviour, never blocked.
+    """
+    try:
+        from src.config.redis_config import get_redis_client, is_redis_available
+
+        redis_client = get_redis_client()
+        if not redis_client or not is_redis_available():
+            logger.debug("Sync guard: Redis unavailable, catalog writes stay unguarded")
+            return False
+
+        redis_client.setex(SYNC_GUARD_KEY, ttl, "1")
+        logger.info("Sync guard: catalog cache writes suppressed (ttl=%ss)", ttl)
+        return True
+    except Exception as e:  # pragma: no cover - defensive, never fail a sync
+        logger.warning("Sync guard: failed to set marker (non-fatal): %s", e)
+        return False
+
+
+def mark_sync_finished() -> bool:
+    """Clear the marker so catalog caches may be written again."""
+    try:
+        from src.config.redis_config import get_redis_client, is_redis_available
+
+        redis_client = get_redis_client()
+        if not redis_client or not is_redis_available():
+            return False
+
+        redis_client.delete(SYNC_GUARD_KEY)
+        logger.info("Sync guard: catalog cache writes re-enabled")
+        return True
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("Sync guard: failed to clear marker (non-fatal): %s", e)
+        return False
+
+
+def is_sync_in_progress() -> bool:
+    """Return True while a catalog sync is mutating the database.
+
+    Fails open: if Redis cannot answer we allow the write, preserving the
+    pre-guard behaviour rather than disabling caching entirely.
+    """
+    try:
+        from src.config.redis_config import get_redis_client, is_redis_available
+
+        redis_client = get_redis_client()
+        if not redis_client or not is_redis_available():
+            return False
+
+        return bool(redis_client.exists(SYNC_GUARD_KEY))
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug("Sync guard: existence check failed, allowing write: %s", e)
+        return False
+
+
+class catalog_sync_guard:  # noqa: N801 - context manager reads as a verb at call sites
+    """Context manager wrapping a sync so the marker is always cleared."""
+
+    def __init__(self, ttl: int = SYNC_GUARD_TTL_SECONDS):
+        self.ttl = ttl
+        self.marked = False
+
+    def __enter__(self) -> catalog_sync_guard:
+        self.marked = mark_sync_started(self.ttl)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        if self.marked:
+            mark_sync_finished()
+        return False

--- a/src/services/cache/model_catalog_cache.py
+++ b/src/services/cache/model_catalog_cache.py
@@ -329,6 +329,40 @@ class ModelCatalogCache:
             )
             return None
 
+    @staticmethod
+    def _should_skip_catalog_write(label: str, payload: list[Any]) -> bool:
+        """Reject catalog cache writes that would persist a known-bad snapshot.
+
+        Two cases, both learned the hard way:
+
+        1. A sync is rewriting ``models`` right now, so any rebuild reads a
+           half-written table. Caching that pins a wrong catalog for the whole
+           TTL — a 12s sync served 30 minutes of bad data.
+        2. The payload is empty. No caller benefits from a cached empty catalog,
+           and it is exactly how a failing query hides: ``get_all_unique_models_
+           for_catalog`` swallowed a schema error into ``[]`` and the warm step
+           cached it, so the emptiness looked deliberate.
+
+        Reads are never blocked — callers fall through to the database.
+        """
+        if not payload:
+            logger.warning(
+                "Cache SET skipped: %s payload is empty (refusing to cache nothing)", label
+            )
+            return True
+
+        from src.services.cache.catalog_sync_guard import is_sync_in_progress
+
+        if is_sync_in_progress():
+            logger.info(
+                "Cache SET skipped: %s — catalog sync in progress, "
+                "refusing to cache a half-written database",
+                label,
+            )
+            return True
+
+        return False
+
     def set_full_catalog(
         self,
         catalog: list[dict[str, Any]],
@@ -344,6 +378,9 @@ class ModelCatalogCache:
             True if successful, False otherwise
         """
         if not self.redis_client or not is_redis_available():
+            return False
+
+        if self._should_skip_catalog_write("full catalog", catalog):
             return False
 
         key = self.PREFIX_FULL_CATALOG
@@ -446,6 +483,9 @@ class ModelCatalogCache:
             True if successful, False otherwise
         """
         if not self.redis_client or not is_redis_available():
+            return False
+
+        if self._should_skip_catalog_write(f"provider catalog ({provider_name})", catalog):
             return False
 
         key = self._generate_key(self.PREFIX_PROVIDER, provider_name)
@@ -1045,6 +1085,9 @@ class ModelCatalogCache:
             True if successful, False otherwise
         """
         if not self.redis_client or not is_redis_available():
+            return False
+
+        if self._should_skip_catalog_write("unique models", unique_models):
             return False
 
         key = self.PREFIX_UNIQUE

--- a/src/services/model_catalog_sync.py
+++ b/src/services/model_catalog_sync.py
@@ -1047,6 +1047,22 @@ def sync_all_providers(
     Returns:
         Dictionary with overall sync results and performance metrics
     """
+    from src.services.cache.catalog_sync_guard import catalog_sync_guard
+
+    # Hold the guard for the whole batch, not per provider: the aggregate catalog
+    # spans every provider, so it is only coherent once the last one is written.
+    # A dry run mutates nothing and needs no guard.
+    if dry_run:
+        return _sync_all_providers_inner(provider_slugs, dry_run)
+
+    with catalog_sync_guard():
+        return _sync_all_providers_inner(provider_slugs, dry_run)
+
+
+def _sync_all_providers_inner(
+    provider_slugs: list[str] | None = None, dry_run: bool = False
+) -> dict[str, Any]:
+    """Body of :func:`sync_all_providers`, run inside the catalog sync guard."""
     import time
 
     try:

--- a/supabase/migrations/20260726000000_add_unique_models_provider_fk.sql
+++ b/supabase/migrations/20260726000000_add_unique_models_provider_fk.sql
@@ -1,0 +1,34 @@
+-- Add the foreign key unique_models_provider.provider_id -> providers.id
+--
+-- 20260129000001_create_unique_models_provider_table.sql declared foreign keys
+-- for unique_model_id and model_id but left provider_id as a bare BIGINT with
+-- only an index. Without the constraint PostgREST has no relationship to follow,
+-- so `providers!inner(...)` embeds fail with PGRST200 and the unique-models
+-- catalog silently returned nothing.
+--
+-- The read path no longer depends on the embed (it joins providers in Python),
+-- but the constraint is still the correct data model: it stops orphan mappings
+-- and restores the embed for any future caller.
+
+-- Drop mappings pointing at providers that no longer exist, otherwise ADD
+-- CONSTRAINT fails. These rows are already unusable — the catalog skips them.
+DELETE FROM unique_models_provider ump
+WHERE NOT EXISTS (
+    SELECT 1 FROM providers p WHERE p.id = ump.provider_id
+);
+
+ALTER TABLE unique_models_provider
+    DROP CONSTRAINT IF EXISTS fk_unique_models_provider_provider;
+
+ALTER TABLE unique_models_provider
+    ADD CONSTRAINT fk_unique_models_provider_provider
+    FOREIGN KEY (provider_id)
+    REFERENCES providers(id)
+    ON DELETE CASCADE;
+
+COMMENT ON CONSTRAINT fk_unique_models_provider_provider ON unique_models_provider
+    IS 'Restores PostgREST embedding of providers and prevents orphan provider mappings.';
+
+-- PostgREST caches the schema; without this the new relationship stays invisible
+-- until the next restart.
+NOTIFY pgrst, 'reload schema';

--- a/tests/db/test_unique_models_catalog.py
+++ b/tests/db/test_unique_models_catalog.py
@@ -1,0 +1,154 @@
+"""The unique-models catalog must not depend on an absent foreign key.
+
+``unique_models_provider`` indexes ``provider_id`` but never declared a foreign
+key to ``providers`` (20260129000001), so PostgREST answered ``providers!inner``
+embeds with PGRST200. The query swallowed that into ``[]``, and the unique
+catalog silently served nothing from the day the table was created.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.db import models_catalog_db
+
+
+class _Query:
+    """Minimal PostgREST query recorder."""
+
+    def __init__(self, table: str, rows_by_table: dict, recorder: dict):
+        self.table = table
+        self.rows_by_table = rows_by_table
+        self.recorder = recorder
+        self._offset = 0
+
+    def select(self, columns: str):
+        self.recorder.setdefault("selects", {})[self.table] = columns
+        return self
+
+    def eq(self, field: str, value):
+        self.recorder.setdefault("eq", []).append((self.table, field, value))
+        return self
+
+    def in_(self, field: str, values):
+        self.recorder.setdefault("in_", []).append((self.table, field, list(values)))
+        return self
+
+    def range(self, start: int, _end: int):
+        self._offset = start
+        return self
+
+    def order(self, *_a, **_k):
+        return self
+
+    def execute(self):
+        rows = self.rows_by_table.get(self.table, [])
+        return MagicMock(data=rows if self._offset == 0 else [])
+
+
+@pytest.fixture
+def fake_supabase(monkeypatch):
+    recorder: dict = {}
+    rows_by_table = {
+        "unique_models": [
+            {"id": 1, "model_name": "GPT-4", "model_count": 1, "sample_model_id": "openai/gpt-4"},
+            {"id": 2, "model_name": "Ghost", "model_count": 1, "sample_model_id": "gone/ghost"},
+        ],
+        "providers": [
+            {"id": 10, "slug": "openai", "name": "OpenAI"},
+            {"id": 99, "slug": "openrouter", "name": "OpenRouter"},
+        ],
+        "unique_models_provider": [
+            {
+                "unique_model_id": 1,
+                "provider_id": 10,
+                "models": {
+                    "id": 500,
+                    "model_name": "GPT-4",
+                    "provider_model_id": "gpt-4",
+                    "metadata": {"pricing_raw": {"prompt": "0.03", "completion": "0.06"}},
+                    "context_length": 8192,
+                    "health_status": "healthy",
+                    "average_response_time_ms": 100,
+                    "modality": "text->text",
+                    "supports_streaming": True,
+                    "supports_function_calling": True,
+                    "supports_vision": False,
+                    "description": "",
+                    "is_active": True,
+                },
+            },
+            {
+                # Mapping to a provider row that is gone — must be skipped, not
+                # emitted with a null provider the router cannot route to.
+                "unique_model_id": 2,
+                "provider_id": 4242,
+                "models": {
+                    "id": 501,
+                    "model_name": "Ghost",
+                    "provider_model_id": "ghost",
+                    "metadata": {},
+                    "context_length": 1,
+                    "health_status": "unknown",
+                    "average_response_time_ms": 0,
+                    "modality": "text->text",
+                    "supports_streaming": False,
+                    "supports_function_calling": False,
+                    "supports_vision": False,
+                    "description": "",
+                    "is_active": True,
+                },
+            },
+        ],
+    }
+
+    client = MagicMock()
+    client.table.side_effect = lambda name: _Query(name, rows_by_table, recorder)
+    monkeypatch.setattr(models_catalog_db, "get_client_for_query", lambda **_k: client)
+    monkeypatch.setattr("src.utils.provider_filter.is_provider_enabled", lambda slug: True)
+    return recorder
+
+
+def test_mappings_query_does_not_embed_providers(fake_supabase):
+    """PGRST200 regression: the embed has no foreign key to resolve."""
+    models_catalog_db.get_all_unique_models_for_catalog(include_inactive=False)
+
+    select = fake_supabase["selects"]["unique_models_provider"]
+    assert "providers!inner" not in select
+    assert "provider_id" in select
+
+
+def test_returns_models_joined_via_provider_id(fake_supabase):
+    result = models_catalog_db.get_all_unique_models_for_catalog(include_inactive=False)
+
+    assert len(result) == 1
+    assert result[0]["providers"][0]["provider_slug"] == "openai"
+
+
+def test_orphan_provider_mapping_is_skipped(fake_supabase):
+    result = models_catalog_db.get_all_unique_models_for_catalog(include_inactive=False)
+
+    assert all(um["model_name"] != "Ghost" for um in result)
+
+
+def test_only_active_providers_are_loaded(fake_supabase):
+    """The unique view must hide deactivated providers like every other surface."""
+    models_catalog_db.get_all_unique_models_for_catalog(include_inactive=False)
+
+    assert ("providers", "is_active", True) in fake_supabase["eq"]
+
+
+def test_disabled_providers_are_filtered_out(monkeypatch, fake_supabase):
+    """ENABLED_PROVIDERS applies here too (North Star §5)."""
+    monkeypatch.setattr("src.utils.provider_filter.is_provider_enabled", lambda slug: False)
+
+    assert models_catalog_db.get_all_unique_models_for_catalog(include_inactive=False) == []
+
+
+def test_provider_filter_is_pushed_into_the_query(fake_supabase):
+    """Filtering in Python paged over every retired provider's mappings."""
+    models_catalog_db.get_all_unique_models_for_catalog(include_inactive=False)
+
+    pushed = [c for c in fake_supabase["in_"] if c[0] == "unique_models_provider"]
+    assert pushed, "provider_id filter must be applied server-side"
+    assert set(pushed[0][2]) == {10, 99}

--- a/tests/services/cache/test_catalog_sync_guard.py
+++ b/tests/services/cache/test_catalog_sync_guard.py
@@ -1,0 +1,115 @@
+"""Catalog cache writes must not persist a half-written database.
+
+Regression cover for the incident where enabling the hourly sync served a wrong
+catalog for 30 minutes: a rebuild ran while ``sync_all_providers`` was mid-write
+and the mid-flight snapshot (openai 84 of 104 rows, anthropic 1 of 5) was cached
+for the full provider TTL.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.services.cache import catalog_sync_guard as guard_mod
+from src.services.cache import model_catalog_cache
+
+
+@pytest.fixture
+def redis(monkeypatch):
+    client = MagicMock()
+    monkeypatch.setattr(guard_mod, "SYNC_GUARD_TTL_SECONDS", 900)
+    monkeypatch.setattr("src.config.redis_config.get_redis_client", lambda: client)
+    monkeypatch.setattr("src.config.redis_config.is_redis_available", lambda: True)
+    return client
+
+
+class TestSyncGuardMarker:
+    def test_mark_started_writes_marker_with_ttl(self, redis):
+        assert guard_mod.mark_sync_started() is True
+        redis.setex.assert_called_once_with(guard_mod.SYNC_GUARD_KEY, 900, "1")
+
+    def test_mark_finished_clears_marker(self, redis):
+        assert guard_mod.mark_sync_finished() is True
+        redis.delete.assert_called_once_with(guard_mod.SYNC_GUARD_KEY)
+
+    def test_is_sync_in_progress_reflects_marker(self, redis):
+        redis.exists.return_value = 1
+        assert guard_mod.is_sync_in_progress() is True
+        redis.exists.return_value = 0
+        assert guard_mod.is_sync_in_progress() is False
+
+    def test_context_manager_clears_marker_even_on_error(self, redis):
+        with pytest.raises(RuntimeError):
+            with guard_mod.catalog_sync_guard():
+                raise RuntimeError("sync exploded")
+
+        redis.delete.assert_called_once_with(guard_mod.SYNC_GUARD_KEY)
+
+    def test_fails_open_without_redis(self, monkeypatch):
+        """A Redis outage must not disable caching — degrade to old behaviour."""
+        monkeypatch.setattr("src.config.redis_config.get_redis_client", lambda: None)
+
+        assert guard_mod.mark_sync_started() is False
+        assert guard_mod.is_sync_in_progress() is False
+
+
+class TestCatalogWritesRespectGuard:
+    @pytest.fixture
+    def cache(self, monkeypatch):
+        client = MagicMock()
+        monkeypatch.setattr(model_catalog_cache, "get_redis_client", lambda: client)
+        monkeypatch.setattr(model_catalog_cache, "is_redis_available", lambda: True)
+        return model_catalog_cache.ModelCatalogCache(), client
+
+    @pytest.fixture
+    def sync_running(self, monkeypatch):
+        def _set(running: bool):
+            monkeypatch.setattr(
+                "src.services.cache.catalog_sync_guard.is_sync_in_progress", lambda: running
+            )
+
+        return _set
+
+    def test_full_catalog_write_skipped_during_sync(self, cache, sync_running):
+        catalog_cache, client = cache
+        sync_running(True)
+
+        assert catalog_cache.set_full_catalog([{"id": "openai/gpt-4"}]) is False
+        client.setex.assert_not_called()
+
+    def test_provider_catalog_write_skipped_during_sync(self, cache, sync_running):
+        catalog_cache, client = cache
+        sync_running(True)
+
+        assert catalog_cache.set_provider_catalog("openai", [{"id": "openai/gpt-4"}]) is False
+        client.setex.assert_not_called()
+
+    def test_unique_models_write_skipped_during_sync(self, cache, sync_running):
+        catalog_cache, client = cache
+        sync_running(True)
+
+        assert catalog_cache.set_unique_models([{"id": "gpt-4"}]) is False
+        client.setex.assert_not_called()
+
+    def test_writes_proceed_when_no_sync_running(self, cache, sync_running):
+        catalog_cache, client = cache
+        sync_running(False)
+
+        assert catalog_cache.set_full_catalog([{"id": "openai/gpt-4"}]) is True
+        client.setex.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "method,args",
+        [
+            ("set_full_catalog", ()),
+            ("set_provider_catalog", ("openai",)),
+            ("set_unique_models", ()),
+        ],
+    )
+    def test_empty_payload_is_never_cached(self, cache, sync_running, method, args):
+        """An empty catalog is how a failing query hides — never persist one."""
+        catalog_cache, client = cache
+        sync_running(False)
+
+        assert getattr(catalog_cache, method)(*args, []) is False
+        client.setex.assert_not_called()

--- a/tests/services/test_model_catalog_sync_delisting.py
+++ b/tests/services/test_model_catalog_sync_delisting.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
+
 from src.services.model_catalog_sync import (
     sync_provider_models,
     transform_normalized_model_to_db_schema,
@@ -268,3 +270,73 @@ def test_sync_provider_models_active_provider_does_not_bulk_delist():
 
     mock_deactivate.assert_not_called()
     assert result["success"] is True
+
+
+class TestSyncHoldsCatalogGuard:
+    """The sync and the cache guard must interlock.
+
+    Fix A (suppress writes during sync) is worthless if the sync forgets to
+    raise the marker, and it deadlocks the catalog if it forgets to clear it.
+    """
+
+    def test_sync_wraps_batch_in_guard_and_releases_it(self, monkeypatch):
+        from src.services import model_catalog_sync
+
+        events = []
+        monkeypatch.setattr(
+            "src.services.cache.catalog_sync_guard.mark_sync_started",
+            lambda ttl=900: events.append("start") or True,
+        )
+        monkeypatch.setattr(
+            "src.services.cache.catalog_sync_guard.mark_sync_finished",
+            lambda: events.append("finish") or True,
+        )
+        monkeypatch.setattr(
+            model_catalog_sync,
+            "_sync_all_providers_inner",
+            lambda *a, **k: events.append("sync") or {"success": True},
+        )
+
+        model_catalog_sync.sync_all_providers(dry_run=False)
+
+        assert events == ["start", "sync", "finish"]
+
+    def test_guard_released_when_sync_raises(self, monkeypatch):
+        from src.services import model_catalog_sync
+
+        events = []
+        monkeypatch.setattr(
+            "src.services.cache.catalog_sync_guard.mark_sync_started",
+            lambda ttl=900: events.append("start") or True,
+        )
+        monkeypatch.setattr(
+            "src.services.cache.catalog_sync_guard.mark_sync_finished",
+            lambda: events.append("finish") or True,
+        )
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("provider API down")
+
+        monkeypatch.setattr(model_catalog_sync, "_sync_all_providers_inner", _boom)
+
+        with pytest.raises(RuntimeError):
+            model_catalog_sync.sync_all_providers(dry_run=False)
+
+        assert events == ["start", "finish"]
+
+    def test_dry_run_does_not_take_the_guard(self, monkeypatch):
+        """A dry run mutates nothing, so it must not suppress anyone's caching."""
+        from src.services import model_catalog_sync
+
+        events = []
+        monkeypatch.setattr(
+            "src.services.cache.catalog_sync_guard.mark_sync_started",
+            lambda ttl=900: events.append("start") or True,
+        )
+        monkeypatch.setattr(
+            model_catalog_sync, "_sync_all_providers_inner", lambda *a, **k: {"success": True}
+        )
+
+        model_catalog_sync.sync_all_providers(dry_run=True)
+
+        assert events == []


### PR DESCRIPTION
Two defects that only surfaced together when the hourly sync was switched on in production, and that have to land together because they disagree about what the catalog contains.

## A — cache writes raced the sync's own DB writes

`sync_all_providers` rewrites `models` provider by provider. Any rebuild during that window — the sync's post-run warm, or an ordinary `GET /models` — read a half-written table and cached it for the full 30-minute provider TTL.

Observed in prod: a **12-second sync served a wrong catalog for 30 minutes** — openai 84 of its 104 rows, anthropic 1 of 5, with Opus 4.7 / Sonnet 5 / Fable 5 missing from the API.

A process-local flag can't fix this (Redis is shared across workers; the worker syncing is rarely the worker answering). So the marker lives in Redis and every catalog cache **write** consults it:

- reads are untouched — during a sync callers fall through to the DB instead of poisoning the cache for everyone
- the marker always carries a TTL, so a crashed sync expires instead of wedging the catalog into permanent no-cache mode
- it fails open: a Redis outage degrades to the old behaviour rather than disabling caching

## B — the unique-models catalog had never returned anything

`20260129000001_create_unique_models_provider_table.sql` declared foreign keys for `unique_model_id` and `model_id` but left `provider_id` a bare `BIGINT` with only an index. PostgREST therefore couldn't resolve the `providers!inner(...)` embed:

```
PGRST200: Could not find a relationship between 'unique_models_provider'
and 'providers' in the schema cache
```

…which the query swallowed into `return []`. `/models?unique_models=true` has served nothing since the table was created, and the sync's warm step cached that emptiness on every run.

Fixed by joining providers in Python (no relationship required) plus a migration adding the missing constraint. **0 → 60 models** against the production database.

## Making them agree

The unique view was the one surface that ignored provider enablement entirely. Fixing the query alone would have exposed **7,254 models from deactivated providers** — including the aggregator North Star §5 bars as primary supply — while every other endpoint hides them. It now filters to active + `ENABLED_PROVIDERS` and returns exactly the 60 models the flat catalog serves.

Pushing that filter into the query instead of discarding rows after transfer also took it from **10.1s → 5.4s**.

**Shared safety net:** an empty payload is never cached. No caller benefits from a cached empty catalog, and it's precisely how B stayed invisible for six months — a failing query became `[]`, the warm step cached it, and the emptiness looked deliberate.

## Verification

Measured against the production database (read-only):

| | before | after |
|---|---|---|
| `get_all_unique_models_for_catalog` | 0 models / 10.1s | 60 models / 5.4s |
| providers represented | — | openai 45, anthropic 5, xai 7, moonshot 3 |
| flat catalog (`/models`) | 47 | unchanged |

Tests: 21 new across three files — guard marker lifecycle (incl. clear-on-exception and fail-open), all three cache setters skipping during sync and refusing empty payloads, sync/guard interlock (`start → sync → finish`, released on raise, not taken for dry runs), and the PGRST200 regression (asserts the embed is gone, orphan mappings skipped, enablement filter pushed server-side).

Broad suite: 1455 passed / 2 failed, both in `test_prometheus_remote_write.py` — confirmed **pre-existing**: they fail identically on unmodified `main` under the parallel runner and pass in isolation on both. black + ruff clean.

## Migration note

`20260726000000_add_unique_models_provider_fk.sql` deletes mappings whose `provider_id` no longer exists before adding the constraint. **Verified 0 orphans of 13,205 rows in production**, so the DELETE is a no-op there; it only guards environments that drifted.

## Follow-up (not in this PR)

The remaining 5.4s is the `unique_models` table pagination (11,228 rows over 12 pages) fetched before the mappings are known. Reordering to fetch mappings first, then only the referenced `unique_models` rows by id, should take it under 1s — a contained but real restructure, deliberately left out of a fix PR.

`ENABLE_SCHEDULED_MODEL_SYNC` stays `false` in prod until this merges and is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)