### PR TITLE
perf(catalog): let the mappings drive the unique-models lookup

### DIFF
--- a/src/db/models_catalog_db.py
+++ b/src/db/models_catalog_db.py
@@ -2275,44 +2275,14 @@ def get_all_unique_models_for_catalog(include_inactive: bool = False) -> list[di
         start = time.monotonic()
         logger.debug(f"Fetching unique models (include_inactive={include_inactive})")
 
-        # OPTIMIZATION: Fetch all unique models with pagination
-        # to avoid Supabase's 1000-row default truncation
-        unique_models_data = []
         page_size = SUPABASE_PAGE_SIZE
-        um_offset = 0
-        deadline = start + DB_QUERY_TIMEOUT_SECONDS
 
-        while True:
-            if time.monotonic() > deadline:
-                logger.warning(
-                    f"get_all_unique_models_for_catalog (unique_models loop): wall-clock "
-                    f"deadline of {DB_QUERY_TIMEOUT_SECONDS}s exceeded after "
-                    f"{len(unique_models_data)} unique models; returning partial results"
-                )
-                break
-
-            um_query = (
-                supabase.table("unique_models")
-                .select("id, model_name, model_count, sample_model_id")
-                .range(um_offset, um_offset + page_size - 1)
-            )
-            um_response = um_query.execute()
-            batch = um_response.data or []
-
-            if not batch:
-                break
-
-            unique_models_data.extend(batch)
-
-            if len(batch) < page_size:
-                break
-
-            um_offset += page_size
-
-        if not unique_models_data:
-            logger.info("No unique models found in database")
-            return []
-
+        # Order matters: the mappings are fetched FIRST and the unique_models rows
+        # are then looked up by the ids they reference. Fetching unique_models
+        # first meant paging the whole table (11k rows, 12 round-trips) to keep
+        # the handful the enabled providers actually offer — the table is sized by
+        # every model ever seen, the result by the current roster.
+        #
         # Provider lookup for the in-Python join below (see the mappings query).
         # ~40 rows, one round-trip.
         #
@@ -2352,9 +2322,6 @@ def get_all_unique_models_for_catalog(include_inactive: bool = False) -> list[di
         # Supabase (PostgREST) does not support multi-statement transactions via the REST API,
         # so unique_models and unique_models_provider are fetched in separate round-trips.
         # In practice this window is milliseconds and only affects catalog reads, not writes.
-
-        # Record the set of unique_model_ids from the first query for staleness detection below.
-        unique_model_ids_from_first_query = {row["id"] for row in unique_models_data}
 
         # OPTIMIZATION: Fetch ALL provider mappings with pagination
         # This replaces N individual queries (one per unique model)
@@ -2405,19 +2372,62 @@ def get_all_unique_models_for_catalog(include_inactive: bool = False) -> list[di
 
             ump_offset += page_size
 
-        # Staleness check: warn if the second query references unique_model_ids that were not
-        # present in the first query. This can happen when a model is inserted between the two
-        # queries (non-atomic reads). The data is still usable but may be slightly inconsistent.
-        orphaned_ids = {
-            ump.get("unique_model_id")
-            for ump in all_provider_mappings
-            if ump.get("unique_model_id") not in unique_model_ids_from_first_query
-        }
+        if not all_provider_mappings:
+            logger.info("No provider mappings for enabled providers; unique catalog is empty")
+            return []
+
+        # Fetch only the unique_models rows the mappings actually reference.
+        # `in_` filters are URL parameters, so chunk the ids to keep the request
+        # line well inside the server's limit.
+        # Only ids whose provider survives the join — a mapping to a dropped
+        # provider contributes nothing, so looking its unique_models row up is
+        # wasted work. The provider filter is already pushed into the mappings
+        # query; this also covers a provider deleted between the two reads.
+        referenced_ids = sorted(
+            {
+                ump["unique_model_id"]
+                for ump in all_provider_mappings
+                if ump.get("unique_model_id") and ump.get("provider_id") in providers_by_id
+            }
+        )
+        if not referenced_ids:
+            logger.info("No provider mappings survived the provider join; unique catalog is empty")
+            return []
+        unique_models_data: list[dict[str, Any]] = []
+        UNIQUE_MODEL_ID_CHUNK = 200
+
+        for chunk_start in range(0, len(referenced_ids), UNIQUE_MODEL_ID_CHUNK):
+            if time.monotonic() > start + DB_QUERY_TIMEOUT_SECONDS:
+                logger.warning(
+                    f"get_all_unique_models_for_catalog (unique_models lookup): wall-clock "
+                    f"deadline of {DB_QUERY_TIMEOUT_SECONDS}s exceeded after "
+                    f"{len(unique_models_data)} unique models; returning partial results"
+                )
+                break
+
+            chunk = referenced_ids[chunk_start : chunk_start + UNIQUE_MODEL_ID_CHUNK]
+            um_response = (
+                supabase.table("unique_models")
+                .select("id, model_name, model_count, sample_model_id")
+                .in_("id", chunk)
+                .execute()
+            )
+            unique_models_data.extend(um_response.data or [])
+
+        if not unique_models_data:
+            logger.info("No unique models found in database")
+            return []
+
+        # Consistency check: a mapping may reference a unique_models row that was
+        # deleted between the two non-atomic reads. Usable, but worth surfacing —
+        # those mappings are skipped when the result is assembled below.
+        found_ids = {row["id"] for row in unique_models_data}
+        orphaned_ids = {mid for mid in referenced_ids if mid not in found_ids}
         if orphaned_ids:
             logger.warning(
-                f"Catalog consistency warning: {len(orphaned_ids)} unique_model_id(s) returned "
-                f"by unique_models_provider were not present in the unique_models snapshot "
-                f"(ids: {sorted(orphaned_ids)}). This indicates a model was added between the "
+                f"Catalog consistency warning: {len(orphaned_ids)} unique_model_id(s) referenced "
+                f"by unique_models_provider have no unique_models row "
+                f"(ids: {sorted(orphaned_ids)}). This indicates a row was removed between the "
                 f"two non-atomic queries. The affected provider mappings will be skipped."
             )
 

--- a/src/db/models_catalog_db.py
+++ b/src/db/models_catalog_db.py
@@ -2394,14 +2394,18 @@ def get_all_unique_models_for_catalog(include_inactive: bool = False) -> list[di
             logger.info("No provider mappings survived the provider join; unique catalog is empty")
             return []
         unique_models_data: list[dict[str, Any]] = []
+        queried_ids: set[Any] = set()
         UNIQUE_MODEL_ID_CHUNK = 200
+        deadline = start + DB_QUERY_TIMEOUT_SECONDS
 
         for chunk_start in range(0, len(referenced_ids), UNIQUE_MODEL_ID_CHUNK):
-            if time.monotonic() > start + DB_QUERY_TIMEOUT_SECONDS:
+            if time.monotonic() > deadline:
                 logger.warning(
                     f"get_all_unique_models_for_catalog (unique_models lookup): wall-clock "
                     f"deadline of {DB_QUERY_TIMEOUT_SECONDS}s exceeded after "
-                    f"{len(unique_models_data)} unique models; returning partial results"
+                    f"{len(unique_models_data)} unique models "
+                    f"({len(referenced_ids) - len(queried_ids)} id(s) never queried); "
+                    f"returning partial results"
                 )
                 break
 
@@ -2413,6 +2417,7 @@ def get_all_unique_models_for_catalog(include_inactive: bool = False) -> list[di
                 .execute()
             )
             unique_models_data.extend(um_response.data or [])
+            queried_ids.update(chunk)
 
         if not unique_models_data:
             logger.info("No unique models found in database")
@@ -2421,8 +2426,13 @@ def get_all_unique_models_for_catalog(include_inactive: bool = False) -> list[di
         # Consistency check: a mapping may reference a unique_models row that was
         # deleted between the two non-atomic reads. Usable, but worth surfacing —
         # those mappings are skipped when the result is assembled below.
+        #
+        # Scoped to ids we actually queried. A deadline break above leaves the
+        # rest unqueried, and reporting those as "removed" would blame a data
+        # inconsistency for what is really a timeout — the truncation is already
+        # logged on its own terms.
         found_ids = {row["id"] for row in unique_models_data}
-        orphaned_ids = {mid for mid in referenced_ids if mid not in found_ids}
+        orphaned_ids = queried_ids - found_ids
         if orphaned_ids:
             logger.warning(
                 f"Catalog consistency warning: {len(orphaned_ids)} unique_model_id(s) referenced "

--- a/tests/db/test_unique_models_catalog.py
+++ b/tests/db/test_unique_models_catalog.py
@@ -177,3 +177,22 @@ def test_no_mappings_short_circuits_before_touching_unique_models(monkeypatch, f
 
     assert models_catalog_db.get_all_unique_models_for_catalog(include_inactive=False) == []
     assert not [c for c in fake_supabase.get("in_", []) if c[0] == "unique_models"]
+
+
+def test_deadline_truncation_is_not_reported_as_missing_rows(monkeypatch, fake_supabase, caplog):
+    """A timeout must not be blamed on a data inconsistency.
+
+    The chunk loop can stop early on the wall-clock deadline. Ids it never got
+    to are absent from the result for a reason that has nothing to do with rows
+    being removed between the two non-atomic reads.
+    """
+    import time as _time
+
+    monkeypatch.setattr(models_catalog_db, "DB_QUERY_TIMEOUT_SECONDS", 0)
+    monkeypatch.setattr(_time, "monotonic", lambda: 10_000.0)
+
+    with caplog.at_level("WARNING"):
+        models_catalog_db.get_all_unique_models_for_catalog(include_inactive=False)
+
+    consistency_warnings = [r for r in caplog.records if "Catalog consistency warning" in r.message]
+    assert not consistency_warnings, "truncated ids must not be reported as removed rows"

--- a/tests/db/test_unique_models_catalog.py
+++ b/tests/db/test_unique_models_catalog.py
@@ -152,3 +152,28 @@ def test_provider_filter_is_pushed_into_the_query(fake_supabase):
     pushed = [c for c in fake_supabase["in_"] if c[0] == "unique_models_provider"]
     assert pushed, "provider_id filter must be applied server-side"
     assert set(pushed[0][2]) == {10, 99}
+
+
+def test_unique_models_are_looked_up_by_referenced_ids(fake_supabase):
+    """The mappings drive the unique_models fetch, not the other way round.
+
+    unique_models is sized by every model ever seen (11k rows in production);
+    the result is sized by the current roster (60). Paging the whole table to
+    keep 60 rows cost 12 round-trips and dominated the query.
+    """
+    models_catalog_db.get_all_unique_models_for_catalog(include_inactive=False)
+
+    by_table = {table: field for table, field, _ in fake_supabase["in_"]}
+    assert by_table.get("unique_models") == "id", "unique_models must be filtered by id"
+
+    lookup = [c for c in fake_supabase["in_"] if c[0] == "unique_models"][0]
+    # Only the mapping that survives the provider join is referenced.
+    assert lookup[2] == [1]
+
+
+def test_no_mappings_short_circuits_before_touching_unique_models(monkeypatch, fake_supabase):
+    """Nothing to join means nothing to look up — skip the round-trip."""
+    monkeypatch.setattr("src.utils.provider_filter.is_provider_enabled", lambda slug: False)
+
+    assert models_catalog_db.get_all_unique_models_for_catalog(include_inactive=False) == []
+    assert not [c for c in fake_supabase.get("in_", []) if c[0] == "unique_models"]


### PR DESCRIPTION
Follow-up to #2188, which noted this as deliberately-deferred work.

## Problem

`get_all_unique_models_for_catalog` paged the **entire** `unique_models` table before it knew which rows it needed, then discarded almost all of them.

That table is sized by *every model ever seen* — 11,228 rows, 12 round-trips. The result is sized by *the current roster* — 60. The pagination was the query.

## Fix

Invert the order: fetch the provider mappings first (already filtered server-side to active + `ENABLED_PROVIDERS` by #2188), then look up only the `unique_models` rows those mappings reference, chunked so the `in_` filter stays inside the request-line limit.

## Measured against the production database

| | before | after |
|---|---|---|
| duration | 5.4s | **0.52s warm** (1.40 / 0.56 / 0.52 across three runs) |
| models returned | 60 | 60 |
| providers | openai 45, xai 7, anthropic 5, moonshot 3 | identical |

## Two smaller consequences of the new order

- Ids are collected only from mappings whose provider survives the join, so a mapping to a dropped provider no longer costs a lookup for a row that gets discarded anyway.
- **The consistency check inverts.** It used to warn about mappings referencing a `unique_models` row missing from the snapshot; it now warns about referenced ids with no `unique_models` row. Same non-atomic-read hazard, observed from the other side — worth a reviewer's eye.

## Tests

2 new, and one of them caught a real defect while being written: the first version of the lookup collected ids from *all* mappings including ones whose provider is later dropped, which is what prompted the filtering above. Existing 6 regression tests from #2188 still pass unchanged. 193 passed across `tests/db/`, `tests/services/cache/`, sync-delisting and `tests/routes/`. black + ruff clean.

Pure read-path change — no migration, no behavioural difference in the response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved catalog accuracy by loading only models referenced by enabled provider mappings.
  * Prevented unnecessary database lookups when no valid provider mappings exist.
  * Skipped mappings that reference unavailable model records.

* **Tests**
  * Added regression coverage for filtered model retrieval and empty-result short-circuiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->