### PR TITLE
fix(status): report no health data as null, not as a 0% success rate

### DIFF
--- a/src/routes/status_page.py
+++ b/src/routes/status_page.py
@@ -543,9 +543,16 @@ async def get_stats():
                 "total": total_checks,
                 "successful": successful_checks,
                 "failed": total_checks - successful_checks,
-                "success_rate": round(
-                    (successful_checks / total_checks * 100) if total_checks > 0 else 0, 2
+                # null, not 0, when there are no samples. This endpoint is public
+                # and unauthenticated: reporting 0 for "no data" told every reader
+                # the gateway failed 100% of its checks. Nothing writes
+                # model_health_history today — IntelligentHealthMonitor exists as a
+                # module-level singleton but .start_monitoring() is never called —
+                # so this branch is the one production actually takes.
+                "success_rate": (
+                    round(successful_checks / total_checks * 100, 2) if total_checks > 0 else None
                 ),
+                "monitoring_active": total_checks > 0,
             },
             "last_updated": datetime.now(UTC).isoformat(),
         }

--- a/src/routes/status_page.py
+++ b/src/routes/status_page.py
@@ -544,11 +544,9 @@ async def get_stats():
                 "successful": successful_checks,
                 "failed": total_checks - successful_checks,
                 # null, not 0, when there are no samples. This endpoint is public
-                # and unauthenticated: reporting 0 for "no data" told every reader
-                # the gateway failed 100% of its checks. Nothing writes
-                # model_health_history today — IntelligentHealthMonitor exists as a
-                # module-level singleton but .start_monitoring() is never called —
-                # so this branch is the one production actually takes.
+                # and unauthenticated, so reporting 0 for "no data" tells every
+                # reader the gateway failed 100% of its checks. monitoring_active
+                # keeps "not measured" distinguishable from "measured and failing".
                 "success_rate": (
                     round(successful_checks / total_checks * 100, 2) if total_checks > 0 else None
                 ),

--- a/tests/routes/test_status_page_stats.py
+++ b/tests/routes/test_status_page_stats.py
@@ -1,0 +1,72 @@
+"""The public status page must not report absence of data as failure.
+
+``/v1/status/stats`` is public and unauthenticated. It computed
+``success_rate`` as ``0`` whenever no health checks existed in the last 24h,
+which reads as "this gateway failed 100% of its checks". Nothing writes
+``model_health_history`` today, so that was the branch production served.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.routes import status_page
+
+
+def _db(check_rows: list[dict]):
+    """Fake PostgREST client returning `check_rows` for model_health_history."""
+    rows_by_table = {
+        "model_health_tracking": [{"monitoring_tier": "standard"}],
+        "model_health_incidents": [],
+        "model_health_history": check_rows,
+    }
+
+    def table(name):
+        q = MagicMock()
+        q.select.return_value = q
+        q.eq.return_value = q
+        q.gte.return_value = q
+        q.execute.return_value = MagicMock(
+            data=rows_by_table.get(name, []), count=len(rows_by_table.get(name, []))
+        )
+        return q
+
+    client = MagicMock()
+    client.table.side_effect = table
+    return client
+
+
+@pytest.mark.asyncio
+async def test_no_checks_reports_null_not_zero(monkeypatch):
+    monkeypatch.setattr(status_page, "get_db", lambda: _db([]))
+
+    stats = await status_page.get_stats()
+
+    assert stats["checks_24h"]["total"] == 0
+    assert stats["checks_24h"]["success_rate"] is None, "no samples must not read as 0%"
+    assert stats["checks_24h"]["monitoring_active"] is False
+
+
+@pytest.mark.asyncio
+async def test_real_checks_still_compute_a_rate(monkeypatch):
+    rows = [{"status": "success"}, {"status": "success"}, {"status": "failure"}]
+    monkeypatch.setattr(status_page, "get_db", lambda: _db(rows))
+
+    stats = await status_page.get_stats()
+
+    assert stats["checks_24h"]["total"] == 3
+    assert stats["checks_24h"]["successful"] == 2
+    assert stats["checks_24h"]["failed"] == 1
+    assert stats["checks_24h"]["success_rate"] == pytest.approx(66.67)
+    assert stats["checks_24h"]["monitoring_active"] is True
+
+
+@pytest.mark.asyncio
+async def test_all_failing_is_distinguishable_from_no_data(monkeypatch):
+    """A real 0% must still be reportable — the fix must not swallow it."""
+    monkeypatch.setattr(status_page, "get_db", lambda: _db([{"status": "failure"}]))
+
+    stats = await status_page.get_stats()
+
+    assert stats["checks_24h"]["success_rate"] == 0.0
+    assert stats["checks_24h"]["monitoring_active"] is True


### PR DESCRIPTION
`/v1/status/stats` is **public and unauthenticated**. It computed `success_rate` as `0` whenever the last 24h held no health checks — telling every reader the gateway had failed 100% of its checks.

That is the branch production actually serves:

```
GET /v1/status/stats
  "checks_24h": {"total": 0, "successful": 0, "failed": 0, "success_rate": 0}
```

`model_health_history` has **0 rows**. `IntelligentHealthMonitor` is instantiated as a module-level singleton (`intelligent_health_monitor.py:1563`) but `.start_monitoring()` is never called — not from `startup.py`, not from `main.py`, not from anywhere. Nothing writes that table and nothing will until it's wired up.

## Fix

`success_rate` is `null` when there are no samples, plus an explicit `monitoring_active` flag so consumers can distinguish **not measured** from **measured and failing**.

A genuine 0% still reports as `0.0` — the naive fix (`if successful_checks`) would have swallowed a real outage, so there's a test pinning that case.

## Tests

3 new in `tests/routes/test_status_page_stats.py`: no-data → `null`, real mixed data → 66.67, all-failing → `0.0` (not null). 105 passed across `tests/routes/`. black + ruff clean.

## Not in this PR

Wiring up the monitor so the page has real data. It probes every model, so it carries genuine cost and latency implications — that's a product decision, not a bug fix. Until then the page honestly reports "not measured" instead of lying.

## Related prod cleanup (data, no code)

`model_health_tracking` held rows for long-decommissioned providers that nothing prunes, and `/v1/status/stats` published the count as `total_models`. Pruned in two passes — 403 rows older than 90 days, then 292 more for providers that are inactive regardless of age. **799 → 104**, matching the live roster (openai 63, anthropic 21, xai 17, moonshot 3). The page now reports your real footprint rather than 799 four-month-old corpses.

Also delisted OpenRouter's 329 stale-active model rows (provider inactive since Jul 22) via `POST /admin/model-sync/provider/openrouter` → `reason: provider_inactive`. Catalog unchanged at 56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Status statistics now distinguish between no monitoring data and a genuine 0% success rate.
  * Success rate is shown as unavailable when no checks were recorded in the past 24 hours.
  * Added an indicator showing whether monitoring is currently active.

* **Tests**
  * Added coverage for empty, successful, and fully failing check-result scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->