### PR TITLE
feat(health): wire up live model probing behind ENABLE_HEALTH_MONITOR

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -491,6 +491,21 @@ class Config:
         "yes",
     }
 
+    # Live per-model health probing (src/services/monitoring/intelligent_health_monitor.py).
+    # Feeds model_health_history, which is what /v1/status/stats reports. With it
+    # off that table stays empty and the status page honestly reports
+    # "not measured" (success_rate: null, monitoring_active: false).
+    #
+    # DEFAULT OFF: probing sends a real billable request per model per tier
+    # interval. It never hides a model — the monitor writes only
+    # model_health_tracking / model_health_history, while catalog gating reads
+    # models.health_status, which only the sweep writes.
+    ENABLE_HEALTH_MONITOR: bool = os.environ.get("ENABLE_HEALTH_MONITOR", "false").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
     # How often to sync models from provider APIs (in minutes)
     # Recommended: 15-30 minutes for balance between freshness and API rate limits
     MODEL_SYNC_INTERVAL_MINUTES: int = int(os.environ.get("MODEL_SYNC_INTERVAL_MINUTES", "30"))

--- a/src/services/monitoring/intelligent_health_monitor.py
+++ b/src/services/monitoring/intelligent_health_monitor.py
@@ -264,6 +264,20 @@ class IntelligentHealthMonitor:
 
             models = response.data or []
 
+            # model_health_tracking outlives the roster: rows persist after a
+            # provider is switched off, and nothing prunes them. Probing those
+            # burns requests on providers we cannot route to and republishes
+            # their failures on the public status page.
+            from src.utils.provider_filter import is_provider_enabled
+
+            before = len(models)
+            models = [m for m in models if is_provider_enabled(m.get("provider") or "")]
+            if before != len(models):
+                logger.info(
+                    "Health monitor skipped %d model(s) on providers outside ENABLED_PROVIDERS",
+                    before - len(models),
+                )
+
             if self.redis_coordination:
                 # Filter out models being checked by other workers
                 models = await self._filter_with_redis_locks(models)
@@ -336,12 +350,15 @@ class IntelligentHealthMonitor:
         response_time_ms = None
 
         try:
-            # Build test payload
+            # Smallest body every provider accepts. Deliberately no temperature:
+            # it tells a liveness probe nothing, and providers disagree about it
+            # per model — Moonshot rejects 0.1 on kimi-k2.6 with
+            # "only 1 is allowed for this model", which would have marked a
+            # perfectly healthy model failed on every single check.
             test_payload = {
                 "model": model_id,
                 "messages": [{"role": "user", "content": "test"}],
                 "max_tokens": max_tokens,
-                "temperature": 0.1,
             }
 
             # Get endpoint URL for gateway
@@ -448,6 +465,24 @@ class IntelligentHealthMonitor:
         except Exception:
             pass
 
+        # Derive from the registry's base_url before reaching for hardcoded values.
+        # Only xai carries an explicit chat_completions_endpoint today, so without
+        # this every other provider on the roster — openai, anthropic, moonshot —
+        # resolves to None, the probe is skipped, and the status page reports
+        # nothing for three quarters of production.
+        try:
+            from src.services.gateway_registry import get_gateway_registry
+
+            base_url = (get_gateway_registry().get(gateway) or {}).get("base_url")
+            if base_url:
+                base = base_url.rstrip("/")
+                if gateway == "anthropic":
+                    # Anthropic speaks /v1/messages, not the OpenAI chat shape.
+                    return base + ("/messages" if base.endswith("/v1") else "/v1/messages")
+                return f"{base}/chat/completions"
+        except Exception:
+            pass
+
         # Fallback to hardcoded endpoints
         _fallback_endpoints = {
             "openrouter": "https://openrouter.ai/api/v1/chat/completions",
@@ -474,7 +509,14 @@ class IntelligentHealthMonitor:
 
             api_key = get_provider_api_key(gateway)
             if api_key:
-                headers["Authorization"] = f"Bearer {api_key}"
+                if gateway == "anthropic":
+                    # Anthropic authenticates with x-api-key and requires a version
+                    # header; a Bearer token is rejected with 401, which would look
+                    # like a broken key rather than a broken probe.
+                    headers["x-api-key"] = api_key
+                    headers["anthropic-version"] = "2023-06-01"
+                else:
+                    headers["Authorization"] = f"Bearer {api_key}"
                 return headers
         except Exception:
             pass

--- a/src/services/monitoring/intelligent_health_monitor.py
+++ b/src/services/monitoring/intelligent_health_monitor.py
@@ -480,8 +480,10 @@ class IntelligentHealthMonitor:
                     # Anthropic speaks /v1/messages, not the OpenAI chat shape.
                     return base + ("/messages" if base.endswith("/v1") else "/v1/messages")
                 return f"{base}/chat/completions"
-        except Exception:
-            pass
+        except Exception as e:
+            # Registry unavailable (DB down, cache cold). Fall through to the
+            # hardcoded map rather than skipping the probe entirely.
+            logger.debug("Could not derive endpoint for %s from registry: %s", gateway, e)
 
         # Fallback to hardcoded endpoints
         _fallback_endpoints = {

--- a/src/services/startup.py
+++ b/src/services/startup.py
@@ -724,6 +724,27 @@ async def lifespan(app):
 
     _create_background_task(_setup_admin_user_background(), name="setup_admin_user")
 
+    # Live per-model health probing. Off by default — every probe is a real
+    # billable request. When off, model_health_history stays empty and
+    # /v1/status/stats reports "not measured" rather than inventing a number.
+    try:
+        from src.config.config import Config as _HealthCfg
+
+        if _HealthCfg.ENABLE_HEALTH_MONITOR:
+            from src.services.monitoring.intelligent_health_monitor import (
+                intelligent_health_monitor,
+            )
+
+            await intelligent_health_monitor.start_monitoring()
+            logger.info("  health_monitor    started (live probing enabled)")
+        else:
+            logger.info(
+                "  health_monitor    DISABLED (ENABLE_HEALTH_MONITOR=false); "
+                "/v1/status/stats will report monitoring_active=false"
+            )
+    except Exception as e:
+        logger.warning(f"Health monitor startup warning (non-fatal): {e}")
+
     logger.info("\n🎉 Application startup complete!")
     logger.info(" API Documentation: http://localhost:8000/docs")
     logger.info(" Health Check: http://localhost:8000/health")
@@ -733,6 +754,21 @@ async def lifespan(app):
 
     # Shutdown
     logger.info("Shutting down monitoring and observability services...")
+
+    # Stop live health probing before anything else so in-flight probes do not
+    # outlive the event loop they were scheduled on.
+    try:
+        from src.config.config import Config as _HealthCfg
+
+        if _HealthCfg.ENABLE_HEALTH_MONITOR:
+            from src.services.monitoring.intelligent_health_monitor import (
+                intelligent_health_monitor,
+            )
+
+            await intelligent_health_monitor.stop_monitoring()
+            logger.info("Health monitor stopped")
+    except Exception as e:
+        logger.warning(f"Health monitor shutdown warning: {e}")
 
     # Stop scheduled model sync (Phase 3 - Issue #996)
     try:

--- a/tests/services/monitoring/test_health_monitor_probes.py
+++ b/tests/services/monitoring/test_health_monitor_probes.py
@@ -1,0 +1,119 @@
+"""Probe construction for the live health monitor.
+
+Every failure here is one a provider would report as a failed model, so the
+status page would publish an outage that does not exist. Each case below was
+verified against the real provider APIs before being pinned.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.services.monitoring.intelligent_health_monitor import IntelligentHealthMonitor
+
+
+@pytest.fixture
+def monitor():
+    return IntelligentHealthMonitor(redis_coordination=False)
+
+
+@pytest.fixture
+def registry(monkeypatch):
+    def _set(entries: dict):
+        monkeypatch.setattr("src.services.gateway_registry.get_gateway_registry", lambda: entries)
+
+    return _set
+
+
+class TestEndpointResolution:
+    """Only xai ships an explicit chat_completions_endpoint; the rest must be
+    derived from base_url or they resolve to None and are never probed."""
+
+    def test_openai_style_derived_from_base_url(self, monitor, registry):
+        registry({"openai": {"base_url": "https://api.openai.com/v1"}})
+        assert monitor._get_gateway_endpoint("openai") == (
+            "https://api.openai.com/v1/chat/completions"
+        )
+
+    def test_moonshot_derived_from_base_url(self, monitor, registry):
+        registry({"moonshot": {"base_url": "https://api.moonshot.ai/v1"}})
+        assert monitor._get_gateway_endpoint("moonshot") == (
+            "https://api.moonshot.ai/v1/chat/completions"
+        )
+
+    def test_anthropic_uses_messages_not_chat_completions(self, monitor, registry):
+        registry({"anthropic": {"base_url": "https://api.anthropic.com"}})
+        assert monitor._get_gateway_endpoint("anthropic") == "https://api.anthropic.com/v1/messages"
+
+    def test_anthropic_base_url_already_versioned(self, monitor, registry):
+        """Must not produce .../v1/v1/messages."""
+        registry({"anthropic": {"base_url": "https://api.anthropic.com/v1"}})
+        assert monitor._get_gateway_endpoint("anthropic") == "https://api.anthropic.com/v1/messages"
+
+    def test_explicit_endpoint_still_wins(self, monitor, registry):
+        registry(
+            {
+                "xai": {
+                    "base_url": "https://api.x.ai/v1",
+                    "chat_completions_endpoint": "https://custom/x/chat",
+                }
+            }
+        )
+        assert monitor._get_gateway_endpoint("xai") == "https://custom/x/chat"
+
+    def test_trailing_slash_does_not_double_up(self, monitor, registry):
+        registry({"openai": {"base_url": "https://api.openai.com/v1/"}})
+        assert monitor._get_gateway_endpoint("openai") == (
+            "https://api.openai.com/v1/chat/completions"
+        )
+
+
+class TestAuthHeaders:
+    @pytest.mark.asyncio
+    async def test_anthropic_uses_x_api_key_and_version(self, monitor, monkeypatch):
+        """A Bearer token gets a 401 from Anthropic — indistinguishable from a
+        genuinely broken key when read off the status page."""
+        monkeypatch.setattr(
+            "src.services.gateway_registry.get_provider_api_key", lambda slug: "sk-test"
+        )
+
+        headers = await monitor._get_auth_headers("anthropic")
+
+        assert headers["x-api-key"] == "sk-test"
+        assert headers["anthropic-version"] == "2023-06-01"
+        assert "Authorization" not in headers
+
+    @pytest.mark.asyncio
+    async def test_other_gateways_use_bearer(self, monitor, monkeypatch):
+        monkeypatch.setattr(
+            "src.services.gateway_registry.get_provider_api_key", lambda slug: "sk-test"
+        )
+
+        headers = await monitor._get_auth_headers("openai")
+
+        assert headers["Authorization"] == "Bearer sk-test"
+        assert "x-api-key" not in headers
+
+
+class TestDisabledProvidersAreNotProbed:
+    @pytest.mark.asyncio
+    async def test_rows_for_disabled_providers_are_dropped(self, monitor, monkeypatch):
+        """model_health_tracking outlives the roster and nothing prunes it."""
+        rows = [
+            {"provider": "openai", "model": "gpt-4o", "gateway": "openai"},
+            {"provider": "openrouter", "model": "x/y", "gateway": "openrouter"},
+        ]
+        q = MagicMock()
+        for m in ("select", "eq", "lte", "order", "limit"):
+            getattr(q, m).return_value = q
+        q.execute.return_value = MagicMock(data=rows)
+        client = MagicMock()
+        client.table.return_value = q
+        monkeypatch.setattr("src.config.supabase_config.supabase", client)
+        monkeypatch.setattr(
+            "src.utils.provider_filter.is_provider_enabled", lambda slug: slug == "openai"
+        )
+
+        result = await monitor._get_models_for_checking()
+
+        assert [r["provider"] for r in result] == ["openai"]


### PR DESCRIPTION
`IntelligentHealthMonitor` has existed as a module-level singleton whose `start_monitoring()` was **never called from anywhere**. So `model_health_history` stayed empty and `/v1/status/stats` had nothing to report (see #2191, which made it say so honestly instead of publishing a fake 0%).

**Starting it as-is would have been worse than leaving it off.** Three of the four providers on the roster could not be probed at all, and a fourth would have failed every single check. Each of these was verified against the live provider APIs before being fixed:

| gap | effect if shipped naively |
|---|---|
| Only `xai` has an explicit `chat_completions_endpoint`; the hardcoded fallback map omits `openai`, `anthropic`, `moonshot` | endpoint resolves to `None` → probe silently skipped → **3 of 4 providers never measured** |
| Anthropic speaks `/v1/messages`, not `/chat/completions` | 404 on every check |
| Anthropic authenticates with `x-api-key` + `anthropic-version`, not Bearer | 401 — on a status page, indistinguishable from a key we broke |
| Probe sent `temperature: 0.1` | Moonshot rejects it: `"invalid temperature: only 1 is allowed for this model"` → **every check fails a perfectly healthy model** |
| No `ENABLED_PROVIDERS` filter | `model_health_tracking` outlives the roster and nothing prunes it, so probes get spent on unroutable providers and their failures get republished publicly |

## After the fix

Endpoints are derived from the registry's `base_url` (guarded against emitting `/v1/v1/messages`), Anthropic gets its own dialect, and the probe body is reduced to the minimum every provider accepts — no `temperature`, which tells a liveness check nothing anyway.

Verified against the real APIs with the production keys, final payload:

```
openai     https://api.openai.com/v1/chat/completions     HTTP 200
anthropic  https://api.anthropic.com/v1/messages          HTTP 200
moonshot   https://api.moonshot.ai/v1/chat/completions    HTTP 200
xai        https://api.x.ai/v1/chat/completions           HTTP 200
```

## Safety

**Default OFF** (`ENABLE_HEALTH_MONITOR=false`) — each probe is a real billable request. Started in the lifespan when enabled, stopped before the other schedulers on shutdown so in-flight probes don't outlive their event loop.

**It cannot hide a model from the catalog.** The monitor writes only `model_health_tracking` and `model_health_history`; catalog gating reads `models.health_status`, which only the sweep writes. Worth stating explicitly given #2190, where a classifier bug hid nine live flagship models.

Cost at the current roster: tiers are `standard` (2h) and `on_demand` (4h) over 104 tracked models, ≈1k probes/day at 5–10 output tokens each.

## Tests

9 new in `tests/services/monitoring/test_health_monitor_probes.py` — endpoint derivation per dialect incl. the double-`/v1` guard and explicit-endpoint precedence, Anthropic vs Bearer auth headers, and disabled-provider rows being dropped. 1410 passed across `tests/services/`, `tests/routes/`, `tests/config/`. black + ruff clean.

The 2 failures in `test_prometheus_remote_write.py` are pre-existing — they fail identically on unmodified `main` under the parallel runner and pass in isolation on both.

## Rollout

Merging leaves it off. Flipping `ENABLE_HEALTH_MONITOR=true` on Railway starts probing; `/v1/status/stats` then reports `monitoring_active: true` with a real `success_rate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)