### PR TITLE
fix(health): probe the native model id, not the catalog id

### DIFF
--- a/src/services/monitoring/intelligent_health_monitor.py
+++ b/src/services/monitoring/intelligent_health_monitor.py
@@ -350,13 +350,33 @@ class IntelligentHealthMonitor:
         response_time_ms = None
 
         try:
+            # model_health_tracking stores the gateway-prefixed catalog id
+            # ("openai/gpt-5.5-pro"), but provider APIs want the native id
+            # ("gpt-5.5-pro") — OpenAI answers "invalid model ID", Anthropic and
+            # Moonshot answer 404. Resolve it the same way the inference path
+            # does, so a probe tests exactly what the router would dispatch.
+            probe_model_id = model_id
+            try:
+                from src.services.model_transformations import transform_model_id
+
+                probe_model_id = transform_model_id(model_id, gateway) or model_id
+            except Exception as e:
+                logger.debug("Model id transform failed for %s: %s", model_id, e)
+
+            # Some gateways have no mapping table, so the prefix survives the
+            # transform. Strip only an exact "<gateway>/" head: a native id that
+            # genuinely contains a slash (openrouter's "openai/gpt-4") is left
+            # alone because its gateway is openrouter, not openai.
+            if probe_model_id.startswith(f"{gateway}/"):
+                probe_model_id = probe_model_id[len(gateway) + 1 :]
+
             # Smallest body every provider accepts. Deliberately no temperature:
             # it tells a liveness probe nothing, and providers disagree about it
             # per model — Moonshot rejects 0.1 on kimi-k2.6 with
             # "only 1 is allowed for this model", which would have marked a
             # perfectly healthy model failed on every single check.
             test_payload = {
-                "model": model_id,
+                "model": probe_model_id,
                 "messages": [{"role": "user", "content": "test"}],
                 "max_tokens": max_tokens,
             }

--- a/tests/services/monitoring/test_health_monitor_probes.py
+++ b/tests/services/monitoring/test_health_monitor_probes.py
@@ -117,3 +117,43 @@ class TestDisabledProvidersAreNotProbed:
         result = await monitor._get_models_for_checking()
 
         assert [r["provider"] for r in result] == ["openai"]
+
+
+class TestProbeUsesNativeModelId:
+    """model_health_tracking stores gateway-prefixed catalog ids; provider APIs
+    want the native id. Probing the prefixed form failed 89 of 100 checks in
+    production — OpenAI answers "invalid model ID", Anthropic and Moonshot 404.
+    """
+
+    @pytest.mark.parametrize(
+        "gateway,stored,expected",
+        [
+            ("openai", "openai/gpt-5.5-pro", "gpt-5.5-pro"),
+            ("openai", "openai/gpt-4o-mini", "gpt-4o-mini"),
+            ("anthropic", "anthropic/claude-opus-4-8", "claude-opus-4-8"),
+            # No mapping table for moonshot, so the prefix survives the
+            # transform and the explicit strip has to catch it.
+            ("moonshot", "moonshot/kimi-k2.6", "kimi-k2.6"),
+            # Already native — must pass through untouched.
+            ("xai", "grok-4", "grok-4"),
+        ],
+    )
+    def test_prefix_is_resolved_to_native_id(self, gateway, stored, expected):
+        from src.services.model_transformations import transform_model_id
+
+        probe_id = transform_model_id(stored, gateway) or stored
+        if probe_id.startswith(f"{gateway}/"):
+            probe_id = probe_id[len(gateway) + 1 :]
+
+        assert probe_id == expected
+
+    def test_slash_in_a_genuine_native_id_is_preserved(self):
+        """OpenRouter serves "openai/gpt-4" as its native id. The strip keys on
+        the gateway name, so an unrelated vendor prefix must survive."""
+        gateway, stored = "openrouter", "openai/gpt-4"
+
+        probe_id = stored
+        if probe_id.startswith(f"{gateway}/"):
+            probe_id = probe_id[len(gateway) + 1 :]
+
+        assert probe_id == "openai/gpt-4"


### PR DESCRIPTION
Follow-up to #2192. Enabling the monitor in production **failed 89 of its first 100 checks**:

```
GET /v1/status/stats
  "checks_24h": {"total": 100, "successful": 11, "failed": 89, "success_rate": 11.0}
```

## Cause

`model_health_tracking` stores the **gateway-prefixed catalog id**; the provider APIs want the **native** one.

| stored id | provider response |
|---|---|
| `openai/gpt-5.5-pro` | 400 `"invalid model ID"` |
| `anthropic/claude-opus-4-8` | 404 Model not found |
| `moonshot/kimi-k3` | 404 Model not found |

The 11 that passed were xai rows, whose ids happened to already be stored unprefixed.

## Fix

Resolve through `transform_model_id` — the same path inference uses — so a probe tests exactly what the router would dispatch. That mapping table has no moonshot entry, so an exact `"<gateway>/"` head surviving the transform is stripped too.

The strip keys on the **gateway** name, so a native id that genuinely contains a slash is left alone: OpenRouter's `openai/gpt-4` has gateway `openrouter`, not `openai`. Pinned in a test.

## Verified live

Re-ran the exact ids that had been failing, against the real provider APIs with production keys:

```
openai/gpt-5.5-pro         -> gpt-5.5-pro        HTTP 404 "not a chat model"
openai/gpt-4o-mini         -> gpt-4o-mini        HTTP 200
anthropic/claude-opus-4-8  -> claude-opus-4-8    HTTP 200
anthropic/claude-sonnet-5  -> claude-sonnet-5    HTTP 200
moonshot/kimi-k2.6         -> kimi-k2.6          HTTP 200
grok-4                     -> grok-4             HTTP 200
```

`gpt-5.5-pro` still 404s, and that is correct — it's one of the four models identified in #2190 as genuinely not servable on `/v1/chat/completions`. Reporting it failed is the right answer.

## Tests

6 new (5 parametrised resolution cases + the slash-preservation guard), 28 passing in `tests/services/monitoring/`. black + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)