### PR TITLE
feat(pricing): keep a price book so new models can be listed

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -491,6 +491,18 @@ class Config:
         "yes",
     }
 
+    # Providers synced purely as a price book. They stay delisted as supply —
+    # ENABLED_PROVIDERS still governs routing and listing — but their catalogs
+    # keep refreshing so models whose own provider publishes no pricing (OpenAI,
+    # Anthropic and xAI all return catalogs with no prices) can still acquire
+    # one. Aggregators are the only place those prices exist in machine-readable
+    # form; §5 bars them as supply, not as data.
+    PRICE_REFERENCE_PROVIDERS: frozenset[str] = frozenset(
+        s.strip()
+        for s in os.environ.get("PRICE_REFERENCE_PROVIDERS", "openrouter").split(",")
+        if s.strip()
+    )
+
     # Live per-model health probing (src/services/monitoring/intelligent_health_monitor.py).
     # Feeds model_health_history, which is what /v1/status/stats reports. With it
     # off that table stays empty and the status page honestly reports

--- a/src/routes/health.py
+++ b/src/routes/health.py
@@ -709,6 +709,30 @@ async def get_catalog_models(
         }
 
 
+@router.get("/health/catalog/unpriced", tags=["health", "catalog"])
+async def get_unpriced_catalog_models():
+    """Models dropped from the catalog because they have no price.
+
+    A model with no price cannot be billed, so it is never listed (North Star
+    §5). That is correct, but it used to happen in silence: Claude Opus 5 was
+    invisible for two days after launch and the only trace was a debug log.
+    This surfaces the drop set so a launch without pricing is caught the same
+    day.
+    """
+    from src.services.pricing.pricing_lookup import get_unpriced_models
+
+    unpriced = get_unpriced_models()
+    return {
+        "count": len(unpriced),
+        "models": unpriced,
+        "note": (
+            "These are offered by their provider but carry no price, so they are "
+            "not listed or sellable. Add pricing to make them available."
+        ),
+        "timestamp": datetime.now(UTC).isoformat(),
+    }
+
+
 @router.get("/health/catalog/providers", tags=["health", "catalog"])
 async def get_catalog_providers(
     priority: str | None = Query(None, description="Filter by priority ('fast' or 'slow')"),

--- a/src/services/model_catalog_sync.py
+++ b/src/services/model_catalog_sync.py
@@ -744,7 +744,21 @@ def sync_provider_models(
                 "models_synced": 0,
             }
 
-        if not provider.get("is_active"):
+        # A price-reference provider keeps syncing while inactive. Its models are
+        # written is_active=False so nothing is ever routed to or listed from it
+        # (North Star §5 bars an aggregator as supply), but the catalog stays
+        # fresh so newly released models can still acquire a price.
+        #
+        # Without this the reference freezes on the day the provider is delisted:
+        # OpenRouter's catalog stopped at 2026-07-20, so Claude Opus 5 — released
+        # on the 24th — had no price anywhere and was filtered out of everything
+        # we sell. Being unsellable supply and being a useful price book are
+        # different things.
+        from src.config.config import Config as _SyncConfig
+
+        is_price_reference = provider_slug in _SyncConfig.PRICE_REFERENCE_PROVIDERS
+
+        if not provider.get("is_active") and not is_price_reference:
             # Sync-time delisting: an inactive (unroutable) provider is not
             # skipped as a pure no-op — its previously-synced models are
             # bulk-deactivated so the live catalog reflects routable reality
@@ -1135,9 +1149,18 @@ def _sync_all_providers_inner(
         # Get providers to sync
         from src.utils.provider_filter import get_enabled_providers, is_provider_enabled
 
+        # Price-reference providers sync alongside the enabled roster. They are
+        # never routed to or listed — their rows are written is_active=False —
+        # but their catalogs are the only machine-readable source of prices for
+        # models whose own provider publishes none.
+        price_refs = Config.PRICE_REFERENCE_PROVIDERS
+
+        def _syncable(slug: str) -> bool:
+            return is_provider_enabled(slug) or slug in price_refs
+
         if provider_slugs:
             # Even explicit slugs must pass the enabled filter
-            providers_to_sync = [p for p in provider_slugs if is_provider_enabled(p)]
+            providers_to_sync = [p for p in provider_slugs if _syncable(p)]
         else:
             # ENABLED_PROVIDERS is the routing/catalog source of truth. Starting
             # from it also bootstraps a newly enabled provider whose DB registry
@@ -1163,9 +1186,8 @@ def _sync_all_providers_inner(
                 except Exception:
                     logger.warning("Failed to load providers from DB; using hardcoded fallback")
                     all_providers = list(PROVIDER_FETCH_FUNCTIONS.keys())
-            providers_to_sync = [
-                p for p in all_providers if p not in skip_set and is_provider_enabled(p)
-            ]
+            all_providers = list(dict.fromkeys(list(all_providers) + sorted(price_refs)))
+            providers_to_sync = [p for p in all_providers if p not in skip_set and _syncable(p)]
             if skip_set:
                 logger.info(
                     f"Skipping {len(skip_set)} providers from sync: {', '.join(sorted(skip_set))}"

--- a/src/services/pricing/pricing_lookup.py
+++ b/src/services/pricing/pricing_lookup.py
@@ -285,6 +285,72 @@ def _is_building_catalog() -> bool:
         return False
 
 
+_unpriced_models: set[str] = set()
+_unpriced_lock = threading.Lock()
+
+
+def record_unpriced_model(model_id: str) -> None:
+    """Remember a model that was dropped for having no price."""
+    if not model_id:
+        return
+    with _unpriced_lock:
+        _unpriced_models.add(str(model_id))
+
+
+def get_unpriced_models() -> list[str]:
+    """Models dropped from the catalog for want of a price, since process start.
+
+    Exposed so a launch that lands without pricing is visible the same day
+    instead of being discovered weeks later, which is how Claude Opus 5 went
+    missing.
+    """
+    with _unpriced_lock:
+        return sorted(_unpriced_models)
+
+
+def clear_unpriced_models() -> None:
+    """Reset the set — called at the start of a full catalog sync."""
+    with _unpriced_lock:
+        _unpriced_models.clear()
+
+
+def _load_price_reference_catalog() -> list[dict]:
+    """Load the aggregator catalog used purely as a price reference.
+
+    Deliberately reads models regardless of ``is_active``. Being *listed* and
+    being a *price reference* are different jobs: OpenRouter is delisted as
+    supply (North Star §5 bars an aggregator as primary supply, and
+    ENABLED_PROVIDERS blocks routing to it), but its catalog is the only place
+    that carries prices for models whose own provider publishes none — OpenAI,
+    Anthropic and xAI all return catalogs with no pricing at all.
+
+    Coupling the two is what silently broke intake: delisting OpenRouter as
+    supply emptied this index, so newly released models — Claude Opus 5 among
+    them — could no longer acquire a price and were filtered out of the catalog
+    entirely. Nothing routes here; only prices are read.
+    """
+    try:
+        from src.db.models_catalog_db import get_models_by_gateway_for_catalog
+
+        rows = get_models_by_gateway_for_catalog(gateway_slug="openrouter", include_inactive=True)
+    except Exception as e:
+        logger.warning("Price reference catalog unavailable: %s", e)
+        return []
+
+    catalog: list[dict] = []
+    for row in rows or []:
+        metadata = row.get("metadata") or {}
+        pricing = metadata.get("pricing_raw") if isinstance(metadata, dict) else None
+        if not isinstance(pricing, dict) or not pricing:
+            continue
+        model_id = row.get("provider_model_id") or row.get("model_name")
+        if model_id:
+            catalog.append({"id": model_id, "pricing": pricing})
+
+    logger.info("Price reference catalog: %d priced models loaded", len(catalog))
+    return catalog
+
+
 def _build_openrouter_pricing_index() -> dict[str, dict]:
     """Build an O(1) lookup index from OpenRouter models.
 
@@ -307,9 +373,7 @@ def _build_openrouter_pricing_index() -> dict[str, dict]:
 
     index: dict[str, dict] = {}
     try:
-        from src.services.models import get_cached_models
-
-        openrouter_models = get_cached_models("openrouter") or []
+        openrouter_models = _load_price_reference_catalog()
         for model in openrouter_models:
             if not isinstance(model, dict):
                 continue
@@ -772,7 +836,15 @@ def enrich_model_with_pricing(
             if _is_building_catalog():
                 logger.debug(f"Catalog building: keeping {model_id} with zero pricing")
                 return model_data
-            logger.debug(f"No pricing found for gateway provider model {model_id}, filtering out")
+            # WARNING, not debug: this silently removes a model from everything
+            # we sell. Claude Opus 5 was invisible for two days after launch and
+            # the only trace was a debug line nobody reads. record_unpriced_model
+            # keeps the running set so it can be surfaced and alerted on.
+            record_unpriced_model(model_id)
+            logger.warning(
+                "No pricing for %s — model will NOT be listed. Add pricing or it stays invisible.",
+                model_id,
+            )
             return None
 
         return model_data

--- a/tests/services/pricing/test_price_reference.py
+++ b/tests/services/pricing/test_price_reference.py
@@ -8,8 +8,6 @@ of everything we sell. Being unsellable supply and being a useful price book
 are different jobs.
 """
 
-from unittest.mock import MagicMock
-
 import pytest
 
 from src.services.pricing import pricing_lookup

--- a/tests/services/pricing/test_price_reference.py
+++ b/tests/services/pricing/test_price_reference.py
@@ -1,0 +1,126 @@
+"""A delisted aggregator must still work as a price book.
+
+Models whose own provider publishes no pricing — OpenAI, Anthropic and xAI all
+return catalogs without prices — can only be priced by cross-referencing an
+aggregator. Delisting OpenRouter as *supply* also emptied that reference, so
+Claude Opus 5 (released 2026-07-24) had no price anywhere and was filtered out
+of everything we sell. Being unsellable supply and being a useful price book
+are different jobs.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.services.pricing import pricing_lookup
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    pricing_lookup._openrouter_pricing_index = None
+    pricing_lookup.clear_unpriced_models()
+    yield
+    pricing_lookup._openrouter_pricing_index = None
+    pricing_lookup.clear_unpriced_models()
+
+
+class TestPriceReferenceCatalog:
+    def test_reads_models_regardless_of_listing_status(self, monkeypatch):
+        """The whole point: delisted rows still carry usable prices."""
+        captured = {}
+
+        def _fake(gateway_slug, include_inactive=False):
+            captured["gateway_slug"] = gateway_slug
+            captured["include_inactive"] = include_inactive
+            return [
+                {
+                    "provider_model_id": "anthropic/claude-opus-5",
+                    "metadata": {"pricing_raw": {"prompt": "0.000015"}},
+                }
+            ]
+
+        monkeypatch.setattr("src.db.models_catalog_db.get_models_by_gateway_for_catalog", _fake)
+
+        catalog = pricing_lookup._load_price_reference_catalog()
+
+        assert captured["include_inactive"] is True, "delisted rows must still be read"
+        assert catalog == [{"id": "anthropic/claude-opus-5", "pricing": {"prompt": "0.000015"}}]
+
+    def test_models_without_pricing_are_skipped(self, monkeypatch):
+        monkeypatch.setattr(
+            "src.db.models_catalog_db.get_models_by_gateway_for_catalog",
+            lambda **_k: [
+                {"provider_model_id": "a/b", "metadata": {}},
+                {"provider_model_id": "c/d", "metadata": {"pricing_raw": {}}},
+                {"provider_model_id": "e/f", "metadata": {"pricing_raw": {"prompt": "1"}}},
+            ],
+        )
+
+        assert [m["id"] for m in pricing_lookup._load_price_reference_catalog()] == ["e/f"]
+
+    def test_fails_soft_when_the_database_is_unavailable(self, monkeypatch):
+        def _boom(**_k):
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr("src.db.models_catalog_db.get_models_by_gateway_for_catalog", _boom)
+
+        assert pricing_lookup._load_price_reference_catalog() == []
+
+    def test_index_keys_both_full_and_base_ids(self, monkeypatch):
+        monkeypatch.setattr(
+            pricing_lookup,
+            "_load_price_reference_catalog",
+            lambda: [{"id": "anthropic/claude-opus-5", "pricing": {"prompt": "0.000015"}}],
+        )
+        monkeypatch.setattr(pricing_lookup, "_is_building_catalog", lambda: False)
+
+        index = pricing_lookup._build_openrouter_pricing_index()
+
+        assert index["anthropic/claude-opus-5"] == {"prompt": "0.000015"}
+        assert index["claude-opus-5"] == {"prompt": "0.000015"}
+
+
+class TestUnpricedVisibility:
+    def test_dropped_models_are_recorded(self):
+        pricing_lookup.record_unpriced_model("anthropic/claude-opus-5")
+        pricing_lookup.record_unpriced_model("openai/gpt-9")
+        pricing_lookup.record_unpriced_model("anthropic/claude-opus-5")
+
+        assert pricing_lookup.get_unpriced_models() == [
+            "anthropic/claude-opus-5",
+            "openai/gpt-9",
+        ]
+
+    def test_blank_ids_are_ignored(self):
+        pricing_lookup.record_unpriced_model("")
+        pricing_lookup.record_unpriced_model(None)
+
+        assert pricing_lookup.get_unpriced_models() == []
+
+    def test_clear_resets_between_syncs(self):
+        pricing_lookup.record_unpriced_model("x/y")
+        pricing_lookup.clear_unpriced_models()
+
+        assert pricing_lookup.get_unpriced_models() == []
+
+
+class TestPriceReferenceProvidersConfig:
+    def test_openrouter_is_a_price_reference_by_default(self, monkeypatch):
+        import importlib
+
+        from src.config import config
+
+        monkeypatch.delenv("PRICE_REFERENCE_PROVIDERS", raising=False)
+        importlib.reload(config)
+
+        assert "openrouter" in config.Config.PRICE_REFERENCE_PROVIDERS
+
+    def test_can_be_disabled_entirely(self, monkeypatch):
+        import importlib
+
+        from src.config import config
+
+        monkeypatch.setenv("PRICE_REFERENCE_PROVIDERS", "")
+        importlib.reload(config)
+
+        assert config.Config.PRICE_REFERENCE_PROVIDERS == frozenset()

--- a/tests/services/test_model_catalog_sync_delisting.py
+++ b/tests/services/test_model_catalog_sync_delisting.py
@@ -238,6 +238,9 @@ def test_batch_sync_bootstraps_enabled_provider_missing_from_registry():
             return_value=synced_result,
         ) as sync_provider,
         patch("src.config.config.Config.MODEL_SYNC_SKIP_PROVIDERS", set()),
+        # Keep this test about bootstrapping. Price-reference providers also
+        # sync (covered separately below) and would otherwise add a second call.
+        patch("src.config.config.Config.PRICE_REFERENCE_PROVIDERS", frozenset()),
         patch("src.services.model_catalog_cache.invalidate_full_catalog"),
         patch("src.services.model_catalog_cache.invalidate_unique_models"),
         patch("src.services.model_catalog_cache.invalidate_catalog_stats"),
@@ -340,3 +343,49 @@ class TestSyncHoldsCatalogGuard:
         model_catalog_sync.sync_all_providers(dry_run=True)
 
         assert events == []
+
+
+def test_price_reference_provider_syncs_even_though_it_is_not_enabled():
+    """The price book has to stay fresh or new models can never be priced.
+
+    OpenRouter is delisted as supply — ENABLED_PROVIDERS excludes it and nothing
+    routes there — but its catalog is the only machine-readable source of prices
+    for models whose own provider publishes none. Freezing it is what left
+    Claude Opus 5 unpriced and therefore unlistable.
+    """
+    synced = {
+        "success": True,
+        "provider": "openrouter",
+        "models_fetched": 1,
+        "models_transformed": 1,
+        "models_skipped": 0,
+        "models_synced": 1,
+        "models_delisted": 0,
+    }
+
+    with (
+        patch(
+            "src.utils.provider_filter.get_enabled_providers",
+            return_value=frozenset({"moonshot"}),
+        ),
+        patch(
+            "src.utils.provider_filter.is_provider_enabled",
+            side_effect=lambda slug: slug == "moonshot",
+        ),
+        patch(
+            "src.services.model_catalog_sync.sync_provider_models", return_value=synced
+        ) as sync_provider,
+        patch("src.config.config.Config.MODEL_SYNC_SKIP_PROVIDERS", set()),
+        patch("src.config.config.Config.PRICE_REFERENCE_PROVIDERS", frozenset({"openrouter"})),
+        patch("src.services.model_catalog_cache.invalidate_full_catalog"),
+        patch("src.services.model_catalog_cache.invalidate_unique_models"),
+        patch("src.services.model_catalog_cache.invalidate_catalog_stats"),
+        patch("src.services.cache.catalog_response_cache.invalidate_catalog_cache"),
+    ):
+        from src.services.model_catalog_sync import sync_all_providers
+
+        sync_all_providers()
+
+    synced_slugs = {call.args[0] for call in sync_provider.call_args_list}
+    assert "openrouter" in synced_slugs, "price reference must sync despite being disabled"
+    assert "moonshot" in synced_slugs


### PR DESCRIPTION
A model with no price is filtered out of the catalog entirely. That's correct — it can't be billed, so it can't be sold (North Star §5). The problem is that **nothing could give a newly released model a price**, so nothing new could ever be listed.

## All three pricing tiers were closed

| tier | why it can't price a new model |
|---|---|
| `database` | reads the price off a row the model doesn't have yet — chicken-and-egg |
| `manual_json` | `"last_updated": "2026-01-26"` — six months stale, stops at `claude-opus-4.5` and `o3-mini` |
| `cross_reference` | reads OpenRouter's catalog, which delisting OpenRouter as supply had **emptied** (`get_cached_models("openrouter")` → 0) |

Claude Opus 5 shipped 2026-07-24 and fell through all three. It was invisible, and the only trace was a debug line.

Not Anthropic-specific — the same gap costs 19 OpenAI and 3 xAI models:

| provider | offered | listed |
|---|---|---|
| openai | 123 | 104 |
| anthropic | 10 | **5** |
| xai | 10 | 7 |

## Fix: separate "supply" from "price book"

A provider named in `PRICE_REFERENCE_PROVIDERS` (default `openrouter`) keeps syncing while inactive:

- its rows are written `is_active=False`, so **nothing is ever routed to or listed from it** — `ENABLED_PROVIDERS` still governs supply
- the catalog stays fresh, and the cross-reference index reads it **regardless of listing status**

§5 bars an aggregator as *supply*, not as *data*. Providers whose own `/models` publishes no pricing — OpenAI, Anthropic and xAI all return catalogs with no prices at all — have no other machine-readable source.

Verified against OpenRouter's live catalog:

```
anthropic/claude-opus-5       prompt=0.000005  completion=0.000025
anthropic/claude-opus-4.5     prompt=0.000005  completion=0.000025
```

So Opus 5 can be priced the day it launches.

## The silence was the other half of the bug

Dropping a model for want of a price is now a **WARNING naming the model**, the drop set is retained, and `GET /health/catalog/unpriced` lists it. A launch that lands without pricing is caught the same day instead of weeks later.

## Tests

9 new in `tests/services/pricing/test_price_reference.py` — the reference reads delisted rows (`include_inactive=True`), unpriced rows are skipped, DB failure degrades soft, index keys both full and base ids, drop-set recording, and the config default plus its off switch.

1 new in the sync suite asserting a price-reference provider syncs **even though `is_provider_enabled()` returns False for it** — the property the whole fix rests on. One existing bootstrap test now pins `PRICE_REFERENCE_PROVIDERS` to empty to stay focused, since the reference legitimately adds a second sync call.

1478 passed. The 2 `test_prometheus_remote_write.py` failures are pre-existing — identical on unmodified `main` under the parallel runner. black + ruff clean.

## After merge

`PRICE_REFERENCE_PROVIDERS` defaults to `openrouter`, so no env change is needed. A sync then prices Opus 5 and the other missing models, and `/health/catalog/unpriced` shows whatever still has no price.

🤖 Generated with [Claude Code](https://claude.com/claude-code)