### PR TITLE
fix(pricing): resolve a provider's price units even when it is disabled

### DIFF
--- a/src/services/gateway_registry.py
+++ b/src/services/gateway_registry.py
@@ -299,6 +299,51 @@ def get_gateway_registry() -> dict[str, dict]:
     return filter_provider_dict(_get_registry())
 
 
+_pricing_format_cache: dict[str, str] | None = None
+
+
+def get_declared_pricing_formats() -> dict[str, str]:
+    """Map provider slug -> declared pricing format, for EVERY provider.
+
+    The registry is built from active providers only and then filtered again by
+    ENABLED_PROVIDERS, which is right for routing and wrong for this: the units
+    a provider's API quotes prices in are true whether or not we route to it.
+    A disabled provider fell through to the PER_1M default, so OpenRouter — which
+    declares per_token and publishes 0.000005 for a $5/Mtok model — had every
+    price divided by a million. Read straight from the table instead.
+    """
+    global _pricing_format_cache
+    if _pricing_format_cache is not None:
+        return _pricing_format_cache
+
+    formats: dict[str, str] = {}
+    try:
+        from src.config.supabase_config import get_client_for_query
+
+        response = (
+            get_client_for_query(read_only=True)
+            .table("providers")
+            .select("slug, metadata")
+            .execute()
+        )
+        for row in response.data or []:
+            slug = (row.get("slug") or "").lower()
+            fmt = (row.get("metadata") or {}).get("pricing_format")
+            if slug and fmt:
+                formats[slug] = fmt
+    except Exception as e:
+        logger.warning("Could not load declared pricing formats: %s", e)
+        return {}
+
+    _pricing_format_cache = formats
+    return formats
+
+
+def invalidate_pricing_format_cache() -> None:
+    global _pricing_format_cache
+    _pricing_format_cache = None
+
+
 def get_valid_gateway_values() -> set[str]:
     """Compute the set of all accepted gateway identifiers.
 

--- a/src/services/gateway_registry.py
+++ b/src/services/gateway_registry.py
@@ -476,6 +476,10 @@ def refresh_registry_cache() -> None:
     global _cache_timestamp
     _cache_timestamp = 0.0
     _load_registry_from_db()
+    # Declared pricing formats come from the same providers table, so they go
+    # stale on exactly the same events. Refreshing one without the other is how
+    # a corrected unit would keep being ignored.
+    invalidate_pricing_format_cache()
     try:
         from src.services.dynamic_provider_loader import invalidate_loader_cache
 

--- a/src/utils/pricing_normalization.py
+++ b/src/utils/pricing_normalization.py
@@ -130,12 +130,19 @@ def get_provider_format(provider_slug: str) -> str:
         PricingFormat constant
     """
     try:
-        from src.services.gateway_registry import get_gateway_registry
+        # Deliberately the UNFILTERED registry. get_gateway_registry() drops
+        # anything outside ENABLED_PROVIDERS, but a pricing format is a fact
+        # about the provider's API, not about whether we route to it. Reading
+        # the filtered view made a disabled provider fall through to the
+        # PER_1M default: OpenRouter declares per_token and publishes
+        # 0.000005 for a $5/Mtok model, so the fallback divided every one of
+        # its prices by a million — and the price book propagated that to
+        # every model priced from it. §4.2 calls a unit error the hardest
+        # data-quality problem in the system for exactly this reason.
+        from src.services.gateway_registry import get_declared_pricing_formats
 
-        registry = get_gateway_registry()
-        entry = registry.get(provider_slug.lower())
-        if entry and entry.get("pricing_format"):
-            fmt = entry["pricing_format"]
+        fmt = get_declared_pricing_formats().get(provider_slug.lower())
+        if fmt:
             if fmt == "per_token":
                 return PricingFormat.PER_TOKEN
             elif fmt == "per_1k":

--- a/tests/utils/test_pricing_format_resolution.py
+++ b/tests/utils/test_pricing_format_resolution.py
@@ -85,3 +85,19 @@ class TestConversionArithmetic:
 
         assert wrong == pytest.approx(5e-12)
         assert wrong != pytest.approx(5e-6)
+
+
+def test_registry_refresh_also_clears_the_format_cache(monkeypatch):
+    """Both caches read the same providers table, so both go stale together.
+
+    Refreshing one without the other would keep serving a unit that has since
+    been corrected — the failure this whole change exists to prevent.
+    """
+    from src.services import gateway_registry
+
+    gateway_registry._pricing_format_cache = {"openrouter": "per_1m"}
+    monkeypatch.setattr(gateway_registry, "_load_registry_from_db", lambda: {})
+
+    gateway_registry.refresh_registry_cache()
+
+    assert gateway_registry._pricing_format_cache is None

--- a/tests/utils/test_pricing_format_resolution.py
+++ b/tests/utils/test_pricing_format_resolution.py
@@ -1,0 +1,87 @@
+"""A provider's pricing units must resolve whether or not we route to it.
+
+get_provider_format read the gateway registry, which is built from ACTIVE
+providers and then filtered again by ENABLED_PROVIDERS. A disabled provider was
+absent from both, fell through to the PER_1M default, and had every price
+divided by a million.
+
+That is not hypothetical. OpenRouter declares per_token and publishes 0.000005
+for a $5/Mtok model. Once it became a price-reference provider, the fallback
+turned that into 5E-12, and every model priced from the reference inherited it —
+claude-opus-5 landed in production at 5E-18 per token. North Star §4.2 names
+this the hardest data-quality problem in the system: a unit error inverts
+arbitrage and bills essentially nothing.
+"""
+
+import pytest
+
+from src.utils.pricing_normalization import PricingFormat, get_provider_format
+
+
+@pytest.fixture
+def declared(monkeypatch):
+    def _set(formats: dict):
+        monkeypatch.setattr(
+            "src.services.gateway_registry.get_declared_pricing_formats", lambda: formats
+        )
+
+    return _set
+
+
+class TestFormatResolution:
+    def test_disabled_provider_still_resolves_its_declared_format(self, declared):
+        """OpenRouter is delisted as supply but still quotes per-token prices."""
+        declared({"openrouter": "per_token"})
+
+        assert get_provider_format("openrouter") == PricingFormat.PER_TOKEN
+
+    @pytest.mark.parametrize(
+        "declared_value,expected",
+        [
+            ("per_token", PricingFormat.PER_TOKEN),
+            ("per_1k", PricingFormat.PER_1K_TOKENS),
+            ("per_1m", PricingFormat.PER_1M_TOKENS),
+        ],
+    )
+    def test_each_declared_format_maps_through(self, declared, declared_value, expected):
+        declared({"someprovider": declared_value})
+
+        assert get_provider_format("someprovider") == expected
+
+    def test_slug_lookup_is_case_insensitive(self, declared):
+        declared({"openrouter": "per_token"})
+
+        assert get_provider_format("OpenRouter") == PricingFormat.PER_TOKEN
+
+    def test_undeclared_provider_falls_back_to_per_1m(self, declared):
+        declared({})
+
+        assert get_provider_format("mystery") == PricingFormat.PER_1M_TOKENS
+
+    def test_lookup_failure_falls_back_rather_than_raising(self, monkeypatch):
+        def _boom():
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr("src.services.gateway_registry.get_declared_pricing_formats", _boom)
+
+        assert get_provider_format("openrouter") == PricingFormat.PER_1M_TOKENS
+
+
+class TestConversionArithmetic:
+    """Guards the actual magnitude, since that is what reached production."""
+
+    def test_per_token_is_not_divided(self):
+        from src.utils.pricing_normalization import normalize_to_per_token
+
+        assert float(normalize_to_per_token("0.000005", PricingFormat.PER_TOKEN)) == pytest.approx(
+            5e-6
+        )
+
+    def test_treating_per_token_as_per_1m_is_the_bug(self):
+        """Documents the failure: 5e-6 becomes 5e-12, a million times too cheap."""
+        from src.utils.pricing_normalization import normalize_to_per_token
+
+        wrong = float(normalize_to_per_token("0.000005", PricingFormat.PER_1M_TOKENS))
+
+        assert wrong == pytest.approx(5e-12)
+        assert wrong != pytest.approx(5e-6)


### PR DESCRIPTION
**Claude Opus 5 reached production priced at `5E-18` per token** — a million times a million too cheap. Caught immediately after #2197 by verifying the stored price rather than trusting the sync's success count.

## Cause

`get_provider_format` read the gateway registry, which is loaded from **active** providers only (`get_all_providers(is_active_only=True)`) and then filtered **again** by `ENABLED_PROVIDERS`. OpenRouter is in neither, so the lookup missed and fell through to the `PER_1M` default.

But OpenRouter declares `per_token` in the database and publishes `0.000005` for a $5/Mtok model. So every price it supplied was divided by a million on sync, and the price book propagated that to every model priced from it:

```
OpenRouter API      prompt = 0.000005      ($5 / Mtok)
stored after sync   prompt = 5E-12         ÷ 1,000,000
claude-opus-5       prompt = 5E-18         ÷ 1,000,000 again, via the price book
```

## Fix

The units an API quotes prices in are a **fact about that API**. They don't depend on whether we route to it. Read them straight from the `providers` table via `get_declared_pricing_formats()`, which covers every provider regardless of activity — with a cache, since it's hit on every model transform.

Verified end to end against the live catalog:

```
openrouter format:  per_token   (was per_1m)
claude-opus-5    :  {'prompt': '0.000005', 'completion': '0.000025'}   ✓ matches OpenRouter
```

## Why it appeared now

Latent until the price book began syncing a *disabled* provider — the very change in #2197 that made new models listable is what exposed it. Nothing about the old behaviour was safe; it simply never ran this path.

North Star §4.2 calls a unit error *"the hardest data-quality problem in the system"* precisely because it's silent: nothing throws, no request fails, the gateway just bills almost nothing.

## Tests

9 new in `tests/utils/test_pricing_format_resolution.py`: a disabled provider still resolves its declared format, each format maps through, case-insensitive slugs, undeclared falls back to `PER_1M`, and a lookup failure degrades instead of raising.

Plus two arithmetic guards on the magnitude itself — one asserting per-token is passed through untouched, one documenting that treating it as per-1M yields `5e-12`. The bug was a number, so the test is about the number.

1558 passed. The 2 `test_prometheus_remote_write.py` failures are pre-existing — identical on unmodified `main` under the parallel runner. black + ruff clean.

## After merge

Re-sync the price book and the roster so the corrupted prices are overwritten, then verify `claude-opus-5` lists at the right figure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)