### PR TITLE
fix(cache): make catalog invalidation reach per-process local caches

### DIFF
--- a/src/services/cache/local_memory_cache.py
+++ b/src/services/cache/local_memory_cache.py
@@ -282,8 +282,13 @@ _epoch_lock = threading.Lock()
 def get_catalog_epoch(force: bool = False) -> int:
     """Current catalog epoch, re-read from Redis at most every few seconds.
 
-    Fails closed to the last known value: if Redis is unreachable we keep
-    serving local entries rather than throwing the cache away on every read.
+    The value only ever moves FORWARD. A read that races a bump — or a replica
+    that lags — can return an older number, and letting that overwrite a newer
+    one would silently un-invalidate a catalog we had just superseded, which is
+    the exact failure this mechanism exists to prevent.
+
+    Fails closed to the last known value: if Redis is unreachable we keep serving
+    local entries rather than discarding every worker's cache on each read.
     """
     global _epoch_value, _epoch_checked_at
 
@@ -291,28 +296,32 @@ def get_catalog_epoch(force: bool = False) -> int:
     with _epoch_lock:
         if not force and (now - _epoch_checked_at) < _EPOCH_RECHECK_SECONDS:
             return _epoch_value
+        # Claim the refresh before releasing the lock so concurrent readers do
+        # not all fire their own Redis GET when the interval lapses.
+        _epoch_checked_at = now
+        known = _epoch_value
 
     try:
         from src.config.redis_config import get_redis_client, is_redis_available
 
         client = get_redis_client()
-        if client and is_redis_available():
-            raw = client.get(CATALOG_EPOCH_KEY)
-            value = int(raw) if raw not in (None, b"", "") else 0
-        else:
-            value = _epoch_value
+        if not client or not is_redis_available():
+            return known
+        raw = client.get(CATALOG_EPOCH_KEY)
+        observed = int(raw) if raw not in (None, b"", "") else 0
     except Exception as e:  # pragma: no cover - defensive
-        logger.debug("Catalog epoch read failed, keeping %s: %s", _epoch_value, e)
-        value = _epoch_value
+        logger.debug("Catalog epoch read failed, keeping %s: %s", known, e)
+        return known
 
     with _epoch_lock:
-        _epoch_value = value
-        _epoch_checked_at = now
-    return value
+        _epoch_value = max(_epoch_value, observed)
+        return _epoch_value
 
 
 def bump_catalog_epoch() -> int:
     """Invalidate every worker's local catalog. Call alongside Redis invalidation."""
+    global _epoch_value, _epoch_checked_at
+
     try:
         from src.config.redis_config import get_redis_client, is_redis_available
 
@@ -320,14 +329,20 @@ def bump_catalog_epoch() -> int:
         if not client or not is_redis_available():
             return _epoch_value
 
+        # INCR already returns the authoritative new value; re-reading it would
+        # cost a round-trip and could observe a lagging replica.
         new_epoch = int(client.incr(CATALOG_EPOCH_KEY))
-        logger.info("Catalog epoch bumped to %s (local caches invalidated)", new_epoch)
-        # Reflect it locally at once so the caller does not serve its own stale copy.
-        get_catalog_epoch(force=True)
-        return new_epoch
     except Exception as e:
         logger.warning("Could not bump catalog epoch: %s", e)
         return _epoch_value
+
+    with _epoch_lock:
+        _epoch_value = max(_epoch_value, new_epoch)
+        _epoch_checked_at = time.time()
+        current = _epoch_value
+
+    logger.info("Catalog epoch bumped to %s (local caches invalidated)", current)
+    return current
 
 
 def get_local_catalog(provider: str) -> tuple[list[dict] | None, bool]:

--- a/src/services/cache/local_memory_cache.py
+++ b/src/services/cache/local_memory_cache.py
@@ -28,6 +28,7 @@ Usage:
 """
 
 import logging
+import threading
 import time
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -257,6 +258,78 @@ def get_local_cache() -> LocalMemoryCache:
 # Convenience functions for catalog caching
 
 
+# --- Cross-process invalidation -------------------------------------------
+#
+# This cache is per-process, so deleting a Redis key cannot reach it. With a
+# 15-minute fresh window and a 1-hour stale grace, a worker could serve a
+# superseded catalog for up to 75 minutes — every catalog correction made today
+# needed a container restart before it became visible, and one of them was a
+# model priced a million-fold too low.
+#
+# So entries carry the epoch they were written under. Invalidation bumps a
+# shared counter in Redis; a local entry stamped with an older epoch is treated
+# as a miss. The epoch read is itself memoised briefly, so the common path stays
+# in-process and staleness is bounded by that interval rather than by the TTL.
+
+CATALOG_EPOCH_KEY = "gw:models:catalog:epoch"
+_EPOCH_RECHECK_SECONDS = 5.0
+
+_epoch_value: int = 0
+_epoch_checked_at: float = 0.0
+_epoch_lock = threading.Lock()
+
+
+def get_catalog_epoch(force: bool = False) -> int:
+    """Current catalog epoch, re-read from Redis at most every few seconds.
+
+    Fails closed to the last known value: if Redis is unreachable we keep
+    serving local entries rather than throwing the cache away on every read.
+    """
+    global _epoch_value, _epoch_checked_at
+
+    now = time.time()
+    with _epoch_lock:
+        if not force and (now - _epoch_checked_at) < _EPOCH_RECHECK_SECONDS:
+            return _epoch_value
+
+    try:
+        from src.config.redis_config import get_redis_client, is_redis_available
+
+        client = get_redis_client()
+        if client and is_redis_available():
+            raw = client.get(CATALOG_EPOCH_KEY)
+            value = int(raw) if raw not in (None, b"", "") else 0
+        else:
+            value = _epoch_value
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug("Catalog epoch read failed, keeping %s: %s", _epoch_value, e)
+        value = _epoch_value
+
+    with _epoch_lock:
+        _epoch_value = value
+        _epoch_checked_at = now
+    return value
+
+
+def bump_catalog_epoch() -> int:
+    """Invalidate every worker's local catalog. Call alongside Redis invalidation."""
+    try:
+        from src.config.redis_config import get_redis_client, is_redis_available
+
+        client = get_redis_client()
+        if not client or not is_redis_available():
+            return _epoch_value
+
+        new_epoch = int(client.incr(CATALOG_EPOCH_KEY))
+        logger.info("Catalog epoch bumped to %s (local caches invalidated)", new_epoch)
+        # Reflect it locally at once so the caller does not serve its own stale copy.
+        get_catalog_epoch(force=True)
+        return new_epoch
+    except Exception as e:
+        logger.warning("Could not bump catalog epoch: %s", e)
+        return _epoch_value
+
+
 def get_local_catalog(provider: str) -> tuple[list[dict] | None, bool]:
     """
     Get cached catalog from local memory.
@@ -266,7 +339,21 @@ def get_local_catalog(provider: str) -> tuple[list[dict] | None, bool]:
     """
     cache = get_local_cache()
     key = f"catalog:{provider}"
-    return cache.get(key)
+    entry, is_stale = cache.get(key)
+    if entry is None:
+        return None, False
+
+    stamped_epoch, catalog = entry
+    current = get_catalog_epoch()
+    if stamped_epoch != current:
+        # Written before the last invalidation — discard rather than serve it.
+        cache.delete(key)
+        logger.debug(
+            "Local catalog for %s dropped: epoch %s != %s", provider, stamped_epoch, current
+        )
+        return None, False
+
+    return catalog, is_stale
 
 
 def set_local_catalog(
@@ -275,7 +362,7 @@ def set_local_catalog(
     ttl: float = 900.0,  # 15 minutes fresh
     stale_ttl: float = 3600.0,  # 1 hour stale
 ) -> None:
-    """Cache catalog in local memory."""
+    """Cache catalog in local memory, stamped with the current epoch."""
     cache = get_local_cache()
     key = f"catalog:{provider}"
-    cache.set(key, catalog, ttl=ttl, stale_ttl=stale_ttl)
+    cache.set(key, (get_catalog_epoch(), catalog), ttl=ttl, stale_ttl=stale_ttl)

--- a/src/services/cache/model_catalog_cache.py
+++ b/src/services/cache/model_catalog_cache.py
@@ -1369,7 +1369,24 @@ def rebuild_full_catalog_from_providers() -> list[dict[str, Any]]:
 def invalidate_full_catalog() -> bool:
     """Invalidate the full catalog cache"""
     cache = get_model_catalog_cache()
-    return cache.invalidate_full_catalog()
+    result = cache.invalidate_full_catalog()
+    _bump_local_cache_epoch()
+    return result
+
+
+def _bump_local_cache_epoch() -> None:
+    """Reach the per-process local caches that a Redis delete cannot.
+
+    Deleting a Redis key leaves every worker's in-process copy untouched, and
+    that copy is good for 15 minutes fresh plus an hour of stale grace. Bumping
+    the shared epoch makes them all treat their entry as a miss.
+    """
+    try:
+        from src.services.cache.local_memory_cache import bump_catalog_epoch
+
+        bump_catalog_epoch()
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("Local cache epoch bump failed: %s", e)
 
 
 def cache_provider_catalog(
@@ -1511,6 +1528,7 @@ def invalidate_provider_catalog(
         True if successful (or scheduled via debouncing), False otherwise
     """
     cache = get_model_catalog_cache()
+    _bump_local_cache_epoch()
     return cache.invalidate_provider_catalog(provider_name, cascade=cascade, debounce=debounce)
 
 

--- a/src/services/cache/model_catalog_cache.py
+++ b/src/services/cache/model_catalog_cache.py
@@ -424,6 +424,9 @@ class ModelCatalogCache:
         try:
             self.redis_client.delete(key)
             self._stats["invalidations"] += 1
+            # After the delete, and here rather than in the module wrapper so
+            # the cascade path (which calls this method directly) also bumps.
+            _bump_local_cache_epoch()
             logger.info("Cache INVALIDATE: Full model catalog")
             return True
 
@@ -546,6 +549,11 @@ class ModelCatalogCache:
             self._stats["invalidations"] += 1
             if cascade:
                 self.invalidate_full_catalog()
+            # After the delete, so no request can re-read the stale Redis value
+            # and re-stamp it locally under the new epoch. Placed here rather
+            # than in the module-level wrapper because a debounced invalidation
+            # re-enters this method directly when it finally runs.
+            _bump_local_cache_epoch()
             logger.info(
                 f"Cache INVALIDATE: Provider catalog for {provider_name} (cascade={cascade})"
             )
@@ -1369,9 +1377,8 @@ def rebuild_full_catalog_from_providers() -> list[dict[str, Any]]:
 def invalidate_full_catalog() -> bool:
     """Invalidate the full catalog cache"""
     cache = get_model_catalog_cache()
-    result = cache.invalidate_full_catalog()
-    _bump_local_cache_epoch()
-    return result
+    # The epoch bump lives inside the method so the cascade path bumps too.
+    return cache.invalidate_full_catalog()
 
 
 def _bump_local_cache_epoch() -> None:
@@ -1528,7 +1535,8 @@ def invalidate_provider_catalog(
         True if successful (or scheduled via debouncing), False otherwise
     """
     cache = get_model_catalog_cache()
-    _bump_local_cache_epoch()
+    # The epoch bump lives inside the method, after the Redis delete, so it also
+    # fires for a debounced invalidation when that finally runs.
     return cache.invalidate_provider_catalog(provider_name, cascade=cascade, debounce=debounce)
 
 

--- a/tests/services/cache/test_local_cache_epoch.py
+++ b/tests/services/cache/test_local_cache_epoch.py
@@ -1,0 +1,99 @@
+"""A Redis delete cannot reach a per-process cache; an epoch can.
+
+The local catalog cache holds entries for 15 minutes fresh plus an hour of stale
+grace. Invalidation deletes a Redis key, which leaves every worker's in-process
+copy untouched — so a corrected catalog could stay invisible for up to 75
+minutes. Every catalog fix made today needed a container restart before it
+showed, including a model priced a million-fold too low.
+
+Entries now carry the epoch they were written under, and invalidation bumps a
+shared counter.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.services.cache import local_memory_cache as lmc
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache(monkeypatch):
+    lmc.get_local_cache().clear()
+    monkeypatch.setattr(lmc, "_epoch_value", 0)
+    monkeypatch.setattr(lmc, "_epoch_checked_at", 0.0)
+    yield
+    lmc.get_local_cache().clear()
+
+
+@pytest.fixture
+def redis(monkeypatch):
+    client = MagicMock()
+    client.get.return_value = b"0"
+    monkeypatch.setattr("src.config.redis_config.get_redis_client", lambda: client)
+    monkeypatch.setattr("src.config.redis_config.is_redis_available", lambda: True)
+    return client
+
+
+class TestEpochInvalidation:
+    def test_entry_survives_while_the_epoch_is_unchanged(self, redis):
+        lmc.set_local_catalog("openai", [{"id": "a"}])
+
+        catalog, _ = lmc.get_local_catalog("openai")
+
+        assert catalog == [{"id": "a"}]
+
+    def test_entry_is_dropped_once_the_epoch_moves(self, redis):
+        """The case that mattered: another worker invalidated, this one must notice."""
+        lmc.set_local_catalog("openai", [{"id": "stale"}])
+
+        # A different process bumped the shared counter.
+        redis.get.return_value = b"1"
+        lmc.get_catalog_epoch(force=True)
+
+        catalog, _ = lmc.get_local_catalog("openai")
+
+        assert catalog is None, "a superseded catalog must not be served"
+
+    def test_bump_increments_and_refreshes_locally(self, redis):
+        redis.incr.return_value = 7
+        redis.get.return_value = b"7"
+
+        assert lmc.bump_catalog_epoch() == 7
+        redis.incr.assert_called_once_with(lmc.CATALOG_EPOCH_KEY)
+        assert lmc.get_catalog_epoch() == 7
+
+    def test_write_after_a_bump_is_readable(self, redis):
+        """Invalidate, then repopulate — the fresh entry must stick."""
+        redis.incr.return_value = 3
+        redis.get.return_value = b"3"
+        lmc.bump_catalog_epoch()
+
+        lmc.set_local_catalog("openai", [{"id": "fresh"}])
+        catalog, _ = lmc.get_local_catalog("openai")
+
+        assert catalog == [{"id": "fresh"}]
+
+
+class TestDegradation:
+    def test_epoch_read_is_memoised(self, redis, monkeypatch):
+        """The common path must stay in-process, not a Redis round-trip per read."""
+        lmc.get_catalog_epoch(force=True)
+        redis.get.reset_mock()
+
+        for _ in range(20):
+            lmc.get_catalog_epoch()
+
+        redis.get.assert_not_called()
+
+    def test_redis_outage_keeps_serving_the_last_known_epoch(self, monkeypatch):
+        """Fail closed: an outage must not throw away every worker's cache."""
+        monkeypatch.setattr(lmc, "_epoch_value", 4)
+        monkeypatch.setattr("src.config.redis_config.get_redis_client", lambda: None)
+
+        assert lmc.get_catalog_epoch(force=True) == 4
+
+    def test_bump_without_redis_does_not_raise(self, monkeypatch):
+        monkeypatch.setattr("src.config.redis_config.get_redis_client", lambda: None)
+
+        assert lmc.bump_catalog_epoch() == lmc._epoch_value

--- a/tests/services/cache/test_local_cache_epoch.py
+++ b/tests/services/cache/test_local_cache_epoch.py
@@ -97,3 +97,59 @@ class TestDegradation:
         monkeypatch.setattr("src.config.redis_config.get_redis_client", lambda: None)
 
         assert lmc.bump_catalog_epoch() == lmc._epoch_value
+
+
+class TestEpochNeverRegresses:
+    """A stale read must not un-invalidate a catalog we just superseded.
+
+    get_catalog_epoch releases the lock to do its Redis read, so a slow reader —
+    or a lagging replica — can return a number older than one another thread
+    already recorded. Overwriting with it would silently resurrect a superseded
+    catalog, defeating the entire mechanism.
+    """
+
+    def test_a_lagging_read_cannot_lower_the_epoch(self, redis, monkeypatch):
+        monkeypatch.setattr(lmc, "_epoch_value", 9)
+        redis.get.return_value = b"4"  # replica behind, or a raced read
+
+        assert lmc.get_catalog_epoch(force=True) == 9
+
+    def test_a_newer_read_does_advance_it(self, redis, monkeypatch):
+        monkeypatch.setattr(lmc, "_epoch_value", 2)
+        redis.get.return_value = b"11"
+
+        assert lmc.get_catalog_epoch(force=True) == 11
+
+    def test_bump_uses_the_incr_result_without_a_second_read(self, redis):
+        """INCR already returns the authoritative value; re-reading can lag."""
+        redis.incr.return_value = 5
+        redis.get.reset_mock()
+
+        assert lmc.bump_catalog_epoch() == 5
+        redis.get.assert_not_called()
+
+    def test_bump_cannot_lower_the_epoch_either(self, redis, monkeypatch):
+        monkeypatch.setattr(lmc, "_epoch_value", 8)
+        redis.incr.return_value = 3
+
+        assert lmc.bump_catalog_epoch() == 8
+
+
+class TestConcurrentRefresh:
+    def test_only_one_thread_fires_the_redis_read_per_interval(self, redis):
+        """The refresh window is claimed under the lock, so a lapsed interval
+        does not produce a burst of GETs from every concurrent reader."""
+        import threading
+
+        lmc.get_catalog_epoch(force=True)
+        redis.get.reset_mock()
+        # Expire the memo window.
+        lmc._epoch_checked_at = 0.0
+
+        threads = [threading.Thread(target=lmc.get_catalog_epoch) for _ in range(12)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert redis.get.call_count == 1


### PR DESCRIPTION
Invalidation deletes a Redis key. That leaves every worker's **in-process** copy untouched — and that copy is good for **15 minutes fresh plus an hour of stale grace**, so a corrected catalog could stay invisible for up to **75 minutes**.

This wasn't theoretical. Every catalog fix made today needed a container restart before it showed:

```
DB row      : claude-opus-5  prompt = 0.000005   ✓ (after #2200)
served      : claude-opus-5  prompt = 5E-12      ✗ from local memory
uncached?   : _cached_at: None                   ← not the response cache
after restart: prompt = 0.000005                 ✓
```

A model priced a million-fold too low kept being served from a cache no invalidation could reach.

## Fix

Local entries carry the epoch they were written under; invalidation bumps a shared counter in Redis. An entry stamped with an older epoch is treated as a miss, so a change made by **any** worker reaches **all** of them.

Wired into both `invalidate_full_catalog()` and `invalidate_provider_catalog()`, alongside the existing Redis deletes.

## Keeping the fast path fast

The epoch read is memoised for a few seconds, so the common path stays in-process rather than becoming a Redis round-trip per cache read. Staleness is bounded by that interval (~5s) instead of by the TTL (~75min).

Both the read and the bump **fail closed**: a Redis outage keeps the last known epoch and keeps serving local entries, rather than throwing every worker's cache away on every read — which would turn a Redis blip into a database stampede.

## Tests

7 new in `tests/services/cache/test_local_cache_epoch.py`:

- an entry survives while the epoch is unchanged
- **an entry is dropped once another process bumps the epoch** — the case that mattered
- bump increments and refreshes locally, so the caller doesn't serve its own stale copy
- write-after-bump is readable (invalidate → repopulate must stick)
- the epoch read is memoised — 20 reads, zero Redis calls
- a Redis outage keeps the last known epoch
- bumping without Redis doesn't raise

1576 passed. The 2 `test_prometheus_remote_write.py` failures are pre-existing and load-dependent — absent from other runs today on unrelated code. black + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved catalog cache invalidation across processes and workers.
  * Ensured deleted or outdated catalog entries are treated as cache misses.
  * Preserved cached catalog access during temporary Redis outages.
  * Improved consistency when catalog data is invalidated or refreshed.

* **Tests**
  * Added coverage for epoch-based invalidation, cache refresh behavior, and Redis availability issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->