### PR TITLE
fix(pricing): bridge Anthropic and OpenRouter model-id spellings

### DIFF
--- a/src/services/pricing/pricing_lookup.py
+++ b/src/services/pricing/pricing_lookup.py
@@ -18,6 +18,7 @@ PricingFormat constant before returning values from this module.
 
 import json
 import logging
+import re
 import threading
 import time
 from pathlib import Path
@@ -444,6 +445,43 @@ def invalidate_openrouter_pricing_index() -> None:
     _openrouter_pricing_index = None
 
 
+# Anthropic and OpenRouter spell the same model differently: Anthropic ships
+# "claude-opus-4-6" and dated snapshots like "claude-haiku-4-5-20251001", while
+# OpenRouter lists "claude-opus-4.6" and "claude-haiku-4.5". normalize_model_name
+# cannot bridge them — it maps "." to "p" but leaves "-" alone, so "4.6" becomes
+# "4p6" and "4-6" stays "4-6" and the two never meet. It also drives provider
+# dispatch, so widening it there risks mis-routing an inference call.
+#
+# These candidates are therefore built only for the price lookup. Four Anthropic
+# models sat unpriced — and so unlistable — purely because of this, with the
+# price sitting in the index under a dotted name.
+_DATE_SUFFIX = re.compile(r"-\d{8}$")
+_VERSION_SEGMENT = re.compile(r"(?<=\d)-(?=\d)")
+
+
+def _cross_reference_candidates(model_id: str, base_model_id: str) -> list[str]:
+    """Lookup keys to try, most literal first."""
+    candidates: list[str] = []
+
+    def add(value: str) -> None:
+        for form in (value, value.lower()):
+            if form and form not in candidates:
+                candidates.append(form)
+
+    for value in (model_id, base_model_id):
+        if not value:
+            continue
+        add(value)
+        # "claude-haiku-4-5-20251001" -> "claude-haiku-4-5"
+        undated = _DATE_SUFFIX.sub("", value)
+        add(undated)
+        # "claude-opus-4-6" -> "claude-opus-4.6" (a hyphen BETWEEN DIGITS only,
+        # so "gpt-4" and "claude-3-opus" are untouched)
+        add(_VERSION_SEGMENT.sub(".", undated))
+
+    return candidates
+
+
 def _get_cross_reference_pricing(
     model_id: str,
     openrouter_index: dict[str, dict] | None = None,
@@ -502,7 +540,7 @@ def _get_cross_reference_pricing(
         # so we must normalize using PER_TOKEN — not PER_1M_TOKENS.
         # This is the canonical format used everywhere in the billing pipeline.
         # See PROVIDER_PRICING_FORMATS["openrouter"] in pricing_normalization.py.
-        for candidate in (model_id, model_id.lower(), base_model_id, base_model_id.lower()):
+        for candidate in _cross_reference_candidates(model_id, base_model_id):
             if candidate and candidate in index:
                 return normalize_pricing_dict(index[candidate], PricingFormat.PER_TOKEN)
 

--- a/tests/services/pricing/test_cross_reference_ids.py
+++ b/tests/services/pricing/test_cross_reference_ids.py
@@ -1,0 +1,86 @@
+"""Anthropic and OpenRouter spell the same model differently.
+
+Anthropic ships "claude-opus-4-6" and dated snapshots like
+"claude-haiku-4-5-20251001". OpenRouter lists "claude-opus-4.6" and
+"claude-haiku-4.5". normalize_model_name cannot bridge them — it maps "." to "p"
+so "4.6" becomes "4p6" while "4-6" stays "4-6" — and it also drives provider
+dispatch, so widening it there risks mis-routing an inference call.
+
+Four Anthropic models sat unpriced, and therefore unlistable, purely because of
+this. The price was in the index the whole time under a dotted name.
+"""
+
+import pytest
+
+from src.services.pricing.pricing_lookup import (
+    _cross_reference_candidates,
+    _get_cross_reference_pricing,
+)
+
+
+class TestCandidateForms:
+    def test_a_dated_snapshot_yields_the_undated_dotted_form(self):
+        candidates = _cross_reference_candidates(
+            "anthropic/claude-haiku-4-5-20251001", "claude-haiku-4-5-20251001"
+        )
+
+        assert "claude-haiku-4.5" in candidates
+        assert "anthropic/claude-haiku-4.5" in candidates
+        # The literal id is still tried first.
+        assert candidates[0] == "anthropic/claude-haiku-4-5-20251001"
+
+    def test_a_hyphenated_version_yields_the_dotted_form(self):
+        candidates = _cross_reference_candidates("anthropic/claude-opus-4-6", "claude-opus-4-6")
+
+        assert "claude-opus-4.6" in candidates
+
+    @pytest.mark.parametrize("model_id", ["openai/gpt-4", "anthropic/claude-3-opus"])
+    def test_hyphens_not_between_digits_are_left_alone(self, model_id):
+        """gpt-4 must not become gpt.4, and claude-3-opus must stay itself."""
+        candidates = _cross_reference_candidates(model_id, model_id.split("/")[-1])
+
+        assert not any("." in c for c in candidates)
+
+    def test_a_digit_run_is_converted(self):
+        """claude-3-5-sonnet is OpenRouter's claude-3.5-sonnet."""
+        candidates = _cross_reference_candidates("anthropic/claude-3-5-sonnet", "claude-3-5-sonnet")
+
+        assert "claude-3.5-sonnet" in candidates
+
+    def test_no_duplicates(self):
+        candidates = _cross_reference_candidates("openai/gpt-4", "gpt-4")
+
+        assert len(candidates) == len(set(candidates))
+
+
+class TestLookupAgainstADottedIndex:
+    @pytest.fixture
+    def index(self):
+        # Shaped like the real one: OpenRouter's dotted, undated ids.
+        return {
+            "anthropic/claude-opus-4.6": {"prompt": "0.000005", "completion": "0.000025"},
+            "claude-opus-4.6": {"prompt": "0.000005", "completion": "0.000025"},
+            "anthropic/claude-haiku-4.5": {"prompt": "0.000001", "completion": "0.000005"},
+            "claude-haiku-4.5": {"prompt": "0.000001", "completion": "0.000005"},
+        }
+
+    def test_hyphenated_id_finds_the_dotted_price(self, index):
+        pricing = _get_cross_reference_pricing("anthropic/claude-opus-4-6", index, "anthropic")
+
+        assert pricing is not None
+        assert float(pricing["prompt"]) == 5e-6
+
+    def test_dated_snapshot_finds_the_undated_price(self, index):
+        pricing = _get_cross_reference_pricing(
+            "anthropic/claude-haiku-4-5-20251001", index, "anthropic"
+        )
+
+        assert pricing is not None
+        assert float(pricing["prompt"]) == 1e-6
+
+    def test_an_unknown_model_still_returns_nothing(self, index):
+        """The widened matching must not invent a price for something absent."""
+        assert (
+            _get_cross_reference_pricing("anthropic/claude-nonexistent-9", index, "anthropic")
+            is None
+        )


### PR DESCRIPTION
Answers "how come no price?" — **they had one all along**, filed under a different spelling.

## The mismatch

| our id (Anthropic's) | OpenRouter's id | price present |
|---|---|---|
| `claude-opus-4-6` | `claude-opus-4.6` | 0.000005 |
| `claude-haiku-4-5-20251001` | `claude-haiku-4.5` | 0.000001 |
| `claude-opus-4-5-20251101` | `claude-opus-4.5` | 0.000005 |
| `claude-sonnet-4-5-20250929` | `claude-sonnet-4.5` | 0.000003 |

Anthropic writes `4-6` and appends a release date; OpenRouter writes `4.6` and doesn't.

`normalize_model_name` can't bridge it — it maps `.` → `p`, so `4.6` becomes `4p6` while `4-6` stays `4-6` and the two never meet:

```
claude-opus-4-6  -> claude-opus-4-6
claude-opus-4.6  -> claude-opus-4p6     match=False
```

Widening that function wasn't an option: it also chooses the model id sent to a provider on a real inference call, so a looser match there risks mis-routing.

## Fix

Extra candidate forms, built **only for the price lookup**: strip a trailing `-YYYYMMDD`, and convert a hyphen **between digits** to a dot. The literal id is still tried first.

The digit-boundary rule is what keeps it safe — `gpt-4` and `claude-3-opus` are untouched, while `claude-3-5-sonnet` correctly becomes `claude-3.5-sonnet`.

## Verified against the live index

```
anthropic/claude-opus-4-6              -> 0.000005
anthropic/claude-haiku-4-5-20251001    -> 0.000001
anthropic/claude-opus-4-5-20251101     -> 0.000005
anthropic/claude-sonnet-4-5-20250929   -> 0.000003
moonshot/kimi-k2.7-code-highspeed      -> None
```

Each matches Anthropic's published rate. The Moonshot one stays unpriced **correctly** — OpenRouter doesn't carry it under any spelling, so that one is a genuine absence rather than a matching failure.

## Tests

9 in `tests/services/pricing/test_cross_reference_ids.py`: dated snapshots and hyphenated versions yield the dotted form, the literal id is tried first, hyphens not between digits are left alone (`gpt-4`, `claude-3-opus`), a digit run is converted (`claude-3-5-sonnet`), no duplicate candidates, lookups against a dotted index succeed — and an unknown model still returns `None`, so the widened matching can't invent a price.

1508 passed across `tests/services/`, `tests/data/`, `tests/utils/`. black + ruff clean.

## After merge

Sync Anthropic and confirm the four list at the right prices — catalog should go 46 → 50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)