### PR TITLE
fix(metrics): align METRICS_EPOCH across payer endpoints; widen capability families

### DIFF
--- a/src/routes/payer_analytics.py
+++ b/src/routes/payer_analytics.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 
 from src.security.deps import require_admin_or_env_key
 from src.services.payer_metrics import (
+    apply_epoch,
     build_weekly_scorecard,
     compute_new_paying_accounts,
     compute_paying_accounts,
@@ -57,6 +58,12 @@ async def payer_trend(
     """
     try:
         payments = fetch_settled_payments()
+        # Apply the same METRICS_EPOCH cutoff the scorecard uses. Without this
+        # the two endpoints report different totals for the same metric, which
+        # is exactly the disagreement docs/METRIC_DEFINITIONS.md exists to
+        # prevent — and the kind a diligence question surfaces at the worst
+        # possible moment.
+        payments, epoch_note = apply_epoch(payments)
         now = datetime.now(UTC)
 
         series = []
@@ -77,6 +84,7 @@ async def payer_trend(
             "total_paying_accounts": len(compute_paying_accounts(payments)),
             "second_topup_rate_pct": compute_second_topup_rate(payments),
             "series": series,
+            "notes": [epoch_note] if epoch_note else [],
         }
     except Exception as e:
         logger.error("Failed to build payer trend: %s", e, exc_info=True)

--- a/src/services/model_capability_surface.py
+++ b/src/services/model_capability_surface.py
@@ -44,22 +44,37 @@ CACHE_CAPABLE_PROVIDERS: frozenset[str] = frozenset(
 # no explicit flag. Matched as substrings against the lowercased model ID.
 KNOWN_TOOL_FAMILIES: tuple[str, ...] = (
     "claude",
+    "gpt-3.5-turbo",
     "gpt-4",
     "gpt-5",
     "gpt-4o",
     "o1",
     "o3",
+    "o4",
     "gemini",
     "mistral-large",
     "command-r",
     "llama-3.1",
     "llama-3.3",
     "llama-4",
+    "qwen",
     "qwen2.5",
     "qwen3",
+    "deepseek",
     "deepseek-v3",
     "deepseek-r1",
     "grok",
+    # Families added when the provider roster moved to direct supply. Without
+    # these, a live production catalog reported tools:false for models that
+    # plainly support tool calling (Kimi K2 among them) — under-reporting fails
+    # safe, but it hides a chunk of the catalog from agent tools that filter on
+    # capability before sending a request.
+    "kimi",
+    "moonshot",
+    "minimax",
+    "glm",
+    "mimo",
+    "step",
 )
 
 KNOWN_VISION_FAMILIES: tuple[str, ...] = (

--- a/tests/services/test_model_capability_surface.py
+++ b/tests/services/test_model_capability_surface.py
@@ -5,6 +5,8 @@ agent that trusts an incorrect "tools: true" fails at runtime, whereas one that
 routes around an under-reported model merely misses an option.
 """
 
+import pytest
+
 from src.services.model_capability_surface import (
     build_supported_parameters,
     enrich_model_with_capabilities,
@@ -111,3 +113,30 @@ class TestEnrichment:
     def test_missing_id_does_not_raise(self):
         model = enrich_model_with_capabilities({})
         assert "supported_parameters" in model
+
+
+class TestCurrentProviderRoster:
+    """Families added when supply moved direct.
+
+    A live production catalog reported tools=false for six models that plainly
+    support tool calling. Under-reporting fails safe, but agent tools that
+    filter on capability before sending a request never see those models.
+    """
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "moonshot/kimi-k2.6",
+            "moonshot/kimi-k2.7-code",
+            "moonshot/kimi-k3",
+            "openai/gpt-3.5-turbo",
+            "openai/gpt-3.5-turbo-0125",
+            "openai/gpt-3.5-turbo-16k",
+        ],
+    )
+    def test_models_that_were_mis_reported_now_advertise_tools(self, model_id):
+        assert supports_tools({"id": model_id}) is True
+
+    def test_genuinely_unknown_model_still_fails_safe(self):
+        """The conservative default must survive the widened family list."""
+        assert supports_tools({"id": "obscure/mystery-model-v1"}) is False

--- a/tests/services/test_payer_metrics.py
+++ b/tests/services/test_payer_metrics.py
@@ -13,6 +13,7 @@ import pytest
 from src.services.payer_metrics import (
     _amount_usd,
     _wow_pct,
+    apply_epoch,
     build_weekly_scorecard,
     compute_new_paying_accounts,
     compute_paying_accounts,
@@ -173,3 +174,35 @@ class TestWeeklyScorecard:
         payments = [_payment(1, 1), _payment(1, 2), _payment(2, 1)]
         card = build_weekly_scorecard(as_of=NOW, payments=payments)
         assert card.second_topup_rate_pct == 50.0
+
+
+class TestEpochConsistency:
+    """Both payer endpoints must apply the same METRICS_EPOCH cutoff.
+
+    The scorecard applied it and the trend endpoint did not, so the two
+    reported different totals for the same metric — exactly the disagreement
+    docs/METRIC_DEFINITIONS.md exists to prevent, and the kind a diligence
+    question surfaces at the worst possible moment.
+    """
+
+    def test_apply_epoch_is_a_no_op_when_unset(self, monkeypatch):
+        monkeypatch.delenv("METRICS_EPOCH", raising=False)
+        payments = [_payment(1, 1), _payment(2, 30)]
+        filtered, note = apply_epoch(payments)
+        assert filtered == payments
+        assert note is None
+
+    def test_apply_epoch_drops_older_rows_and_says_how_many(self, monkeypatch):
+        monkeypatch.setenv("METRICS_EPOCH", (NOW - timedelta(days=5)).date().isoformat())
+        payments = [_payment(1, 1), _payment(2, 30)]
+        filtered, note = apply_epoch(payments)
+        assert len(filtered) == 1
+        assert "Excluded 1 payment" in note
+
+    def test_unparseable_epoch_is_ignored_rather_than_dropping_everything(self, monkeypatch):
+        """A typo in the env var must not silently zero every metric."""
+        monkeypatch.setenv("METRICS_EPOCH", "not-a-date")
+        payments = [_payment(1, 1), _payment(2, 30)]
+        filtered, note = apply_epoch(payments)
+        assert filtered == payments
+        assert note is None


### PR DESCRIPTION
Two bugs found by inspecting the live deploy of #2207, not by tests.

## 1. The two payer endpoints disagreed

`/admin/payers/scorecard` applied `METRICS_EPOCH`; `/admin/payers/trend` did not. Same metric, two different totals depending on which endpoint you asked.

That is exactly the disagreement `docs/METRIC_DEFINITIONS.md` was written to prevent — and the kind that surfaces during diligence rather than during development. Trend now applies the same cutoff and reports what it excluded.

Also covered: an unparseable `METRICS_EPOCH` is ignored rather than treated as "exclude everything". A typo in that env var would otherwise silently zero every metric on the dashboard, which looks identical to having no customers.

## 2. Six live models under-reported tool support

Production was returning `tools: false` for models that plainly support tool calling:

```
moonshot/kimi-k2.6, moonshot/kimi-k2.7-code, moonshot/kimi-k3
openai/gpt-3.5-turbo, openai/gpt-3.5-turbo-0125, openai/gpt-3.5-turbo-16k
```

The family heuristics were written against the old 30-provider roster and never learned the families added when supply moved direct. 44 of 50 models were correct; these six were not.

Nothing broke, because under-reporting fails safe by design — an agent routes around the model rather than calling a tool that errors. But agent tools that filter on capability before sending a request never saw them, which is 12% of the catalog including Kimi.

Adds `kimi`, `moonshot`, `minimax`, `glm`, `mimo`, `step` and `gpt-3.5-turbo`. The conservative default is unchanged and still explicitly tested: a genuinely unknown model reports no support.

## Verification

10 new tests. Full suite 2781 passed. ruff, black and isort all clean.

Worth noting for context: the live scorecard currently reports **0 paying accounts against 90,945 tokens served this week**, and the trend endpoint confirms zero settled payments across six weeks with no epoch filter applied. That is consistent with the GTM plan's own premise, but if it is unexpected, the note the scorecard emits is pointing at the right place — check the payments table and the Stripe webhook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded tool support recognition for additional AI model families.
  * Added epoch information to payer trend responses when applicable.

* **Bug Fixes**
  * Historical payer metrics now consistently exclude payments before the configured metrics cutoff.
  * Unknown model identifiers continue to fail safely.

* **Tests**
  * Added coverage for supported model detection and metrics-epoch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->