### PR TITLE
fix(catalog): advertise model capabilities at serve time, not only after a resync

### DIFF
--- a/src/routes/catalog.py
+++ b/src/routes/catalog.py
@@ -954,10 +954,21 @@ async def get_models(
         # `id`, which most clients accept, but strict ones validate `object` on
         # the envelope and on each entry and hard-fail model discovery without
         # it. Additive, so every existing consumer is unaffected.
+        #
+        # Capability advertisement happens here too, at serve time, NOT in
+        # enrich_model_with_pricing. That hook only runs when the catalog is
+        # rebuilt from providers, so models served from the models_catalog table
+        # came back with no `capabilities` or `supported_parameters` at all —
+        # the fields appeared right after a resync and vanished on the next one.
+        # Agent tools that filter on capability before sending a request saw an
+        # empty capability set and had to assume nothing was supported.
+        from src.services.model_capability_surface import enrich_model_with_capabilities
+
         for _model in enhanced_models:
             if isinstance(_model, dict):
                 _model.setdefault("object", "model")
                 _model.setdefault("owned_by", _model.get("provider_slug") or "gatewayz")
+                enrich_model_with_capabilities(_model)
 
         result = {
             "object": "list",

--- a/tests/services/test_model_capability_surface.py
+++ b/tests/services/test_model_capability_surface.py
@@ -140,3 +140,38 @@ class TestCurrentProviderRoster:
     def test_genuinely_unknown_model_still_fails_safe(self):
         """The conservative default must survive the widened family list."""
         assert supports_tools({"id": "obscure/mystery-model-v1"}) is False
+
+
+class TestServeTimeEnrichment:
+    """Capabilities must be derivable from a bare DB row.
+
+    Regression: enrichment was hooked into enrich_model_with_pricing, which
+    only runs when the catalog is rebuilt from providers. Models served from
+    the models_catalog table came back with no `capabilities` or
+    `supported_parameters` keys at all — the fields appeared after a manual
+    resync and vanished on the next scheduled one. Agent tools that filter on
+    capability before sending a request saw nothing and assumed nothing.
+    """
+
+    DB_ROW = {
+        "id": "anthropic/claude-sonnet-4",
+        "provider_slug": "anthropic",
+        "context_length": 200000,
+        "pricing": {"prompt": "0.000003", "completion": "0.000015"},
+    }
+
+    def test_bare_db_row_gains_capabilities(self):
+        model = enrich_model_with_capabilities(dict(self.DB_ROW))
+        assert model["capabilities"]["tools"] is True
+        assert "tools" in model["supported_parameters"]
+
+    def test_enrichment_is_idempotent(self):
+        """Serve-time enrichment runs on every request; twice must equal once."""
+        once = enrich_model_with_capabilities(dict(self.DB_ROW))
+        twice = enrich_model_with_capabilities(dict(once))
+        assert once["capabilities"] == twice["capabilities"]
+        assert once["supported_parameters"] == twice["supported_parameters"]
+
+    def test_row_with_no_pricing_or_provider_still_enriches(self):
+        model = enrich_model_with_capabilities({"id": "anthropic/claude-sonnet-4"})
+        assert model["capabilities"]["tools"] is True


### PR DESCRIPTION
`/v1/models` was returning **no `capabilities` or `supported_parameters` keys at all**.

Verified live just now: **0 of 50** models advertised tool support — hours after a manual resync had shown **50 of 50**.

## Cause

Enrichment was hooked into `enrich_model_with_pricing`, which only runs when the catalog is **rebuilt from providers**. Models served from the `models_catalog` table never passed through it. So the fields appeared right after a resync and disappeared on the next scheduled one.

The `object` and `owned_by` discriminators survived, because those are set at response assembly in `get_models` — which is where capability enrichment belonged all along.

## Impact

Tool calling itself always worked; `tools`, `tool_choice`, `response_format` and `parallel_tool_calls` reach providers fine. What broke was **discovery**: an agent tool that checks `capabilities.tools` before sending a request saw an empty set and had to assume nothing was supported.

That is the failure mode the capability surface was added to prevent, so it was worth fixing at the right layer rather than papering over with another manual resync.

## Fix

Moved into the response-assembly loop in `get_models`, so every served model is enriched regardless of source. The pricing-path hook stays — harmless, and it keeps persisted rows carrying the fields.

## Tests

3 new, covering the regression directly:
- a bare DB row (no capability keys) gains them
- enrichment is idempotent, since it now runs on every request rather than once per sync
- a row with no pricing or provider slug still enriches

Suite **2788 passed**. ruff, black, isort clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model listings now include capability and supported-parameter information, including models loaded from the catalog.
  * Capability details are available even when pricing or provider metadata is missing.

* **Bug Fixes**
  * Improved consistency of capability information across served models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->