### PR TITLE
fix(stream): report the cache tokens that streaming already bills for

### DIFF
--- a/src/adapters/chat/openai.py
+++ b/src/adapters/chat/openai.py
@@ -209,6 +209,16 @@ class OpenAIChatAdapter(BaseChatAdapter):
                         "completion_tokens": chunk.usage.completion_tokens,
                         "total_tokens": chunk.usage.total_tokens,
                     }
+                    # Prompt-cache counts, when the provider reported any. The
+                    # non-streaming path has emitted these since #2207; this one
+                    # did not, so streaming callers saw no cache tokens even
+                    # though they were billed at the cache rate.
+                    _cr = getattr(chunk.usage, "cache_read_input_tokens", 0) or 0
+                    _cw = getattr(chunk.usage, "cache_creation_input_tokens", 0) or 0
+                    if _cr or _cw:
+                        chunk_response["usage"]["cache_read_input_tokens"] = _cr
+                        chunk_response["usage"]["cache_creation_input_tokens"] = _cw
+                        chunk_response["usage"]["prompt_tokens_details"] = {"cached_tokens": _cr}
 
                 # Format as SSE
                 sse_data = f"data: {json.dumps(chunk_response)}\n\n"

--- a/src/handlers/chat_handler.py
+++ b/src/handlers/chat_handler.py
@@ -1369,6 +1369,23 @@ class ChatInferenceHandler:
                                         prompt_tokens=prompt_tokens,
                                         completion_tokens=completion_tokens,
                                         total_tokens=prompt_tokens + completion_tokens,
+                                        # Cache counts are already extracted above
+                                        # for BILLING; carry them onto the chunk so
+                                        # the caller can see them too. Without this
+                                        # a streaming client is charged the cache
+                                        # rate but shown no cache tokens, and has no
+                                        # way to verify the saving it just got.
+                                        **(
+                                            {
+                                                "cache_read_input_tokens": cache_read_tokens,
+                                                "cache_creation_input_tokens": cache_write_tokens,
+                                                "prompt_tokens_details": {
+                                                    "cached_tokens": cache_read_tokens
+                                                },
+                                            }
+                                            if (cache_read_tokens or cache_write_tokens)
+                                            else {}
+                                        ),
                                     )
                                     if prompt_tokens > 0 or completion_tokens > 0
                                     else None

--- a/tests/services/test_streaming_cache_usage.py
+++ b/tests/services/test_streaming_cache_usage.py
@@ -1,0 +1,61 @@
+"""Streaming must report the cache tokens it bills for."""
+
+import json
+
+import pytest
+
+from src.adapters.chat.openai import OpenAIChatAdapter
+from src.schemas.internal.chat import InternalStreamChunk, InternalUsage
+
+
+def _chunk(**usage_kw):
+    return InternalStreamChunk(
+        id="x",
+        model="m",
+        created=1,
+        content="hi",
+        finish_reason="stop",
+        usage=InternalUsage(prompt_tokens=100, completion_tokens=10, total_tokens=110, **usage_kw),
+    )
+
+
+async def _collect(chunk):
+    async def gen():
+        yield chunk
+
+    out = []
+    async for line in OpenAIChatAdapter().from_internal_stream(gen()):
+        if line.startswith("data: ") and line[6:].strip() != "[DONE]":
+            out.append(json.loads(line[6:].strip()))
+    return out
+
+
+class TestStreamingCacheUsage:
+    """Billing already used these counts; the client could not see them.
+
+    Verified in production 2026-08-11: non-streaming reported
+    cache_creation_input_tokens=3201 while an identical streaming request
+    reported none. The charge was correct either way, so a caller was billed
+    the cache rate with no way to verify the saving.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cache_tokens_reach_the_sse_usage_chunk(self):
+        chunks = await _collect(_chunk(cache_read_input_tokens=900, cache_creation_input_tokens=50))
+        usage = [c for c in chunks if "usage" in c][0]["usage"]
+        assert usage["cache_read_input_tokens"] == 900
+        assert usage["cache_creation_input_tokens"] == 50
+        assert usage["prompt_tokens_details"]["cached_tokens"] == 900
+
+    @pytest.mark.asyncio
+    async def test_absent_cache_fields_are_not_invented(self):
+        chunks = await _collect(_chunk())
+        usage = [c for c in chunks if "usage" in c][0]["usage"]
+        assert "cache_read_input_tokens" not in usage
+
+    @pytest.mark.asyncio
+    async def test_core_token_counts_are_unchanged(self):
+        chunks = await _collect(_chunk(cache_read_input_tokens=900))
+        usage = [c for c in chunks if "usage" in c][0]["usage"]
+        assert usage["prompt_tokens"] == 100
+        assert usage["total_tokens"] == 110


### PR DESCRIPTION
A streaming request is charged the cache rate but shown **no cache tokens**.

Verified in production — identical prompt, same cache breakpoint:

```
stream=False: cache_creation_input_tokens=3201  read=0
stream=True:  cache_creation_input_tokens=None  read=None
```

## Billing was never wrong

`chat_handler` extracts the counts from the provider chunk and passes them to `_loss_proof_cost_split`, so streaming requests have been priced at cache rates correctly the whole time.

What was missing is the **report**. The counts were dropped in two places on the way back to the caller:

| where | what |
|---|---|
| `chat_handler` | `InternalStreamChunk.usage` built with three fields only |
| `adapters/chat/openai.py` | `from_internal_stream` serialised the same three |

#2207 added cache fields to `from_internal_response` and missed the streaming twin, so this asymmetry has existed since caching shipped.

## Why it matters more than a cosmetic gap

Coding agents stream. Streaming is precisely where the cost advantage has to be demonstrable, and a customer had no way to verify a saving they were already receiving.

It also explains the benchmark: the harness reads this field, measured zero cache activity, and **correctly refused to publish a cost-advantage claim**. That guard did its job — the data it was reading was simply absent.

## Verification

3 tests covering the SSE usage chunk, that absent cache fields are not invented, and that core token counts are unchanged.

Suite **2794 passed**; ruff, black, isort clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming chat responses now report prompt-cache usage, including cache reads, cache creation, and cached token details.
  * Streaming usage data now aligns with non-streaming responses while preserving existing token counts and billing behavior.

* **Bug Fixes**
  * Cache usage fields are omitted when no cache activity is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->