### PR TITLE
Auto-routing Phase 1: composed capability+cost+quality catalog query

### DIFF
--- a/src/db/models_catalog_db.py
+++ b/src/db/models_catalog_db.py
@@ -1469,6 +1469,140 @@ def get_models_by_category(
         return []
 
 
+@with_retry(**_CATALOG_DB_RETRY)
+def get_candidate_models(
+    required_capabilities: set[str] | frozenset[str] | None = None,
+    min_context_length: int | None = None,
+    quality_tier: str | None = None,
+    cost_ceiling: float | None = None,
+    limit: int = 200,
+) -> list[dict[str, Any]]:
+    """
+    Shortlist candidate models by capability, context length, quality tier and cost.
+
+    Composes existing catalog primitives rather than re-deriving them:
+      - `quality_tier` ("flagship"/"mid"/"budget") filters on the `categories`
+        tag already written by the nightly categorizer sync (see
+        `_sync_categories`). A model that hasn't been categorized yet is
+        excluded, not guessed at — same "missing data never fabricates a tag"
+        rule as `model_categorizer`.
+      - `required_capabilities` (any of {"tools", "vision", "caching"}) are
+        evaluated live per row via `model_capability_surface`, the same
+        convention used at query time in `routes/catalog.py` and
+        `pricing/pricing_lookup.py`.
+      - `cost_ceiling` is a completion-weighted blended $/1M-token price (the
+        same 0.25/0.75 input/output weights as the `cheapest` category rule),
+        computed from `model_pricing` rows fetched for the shortlisted rows.
+        Models with no known price never pass a cost ceiling.
+
+    Args:
+        required_capabilities: capability names the model must support, a
+            subset of {"tools", "vision", "caching"}. None/empty = no filter.
+        min_context_length: minimum context window in tokens. None = no filter.
+        quality_tier: one of "flagship" / "mid" / "budget". None = no filter.
+        cost_ceiling: max blended $ per 1M tokens. None = no filter.
+        limit: max rows to return after filtering.
+
+    Returns:
+        List of model dicts (with provider info), cheapest-first when
+        `cost_ceiling` is set. [] on error or no matches.
+    """
+    from src.services.model_capability_surface import (
+        supports_caching,
+        supports_tools,
+        supports_vision,
+    )
+
+    try:
+        supabase = get_client_for_query(read_only=True)
+        query = (
+            supabase.table("models")
+            .select("*, providers!inner(*)")
+            .eq("is_active", True)
+            .is_("deprecated_at", "null")
+        )
+        if quality_tier:
+            query = query.contains("categories", [quality_tier])
+        if min_context_length is not None:
+            query = query.gte("context_length", min_context_length)
+
+        # Over-fetch before capability/cost filtering trims the set, bounded
+        # well under SUPABASE_PAGE_SIZE so this stays a single-page query.
+        fetch_limit = min(max(limit * 5, limit), SUPABASE_PAGE_SIZE)
+        response = query.limit(fetch_limit).execute()
+        candidates = response.data or []
+
+        if required_capabilities:
+            capability_checks = {
+                "tools": supports_tools,
+                "vision": supports_vision,
+                "caching": supports_caching,
+            }
+            filtered = []
+            for model in candidates:
+                try:
+                    if all(
+                        capability_checks[name](model)
+                        for name in required_capabilities
+                        if name in capability_checks
+                    ):
+                        filtered.append(model)
+                except Exception as cap_err:
+                    logger.warning(
+                        f"Capability check failed for model {model.get('id')}: {cap_err}"
+                    )
+            candidates = filtered
+
+        if cost_ceiling is not None:
+            candidates = _filter_and_sort_by_cost(supabase, candidates, cost_ceiling)
+
+        return candidates[:limit]
+    except Exception as e:
+        logger.error(f"Error fetching candidate models: {e}")
+        return []
+
+
+def _filter_and_sort_by_cost(
+    supabase: Any, candidates: list[dict[str, Any]], cost_ceiling: float
+) -> list[dict[str, Any]]:
+    """Drop candidates above `cost_ceiling` and sort the rest cheapest-first.
+
+    Blended price uses the same 0.25 input / 0.75 output weighting as
+    `model_categorizer`'s `cheapest` rule. A model with no priced row in
+    `model_pricing` is excluded — unknown price never passes a ceiling.
+    """
+    ids = [m["id"] for m in candidates if m.get("id")]
+    if not ids:
+        return []
+
+    pricing_by_id: dict[Any, dict[str, float | None]] = {}
+    for i in range(0, len(ids), 500):
+        chunk = ids[i : i + 500]
+        resp = (
+            supabase.table("model_pricing")
+            .select("model_id, price_per_input_token, price_per_output_token")
+            .in_("model_id", chunk)
+            .execute()
+        )
+        for row in resp.data or []:
+            pricing_by_id[row["model_id"]] = {
+                "in": _to_float(row.get("price_per_input_token")),
+                "out": _to_float(row.get("price_per_output_token")),
+            }
+
+    priced: list[tuple[float, dict[str, Any]]] = []
+    for model in candidates:
+        price = pricing_by_id.get(model.get("id"))
+        if not price or (price.get("in") is None and price.get("out") is None):
+            continue
+        blended = ((price.get("in") or 0.0) * 0.25 + (price.get("out") or 0.0) * 0.75) * 1_000_000
+        if blended <= cost_ceiling:
+            priced.append((blended, model))
+
+    priced.sort(key=lambda pair: pair[0])
+    return [model for _, model in priced]
+
+
 def get_all_models_for_catalog(include_inactive: bool = False) -> list[dict[str, Any]]:
     """
     Get ALL models from database optimized for catalog building.

--- a/src/db/models_catalog_db.py
+++ b/src/db/models_catalog_db.py
@@ -1495,6 +1495,12 @@ def get_candidate_models(
         computed from `model_pricing` rows fetched for the shortlisted rows.
         Models with no known price never pass a cost ceiling.
 
+    An unrecognized `required_capabilities` name fails closed (returns no
+    candidates, with a logged warning) rather than silently matching every
+    model. Because rows are over-fetched then filtered in Python, a very
+    selective filter combination can return fewer than `limit` rows even when
+    more matches exist deeper in the catalog.
+
     Args:
         required_capabilities: capability names the model must support, a
             subset of {"tools", "vision", "caching"}. None/empty = no filter.
@@ -1538,20 +1544,28 @@ def get_candidate_models(
                 "vision": supports_vision,
                 "caching": supports_caching,
             }
-            filtered = []
-            for model in candidates:
-                try:
-                    if all(
-                        capability_checks[name](model)
-                        for name in required_capabilities
-                        if name in capability_checks
-                    ):
-                        filtered.append(model)
-                except Exception as cap_err:
-                    logger.warning(
-                        f"Capability check failed for model {model.get('id')}: {cap_err}"
-                    )
-            candidates = filtered
+            unknown = set(required_capabilities) - capability_checks.keys()
+            if unknown:
+                # An unrecognized capability name can never be verified as
+                # satisfied — fail closed rather than silently matching every
+                # model (an empty `all()` over zero known checks is True).
+                logger.warning(
+                    f"get_candidate_models: unknown required_capabilities {sorted(unknown)}; "
+                    "no candidates can satisfy them"
+                )
+                candidates = []
+            else:
+                checks = [capability_checks[name] for name in required_capabilities]
+                filtered = []
+                for model in candidates:
+                    try:
+                        if all(check(model) for check in checks):
+                            filtered.append(model)
+                    except Exception as cap_err:
+                        logger.warning(
+                            f"Capability check failed for model {model.get('id')}: {cap_err}"
+                        )
+                candidates = filtered
 
         if cost_ceiling is not None:
             candidates = _filter_and_sort_by_cost(supabase, candidates, cost_ceiling)

--- a/src/services/capability_requirements.py
+++ b/src/services/capability_requirements.py
@@ -1,0 +1,105 @@
+"""
+Capability Requirements.
+
+Derives what a chat request needs from a model — tool support, vision, JSON
+mode, a rough input-token estimate — purely from the request shape (messages,
+tools, response_format). No I/O, no catalog lookups; the output plugs directly
+into `models_catalog_db.get_candidate_models(required_capabilities=...)`.
+
+This replaces the extraction half of the deleted D2 auto-router's
+`capability_gating.py` (removed in commit e94e095c along with the rest of that
+cluster). It is a fresh, self-contained module rather than a revival: the
+original imported `ModelCapabilities`/`RequiredCapabilities` from
+`schemas/router.py`, which was deleted separately and would otherwise have to
+be resurrected just for its types.
+
+Key properties:
+  * `extract_required_capabilities()` is PURE and deterministic — no I/O,
+    fully unit-testable.
+  * Vision detection recognizes both OpenAI-style (`type: "image_url"`) and
+    Anthropic-style (`type: "image"`) content blocks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RequiredCapabilities:
+    """What one chat request needs from a model."""
+
+    # Subset of {"tools", "vision"} — feeds directly into
+    # get_candidate_models(required_capabilities=...).
+    capability_names: frozenset[str] = field(default_factory=frozenset)
+    needs_json: bool = False
+    estimated_input_tokens: int = 0
+    max_cost_per_1k: float | None = None
+
+
+def _has_image_content(messages: list[dict[str, Any]] | None) -> bool:
+    """True if any message contains an image content block.
+
+    Recognizes OpenAI's `{"type": "image_url", ...}` and Anthropic's
+    `{"type": "image", "source": {...}}` shapes.
+    """
+    for message in messages or []:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            if part.get("type") in ("image", "image_url"):
+                return True
+    return False
+
+
+def _estimate_input_tokens(messages: list[dict[str, Any]] | None) -> int:
+    """Rough ~4-chars-per-token estimate, used only to gate long-context routing."""
+    total_chars = 0
+    for message in messages or []:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if isinstance(content, str):
+            total_chars += len(content)
+        elif isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and isinstance(part.get("text"), str):
+                    total_chars += len(part["text"])
+    return total_chars // 4
+
+
+def extract_required_capabilities(
+    messages: list[dict[str, Any]] | None,
+    tools: list[dict[str, Any]] | None = None,
+    response_format: dict[str, Any] | None = None,
+    max_cost_per_1k: float | None = None,
+) -> RequiredCapabilities:
+    """Derive `RequiredCapabilities` from raw chat-request fields.
+
+    Args:
+        messages: the request's message list (OpenAI or Anthropic shape).
+        tools: the request's tool/function definitions, if any.
+        response_format: the request's response_format field, if any.
+        max_cost_per_1k: caller-supplied cost ceiling to pass through.
+
+    Returns:
+        A `RequiredCapabilities` describing what a candidate model must support.
+    """
+    capability_names: set[str] = set()
+    if tools:
+        capability_names.add("tools")
+    if _has_image_content(messages):
+        capability_names.add("vision")
+
+    return RequiredCapabilities(
+        capability_names=frozenset(capability_names),
+        needs_json=bool(response_format),
+        estimated_input_tokens=_estimate_input_tokens(messages),
+        max_cost_per_1k=max_cost_per_1k,
+    )

--- a/tests/db/test_models_catalog_db.py
+++ b/tests/db/test_models_catalog_db.py
@@ -82,6 +82,20 @@ def test_min_context_length_applies_gte_filter(sb):
     models_query.gte.assert_called_once_with("context_length", 128_000)
 
 
+def test_unknown_required_capability_fails_closed(sb):
+    """A typo'd/unknown capability name must exclude everything, not match
+    everything (an `all()` over zero known checks would otherwise be True)."""
+    fake_rows = [{"id": 1, "model_name": "a"}, {"id": 2, "model_name": "b"}]
+    client, _, _ = _mock_client_for(fake_rows)
+
+    with patch("src.db.models_catalog_db.get_client_for_query", return_value=client):
+        from src.db.models_catalog_db import get_candidate_models
+
+        result = get_candidate_models(required_capabilities={"not_a_real_capability"})
+
+    assert result == []
+
+
 def test_required_capabilities_filters_out_non_matching_models(sb):
     fake_rows = [
         {"id": 1, "model_name": "tool-model", "supports_tools": True},

--- a/tests/db/test_models_catalog_db.py
+++ b/tests/db/test_models_catalog_db.py
@@ -1,0 +1,161 @@
+"""Tests for get_candidate_models (gatewayz-backend#2212).
+
+Pure unit tests against a fully mocked Supabase client — no real DB.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def sb():
+    """No-op fixture whose mere presence bypasses the autouse DB-skip in
+    tests/conftest.py — this is a pure unit test with everything mocked, so
+    we do not need a real Supabase connection."""
+    return None
+
+
+def _chainable_query_mock(execute_return):
+    """A MagicMock whose builder methods (eq/is_/contains/gte/limit/...) all
+    return itself, so any chain order terminates in `.execute()`."""
+    query = MagicMock()
+    for method in ("select", "eq", "is_", "contains", "gte", "limit", "in_"):
+        getattr(query, method).return_value = query
+    query.execute.return_value = execute_return
+    return query
+
+
+def _mock_client_for(models_data, pricing_data=None):
+    models_query = _chainable_query_mock(MagicMock(data=models_data))
+    pricing_query = _chainable_query_mock(MagicMock(data=pricing_data or []))
+
+    def table_side_effect(name):
+        if name == "models":
+            return models_query
+        if name == "model_pricing":
+            return pricing_query
+        raise AssertionError(f"unexpected table: {name}")
+
+    client = MagicMock()
+    client.table.side_effect = table_side_effect
+    return client, models_query, pricing_query
+
+
+def test_no_filters_returns_active_models(sb):
+    fake_rows = [{"id": 1, "model_name": "a"}, {"id": 2, "model_name": "b"}]
+    client, models_query, _ = _mock_client_for(fake_rows)
+
+    with patch("src.db.models_catalog_db.get_client_for_query", return_value=client):
+        from src.db.models_catalog_db import get_candidate_models
+
+        result = get_candidate_models()
+
+    assert result == fake_rows
+    models_query.contains.assert_not_called()
+    models_query.gte.assert_not_called()
+
+
+def test_quality_tier_filters_via_categories_contains(sb):
+    fake_rows = [{"id": 1, "model_name": "flagship-model"}]
+    client, models_query, _ = _mock_client_for(fake_rows)
+
+    with patch("src.db.models_catalog_db.get_client_for_query", return_value=client):
+        from src.db.models_catalog_db import get_candidate_models
+
+        result = get_candidate_models(quality_tier="flagship")
+
+    assert result == fake_rows
+    models_query.contains.assert_called_once_with("categories", ["flagship"])
+
+
+def test_min_context_length_applies_gte_filter(sb):
+    fake_rows = [{"id": 1, "model_name": "long-ctx", "context_length": 200_000}]
+    client, models_query, _ = _mock_client_for(fake_rows)
+
+    with patch("src.db.models_catalog_db.get_client_for_query", return_value=client):
+        from src.db.models_catalog_db import get_candidate_models
+
+        result = get_candidate_models(min_context_length=128_000)
+
+    assert result == fake_rows
+    models_query.gte.assert_called_once_with("context_length", 128_000)
+
+
+def test_required_capabilities_filters_out_non_matching_models(sb):
+    fake_rows = [
+        {"id": 1, "model_name": "tool-model", "supports_tools": True},
+        {"id": 2, "model_name": "no-tools-model", "supports_tools": False},
+    ]
+    client, _, _ = _mock_client_for(fake_rows)
+
+    with patch("src.db.models_catalog_db.get_client_for_query", return_value=client):
+        from src.db.models_catalog_db import get_candidate_models
+
+        result = get_candidate_models(required_capabilities={"tools"})
+
+    assert [m["id"] for m in result] == [1]
+
+
+def test_required_capabilities_falls_back_to_family_heuristic(sb):
+    """No explicit flag on the row -> model_capability_surface's family match decides."""
+    fake_rows = [
+        {"id": "anthropic/claude-3-opus", "model_name": "claude-3-opus"},
+        {"id": "some-provider/unknown-model", "model_name": "unknown-model"},
+    ]
+    client, _, _ = _mock_client_for(fake_rows)
+
+    with patch("src.db.models_catalog_db.get_client_for_query", return_value=client):
+        from src.db.models_catalog_db import get_candidate_models
+
+        result = get_candidate_models(required_capabilities={"vision"})
+
+    assert [m["id"] for m in result] == ["anthropic/claude-3-opus"]
+
+
+def test_cost_ceiling_excludes_expensive_and_unpriced_then_sorts_cheapest_first(sb):
+    fake_rows = [
+        {"id": 1, "model_name": "expensive"},
+        {"id": 2, "model_name": "cheap"},
+        {"id": 3, "model_name": "unpriced"},
+    ]
+    pricing_rows = [
+        # blended = 10*0.25 + 30*0.75 = 25 (per-token, *1e6 applied in code)
+        {"model_id": 1, "price_per_input_token": 0.00001, "price_per_output_token": 0.00003},
+        # blended = 1*0.25 + 2*0.75 = 1.75
+        {"model_id": 2, "price_per_input_token": 0.000001, "price_per_output_token": 0.000002},
+        # id 3 has no pricing row at all
+    ]
+    client, _, pricing_query = _mock_client_for(fake_rows, pricing_rows)
+
+    with patch("src.db.models_catalog_db.get_client_for_query", return_value=client):
+        from src.db.models_catalog_db import get_candidate_models
+
+        result = get_candidate_models(cost_ceiling=20.0)
+
+    assert [m["id"] for m in result] == [2]
+    pricing_query.in_.assert_called_once_with("model_id", [1, 2, 3])
+
+
+def test_limit_caps_returned_rows(sb):
+    fake_rows = [{"id": i, "model_name": f"m{i}"} for i in range(5)]
+    client, _, _ = _mock_client_for(fake_rows)
+
+    with patch("src.db.models_catalog_db.get_client_for_query", return_value=client):
+        from src.db.models_catalog_db import get_candidate_models
+
+        result = get_candidate_models(limit=2)
+
+    assert len(result) == 2
+
+
+def test_returns_empty_list_on_error(sb):
+    client = MagicMock()
+    client.table.side_effect = RuntimeError("boom")
+
+    with patch("src.db.models_catalog_db.get_client_for_query", return_value=client):
+        from src.db.models_catalog_db import get_candidate_models
+
+        result = get_candidate_models()
+
+    assert result == []

--- a/tests/services/test_capability_requirements.py
+++ b/tests/services/test_capability_requirements.py
@@ -1,0 +1,112 @@
+"""Tests for src.services.capability_requirements (gatewayz-backend#2212)."""
+
+from src.services.capability_requirements import (
+    RequiredCapabilities,
+    extract_required_capabilities,
+)
+
+
+def test_no_tools_no_images_yields_no_capability_names():
+    result = extract_required_capabilities(messages=[{"role": "user", "content": "hi"}])
+
+    assert result.capability_names == frozenset()
+    assert result.needs_json is False
+
+
+def test_tools_present_requires_tools_capability():
+    result = extract_required_capabilities(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[{"type": "function", "function": {"name": "get_weather"}}],
+    )
+
+    assert "tools" in result.capability_names
+
+
+def test_empty_tools_list_does_not_require_tools_capability():
+    result = extract_required_capabilities(messages=[], tools=[])
+
+    assert "tools" not in result.capability_names
+
+
+def test_openai_style_image_url_requires_vision_capability():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "what is this?"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/x.png"}},
+            ],
+        }
+    ]
+
+    result = extract_required_capabilities(messages=messages)
+
+    assert "vision" in result.capability_names
+
+
+def test_anthropic_style_image_block_requires_vision_capability():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "what is this?"},
+                {
+                    "type": "image",
+                    "source": {"type": "base64", "media_type": "image/png", "data": "abc"},
+                },
+            ],
+        }
+    ]
+
+    result = extract_required_capabilities(messages=messages)
+
+    assert "vision" in result.capability_names
+
+
+def test_plain_string_content_does_not_require_vision():
+    result = extract_required_capabilities(messages=[{"role": "user", "content": "just text"}])
+
+    assert "vision" not in result.capability_names
+
+
+def test_response_format_sets_needs_json():
+    result = extract_required_capabilities(messages=[], response_format={"type": "json_object"})
+
+    assert result.needs_json is True
+
+
+def test_estimates_input_tokens_from_string_content():
+    result = extract_required_capabilities(messages=[{"role": "user", "content": "a" * 400}])
+
+    assert result.estimated_input_tokens == 100
+
+
+def test_estimates_input_tokens_from_multipart_text_blocks():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "a" * 40},
+                {"type": "text", "text": "b" * 40},
+            ],
+        }
+    ]
+
+    result = extract_required_capabilities(messages=messages)
+
+    assert result.estimated_input_tokens == 20
+
+
+def test_max_cost_per_1k_passes_through_unchanged():
+    result = extract_required_capabilities(messages=[], max_cost_per_1k=0.5)
+
+    assert result.max_cost_per_1k == 0.5
+
+
+def test_malformed_messages_do_not_raise():
+    messages = [None, "not-a-dict", {"role": "user", "content": [None, {"no_type": True}]}]
+
+    result = extract_required_capabilities(messages=messages)
+
+    assert isinstance(result, RequiredCapabilities)
+    assert result.capability_names == frozenset()


### PR DESCRIPTION
## Summary
- Adds `get_candidate_models()` (+ `_filter_and_sort_by_cost` helper) to `src/db/models_catalog_db.py`, composing existing catalog primitives — `categories` tier tags, `model_capability_surface`, `model_pricing` — into a single capability+cost+quality shortlist query, instead of re-deriving quality/tier scoring.
- Adds `src/services/capability_requirements.py`, a fresh (non-revived) module deriving what a chat request needs from a model (tools/vision/JSON/token estimate) purely from message shape — replaces the extraction half of the deleted D2 auto-router's `capability_gating.py`, and fixes that file's dead redundant vision-detection branch in the process.
- Fail-closed fix from self-review: an unrecognized/typo'd `required_capabilities` name previously matched every model (`all()` over zero known checks is `True`); now returns no candidates with a logged warning.

Closes #2212. Phase 1 of the auto-routing backlog (#2212–#2216) — catalog/DB layer only, no wiring into `chat.py`/`chat_request.py`/`chat_routing.py`.

## Test plan
- [x] `pytest tests/db/test_models_catalog_db.py tests/services/test_capability_requirements.py` — 20/20 passing (new)
- [x] `pytest tests/services/test_model_capability_surface.py tests/services/test_model_categorizer.py tests/services/test_quality_inference.py tests/db/test_models_catalog_db_cache.py tests/db/test_unique_models_catalog.py` — 77/77 passing (no regressions)
- [x] `ruff check` / `black --check` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automatic model selection based on request capabilities, including tool use, image understanding, and structured JSON responses.
  * Model matching now considers context length, quality tier, pricing limits, and supported capabilities.
  * Eligible models are prioritized by estimated cost, while unavailable or unsupported options are excluded.
  * Added input-size estimation to help select models appropriate for larger requests.
* **Reliability**
  * Improved handling of malformed requests, unknown capabilities, missing pricing, and model lookup errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->