### PR TITLE
Add Meta Model API (Muse Spark) as a new provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,11 @@ NOSANA_BASE_URL=https://dashboard.k8s.prd.nos.ci/api
 # Documentation: https://docs.z.ai
 ZAI_API_KEY=your-zai-api-key
 
+# Meta Model API Configuration (Muse Spark model family)
+# Get API key from: https://dev.meta.ai
+# Documentation: https://dev.meta.ai/docs/api-reference
+META_API_KEY=your-meta-model-api-key
+
 # Helicone AI Gateway Configuration (for LLM observability & logging)
 # Get your API key from: https://helicone.ai/developer
 # Helicone provides request logging, caching, rate limiting, and analytics

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -307,6 +307,9 @@ class Config:
     # Xiaomi MiMo Configuration (MiMo model family)
     XIAOMI_API_KEY = os.environ.get("XIAOMI_API_KEY")
 
+    # Meta Llama API Configuration (Llama model family, OpenAI-compatible)
+    META_API_KEY = os.environ.get("META_API_KEY")
+
     # Soundsgood Configuration (GLM-4.5-Air distilled model)
     SOUNDSGOOD_API_KEY = os.environ.get("SOUNDSGOOD_API_KEY")
 

--- a/src/handlers/provider_registry.py
+++ b/src/handlers/provider_registry.py
@@ -225,6 +225,7 @@ PROVIDER_ROUTING: dict[str, ProviderRouting] = {
     "moonshot": _safe_adapter_routing("moonshot"),
     "minimax": _safe_adapter_routing("minimax"),
     "xiaomi": _safe_adapter_routing("xiaomi"),
+    "meta": _safe_adapter_routing("meta"),
 }
 
 # Strip disabled providers from routing so they are completely unreachable

--- a/src/services/model_catalog_sync.py
+++ b/src/services/model_catalog_sync.py
@@ -23,6 +23,7 @@ from src.services.providers.featherless_client import fetch_models_from_featherl
 from src.services.providers.fireworks_catalog import fetch_models_from_fireworks
 from src.services.providers.google_vertex_catalog import fetch_models_from_google_vertex
 from src.services.providers.groq_catalog import fetch_models_from_groq
+from src.services.providers.meta_catalog import fetch_models_from_meta
 from src.services.providers.minimax_catalog import fetch_models_from_minimax
 from src.services.providers.moonshot_catalog import fetch_models_from_moonshot
 from src.services.providers.novita_client import fetch_models_from_novita
@@ -75,6 +76,7 @@ PROVIDER_FETCH_FUNCTIONS = _FALLBACK_FETCH_FUNCTIONS = {
     "moonshot": fetch_models_from_moonshot,
     "minimax": fetch_models_from_minimax,
     "xiaomi": fetch_models_from_xiaomi,
+    "meta": fetch_models_from_meta,
 }
 
 

--- a/src/services/providers/adapter_configs.py
+++ b/src/services/providers/adapter_configs.py
@@ -116,6 +116,20 @@ ADAPTER_CONFIGS: dict[str, ProviderConfig] = {
         api_key_env="XIAOMI_API_KEY",
         display_name="Xiaomi MiMo",
     ),
+    # Meta Model API — serves the Muse Spark model family, OpenAI-compatible.
+    # Verified live: GET /v1/models and POST /v1/chat/completions both
+    # succeed with a real key (https://dev.meta.ai/docs/api-reference).
+    # Note: this is a distinct product from Meta's older Llama API
+    # (llama.developer.meta.com / api.llama.com) — do not confuse the two.
+    "meta": ProviderConfig(
+        slug="meta",
+        base_url="https://api.meta.ai/v1",
+        api_key_env="META_API_KEY",
+        display_name="Meta",
+        # Catalog stores ids as "meta/muse-spark-1.1"; Meta's API expects the
+        # bare model name. Strip the slug prefix before the upstream call.
+        model_prefix="meta/",
+    ),
 }
 
 ADAPTERS: dict[str, OpenAICompatAdapter] = {

--- a/src/services/providers/meta_catalog.py
+++ b/src/services/providers/meta_catalog.py
@@ -1,0 +1,132 @@
+"""Meta Model API model-catalog functions (fetch + normalize).
+
+Minimal httpx fetcher for Meta's OpenAI-compatible ``/models`` endpoint
+(Muse Spark model family — https://dev.meta.ai/docs/api-reference),
+following the pattern of the other Tier-2 ``<slug>_catalog.py`` modules
+(e.g. ``deepseek_catalog.py``). Meta's ``/models`` response does not include
+pricing or context_length, so both are left conservatively unset / defaulted
+rather than guessed — the pricing pipeline gates unpriced models
+automatically (see ``src/services/pricing/pricing_lookup.py``).
+"""
+
+import logging
+
+import httpx
+
+from src.config import Config
+from src.services.model_catalog_cache import cache_gateway_catalog
+from src.utils.model_name_validator import clean_model_name
+from src.utils.security_validators import sanitize_for_logging
+
+logger = logging.getLogger(__name__)
+
+MODALITY_TEXT_TO_TEXT = "text->text"
+
+
+def normalize_meta_model(meta_model: dict) -> dict | None:
+    """Normalize Meta catalog entries to resemble the OpenRouter model shape."""
+    from src.services.pricing_lookup import enrich_model_with_pricing
+
+    provider_model_id = meta_model.get("id")
+    if not provider_model_id:
+        return {"source_gateway": "meta", "raw_meta": meta_model or {}}
+
+    slug = f"meta/{provider_model_id}"
+    provider_slug = "meta"
+
+    display_name = clean_model_name(provider_model_id.replace("-", " ").replace("_", " ").title())
+    owned_by = meta_model.get("owned_by", "meta")
+    description = f"Meta model {provider_model_id}, provided by {owned_by}."
+
+    # Meta's compat /models endpoint does not return context_length or pricing.
+    context_length = meta_model.get("context_length") or 0
+
+    pricing = {
+        "prompt": None,
+        "completion": None,
+        "request": None,
+        "image": None,
+        "web_search": None,
+        "internal_reasoning": None,
+    }
+
+    architecture = {
+        "modality": MODALITY_TEXT_TO_TEXT,
+        "input_modalities": ["text"],
+        "output_modalities": ["text"],
+        "tokenizer": None,
+        "instruct_type": None,
+    }
+
+    normalized = {
+        "id": slug,
+        "slug": slug,
+        "canonical_slug": slug,
+        "hugging_face_id": None,
+        "name": display_name,
+        "created": meta_model.get("created"),
+        "description": description,
+        "context_length": context_length,
+        "architecture": architecture,
+        "pricing": pricing,
+        "per_request_limits": None,
+        "supported_parameters": [],
+        "default_parameters": {},
+        "provider_slug": provider_slug,
+        "provider_site_url": "https://meta.com",
+        "model_logo_url": None,
+        "source_gateway": "meta",
+        "raw_meta": meta_model,
+    }
+
+    return enrich_model_with_pricing(normalized, "meta")
+
+
+def fetch_models_from_meta():
+    """Fetch models from Meta's OpenAI-compatible Model API and normalize them."""
+    from src.services.gateway_health_service import clear_gateway_error, set_gateway_error
+
+    try:
+        if not Config.META_API_KEY:
+            logger.error("Meta API key not configured")
+            return None
+
+        headers = {
+            "Authorization": f"Bearer {Config.META_API_KEY}",
+            "Content-Type": "application/json",
+        }
+
+        url = "https://api.meta.ai/v1/models"
+        logger.info("Fetching models from Meta Model API")
+
+        response = httpx.get(url, headers=headers, timeout=20.0)
+        response.raise_for_status()
+
+        payload = response.json()
+        raw_models = payload.get("data", [])
+
+        logger.info(f"Fetched {len(raw_models)} models from Meta")
+
+        normalized_models = [
+            norm_model
+            for model in raw_models
+            if model
+            for norm_model in [normalize_meta_model(model)]
+            if norm_model is not None
+        ]
+
+        cache_gateway_catalog("meta", normalized_models)
+        clear_gateway_error("meta")
+
+        logger.info(f"Successfully cached {len(normalized_models)} Meta models")
+        return normalized_models
+    except httpx.HTTPStatusError as e:
+        error_msg = f"HTTP {e.response.status_code} - {sanitize_for_logging(e.response.text)}"
+        logger.error("Meta HTTP error: %s", error_msg)
+        set_gateway_error("meta", error_msg)
+        return None
+    except Exception as e:
+        error_msg = sanitize_for_logging(str(e))
+        logger.error("Failed to fetch models from Meta: %s", error_msg)
+        set_gateway_error("meta", error_msg)
+        return None

--- a/tests/services/providers/test_openai_compat.py
+++ b/tests/services/providers/test_openai_compat.py
@@ -370,9 +370,9 @@ class TestAdapterRegistry:
     def test_contains_exactly_the_known_adapter_slugs(self):
         """ADAPTERS is an exact-set drift guard over the full known roster.
 
-        Five Tier-1 consolidated providers plus four Tier-2 providers added
-        in Task 18 (deepseek, moonshot, minimax, xiaomi — see
-        tests/services/providers/test_tier2_adapters.py). Any new adapter
+        Five Tier-1 consolidated providers plus five Tier-2 providers added
+        in Task 18 / Meta wiring (deepseek, moonshot, minimax, xiaomi, meta —
+        see tests/services/providers/test_tier2_adapters.py). Any new adapter
         slug, or the removal of one, must update this assertion deliberately
         rather than silently widen/narrow it.
         """
@@ -388,6 +388,7 @@ class TestAdapterRegistry:
             "moonshot",
             "minimax",
             "xiaomi",
+            "meta",
         }
 
     def test_all_entries_satisfy_protocol(self):

--- a/tests/services/providers/test_tier2_adapters.py
+++ b/tests/services/providers/test_tier2_adapters.py
@@ -19,7 +19,7 @@ from src.config import Config
 from src.services.providers.base import ProviderAdapter
 from src.services.providers.openai_compat import OpenAICompatAdapter
 
-TIER2_SLUGS = ["deepseek", "moonshot", "minimax", "xiaomi"]
+TIER2_SLUGS = ["deepseek", "moonshot", "minimax", "xiaomi", "meta"]
 
 # slug -> (base_url, api_key_env, error_match)
 EXPECTED_CONFIG = {
@@ -42,6 +42,11 @@ EXPECTED_CONFIG = {
         "https://api.xiaomimimo.com/v1",
         "XIAOMI_API_KEY",
         "Xiaomi MiMo API key not configured",
+    ),
+    "meta": (
+        "https://api.meta.ai/v1",
+        "META_API_KEY",
+        "Meta API key not configured",
     ),
 }
 
@@ -226,7 +231,13 @@ class TestTier2RequestTargeting:
 class TestTier2ConfigEnvVars:
     @pytest.mark.parametrize(
         "attr",
-        ["DEEPSEEK_API_KEY", "MOONSHOT_API_KEY", "MINIMAX_API_KEY", "XIAOMI_API_KEY"],
+        [
+            "DEEPSEEK_API_KEY",
+            "MOONSHOT_API_KEY",
+            "MINIMAX_API_KEY",
+            "XIAOMI_API_KEY",
+            "META_API_KEY",
+        ],
     )
     def test_config_has_attribute(self, attr):
         assert hasattr(Config, attr), f"Config.{attr} not defined"

--- a/tests/services/test_provider_contract.py
+++ b/tests/services/test_provider_contract.py
@@ -34,10 +34,11 @@ def test_every_provider_declares_a_full_trio():
     #     alibaba_cloud, openai, anthropic (+ openrouter as fallback,
     #     injected separately)
     #   adapter-served (Tier-1): deepinfra, together, fireworks, groq, zai
-    #   adapter-served (Tier-2, Task 18): deepseek, moonshot, minimax, xiaomi
+    #   adapter-served (Tier-2, Task 18 + Meta): deepseek, moonshot, minimax,
+    #     xiaomi, meta
     assert len(PROVIDER_FUNCTIONS) >= 7, "expected ~8 bespoke MVP-roster providers declared"
     # Exact-set drift guard: ADAPTERS must be precisely the five Tier-1
-    # consolidated providers plus the four Tier-2 providers from Task 18 —
+    # consolidated providers plus the five Tier-2 providers (Task 18 + Meta) —
     # not merely a superset. Adding/removing an adapter slug must update
     # this assertion deliberately.
     assert set(ADAPTERS) == {
@@ -50,10 +51,11 @@ def test_every_provider_declares_a_full_trio():
         "moonshot",
         "minimax",
         "xiaomi",
+        "meta",
     }
     assert (
-        len(PROVIDER_FUNCTIONS) + len(ADAPTERS) >= 12
-    ), "expected ~13 MVP-roster providers declared across bespoke + adapter"
+        len(PROVIDER_FUNCTIONS) + len(ADAPTERS) >= 13
+    ), "expected ~14 MVP-roster providers declared across bespoke + adapter"
     assert not (set(PROVIDER_FUNCTIONS) & set(ADAPTERS)), "provider declared in both registries"
     for slug, fns in PROVIDER_FUNCTIONS.items():
         has_process = any(f.startswith("process_") for f in fns)


### PR DESCRIPTION
## Summary
- Wires in Meta's Model API (Muse Spark model family, `https://api.meta.ai/v1`, OpenAI-compatible) as a new provider, following the existing Tier-2 config-driven adapter pattern (deepseek/moonshot/minimax/xiaomi).
- Adds `Config.META_API_KEY`, an `ADAPTER_CONFIGS["meta"]` entry, `PROVIDER_ROUTING["meta"]`, and `src/services/providers/meta_catalog.py` for catalog sync.
- Matching test coverage added/updated in `test_tier2_adapters.py`, `test_openai_compat.py`, `test_provider_contract.py`.

## Test plan
- [x] `pytest tests/services/providers/ tests/services/test_provider_contract.py` — 205 passed
- [x] Live smoke test through the actual wired adapter (`ADAPTERS["meta"].request(...)`) — got a real 200 + completion from `api.meta.ai`
- [ ] Set `META_API_KEY` and add `meta` to `ENABLED_PROVIDERS` in the production Railway environment (not part of this PR — separate deploy config step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Meta as a supported model provider.
  * Added Meta model discovery through its compatible API.
  * Added model catalog normalization, pricing enrichment, caching, and error handling.
  * Added configuration support for the Meta API key.

* **Tests**
  * Expanded provider, adapter, registry, and catalog coverage to include Meta.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->