### PR TITLE
Auto-routing Phase 3: model selection/scoring engine (shadow-mode only)

### DIFF
--- a/src/db/models_catalog_db.py
+++ b/src/db/models_catalog_db.py
@@ -1576,20 +1576,14 @@ def get_candidate_models(
         return []
 
 
-def _filter_and_sort_by_cost(
-    supabase: Any, candidates: list[dict[str, Any]], cost_ceiling: float
-) -> list[dict[str, Any]]:
-    """Drop candidates above `cost_ceiling` and sort the rest cheapest-first.
+def get_model_pricing_by_ids(supabase: Any, ids: list[Any]) -> dict[Any, dict[str, float | None]]:
+    """Normalized per-token pricing for a set of `models.id` values.
 
-    Blended price uses the same 0.25 input / 0.75 output weighting as
-    `model_categorizer`'s `cheapest` rule. A model with no priced row in
-    `model_pricing` is excluded — unknown price never passes a ceiling.
+    Returns {model_id: {"in": price_per_input_token, "out": price_per_output_token}},
+    both possibly None when unpriced. Missing ids are simply absent from the result.
     """
-    ids = [m["id"] for m in candidates if m.get("id")]
-    if not ids:
-        return []
-
     pricing_by_id: dict[Any, dict[str, float | None]] = {}
+    ids = [i for i in ids if i]
     for i in range(0, len(ids), 500):
         chunk = ids[i : i + 500]
         resp = (
@@ -1603,6 +1597,23 @@ def _filter_and_sort_by_cost(
                 "in": _to_float(row.get("price_per_input_token")),
                 "out": _to_float(row.get("price_per_output_token")),
             }
+    return pricing_by_id
+
+
+def _filter_and_sort_by_cost(
+    supabase: Any, candidates: list[dict[str, Any]], cost_ceiling: float
+) -> list[dict[str, Any]]:
+    """Drop candidates above `cost_ceiling` and sort the rest cheapest-first.
+
+    Blended price uses the same 0.25 input / 0.75 output weighting as
+    `model_categorizer`'s `cheapest` rule. A model with no priced row in
+    `model_pricing` is excluded — unknown price never passes a ceiling.
+    """
+    ids = [m["id"] for m in candidates if m.get("id")]
+    if not ids:
+        return []
+
+    pricing_by_id = get_model_pricing_by_ids(supabase, ids)
 
     priced: list[tuple[float, dict[str, Any]]] = []
     for model in candidates:

--- a/src/services/model_selector.py
+++ b/src/services/model_selector.py
@@ -1,0 +1,249 @@
+"""
+Model Selector.
+
+Picks/ranks the actual model to route to, given a candidate shortlist
+(Phase 1's `get_candidate_models`) and a task classification (Phase 2's
+`classify_task`). Revives the scoring formula and MD5-hash sticky/hysteresis
+design from the deleted `src/services/model_selector.py` (commit `e94e095c`),
+but sources quality from the real DB-backed
+`model_capabilities_cache.get_quality_priors()` instead of a hardcoded table,
+and cost from `get_model_pricing_by_ids()` instead of a `ModelCapabilities`
+schema object (that schema, `schemas/router.py`, was deleted separately and
+is not revived here — see gatewayz-backend#2214).
+
+Shadow-mode only: this module scores/selects but is not wired into any live
+request path yet. `log_shadow_selection()` gives a caller a structured way to
+record what this engine would have chosen, without changing behavior.
+
+Not to be confused with `Config.SMART_ROUTER_POLICY` (`src/config/config.py`),
+which governs PROVIDER choice for an already-chosen model, one layer below
+this. The optimization modes here (price/quality/fast/balanced) are a
+separate, model-choice-level concept that happens to share the same four names.
+
+Key properties:
+  * `select_model()` is deterministic given the same inputs + conversation_id.
+  * Sticky routing: the same (conversation_id, task_type) always resolves to
+    the same model among near-top-scorers (within `HYSTERESIS_THRESHOLD`
+    points), so a multi-turn conversation doesn't flip models on score noise.
+  * The deleted formula's realtime retry/format-failure penalty is
+    deliberately OMITTED — no data source for it exists anywhere in this
+    codebase (it was in-memory-only in the deleted version, and there is no
+    live traffic through this engine yet to observe outcomes from). A later
+    phase that wires live traffic is the natural place to add it.
+  * Never raises: pricing/quality lookup failures degrade to neutral default
+    scores rather than blocking selection.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from src.config.supabase_config import get_client_for_query
+from src.db.models_catalog_db import get_model_pricing_by_ids
+from src.services.cache.model_capabilities_cache import get_quality_priors
+from src.services.task_classifier import TaskClassification
+
+logger = logging.getLogger(__name__)
+
+OptimizationMode = Literal["price", "quality", "fast", "balanced"]
+
+# Any candidate scoring within this many points of the top score is treated
+# as a near-tie; sticky routing picks deterministically among that cluster
+# rather than always taking the single top scorer.
+HYSTERESIS_THRESHOLD = 5.0
+
+# Cost-tier lookup: $/1k input tokens -> score. Mirrors the deleted formula.
+_COST_TIER_THRESHOLDS: tuple[tuple[float, float], ...] = (
+    (0.0001, 95.0),
+    (0.0005, 85.0),
+    (0.001, 75.0),
+    (0.005, 60.0),
+    (0.01, 45.0),
+    (0.05, 30.0),
+)
+_COST_SCORE_FLOOR = 15.0
+_COST_SCORE_DEFAULT = 50.0
+_QUALITY_SCORE_DEFAULT = 50.0
+_PREFERRED_MODEL_BOOST = 3.0
+
+_WEIGHTS: dict[OptimizationMode, tuple[float, float]] = {
+    # (quality_weight, cost_weight)
+    "price": (0.3, 0.7),
+    "quality": (0.8, 0.2),
+    "fast": (0.4, 0.6),
+    "balanced": (0.5, 0.5),
+}
+
+
+@dataclass(frozen=True)
+class ModelSelection:
+    """The chosen model + why, for one selection call."""
+
+    model_id: str | None
+    reason: str
+    score: float | None = None
+    considered: int = 0
+
+
+def _cost_score(price_per_input_token: float | None) -> float:
+    """$/1k-input-token tiered score. Unknown price -> neutral default."""
+    if price_per_input_token is None:
+        return _COST_SCORE_DEFAULT
+    price_per_1k = price_per_input_token * 1000
+    for threshold, score in _COST_TIER_THRESHOLDS:
+        if price_per_1k <= threshold:
+            return score
+    return _COST_SCORE_FLOOR
+
+
+def _quality_score(
+    model_id: str | None,
+    canonical_id: str | None,
+    task_type: str,
+    quality_priors: dict[str, dict[str, float]],
+) -> float:
+    """Task-specific quality prior.
+
+    `get_quality_priors()` is keyed by `canonical_id.lower()` (per
+    `model_quality_scores.model_id`, which stores canonical ids), NOT by the
+    row's display `id` — using the wrong key silently returns no signal.
+    """
+    key = (canonical_id or model_id or "").lower()
+    priors = quality_priors.get(key)
+    if not priors:
+        return _QUALITY_SCORE_DEFAULT
+    return priors.get(task_type, priors.get("unknown", _QUALITY_SCORE_DEFAULT))
+
+
+def _blended_score(quality: float, cost: float, mode: OptimizationMode) -> float:
+    quality_weight, cost_weight = _WEIGHTS.get(mode, _WEIGHTS["balanced"])
+    return quality * quality_weight + cost * cost_weight
+
+
+def _hash_for_selection(conversation_id: str, task_type: str) -> int:
+    """Deterministic index seed for sticky routing among near-top-scorers."""
+    data = f"{conversation_id}:{task_type}"
+    hash_bytes = hashlib.md5(data.encode(), usedforsecurity=False).digest()
+    return int.from_bytes(hash_bytes[:4], byteorder="big")
+
+
+def _fetch_pricing(ids: list[Any]) -> dict[Any, dict[str, float | None]]:
+    if not ids:
+        return {}
+    try:
+        supabase = get_client_for_query(read_only=True)
+        return get_model_pricing_by_ids(supabase, ids)
+    except Exception as e:
+        logger.warning(f"model_selector: pricing fetch failed, scoring without cost signal: {e}")
+        return {}
+
+
+def _fetch_quality_priors() -> dict[str, dict[str, float]]:
+    try:
+        return get_quality_priors()
+    except Exception as e:
+        logger.warning(f"model_selector: quality priors fetch failed, using defaults: {e}")
+        return {}
+
+
+def select_model(
+    candidates: list[dict[str, Any]],
+    classification: TaskClassification,
+    mode: OptimizationMode = "balanced",
+    conversation_id: str | None = None,
+    preferred_models: list[str] | None = None,
+) -> ModelSelection:
+    """
+    Pick/rank a model from `candidates` for the given task classification.
+
+    Args:
+        candidates: model rows from `get_candidate_models` (must carry "id";
+            "canonical_id" is used for the quality lookup when present).
+        classification: Phase 2's `TaskClassification` — `task_type` drives
+            the quality-prior lookup.
+        mode: "price" / "quality" / "fast" / "balanced" — a model-choice-level
+            concept, distinct from `Config.SMART_ROUTER_POLICY` (provider
+            choice for an already-chosen model).
+        conversation_id: when provided, enables sticky routing so repeat
+            calls for the same conversation + task_type land on the same
+            model among near-top-scorers.
+        preferred_models: model ids that get a small score boost.
+
+    Returns:
+        A `ModelSelection`. `model_id` is None when `candidates` is empty or
+        none of them carry an "id".
+    """
+    if not candidates:
+        return ModelSelection(model_id=None, reason="no_candidates", considered=0)
+
+    ids = [c["id"] for c in candidates if c.get("id")]
+    pricing_by_id = _fetch_pricing(ids)
+    quality_priors = _fetch_quality_priors()
+    preferred = set(preferred_models or [])
+
+    scored: list[tuple[float, dict[str, Any]]] = []
+    for model in candidates:
+        model_id = model.get("id")
+        if not model_id:
+            continue
+        quality = _quality_score(
+            model_id, model.get("canonical_id"), classification.task_type, quality_priors
+        )
+        price = pricing_by_id.get(model_id, {})
+        cost = _cost_score(price.get("in"))
+        score = _blended_score(quality, cost, mode)
+        if model_id in preferred:
+            score += _PREFERRED_MODEL_BOOST
+        scored.append((score, model))
+
+    if not scored:
+        return ModelSelection(
+            model_id=None, reason="no_scored_candidates", considered=len(candidates)
+        )
+
+    scored.sort(key=lambda pair: pair[0], reverse=True)
+    top_score, top_model = scored[0]
+
+    if conversation_id and len(scored) > 1:
+        similar = [(s, m) for s, m in scored if top_score - s < HYSTERESIS_THRESHOLD]
+        if len(similar) > 1:
+            hash_val = _hash_for_selection(conversation_id, classification.task_type)
+            idx = hash_val % len(similar)
+            selected_score, selected_model = similar[idx]
+            return ModelSelection(
+                model_id=selected_model.get("id"),
+                reason="stable_selection",
+                score=selected_score,
+                considered=len(scored),
+            )
+
+    return ModelSelection(
+        model_id=top_model.get("id"),
+        reason="top_scorer",
+        score=top_score,
+        considered=len(scored),
+    )
+
+
+def log_shadow_selection(
+    actual_model: str | None, selection: ModelSelection, task_type: str
+) -> None:
+    """Record what this engine would have chosen vs. what was actually used.
+
+    Logging only — no live behavior change, no new DB table (persisted
+    shadow-comparison analytics is a later rollout-safety phase's job).
+    """
+    logger.info(
+        "model_selector shadow: task_type=%s actual=%s would_select=%s reason=%s "
+        "score=%s considered=%d match=%s",
+        task_type,
+        actual_model,
+        selection.model_id,
+        selection.reason,
+        selection.score,
+        selection.considered,
+        actual_model == selection.model_id,
+    )

--- a/tests/services/test_model_selector.py
+++ b/tests/services/test_model_selector.py
@@ -1,0 +1,182 @@
+"""Tests for src.services.model_selector (gatewayz-backend#2214)."""
+
+from unittest.mock import patch
+
+from src.services.model_selector import (
+    ModelSelection,
+    _cost_score,
+    _hash_for_selection,
+    _quality_score,
+    log_shadow_selection,
+    select_model,
+)
+from src.services.task_classifier import TaskClassification
+
+
+def _classification(task_type="code_generation"):
+    return TaskClassification(task_type=task_type, capability_names=frozenset(), confidence=0.8)
+
+
+def _patched_select(candidates, classification, **kwargs):
+    """select_model with pricing/quality fetches mocked to fixed dicts."""
+    pricing = kwargs.pop("pricing", {})
+    quality_priors = kwargs.pop("quality_priors", {})
+    with (
+        patch("src.services.model_selector._fetch_pricing", return_value=pricing),
+        patch("src.services.model_selector._fetch_quality_priors", return_value=quality_priors),
+    ):
+        return select_model(candidates, classification, **kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# Pure scoring helpers
+# --------------------------------------------------------------------------- #
+def test_cost_score_tiers():
+    # _cost_score takes $/token and converts to $/1k internally (x1000).
+    assert _cost_score(0.00000005) == 95.0  # $0.00005/1k -> top tier
+    assert _cost_score(0.0000003) == 85.0  # $0.0003/1k
+    assert _cost_score(0.00006) == 15.0  # $0.06/1k -> floor
+    assert _cost_score(None) == 50.0  # unknown -> neutral default
+
+
+def test_quality_score_uses_canonical_id_not_display_id():
+    priors = {"openai/gpt-4o-mini": {"code_generation": 80.0}}
+
+    # display id "gpt-4o-mini" (no provider prefix) must NOT match; canonical_id must.
+    assert _quality_score("gpt-4o-mini", "openai/gpt-4o-mini", "code_generation", priors) == 80.0
+    assert _quality_score("gpt-4o-mini", None, "code_generation", priors) == 50.0
+
+
+def test_quality_score_falls_back_to_unknown_task_then_default():
+    priors_with_unknown = {"model-a": {"unknown": 70.0}}
+    assert _quality_score("model-a", None, "code_generation", priors_with_unknown) == 70.0
+
+    priors_without_task = {"model-a": {}}
+    assert _quality_score("model-a", None, "code_generation", priors_without_task) == 50.0
+
+
+def test_hash_for_selection_is_deterministic():
+    a = _hash_for_selection("conv-123", "code_generation")
+    b = _hash_for_selection("conv-123", "code_generation")
+    assert a == b
+
+
+def test_hash_for_selection_varies_by_task_type():
+    a = _hash_for_selection("conv-123", "code_generation")
+    b = _hash_for_selection("conv-123", "creative_writing")
+    assert a != b
+
+
+# --------------------------------------------------------------------------- #
+# select_model
+# --------------------------------------------------------------------------- #
+def test_no_candidates_returns_none():
+    result = select_model([], _classification())
+
+    assert result == ModelSelection(model_id=None, reason="no_candidates", considered=0)
+
+
+def test_candidates_without_id_are_skipped():
+    result = _patched_select([{"model_name": "no id here"}], _classification())
+
+    assert result.model_id is None
+    assert result.reason == "no_scored_candidates"
+
+
+def test_picks_top_scorer_by_default():
+    candidates = [{"id": "cheap-model"}, {"id": "expensive-model"}]
+    pricing = {
+        "cheap-model": {"in": 0.00005, "out": 0.0001},
+        "expensive-model": {"in": 0.06, "out": 0.1},
+    }
+
+    result = _patched_select(candidates, _classification(), mode="price", pricing=pricing)
+
+    assert result.model_id == "cheap-model"
+    assert result.reason == "top_scorer"
+    assert result.considered == 2
+
+
+def test_preferred_model_gets_boosted():
+    candidates = [{"id": "model-a"}, {"id": "model-b"}]
+    # Identical pricing/quality so the boost is the only differentiator.
+    pricing = {"model-a": {"in": 0.001, "out": 0.001}, "model-b": {"in": 0.001, "out": 0.001}}
+
+    result = _patched_select(
+        candidates, _classification(), pricing=pricing, preferred_models=["model-b"]
+    )
+
+    assert result.model_id == "model-b"
+
+
+def test_sticky_routing_is_stable_across_calls_for_same_conversation():
+    candidates = [{"id": "model-a"}, {"id": "model-b"}, {"id": "model-c"}]
+    # All within the hysteresis band of each other (identical pricing/quality).
+    pricing = {m["id"]: {"in": 0.001, "out": 0.001} for m in candidates}
+
+    first = _patched_select(
+        candidates, _classification(), pricing=pricing, conversation_id="conv-abc"
+    )
+    second = _patched_select(
+        candidates, _classification(), pricing=pricing, conversation_id="conv-abc"
+    )
+
+    assert first.model_id == second.model_id
+    assert first.reason == "stable_selection"
+
+
+def test_sticky_routing_only_considers_near_top_scorers():
+    candidates = [{"id": "top"}, {"id": "far-behind"}]
+    pricing = {
+        "top": {"in": 0.00000005, "out": 0.00000005},  # cost_score 95 (top tier)
+        "far-behind": {"in": 0.00006, "out": 0.00006},  # cost_score 15 (floor)
+    }
+    # Score gap (36 vs ~25.5, mode="price") exceeds HYSTERESIS_THRESHOLD, so
+    # far-behind never enters the near-top-scorer cluster.
+
+    result = _patched_select(
+        candidates, _classification(), mode="price", pricing=pricing, conversation_id="any-conv"
+    )
+
+    assert result.model_id == "top"
+    assert result.reason == "top_scorer"
+
+
+def test_mode_changes_which_model_wins():
+    candidates = [{"id": "cheap-low-quality"}, {"id": "pricey-high-quality"}]
+    pricing = {
+        "cheap-low-quality": {"in": 0.00000005, "out": 0.00000005},  # cost_score 95 (top tier)
+        "pricey-high-quality": {"in": 0.00006, "out": 0.00006},  # cost_score 15 (floor)
+    }
+    quality_priors = {
+        "cheap-low-quality": {"code_generation": 40.0},
+        "pricey-high-quality": {"code_generation": 95.0},
+    }
+
+    price_mode = _patched_select(
+        candidates, _classification(), mode="price", pricing=pricing, quality_priors=quality_priors
+    )
+    quality_mode = _patched_select(
+        candidates,
+        _classification(),
+        mode="quality",
+        pricing=pricing,
+        quality_priors=quality_priors,
+    )
+
+    assert price_mode.model_id == "cheap-low-quality"
+    assert quality_mode.model_id == "pricey-high-quality"
+
+
+# --------------------------------------------------------------------------- #
+# log_shadow_selection
+# --------------------------------------------------------------------------- #
+def test_log_shadow_selection_never_raises_and_logs():
+    selection = ModelSelection(model_id="model-a", reason="top_scorer", score=72.5, considered=2)
+
+    with patch("src.services.model_selector.logger") as mock_logger:
+        log_shadow_selection("model-a", selection, "code_generation")
+
+    mock_logger.info.assert_called_once()
+    args = mock_logger.info.call_args.args
+    assert "model_selector shadow" in args[0]


### PR DESCRIPTION
## Summary
**Stacked on #2220 — base this PR against `feat/auto-routing-phase2-task-classifier` so the diff here is Phase 3 only. Merge #2219 then #2220 first, then this.**

- Adds `src/services/model_selector.py`: revives the scoring formula and MD5-hash sticky/hysteresis design from the deleted `src/services/model_selector.py` (`e94e095c`), adapted to compose with Phase 1/2 instead of the hardcoded `QUALITY_PRIORS` table and deleted `ModelCapabilities` schema it used to depend on.
  - Quality comes from the real `model_capabilities_cache.get_quality_priors()` — keyed by **`canonical_id`**, not the display `id` (verified by tracing `model_quality_scores.model_id`, which actually stores canonical ids; getting this key wrong would have silently degraded every model to the neutral default with zero signal).
  - Cost comes from a new `get_model_pricing_by_ids()`, extracted out of Phase 1's `_filter_and_sort_by_cost` (`models_catalog_db.py`) so both callers share one chunked `model_pricing` query instead of a third copy of it.
  - The deleted formula's realtime retry/format-failure penalty is deliberately **omitted** — no data source for it exists anywhere in this codebase, and there's no live traffic through this engine yet to observe outcomes from.
- The optimization modes (`price`/`quality`/`fast`/`balanced`) are named like `Config.SMART_ROUTER_POLICY` but are a distinct, model-choice-level concept one layer above it — documented prominently in the module docstring to head off confusion between the two systems.
- `log_shadow_selection()` — a structured log line for "what would this engine have picked vs. what was actually used." Logging only, no new DB table; persisted shadow-comparison analytics is Phase 5's job (`#2216`).

Closes #2214. Phase 3 of the auto-routing backlog — standalone service, no request-flow wiring.

## Test plan
- [x] `pytest tests/services/test_model_selector.py` — 13/13 passing (new)
- [x] `pytest tests/db/test_models_catalog_db.py tests/services/test_task_classifier.py tests/services/test_query_classifier.py tests/services/test_capability_requirements.py` — 52/52 passing (no regressions after the pricing-helper extraction)
- [x] `ruff check` / `black --check` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)