### PR TITLE
Auto-routing Phase 4: wire into chat request flow (HIGHEST RISK — extra review requested)

### DIFF
--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -306,7 +306,7 @@ def _fallback_get_user(api_key: str):
 
 from src.routes.chat_context import inject_conversation_history, persist_conversation_turn
 from src.routes.chat_request import prepare_upstream_request
-from src.routes.chat_routing import resolve_model_routing
+from src.routes.chat_routing import resolve_auto_routed_model, resolve_model_routing
 from src.routes.chat_streaming import stream_generator  # noqa: F401
 
 # Log route registration for debugging
@@ -354,6 +354,17 @@ async def chat_completions(
     # Abuse-control gates (anonymous + unpriced models). Centralized helpers so
     # /v1/images and /v1/audio can adopt the same policy.
     enforce_anonymous_gate(is_anonymous, request_id=request_id, model_id=req.model)
+
+    # Resolve `auto`/`router:*` aliases to a real model BEFORE the pricing gate
+    # below, which treats req.model as a real catalog/pricing model and 400s
+    # otherwise. No-op for explicit models and for anonymous requests (see
+    # resolve_auto_routed_model's docstring for why anonymous is excluded).
+    await resolve_auto_routed_model(
+        req,
+        is_anonymous=is_anonymous,
+        conversation_id=str(session_id) if session_id else None,
+    )
+
     await enforce_model_pricing_gate(
         req.model,
         request_id=request_id,

--- a/src/routes/chat_routing.py
+++ b/src/routes/chat_routing.py
@@ -95,6 +95,15 @@ async def resolve_auto_routed_model(
     (an LLM HTTP call and Supabase reads respectively) -- both are run via
     `asyncio.to_thread` so they never stall this (async) request's event loop.
 
+    Known gap: `get_candidate_models` is never given a `min_context_length`
+    here, even for long messages -- `TaskClassification` doesn't carry an
+    estimated-token-count signal (it's computed internally by
+    `extract_required_capabilities` but discarded before it reaches this
+    caller), so a long request can still be routed to a small-context model.
+    Not a new failure mode (the resulting provider error is the same one a
+    human picking the wrong model manually would hit) but worth closing in a
+    follow-up by exposing that estimate on `TaskClassification`.
+
     Raises the same 400 as `resolve_model_routing` on any failure to resolve
     (classifier error, or no candidate could be selected) -- fail-SAFE, not
     fail-open, since this sits in front of billing-adjacent gates.

--- a/src/routes/chat_routing.py
+++ b/src/routes/chat_routing.py
@@ -1,18 +1,25 @@
 """Model routing gate for the chat route.
 
-The prompt/code/general auto-routing engine (D2 cluster) was removed in the MVP
-refactor (Task 13). The public contract for the ``auto`` / ``router:*`` model
-aliases is now an explicit 400 rather than silent classification-based routing:
-callers must specify an explicit model id.
+The original prompt/code/general auto-routing engine (D2 cluster) was removed
+in the MVP refactor (Task 13). ``resolve_auto_routed_model`` is its replacement
+(gatewayz-backend#2215), built on the Phase 1-3 catalog/classifier/scoring
+engine (``get_candidate_models`` / ``classify_task`` / ``select_model``)
+instead of the deleted keyword-classifier cluster.
 
 ``resolve_model_routing`` keeps its call shape (returns
 ``(code_router_decision, is_code_route)``) so downstream provider detection and
-response-metadata code paths are unchanged for ordinary model ids.
+response-metadata code paths are unchanged for ordinary model ids. It still
+rejects any alias that reaches it unresolved -- in normal operation that never
+happens (``resolve_auto_routed_model`` runs earlier and either resolves the
+alias in place or raises), but it stays as a defense-in-depth backstop rather
+than being removed.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from typing import Any
 
 from fastapi import HTTPException
 
@@ -51,3 +58,89 @@ async def resolve_model_routing(req, original_model: str) -> tuple[None, bool]:
             ),
         )
     return None, False
+
+
+def _raise_auto_routing_failed() -> None:
+    raise HTTPException(
+        status_code=400,
+        detail=(
+            "Unable to automatically select a model for this request. "
+            "Specify an explicit model id (e.g. 'openai/gpt-4o-mini')."
+        ),
+    )
+
+
+async def resolve_auto_routed_model(
+    req: Any,
+    is_anonymous: bool,
+    conversation_id: str | None = None,
+) -> None:
+    """Resolve an `auto`/`router:*` alias to a real model, in place on `req`.
+
+    No-op for explicit model ids and for anonymous requests: auto-routing
+    costs a real LLM call (Phase 2's `classify_task`), and anonymous traffic
+    never had alias access to begin with -- it is still rejected downstream by
+    `enforce_model_pricing_gate` exactly as before this phase. Restricting the
+    engine to authenticated requests closes the one abuse vector this phase
+    would otherwise open (anonymous IPs triggering unlimited paid
+    classification calls via `model=auto`), at no cost to the feature.
+
+    MUST be called before any gate that treats `req.model` as a real, priced
+    model (`enforce_model_pricing_gate` in particular) -- that gate 400s on
+    `auto` today because it isn't a catalog/pricing model, which is what makes
+    this the actual insertion point rather than the later `resolve_model_routing`
+    call site.
+
+    `classify_task` and `select_model` are synchronous, blocking functions
+    (an LLM HTTP call and Supabase reads respectively) -- both are run via
+    `asyncio.to_thread` so they never stall this (async) request's event loop.
+
+    Raises the same 400 as `resolve_model_routing` on any failure to resolve
+    (classifier error, or no candidate could be selected) -- fail-SAFE, not
+    fail-open, since this sits in front of billing-adjacent gates.
+    """
+    if is_anonymous or not _is_router_model(req.model):
+        return
+
+    from src.db.models_catalog_db import get_candidate_models
+    from src.services.model_selector import select_model
+    from src.services.task_classifier import classify_task
+
+    original_alias = req.model
+    messages = [m.model_dump() for m in (req.messages or [])]
+
+    classification = await asyncio.to_thread(
+        classify_task,
+        messages,
+        tools=req.tools,
+        response_format=req.response_format,
+    )
+    if classification.error is not None:
+        logger.warning(
+            f"auto-routing: classification failed for alias {original_alias!r} "
+            f"({classification.error}); rejecting"
+        )
+        _raise_auto_routing_failed()
+
+    candidates = await asyncio.to_thread(
+        get_candidate_models,
+        required_capabilities=classification.capability_names or None,
+    )
+    selection = await asyncio.to_thread(
+        select_model,
+        candidates,
+        classification,
+        conversation_id=conversation_id,
+    )
+    if not selection.model_id:
+        logger.warning(
+            f"auto-routing: no candidate selected for alias {original_alias!r} "
+            f"(reason={selection.reason}, considered={selection.considered}); rejecting"
+        )
+        _raise_auto_routing_failed()
+
+    logger.info(
+        f"auto-routing: resolved alias {original_alias!r} -> {selection.model_id!r} "
+        f"(task_type={classification.task_type}, reason={selection.reason})"
+    )
+    req.model = selection.model_id

--- a/tests/routes/test_chat_auto_routing.py
+++ b/tests/routes/test_chat_auto_routing.py
@@ -1,0 +1,203 @@
+"""Tests for auto-routing wiring into the chat request flow (gatewayz-backend#2215).
+
+`resolve_auto_routed_model` is tested directly (no live app/DB), matching the
+`dispatch_non_streaming`-direct-call convention used elsewhere in tests/routes/
+for pieces of `chat.py` that don't have a dedicated test module yet. A separate
+AST-structural test guards the ordering invariant this whole phase depends on:
+resolution must run before `enforce_model_pricing_gate`, which 400s on
+unresolved aliases.
+"""
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.routes.chat_routing import resolve_auto_routed_model
+from src.schemas.proxy import Message
+from src.services.model_selector import ModelSelection
+from src.services.task_classifier import TaskClassification
+
+CHAT_PY = Path(__file__).resolve().parents[2] / "src" / "routes" / "chat.py"
+
+
+def _req(model="auto", content="write a fibonacci function", tools=None, response_format=None):
+    return SimpleNamespace(
+        model=model,
+        messages=[Message(role="user", content=content)],
+        tools=tools,
+        response_format=response_format,
+    )
+
+
+def _passthrough_to_thread():
+    """asyncio.to_thread that runs the target function inline (no real thread),
+    while still letting tests assert it was actually used for each blocking call."""
+
+    async def _run(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    return AsyncMock(side_effect=_run)
+
+
+# --------------------------------------------------------------------------- #
+# Structural ordering invariant
+# --------------------------------------------------------------------------- #
+def test_resolve_auto_routed_model_runs_before_pricing_gate():
+    tree = ast.parse(CHAT_PY.read_text())
+    fn = next(
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.AsyncFunctionDef) and n.name == "chat_completions"
+    )
+
+    def _call_lineno(func_name):
+        for node in ast.walk(fn):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == func_name
+            ):
+                return node.lineno
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == func_name
+            ):
+                return node.lineno
+        raise AssertionError(f"no call to {func_name!r} found in chat_completions")
+
+    resolve_line = _call_lineno("resolve_auto_routed_model")
+    pricing_gate_line = _call_lineno("enforce_model_pricing_gate")
+
+    assert resolve_line < pricing_gate_line, (
+        "resolve_auto_routed_model must run BEFORE enforce_model_pricing_gate — "
+        "that gate 400s on unresolved aliases like 'auto' since they have no "
+        "catalog/pricing row."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# resolve_auto_routed_model behavior
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_noop_for_anonymous_requests():
+    req = _req(model="auto")
+
+    with patch("src.services.task_classifier.classify_task") as mock_classify:
+        await resolve_auto_routed_model(req, is_anonymous=True)
+
+    assert req.model == "auto"
+    mock_classify.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_noop_for_explicit_model():
+    req = _req(model="openai/gpt-4o-mini")
+
+    with patch("src.services.task_classifier.classify_task") as mock_classify:
+        await resolve_auto_routed_model(req, is_anonymous=False)
+
+    assert req.model == "openai/gpt-4o-mini"
+    mock_classify.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_successful_resolution_mutates_req_model_in_place():
+    req = _req(model="auto")
+    classification = TaskClassification(
+        task_type="code_generation", capability_names=frozenset({"tools"}), confidence=0.9
+    )
+    selection = ModelSelection(model_id="openai/gpt-4o-mini", reason="top_scorer", score=80.0)
+
+    with (
+        patch("asyncio.to_thread", new=_passthrough_to_thread()) as mock_to_thread,
+        patch(
+            "src.db.models_catalog_db.get_candidate_models",
+            return_value=[{"id": "openai/gpt-4o-mini"}],
+        ),
+        patch("src.services.task_classifier.classify_task", return_value=classification),
+        patch("src.services.model_selector.select_model", return_value=selection),
+    ):
+        await resolve_auto_routed_model(req, is_anonymous=False)
+
+    assert req.model == "openai/gpt-4o-mini"
+    # classify_task, get_candidate_models, select_model — all three blocking
+    # calls must go through asyncio.to_thread, never called directly.
+    assert mock_to_thread.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_classification_error_raises_400_and_leaves_model_unchanged():
+    req = _req(model="auto")
+    failed_classification = TaskClassification(error="timeout")
+
+    with (
+        patch("asyncio.to_thread", new=_passthrough_to_thread()),
+        patch("src.services.task_classifier.classify_task", return_value=failed_classification),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await resolve_auto_routed_model(req, is_anonymous=False)
+
+    assert exc_info.value.status_code == 400
+    assert req.model == "auto"
+
+
+@pytest.mark.asyncio
+async def test_no_candidate_selected_raises_400():
+    req = _req(model="router:general")
+    classification = TaskClassification(task_type="unknown", capability_names=frozenset())
+    empty_selection = ModelSelection(model_id=None, reason="no_candidates")
+
+    with (
+        patch("asyncio.to_thread", new=_passthrough_to_thread()),
+        patch("src.db.models_catalog_db.get_candidate_models", return_value=[]),
+        patch("src.services.task_classifier.classify_task", return_value=classification),
+        patch("src.services.model_selector.select_model", return_value=empty_selection),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await resolve_auto_routed_model(req, is_anonymous=False)
+
+    assert exc_info.value.status_code == 400
+    assert req.model == "router:general"
+
+
+@pytest.mark.asyncio
+async def test_conversation_id_threaded_through_to_select_model():
+    req = _req(model="auto")
+    classification = TaskClassification(task_type="code_generation", capability_names=frozenset())
+    selection = ModelSelection(model_id="openai/gpt-4o-mini", reason="top_scorer")
+
+    with (
+        patch("asyncio.to_thread", new=_passthrough_to_thread()),
+        patch("src.db.models_catalog_db.get_candidate_models", return_value=[{"id": "m"}]),
+        patch("src.services.task_classifier.classify_task", return_value=classification),
+        patch("src.services.model_selector.select_model", return_value=selection) as mock_select,
+    ):
+        await resolve_auto_routed_model(req, is_anonymous=False, conversation_id="42")
+
+    assert mock_select.call_args.kwargs["conversation_id"] == "42"
+
+
+@pytest.mark.asyncio
+async def test_messages_are_converted_to_dicts_before_classification():
+    req = _req(model="auto", content="hello there")
+    classification = TaskClassification(task_type="conversation", capability_names=frozenset())
+    selection = ModelSelection(model_id="openai/gpt-4o-mini", reason="top_scorer")
+
+    with (
+        patch("asyncio.to_thread", new=_passthrough_to_thread()),
+        patch("src.db.models_catalog_db.get_candidate_models", return_value=[{"id": "m"}]),
+        patch(
+            "src.services.task_classifier.classify_task", return_value=classification
+        ) as mock_classify,
+        patch("src.services.model_selector.select_model", return_value=selection),
+    ):
+        await resolve_auto_routed_model(req, is_anonymous=False)
+
+    sent_messages = mock_classify.call_args.args[0]
+    assert sent_messages == [Message(role="user", content="hello there").model_dump()]
+    assert isinstance(sent_messages[0], dict)


### PR DESCRIPTION
## Summary
**Stacked on #2222 — base this PR against `feat/auto-routing-phase3-scoring-engine`. Merge #2219 -> #2220 -> #2222 first, then this. This is the riskiest phase in the backlog: it touches the live `/chat` request path and billing-adjacent gates. Requesting careful human review before merge, beyond the usual bar.**

- Adds `resolve_auto_routed_model()` to `chat_routing.py`, called from `chat.py` right after `enforce_anonymous_gate` — **before `enforce_model_pricing_gate`**, not at the old `resolve_model_routing` call site (~line 733) the original issue scoped around.
- **Scope-changing discovery during planning**: `enforce_model_pricing_gate` (`chat.py:357`) — not the later credit/trial gates — is the actual first blocker for `model="auto"` today (400 `model_not_priced`, since aliases have no catalog/pricing row). This means `chat_routing.py`'s own alias-rejection code at the old call site is currently **dead/unreachable** — it never fires because the pricing gate kills the request first. Resolution has to happen earlier than the issue originally scoped.
- Confirmed via a dedicated check that this is **not an auth-bypass**: `api_key`/`is_anonymous` are fully resolved via FastAPI `Depends()` before the handler body runs, so the new resolution step always sees an already-validated key-or-None.
- **Two deliberate scope decisions, both load-bearing**:
  1. **Authenticated requests only.** Anonymous traffic never had alias access (blocked by the model whitelist regardless) and hits the exact same pricing-gate 400 as before — completely unchanged. This closes the one real abuse vector this phase would otherwise open: unauthenticated `model=auto` spam triggering unlimited paid LLM classification calls.
  2. **`asyncio.to_thread` around every blocking call.** `classify_task`/`get_candidate_models`/`select_model` are all synchronous (LLM HTTP call, Supabase reads) — calling them directly from this `async def` handler would stall the whole worker's event loop for every concurrent request during that window. A dedicated test asserts `asyncio.to_thread` is actually used, not just that a mock "works."
- Integration mechanism: mutates `req.model` in place before `original_model = req.model` is captured — reuses an existing hook (`chat_request.py:175` already prefers `req.model` over `original_model`) that the old (deleted) code-router exploited the same way. Zero changes needed in `chat_request.py`.
- `resolve_model_routing` itself is untouched, still runs at its original call site as a defense-in-depth backstop (never fires in normal operation now, but costs nothing to keep).
- Fails **safe**: classifier error or no selectable candidate raises the same-shape 400, `req.model` is left untouched on any failure path.
- **Known gap, documented not fixed here**: `TaskClassification` doesn't expose the token-count estimate `extract_required_capabilities` computes internally, so `get_candidate_models` never gets a `min_context_length` — a long request could still land on a small-context model. Not a new failure mode (same error a human picking wrong would hit), flagged as a fast-follow rather than reaching back into Phase 2's dataclass under this phase's banner.
- **Pre-existing risk inherited, not introduced**: `_is_router_model`'s bare `"router"` prefix match would misclassify any real model literally named `router*` as an alias. Grepped the static catalog config, found no such model today — flagging since this phase changes the consequence of a false match from "annoying 400" to "silent reroute away from the user's explicit choice."

Closes #2215. `completions.py`/`embeddings.py`/`messages.py` still read `req.model` directly and are explicitly out of scope.

## Test plan
- [x] `pytest tests/routes/test_chat_auto_routing.py` — 8/8 passing (new): AST-structural ordering invariant (resolution before pricing gate) + direct-call behavior tests (anonymous no-op, explicit-model no-op, success mutates `req.model`, classifier-error fail-safe, no-candidate fail-safe, conversation_id threading, message-dict conversion, `asyncio.to_thread` usage verified)
- [x] `pytest tests/routes/` — 113 passed, 2 pre-existing xpass (flaky markers, unrelated) — full route suite, no regressions
- [x] `python3 -c "import src.routes.chat"` — module loads cleanly, no circular imports
- [x] `ruff check` / `black --check` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)