### PR TITLE
Auto-routing Phase 5: rollout safety — kill-switch, per-key opt-out, eval harness

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -197,6 +197,19 @@ class Config:
         os.environ.get("TASK_CLASSIFIER_TIMEOUT_SECONDS", "5.0")
     )
 
+    # Auto-routing Phase 5 — rollout kill-switch. `resolve_auto_routed_model`
+    # (chat_routing.py) fully no-ops when this is false: `auto`/`router:*`
+    # aliases keep 400ing exactly as before Phases 1-4 existed. Disabled by
+    # default -- this is the gate that keeps the whole feature inert until
+    # someone deliberately turns it on, per gatewayz-backend#2216. A per-key
+    # `routing_policies` row (see db/routing_policies.py) can opt a key out
+    # even when this is globally true, but cannot turn it on when it's false.
+    AUTO_ROUTING_ENABLED = os.environ.get("AUTO_ROUTING_ENABLED", "false").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
     # Gatewayz One Phase 5 — multi-region (rollout phase 1: inventory + wire, no
     # traffic change). The region_router selection core is fed from these. Until
     # MULTI_REGION_ENABLED is true the inventory is just this single region, so all

--- a/src/db/routing_policies.py
+++ b/src/db/routing_policies.py
@@ -1,0 +1,64 @@
+"""Per-key auto-routing policy overrides (gatewayz-backend#2216).
+
+`routing_policies` (supabase/migrations/20260617000000_gatewayz_one_phase1_registry.sql)
+already existed for Gatewayz One's provider-choice smart_router, keyed by
+`api_key_id` (NULL = system default). No code read it before this phase --
+`smart_router_bridge.py` computes its policy purely from the global
+`Config.SMART_ROUTER_POLICY`. This module adds the read path Phase 5 needs:
+letting a key opt OUT of the (separately-flagged) model-choice auto-routing
+engine, via the `auto_routing_enabled` column added alongside this module
+(20260812000000_add_auto_routing_enabled_to_routing_policies.sql).
+
+Mirrors the api_key -> api_keys_new.id -> per-key-row lookup pattern already
+established in src/db/rate_limits.py::get_user_rate_limits.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from src.config.supabase_config import get_supabase_client
+
+logger = logging.getLogger(__name__)
+
+
+def get_routing_policy_for_key(api_key: str) -> dict[str, Any] | None:
+    """Look up the `routing_policies` row for one API key, if any.
+
+    Returns None on no row / any lookup error -- callers must treat that as
+    "no override, fall back to the global default," never as a hard failure.
+    """
+    try:
+        client = get_supabase_client()
+        key_record = client.table("api_keys_new").select("id").eq("api_key", api_key).execute()
+        if not key_record.data:
+            return None
+
+        policy_row = (
+            client.table("routing_policies")
+            .select("*")
+            .eq("api_key_id", key_record.data[0]["id"])
+            .execute()
+        )
+        if not policy_row.data:
+            return None
+        return policy_row.data[0]
+    except Exception as e:
+        logger.warning(f"routing_policies lookup failed, using default: {e}")
+        return None
+
+
+def is_auto_routing_disabled_for_key(api_key: str | None) -> bool:
+    """True only if this key's routing_policies row explicitly opts out.
+
+    No row, a lookup error, or an explicit `true` all mean "not disabled" --
+    this function only ever narrows access relative to the global
+    `Config.AUTO_ROUTING_ENABLED` flag, never widens it.
+    """
+    if not api_key:
+        return False
+    policy = get_routing_policy_for_key(api_key)
+    if not policy:
+        return False
+    return policy.get("auto_routing_enabled") is False

--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -362,6 +362,7 @@ async def chat_completions(
     await resolve_auto_routed_model(
         req,
         is_anonymous=is_anonymous,
+        api_key=api_key,
         conversation_id=str(session_id) if session_id else None,
     )
 

--- a/src/routes/chat_routing.py
+++ b/src/routes/chat_routing.py
@@ -23,6 +23,8 @@ from typing import Any
 
 from fastapi import HTTPException
 
+from src.config import Config
+
 logger = logging.getLogger(__name__)
 
 # Bare aliases that used to fold onto the `router` prefix. `openrouter/auto` is
@@ -73,17 +75,26 @@ def _raise_auto_routing_failed() -> None:
 async def resolve_auto_routed_model(
     req: Any,
     is_anonymous: bool,
+    api_key: str | None = None,
     conversation_id: str | None = None,
 ) -> None:
     """Resolve an `auto`/`router:*` alias to a real model, in place on `req`.
 
-    No-op for explicit model ids and for anonymous requests: auto-routing
-    costs a real LLM call (Phase 2's `classify_task`), and anonymous traffic
-    never had alias access to begin with -- it is still rejected downstream by
-    `enforce_model_pricing_gate` exactly as before this phase. Restricting the
-    engine to authenticated requests closes the one abuse vector this phase
-    would otherwise open (anonymous IPs triggering unlimited paid
-    classification calls via `model=auto`), at no cost to the feature.
+    No-op (falls through to today's exact 400-on-alias behavior downstream)
+    unless ALL of the following hold:
+      - the request is authenticated (auto-routing costs a real LLM call;
+        anonymous traffic never had alias access to begin with -- it's still
+        rejected by `enforce_model_pricing_gate` exactly as before this phase)
+      - `req.model` is actually a router alias
+      - `Config.AUTO_ROUTING_ENABLED` is true (gatewayz-backend#2216's global
+        kill-switch -- disabled by default, so this whole function is inert
+        until someone deliberately turns it on)
+      - the caller didn't pass `auto_routing=False` on the request
+      - the key's `routing_policies` row (if any) doesn't explicitly opt out
+
+    Each of these can only NARROW access relative to the one before it --
+    none of them can force auto-routing on when a higher-priority setting
+    says no.
 
     MUST be called before any gate that treats `req.model` as a real, priced
     model (`enforce_model_pricing_gate` in particular) -- that gate 400s on
@@ -94,6 +105,7 @@ async def resolve_auto_routed_model(
     `classify_task` and `select_model` are synchronous, blocking functions
     (an LLM HTTP call and Supabase reads respectively) -- both are run via
     `asyncio.to_thread` so they never stall this (async) request's event loop.
+    The per-key policy lookup is the same shape of call and is also offloaded.
 
     Known gap: `get_candidate_models` is never given a `min_context_length`
     here, even for long messages -- `TaskClassification` doesn't carry an
@@ -108,7 +120,22 @@ async def resolve_auto_routed_model(
     (classifier error, or no candidate could be selected) -- fail-SAFE, not
     fail-open, since this sits in front of billing-adjacent gates.
     """
-    if is_anonymous or not _is_router_model(req.model):
+    if (
+        is_anonymous
+        or not _is_router_model(req.model)
+        or not Config.AUTO_ROUTING_ENABLED
+        or getattr(req, "auto_routing", None) is False
+    ):
+        return
+
+    from src.db.routing_policies import is_auto_routing_disabled_for_key
+
+    if await asyncio.to_thread(is_auto_routing_disabled_for_key, api_key):
+        # Same as the other three narrowing checks above: fall through
+        # silently to enforce_model_pricing_gate's standard 400 downstream,
+        # rather than raising a distinct message here. All four opt-out
+        # paths must behave identically regardless of which setting fired.
+        logger.info("auto-routing: disabled by routing_policies for this key")
         return
 
     from src.db.models_catalog_db import get_candidate_models
@@ -150,6 +177,7 @@ async def resolve_auto_routed_model(
 
     logger.info(
         f"auto-routing: resolved alias {original_alias!r} -> {selection.model_id!r} "
-        f"(task_type={classification.task_type}, reason={selection.reason})"
+        f"(task_type={classification.task_type}, confidence={classification.confidence}, "
+        f"reason={selection.reason})"
     )
     req.model = selection.model_id

--- a/src/schemas/proxy.py
+++ b/src/schemas/proxy.py
@@ -213,6 +213,17 @@ class ProxyRequest(BaseModel):
             "Only used when auto_web_search is 'auto'. Default is 0.5."
         ),
     )
+    auto_routing: bool | None = Field(
+        default=None,
+        description=(
+            "Per-request override for auto-routing of 'auto'/'router:*' model aliases. "
+            "None (default) defers to the per-key routing_policies row and the global "
+            "AUTO_ROUTING_ENABLED flag. Set to False to force today's explicit-400 "
+            "behavior for this request regardless of those settings. Setting True does "
+            "NOT enable auto-routing if it's disabled at the key or global level -- "
+            "this field can only narrow access, never widen it."
+        ),
+    )
 
     class Config:
         extra = "allow"

--- a/supabase/migrations/20260812000000_add_auto_routing_enabled_to_routing_policies.sql
+++ b/supabase/migrations/20260812000000_add_auto_routing_enabled_to_routing_policies.sql
@@ -1,0 +1,23 @@
+-- Auto-routing Phase 5 (gatewayz-backend#2216): per-key opt-out for the
+-- model-choice auto-routing engine (Config.AUTO_ROUTING_ENABLED gates it
+-- globally; this column lets an individual key opt out even when the global
+-- flag is on -- it cannot turn auto-routing ON when the global flag is off).
+--
+-- `routing_policies` already existed (20260617000000_gatewayz_one_phase1_registry.sql)
+-- for the separate provider-choice smart_router policy (cost/latency/quality/
+-- balanced weights) and was never read by any code before this phase. Reusing
+-- the same table -- keyed the same way by api_key_id -- rather than adding a
+-- new one for a single boolean.
+--
+-- Guarded: skip cleanly if routing_policies is absent (mirrors the guard
+-- style used throughout 20260617000000 for cross-environment safety).
+DO $$
+BEGIN
+    IF to_regclass('public.routing_policies') IS NULL THEN
+        RAISE NOTICE 'public.routing_policies not found — skipping auto_routing_enabled column';
+        RETURN;
+    END IF;
+
+    ALTER TABLE public.routing_policies
+        ADD COLUMN IF NOT EXISTS auto_routing_enabled boolean NOT NULL DEFAULT true;
+END $$;

--- a/tests/db/test_routing_policies.py
+++ b/tests/db/test_routing_policies.py
@@ -1,0 +1,112 @@
+"""Tests for src.db.routing_policies (gatewayz-backend#2216)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.db.routing_policies import get_routing_policy_for_key, is_auto_routing_disabled_for_key
+
+
+@pytest.fixture
+def sb():
+    """No-op fixture whose mere presence bypasses the autouse DB-skip in
+    tests/conftest.py — this is a pure unit test with everything mocked, so
+    we do not need a real Supabase connection."""
+    return None
+
+
+def _mock_client(key_record_data, policy_data):
+    key_query = MagicMock()
+    key_query.select.return_value = key_query
+    key_query.eq.return_value = key_query
+    key_query.execute.return_value = MagicMock(data=key_record_data)
+
+    policy_query = MagicMock()
+    policy_query.select.return_value = policy_query
+    policy_query.eq.return_value = policy_query
+    policy_query.execute.return_value = MagicMock(data=policy_data)
+
+    def table_side_effect(name):
+        if name == "api_keys_new":
+            return key_query
+        if name == "routing_policies":
+            return policy_query
+        raise AssertionError(f"unexpected table: {name}")
+
+    client = MagicMock()
+    client.table.side_effect = table_side_effect
+    return client
+
+
+def test_returns_none_when_key_not_found(sb):
+    client = _mock_client(key_record_data=[], policy_data=[])
+
+    with patch("src.db.routing_policies.get_supabase_client", return_value=client):
+        result = get_routing_policy_for_key("gw_missing")
+
+    assert result is None
+
+
+def test_returns_none_when_no_policy_row(sb):
+    client = _mock_client(key_record_data=[{"id": 7}], policy_data=[])
+
+    with patch("src.db.routing_policies.get_supabase_client", return_value=client):
+        result = get_routing_policy_for_key("gw_live_abc")
+
+    assert result is None
+
+
+def test_returns_policy_row_when_present(sb):
+    row = {"id": 1, "api_key_id": 7, "policy": "balanced", "auto_routing_enabled": False}
+    client = _mock_client(key_record_data=[{"id": 7}], policy_data=[row])
+
+    with patch("src.db.routing_policies.get_supabase_client", return_value=client):
+        result = get_routing_policy_for_key("gw_live_abc")
+
+    assert result == row
+
+
+def test_returns_none_on_client_error(sb):
+    client = MagicMock()
+    client.table.side_effect = RuntimeError("boom")
+
+    with patch("src.db.routing_policies.get_supabase_client", return_value=client):
+        result = get_routing_policy_for_key("gw_live_abc")
+
+    assert result is None
+
+
+def test_is_disabled_false_for_no_api_key(sb):
+    assert is_auto_routing_disabled_for_key(None) is False
+
+
+def test_is_disabled_false_when_no_policy_row(sb):
+    with patch("src.db.routing_policies.get_routing_policy_for_key", return_value=None):
+        assert is_auto_routing_disabled_for_key("gw_live_abc") is False
+
+
+def test_is_disabled_false_when_flag_explicitly_true(sb):
+    with patch(
+        "src.db.routing_policies.get_routing_policy_for_key",
+        return_value={"auto_routing_enabled": True},
+    ):
+        assert is_auto_routing_disabled_for_key("gw_live_abc") is False
+
+
+def test_is_disabled_true_only_when_flag_explicitly_false(sb):
+    with patch(
+        "src.db.routing_policies.get_routing_policy_for_key",
+        return_value={"auto_routing_enabled": False},
+    ):
+        assert is_auto_routing_disabled_for_key("gw_live_abc") is True
+
+
+def test_is_disabled_false_when_column_missing_from_row(sb):
+    """A routing_policies row that predates the auto_routing_enabled column
+    (e.g. one created for the smart_router-only feature) must not accidentally
+    disable auto-routing -- missing means "not disabled", not "disabled"."""
+    with patch(
+        "src.db.routing_policies.get_routing_policy_for_key",
+        return_value={"policy": "cost"},
+    ):
+        assert is_auto_routing_disabled_for_key("gw_live_abc") is False

--- a/tests/eval/__init__.py
+++ b/tests/eval/__init__.py
@@ -1,0 +1,1 @@
+# Test package

--- a/tests/eval/test_classifier_eval_harness.py
+++ b/tests/eval/test_classifier_eval_harness.py
@@ -1,0 +1,168 @@
+"""Task classifier eval harness (gatewayz-backend#2216).
+
+The old (deleted) D2 auto-router never had a way to catch classifier
+regressions before merge -- the deletion commit (e94e095c) left no eval
+trail behind it to learn from. This is that safety net for the new
+classifier (`src/services/task_classifier.py`), built as two tiers:
+
+1. DETERMINISTIC (always runs in CI): each fixture's expected label is fed
+   back as a mocked LLM response, and the test asserts `classify_task`'s
+   parsing/validation pipeline reconstructs it correctly. This is a
+   regression net for the harness's own plumbing (TASK_TYPES validation,
+   reasoning-flag threading, capability merging) across a wide variety of
+   shapes -- it does NOT tell you whether the real gpt-4o-mini still
+   classifies well, only that the code around it still works.
+
+2. LIVE (opt-in, skipped by default): the same fixtures against the REAL
+   classifier, no mocking. This is the actual drift check, and it is
+   deliberately NOT wired into the default CI run: this repo has a written
+   policy of mocking all external LLM calls in tests
+   (tests/documentation/TESTING_BEST_PRACTICES.md), and no CI job anywhere
+   requires a real API key today (every secret has a fake fallback in
+   ci.yml). Making this tier mandatory would be a first-of-its-kind
+   exception to that policy -- run it manually via:
+       RUN_LIVE_CLASSIFIER_EVAL=1 pytest tests/eval/test_classifier_eval_harness.py -k live
+   with a real OPENAI_API_KEY configured, e.g. before/after changing the
+   classifier's prompt or model.
+"""
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.services.quality_inference import TASK_TYPES
+from src.services.task_classifier import classify_task
+
+# One fixture per TASK_TYPES category the classifier can realistically be
+# asked to distinguish (mirrors the deleted D2 cluster's taxonomy checklist --
+# code/math/translation/summarization/data/reasoning/creative/short-QA --
+# mapped onto quality_inference.TASK_TYPES, not resurrecting its regex engine).
+FIXTURES = [
+    {
+        "id": "code_generation",
+        "prompt": "Write a Python function that returns the nth Fibonacci number.",
+        "expected_task_type": "code_generation",
+        "expected_needs_reasoning": False,
+    },
+    {
+        "id": "code_review",
+        "prompt": "Review this function for bugs: def add(a, b): return a - b",
+        "expected_task_type": "code_review",
+        "expected_needs_reasoning": False,
+    },
+    {
+        "id": "translation",
+        "prompt": "Translate 'Good morning, how are you?' into French.",
+        "expected_task_type": "translation",
+        "expected_needs_reasoning": False,
+    },
+    {
+        "id": "summarization",
+        "prompt": "Summarize the plot of Romeo and Juliet in three sentences.",
+        "expected_task_type": "summarization",
+        "expected_needs_reasoning": False,
+    },
+    {
+        "id": "simple_qa",
+        "prompt": "What is the capital of France?",
+        "expected_task_type": "simple_qa",
+        "expected_needs_reasoning": False,
+    },
+    {
+        "id": "math_calculation",
+        "prompt": (
+            "A train leaves station A at 60mph and another leaves station B, "
+            "300 miles away, at 40mph heading toward it. How long until they meet?"
+        ),
+        "expected_task_type": "math_calculation",
+        "expected_needs_reasoning": True,
+    },
+    {
+        "id": "data_analysis",
+        "prompt": "Given monthly sales figures for 2025, which month had the highest growth rate?",
+        "expected_task_type": "data_analysis",
+        "expected_needs_reasoning": True,
+    },
+    {
+        "id": "creative_writing",
+        "prompt": "Write a short story about a lighthouse keeper who finds a message in a bottle.",
+        "expected_task_type": "creative_writing",
+        "expected_needs_reasoning": False,
+    },
+    {
+        "id": "conversation",
+        "prompt": "hey, what's up?",
+        "expected_task_type": "conversation",
+        "expected_needs_reasoning": False,
+    },
+    {
+        "id": "complex_reasoning",
+        "prompt": (
+            "All bloops are razzles. All razzles are lazzles. Are all bloops lazzles? "
+            "Explain your reasoning step by step."
+        ),
+        "expected_task_type": "complex_reasoning",
+        "expected_needs_reasoning": True,
+    },
+]
+
+
+def test_fixture_task_types_are_all_valid():
+    """Guard the fixture set itself: every expected_task_type must be a real
+    TASK_TYPES member, or the fixtures would silently test nothing meaningful."""
+    valid = set(TASK_TYPES)
+    for fixture in FIXTURES:
+        assert fixture["expected_task_type"] in valid, (
+            f"fixture {fixture['id']!r} expects an invalid task_type "
+            f"{fixture['expected_task_type']!r} -- not in quality_inference.TASK_TYPES"
+        )
+
+
+@pytest.mark.parametrize("fixture", FIXTURES, ids=[f["id"] for f in FIXTURES])
+def test_classifier_pipeline_reconstructs_expected_label(fixture):
+    """Deterministic tier: mocks the LLM to return exactly the expected label,
+    then asserts classify_task's parsing/validation round-trips it correctly."""
+    mocked_content = json.dumps(
+        {
+            "task_type": fixture["expected_task_type"],
+            "needs_reasoning": fixture["expected_needs_reasoning"],
+            "confidence": 0.9,
+        }
+    )
+    mocked_response = MagicMock(choices=[MagicMock(message=MagicMock(content=mocked_content))])
+
+    with patch("src.services.task_classifier.make_openai_request", return_value=mocked_response):
+        result = classify_task(messages=[{"role": "user", "content": fixture["prompt"]}])
+
+    assert result.task_type == fixture["expected_task_type"]
+    assert ("reasoning" in result.capability_names) == fixture["expected_needs_reasoning"]
+    assert result.error is None
+
+
+@pytest.mark.skipif(
+    not os.environ.get("RUN_LIVE_CLASSIFIER_EVAL"),
+    reason=(
+        "opt-in live drift check -- set RUN_LIVE_CLASSIFIER_EVAL=1 and a real "
+        "OPENAI_API_KEY to run this against the actual classifier model. Not "
+        "part of the default CI run (see module docstring)."
+    ),
+)
+def test_live_classifier_matches_expected_labels_above_threshold():
+    """Live tier: calls the REAL classify_task, no mocking. Manual-run only."""
+    mismatches = []
+    for fixture in FIXTURES:
+        result = classify_task(messages=[{"role": "user", "content": fixture["prompt"]}])
+        if result.task_type != fixture["expected_task_type"]:
+            mismatches.append(
+                f"{fixture['id']}: expected {fixture['expected_task_type']!r}, "
+                f"got {result.task_type!r} (error={result.error})"
+            )
+
+    accuracy = (len(FIXTURES) - len(mismatches)) / len(FIXTURES)
+    assert (
+        accuracy >= 0.8
+    ), f"live classifier accuracy {accuracy:.0%} below 80% threshold. Mismatches:\n" + "\n".join(
+        mismatches
+    )

--- a/tests/routes/test_chat_auto_routing.py
+++ b/tests/routes/test_chat_auto_routing.py
@@ -9,6 +9,7 @@ unresolved aliases.
 """
 
 import ast
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -24,13 +25,31 @@ from src.services.task_classifier import TaskClassification
 CHAT_PY = Path(__file__).resolve().parents[2] / "src" / "routes" / "chat.py"
 
 
-def _req(model="auto", content="write a fibonacci function", tools=None, response_format=None):
+def _req(
+    model="auto",
+    content="write a fibonacci function",
+    tools=None,
+    response_format=None,
+    auto_routing=None,
+):
     return SimpleNamespace(
         model=model,
         messages=[Message(role="user", content=content)],
         tools=tools,
         response_format=response_format,
+        auto_routing=auto_routing,
     )
+
+
+@contextmanager
+def _enabled():
+    """Enable the global kill-switch and a not-disabled per-key policy — the
+    baseline every test exercising the actual engine needs (default is OFF)."""
+    with (
+        patch("src.routes.chat_routing.Config.AUTO_ROUTING_ENABLED", True),
+        patch("src.db.routing_policies.is_auto_routing_disabled_for_key", return_value=False),
+    ):
+        yield
 
 
 def _passthrough_to_thread():
@@ -81,13 +100,74 @@ def test_resolve_auto_routed_model_runs_before_pricing_gate():
 
 
 # --------------------------------------------------------------------------- #
+# Rollout-safety gates (gatewayz-backend#2216) — each must independently be
+# able to no-op the engine, regardless of the other three saying yes.
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_noop_when_global_flag_is_off_by_default():
+    """AUTO_ROUTING_ENABLED defaults to False — the engine must stay fully
+    inert with no patching at all, exactly like before Phase 4 existed."""
+    req = _req(model="auto")
+
+    with patch("src.services.task_classifier.classify_task") as mock_classify:
+        await resolve_auto_routed_model(req, is_anonymous=False)
+
+    assert req.model == "auto"
+    mock_classify.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_noop_when_request_explicitly_opts_out():
+    req = _req(model="auto", auto_routing=False)
+
+    with (
+        _enabled(),
+        patch("src.services.task_classifier.classify_task") as mock_classify,
+    ):
+        await resolve_auto_routed_model(req, is_anonymous=False)
+
+    assert req.model == "auto"
+    mock_classify.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_request_auto_routing_true_does_not_override_global_flag_off():
+    """auto_routing can only narrow access, never widen it past the global flag."""
+    req = _req(model="auto", auto_routing=True)
+
+    with patch("src.services.task_classifier.classify_task") as mock_classify:
+        await resolve_auto_routed_model(req, is_anonymous=False)
+
+    assert req.model == "auto"
+    mock_classify.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_noop_when_per_key_policy_disables_it():
+    req = _req(model="auto")
+
+    with (
+        patch("src.routes.chat_routing.Config.AUTO_ROUTING_ENABLED", True),
+        patch(
+            "src.db.routing_policies.is_auto_routing_disabled_for_key", return_value=True
+        ) as mock_policy,
+        patch("src.services.task_classifier.classify_task") as mock_classify,
+    ):
+        await resolve_auto_routed_model(req, is_anonymous=False, api_key="gw_live_abc123")
+
+    assert req.model == "auto"
+    mock_classify.assert_not_called()
+    mock_policy.assert_called_once_with("gw_live_abc123")
+
+
+# --------------------------------------------------------------------------- #
 # resolve_auto_routed_model behavior
 # --------------------------------------------------------------------------- #
 @pytest.mark.asyncio
 async def test_noop_for_anonymous_requests():
     req = _req(model="auto")
 
-    with patch("src.services.task_classifier.classify_task") as mock_classify:
+    with _enabled(), patch("src.services.task_classifier.classify_task") as mock_classify:
         await resolve_auto_routed_model(req, is_anonymous=True)
 
     assert req.model == "auto"
@@ -114,6 +194,7 @@ async def test_successful_resolution_mutates_req_model_in_place():
     selection = ModelSelection(model_id="openai/gpt-4o-mini", reason="top_scorer", score=80.0)
 
     with (
+        _enabled(),
         patch("asyncio.to_thread", new=_passthrough_to_thread()) as mock_to_thread,
         patch(
             "src.db.models_catalog_db.get_candidate_models",
@@ -125,9 +206,10 @@ async def test_successful_resolution_mutates_req_model_in_place():
         await resolve_auto_routed_model(req, is_anonymous=False)
 
     assert req.model == "openai/gpt-4o-mini"
-    # classify_task, get_candidate_models, select_model — all three blocking
-    # calls must go through asyncio.to_thread, never called directly.
-    assert mock_to_thread.call_count == 3
+    # is_auto_routing_disabled_for_key, classify_task, get_candidate_models,
+    # select_model — all four blocking calls must go through asyncio.to_thread,
+    # never called directly.
+    assert mock_to_thread.call_count == 4
 
 
 @pytest.mark.asyncio
@@ -136,6 +218,7 @@ async def test_classification_error_raises_400_and_leaves_model_unchanged():
     failed_classification = TaskClassification(error="timeout")
 
     with (
+        _enabled(),
         patch("asyncio.to_thread", new=_passthrough_to_thread()),
         patch("src.services.task_classifier.classify_task", return_value=failed_classification),
     ):
@@ -153,6 +236,7 @@ async def test_no_candidate_selected_raises_400():
     empty_selection = ModelSelection(model_id=None, reason="no_candidates")
 
     with (
+        _enabled(),
         patch("asyncio.to_thread", new=_passthrough_to_thread()),
         patch("src.db.models_catalog_db.get_candidate_models", return_value=[]),
         patch("src.services.task_classifier.classify_task", return_value=classification),
@@ -172,6 +256,7 @@ async def test_conversation_id_threaded_through_to_select_model():
     selection = ModelSelection(model_id="openai/gpt-4o-mini", reason="top_scorer")
 
     with (
+        _enabled(),
         patch("asyncio.to_thread", new=_passthrough_to_thread()),
         patch("src.db.models_catalog_db.get_candidate_models", return_value=[{"id": "m"}]),
         patch("src.services.task_classifier.classify_task", return_value=classification),
@@ -189,6 +274,7 @@ async def test_messages_are_converted_to_dicts_before_classification():
     selection = ModelSelection(model_id="openai/gpt-4o-mini", reason="top_scorer")
 
     with (
+        _enabled(),
         patch("asyncio.to_thread", new=_passthrough_to_thread()),
         patch("src.db.models_catalog_db.get_candidate_models", return_value=[{"id": "m"}]),
         patch(

--- a/tests/schemas/test_proxy.py
+++ b/tests/schemas/test_proxy.py
@@ -572,6 +572,26 @@ class TestMessageContentValidation:
         with pytest.raises(ValidationError, match="must have non-empty content"):
             Message(role="user", content="   \n\t  ")
 
+
+class TestAutoRoutingField:
+    """gatewayz-backend#2216: per-request opt-out for auto-routing."""
+
+    def test_defaults_to_none(self):
+        request = ProxyRequest(model="auto", messages=[{"role": "user", "content": "hi"}])
+        assert request.auto_routing is None
+
+    def test_accepts_explicit_false(self):
+        request = ProxyRequest(
+            model="auto", messages=[{"role": "user", "content": "hi"}], auto_routing=False
+        )
+        assert request.auto_routing is False
+
+    def test_accepts_explicit_true(self):
+        request = ProxyRequest(
+            model="auto", messages=[{"role": "user", "content": "hi"}], auto_routing=True
+        )
+        assert request.auto_routing is True
+
     def test_system_message_rejects_empty_string(self):
         """Test that system messages reject empty string content"""
         with pytest.raises(ValidationError, match="must have non-empty content"):


### PR DESCRIPTION
## Summary
**Stacked on #2223 — base this PR against `feat/auto-routing-phase4-request-wiring`. Merge #2219 -> #2220 -> #2222 -> #2223 first, then this (final phase). This PR also retrofits a missing kill-switch into #2223's code — see below.**

The old D2 auto-router was deleted wholesale with no evidence it was ever validated against misrouting, and no eval trail to learn from. This is the safety net it never had, gating everything Phases 1-4 built before any of it reaches production.

- **`Config.AUTO_ROUTING_ENABLED`** (default `false`) — `resolve_auto_routed_model` is now fully inert unless someone deliberately turns this on. **Phase 4's PR (#2223) shipped without any kill-switch** — retrofitting it here rather than reopening that PR, since nothing is merged yet and this phase owns rollout safety.
- **Per-key opt-out via the `routing_policies` table** — it already existed (`20260617000000_gatewayz_one_phase1_registry.sql`) for the *separate* provider-choice smart_router policy and was never read by any code. Reused rather than adding a new table; one additive column (`auto_routing_enabled`, default `true`) added via a small guarded migration for this narrower ask.
- **`ProxyRequest.auto_routing: bool | None`** — per-request opt-out, placed next to the existing `provider`/`auto_web_search` gateway parameters.
- All three new gates (global flag, per-key policy, per-request field) can only **narrow** access relative to each other, never widen it — verified by a dedicated test per gate, plus one confirming `auto_routing=True` cannot override the global flag being off.
- **Two-tier eval harness** (`tests/eval/`): a deterministic tier that always runs in CI (mocks the LLM response, asserts `classify_task`'s parsing/validation pipeline reconstructs 10 fixture labels spanning `quality_inference.TASK_TYPES` correctly), and an opt-in live tier (skipped by default, `RUN_LIVE_CLASSIFIER_EVAL=1` + a real key) for actually checking model drift.
  - **Deliberate deviation from the issue's literal wording, flagged for review**: the issue asked for a harness that "runs in CI to catch classifier drift." This repo has a written policy of mocking all external LLM calls in tests (`tests/documentation/TESTING_BEST_PRACTICES.md`), and no CI job anywhere requires a real API key today (every secret has a fake fallback in `ci.yml`). Forcing the live-drift tier into mandatory CI would be a first-of-its-kind exception to that policy — chose the two-tier split instead so the tool exists without breaking house style. Happy to flip this if the team would rather force the real-call path into CI.
- **Routing-decision observability is structured application logs**, not a new DB column — no metadata/JSON column exists on `chat_completion_requests`, and a rollout-*safety* phase shouldn't introduce its own schema-change risk just to observe itself.

Closes #2216 — the final phase of the auto-routing backlog (#2212-#2216).

## Test plan
- [x] `pytest tests/routes/test_chat_auto_routing.py` — 12/12 passing (4 new: global-flag-off default, per-request opt-out, opt-out-can't-be-overridden, per-key-policy opt-out; existing Phase 4 tests updated to explicitly enable the now-default-off flag)
- [x] `pytest tests/db/test_routing_policies.py` — 9/9 passing (new)
- [x] `pytest tests/schemas/test_proxy.py` — 59/59 passing (3 new for `auto_routing` field)
- [x] `pytest tests/eval/test_classifier_eval_harness.py` — 11 passed, 1 correctly skipped (live tier, opt-in only)
- [x] `pytest tests/eval/ tests/db/test_routing_policies.py tests/db/test_models_catalog_db.py tests/schemas/test_proxy.py tests/routes/ tests/services/test_task_classifier.py tests/services/test_model_selector.py tests/services/test_capability_requirements.py tests/services/test_query_classifier.py` — 261 passed, 1 skipped (intentional), 2 xpassed (pre-existing flaky markers, unrelated) — full accumulated regression across all five phases
- [x] `ruff check` / `black --check` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)