### PR TITLE
feat(routing): brand the auto-routing alias as gatewayz-router

### DIFF
--- a/src/routes/chat_routing.py
+++ b/src/routes/chat_routing.py
@@ -29,7 +29,9 @@ logger = logging.getLogger(__name__)
 
 # Bare aliases that used to fold onto the `router` prefix. `openrouter/auto` is
 # deliberately EXCLUDED — it is a real passthrough model served by OpenRouter.
-_ROUTER_BARE_ALIASES = {"auto", "gatewayz/auto"}
+# `gatewayz-router` is the branded name for this feature (gatewayz-backend#2216
+# follow-up) -- same resolution path as `auto`, just a friendlier model id.
+_ROUTER_BARE_ALIASES = {"auto", "gatewayz/auto", "gatewayz-router"}
 _ROUTER_PREFIXES = ("router", "auto:", "gatewayz-general", "gatewayz-code")
 
 

--- a/tests/routes/test_chat_auto_routing.py
+++ b/tests/routes/test_chat_auto_routing.py
@@ -17,7 +17,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi import HTTPException
 
-from src.routes.chat_routing import resolve_auto_routed_model
+from src.routes.chat_routing import _is_router_model, resolve_auto_routed_model
 from src.schemas.proxy import Message
 from src.services.model_selector import ModelSelection
 from src.services.task_classifier import TaskClassification
@@ -183,6 +183,33 @@ async def test_noop_for_explicit_model():
 
     assert req.model == "openai/gpt-4o-mini"
     mock_classify.assert_not_called()
+
+
+def test_gatewayz_router_is_a_recognized_alias():
+    """`gatewayz-router` is the branded name for this feature -- same
+    resolution path as `auto`, just a friendlier model id."""
+    assert _is_router_model("gatewayz-router") is True
+    assert _is_router_model("GATEWAYZ-ROUTER") is True  # case-insensitive, matches _is_router_model
+
+
+@pytest.mark.asyncio
+async def test_gatewayz_router_alias_resolves_like_auto():
+    req = _req(model="gatewayz-router")
+    classification = TaskClassification(
+        task_type="code_generation", capability_names=frozenset(), confidence=0.9
+    )
+    selection = ModelSelection(model_id="openai/gpt-4o-mini", reason="top_scorer")
+
+    with (
+        _enabled(),
+        patch("asyncio.to_thread", new=_passthrough_to_thread()),
+        patch("src.db.models_catalog_db.get_candidate_models", return_value=[{"id": "m"}]),
+        patch("src.services.task_classifier.classify_task", return_value=classification),
+        patch("src.services.model_selector.select_model", return_value=selection),
+    ):
+        await resolve_auto_routed_model(req, is_anonymous=False)
+
+    assert req.model == "openai/gpt-4o-mini"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Adds `gatewayz-router` as a recognized alias for the auto-routing feature shipped in #2212-#2216, alongside the existing `auto`/`gatewayz/auto`. Same resolution path, no behavior change for existing aliases — this is purely a branded, friendlier model id for the same engine.

Once merged, this ships enabled behind `Config.AUTO_ROUTING_ENABLED` (still needs to be flipped to `true` — that's a separate production env var change, not part of this PR's diff).

## Test plan
- [x] `pytest tests/routes/test_chat_auto_routing.py` — 14/14 passing (2 new: alias recognition, end-to-end resolution)
- [x] `ruff check` / `black --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)