### PR TITLE
fix(routing): stop auto-routing crashing on real catalog rows

### DIFF
--- a/src/db/models_catalog_db.py
+++ b/src/db/models_catalog_db.py
@@ -1486,7 +1486,7 @@ def get_candidate_models(
         `_sync_categories`). A model that hasn't been categorized yet is
         excluded, not guessed at — same "missing data never fabricates a tag"
         rule as `model_categorizer`.
-      - `required_capabilities` (any of {"tools", "vision", "caching"}) are
+      - `required_capabilities` (any of {"tools", "vision", "caching", "reasoning"}) are
         evaluated live per row via `model_capability_surface`, the same
         convention used at query time in `routes/catalog.py` and
         `pricing/pricing_lookup.py`.
@@ -1503,7 +1503,7 @@ def get_candidate_models(
 
     Args:
         required_capabilities: capability names the model must support, a
-            subset of {"tools", "vision", "caching"}. None/empty = no filter.
+            subset of {"tools", "vision", "caching", "reasoning"}. None/empty = no filter.
         min_context_length: minimum context window in tokens. None = no filter.
         quality_tier: one of "flagship" / "mid" / "budget". None = no filter.
         cost_ceiling: max blended $ per 1M tokens. None = no filter.
@@ -1515,6 +1515,7 @@ def get_candidate_models(
     """
     from src.services.model_capability_surface import (
         supports_caching,
+        supports_reasoning,
         supports_tools,
         supports_vision,
     )
@@ -1543,6 +1544,7 @@ def get_candidate_models(
                 "tools": supports_tools,
                 "vision": supports_vision,
                 "caching": supports_caching,
+                "reasoning": supports_reasoning,
             }
             unknown = set(required_capabilities) - capability_checks.keys()
             if unknown:

--- a/src/services/model_capability_surface.py
+++ b/src/services/model_capability_surface.py
@@ -126,9 +126,18 @@ def _model_identifier(model: dict[str, Any]) -> str:
 
 
 def supports_tools(model: dict[str, Any]) -> bool:
-    explicit = _flag(model, "supports_tools", "tools", "function_calling", "supports_function_calling")
+    explicit = _flag(model, "supports_tools", "tools", "function_calling")
     if explicit is not None:
         return explicit
+    # `supports_function_calling` is the raw catalog-sync column -- trust an
+    # explicit True from it, but NOT an explicit False: that column's own
+    # detection heuristic is narrower than KNOWN_TOOL_FAMILIES (that's why
+    # the family list exists -- it was added specifically to rescue models,
+    # e.g. Kimi/Moonshot/MiniMax/GLM/Mimo/Step, that this column under-reports
+    # for). Short-circuiting on its False would silently reintroduce that
+    # exact under-reporting bug for the auto-routing path.
+    if model.get("supports_function_calling") is True:
+        return True
     return _matches_family(_model_identifier(model), KNOWN_TOOL_FAMILIES)
 
 

--- a/src/services/model_capability_surface.py
+++ b/src/services/model_capability_surface.py
@@ -165,13 +165,17 @@ def supports_caching(model: dict[str, Any]) -> bool:
     if explicit is not None:
         return explicit
     metadata = model.get("metadata") if isinstance(model.get("metadata"), dict) else {}
-    provider = str(
-        model.get("provider_slug")
-        or model.get("source_gateway")
-        or metadata.get("provider_slug")
-        or metadata.get("source_gateway")
-        or ""
-    ).strip().lower()
+    provider = (
+        str(
+            model.get("provider_slug")
+            or model.get("source_gateway")
+            or metadata.get("provider_slug")
+            or metadata.get("source_gateway")
+            or ""
+        )
+        .strip()
+        .lower()
+    )
     if provider in CACHE_CAPABLE_PROVIDERS:
         return True
     model_id = _model_identifier(model).lower()

--- a/src/services/model_capability_surface.py
+++ b/src/services/model_capability_surface.py
@@ -110,18 +110,44 @@ def _flag(model: dict[str, Any], *names: str) -> bool | None:
     return None
 
 
+def _model_identifier(model: dict[str, Any]) -> str:
+    """The string identifier to pattern-match against, from either row shape.
+
+    A public/API-formatted model dict (routes/catalog.py, pricing_lookup.py)
+    carries a string ``id``. A raw ``models`` table row (models_catalog_db.py's
+    ``get_candidate_models``, used by auto-routing) carries an integer PK in
+    ``id`` and the actual model slug in ``provider_model_id`` instead --
+    calling ``.lower()`` on the raw int used to raise unconditionally for
+    every auto-routing candidate. Prefer the slug when present; str() the
+    fallback defensively so a non-string ``id`` can never crash this again.
+    """
+    identifier = model.get("provider_model_id") or model.get("id") or ""
+    return str(identifier)
+
+
 def supports_tools(model: dict[str, Any]) -> bool:
-    explicit = _flag(model, "supports_tools", "tools", "function_calling")
+    explicit = _flag(model, "supports_tools", "tools", "function_calling", "supports_function_calling")
     if explicit is not None:
         return explicit
-    return _matches_family(model.get("id", ""), KNOWN_TOOL_FAMILIES)
+    return _matches_family(_model_identifier(model), KNOWN_TOOL_FAMILIES)
 
 
 def supports_vision(model: dict[str, Any]) -> bool:
     explicit = _flag(model, "supports_vision", "vision", "multimodal")
     if explicit is not None:
         return explicit
-    return _matches_family(model.get("id", ""), KNOWN_VISION_FAMILIES)
+    return _matches_family(_model_identifier(model), KNOWN_VISION_FAMILIES)
+
+
+def supports_reasoning(model: dict[str, Any]) -> bool:
+    """Whether the model is a dedicated reasoning model (catalog `is_reasoning` flag).
+
+    No family-matching fallback: unlike tools/vision, reasoning capability
+    isn't reliably inferable from a model id, so an unflagged model reports
+    unsupported rather than guessing (same honesty rule as the module docstring).
+    """
+    explicit = _flag(model, "is_reasoning", "supports_reasoning")
+    return bool(explicit)
 
 
 def supports_caching(model: dict[str, Any]) -> bool:
@@ -129,10 +155,17 @@ def supports_caching(model: dict[str, Any]) -> bool:
     explicit = _flag(model, "supports_caching", "prompt_caching")
     if explicit is not None:
         return explicit
-    provider = str(model.get("provider_slug") or model.get("source_gateway") or "").strip().lower()
+    metadata = model.get("metadata") if isinstance(model.get("metadata"), dict) else {}
+    provider = str(
+        model.get("provider_slug")
+        or model.get("source_gateway")
+        or metadata.get("provider_slug")
+        or metadata.get("source_gateway")
+        or ""
+    ).strip().lower()
     if provider in CACHE_CAPABLE_PROVIDERS:
         return True
-    model_id = (model.get("id") or "").lower()
+    model_id = _model_identifier(model).lower()
     return any(p in model_id for p in CACHE_CAPABLE_PROVIDERS)
 
 

--- a/src/services/model_selector.py
+++ b/src/services/model_selector.py
@@ -11,9 +11,12 @@ and cost from `get_model_pricing_by_ids()` instead of a `ModelCapabilities`
 schema object (that schema, `schemas/router.py`, was deleted separately and
 is not revived here — see gatewayz-backend#2214).
 
-Shadow-mode only: this module scores/selects but is not wired into any live
-request path yet. `log_shadow_selection()` gives a caller a structured way to
-record what this engine would have chosen, without changing behavior.
+Live since gatewayz-backend#2223 (`chat_routing.resolve_auto_routed_model`
+calls `select_model()` directly and assigns its result to `req.model`) --
+despite this module's original "shadow-mode only" design, it is on the
+request path whenever `Config.AUTO_ROUTING_ENABLED` is true.
+`log_shadow_selection()` remains for callers that want to log what this
+engine would have chosen without acting on it.
 
 Not to be confused with `Config.SMART_ROUTER_POLICY` (`src/config/config.py`),
 which governs PROVIDER choice for an already-chosen model, one layer below
@@ -100,7 +103,7 @@ def _cost_score(price_per_input_token: float | None) -> float:
 
 
 def _quality_score(
-    model_id: str | None,
+    model_id: Any,
     canonical_id: str | None,
     task_type: str,
     quality_priors: dict[str, dict[str, float]],
@@ -110,12 +113,30 @@ def _quality_score(
     `get_quality_priors()` is keyed by `canonical_id.lower()` (per
     `model_quality_scores.model_id`, which stores canonical ids), NOT by the
     row's display `id` — using the wrong key silently returns no signal.
+    `model_id` is str()'d defensively: candidates from `get_candidate_models`
+    carry the `models` table's integer PK as `id`, not a string, and this used
+    to raise unconditionally for every real candidate (`.lower()` on an int).
     """
-    key = (canonical_id or model_id or "").lower()
+    key = str(canonical_id or model_id or "").lower()
     priors = quality_priors.get(key)
     if not priors:
         return _QUALITY_SCORE_DEFAULT
     return priors.get(task_type, priors.get("unknown", _QUALITY_SCORE_DEFAULT))
+
+
+def _display_model_id(model: dict[str, Any]) -> Any:
+    """The request-facing model identifier for a candidate row.
+
+    `get_candidate_models` returns raw `models` table rows: `id` is that
+    table's integer primary key (only meaningful for the `model_pricing`
+    join), while `provider_model_id` is the actual model string (what
+    `req.model`, `get_model_pricing()`, and `model_quality_scores.model_id`
+    all mean by "model id" elsewhere in the codebase). Prefer `canonical_id`
+    when populated (the intended long-term key), else `provider_model_id`,
+    and only fall back to the raw `id` for candidate shapes (tests) that
+    already use a string there directly.
+    """
+    return model.get("canonical_id") or model.get("provider_model_id") or model.get("id")
 
 
 def _blended_score(quality: float, cost: float, mode: OptimizationMode) -> float:
@@ -160,8 +181,10 @@ def select_model(
     Pick/rank a model from `candidates` for the given task classification.
 
     Args:
-        candidates: model rows from `get_candidate_models` (must carry "id";
-            "canonical_id" is used for the quality lookup when present).
+        candidates: model rows from `get_candidate_models` (must carry "id",
+            the `models` table's integer PK, used for the pricing join;
+            the returned `ModelSelection.model_id` prefers "canonical_id"
+            then "provider_model_id" -- see `_display_model_id`).
         classification: Phase 2's `TaskClassification` — `task_type` drives
             the quality-prior lookup.
         mode: "price" / "quality" / "fast" / "balanced" — a model-choice-level
@@ -189,13 +212,14 @@ def select_model(
         model_id = model.get("id")
         if not model_id:
             continue
+        display_id = _display_model_id(model)
         quality = _quality_score(
-            model_id, model.get("canonical_id"), classification.task_type, quality_priors
+            display_id, model.get("canonical_id"), classification.task_type, quality_priors
         )
         price = pricing_by_id.get(model_id, {})
         cost = _cost_score(price.get("in"))
         score = _blended_score(quality, cost, mode)
-        if model_id in preferred:
+        if display_id in preferred:
             score += _PREFERRED_MODEL_BOOST
         scored.append((score, model))
 
@@ -214,14 +238,14 @@ def select_model(
             idx = hash_val % len(similar)
             selected_score, selected_model = similar[idx]
             return ModelSelection(
-                model_id=selected_model.get("id"),
+                model_id=_display_model_id(selected_model),
                 reason="stable_selection",
                 score=selected_score,
                 considered=len(scored),
             )
 
     return ModelSelection(
-        model_id=top_model.get("id"),
+        model_id=_display_model_id(top_model),
         reason="top_scorer",
         score=top_score,
         considered=len(scored),

--- a/src/services/model_selector.py
+++ b/src/services/model_selector.py
@@ -134,9 +134,14 @@ def _display_model_id(model: dict[str, Any]) -> Any:
     all mean by "model id" elsewhere in the codebase). Prefer `canonical_id`
     when populated (the intended long-term key), else `provider_model_id`,
     and only fall back to the raw `id` for candidate shapes (tests) that
-    already use a string there directly.
+    already use a string there directly. `provider_model_id` is a NOT NULL
+    column today so the final fallback shouldn't be reachable for a real
+    catalog row, but str() it anyway -- this exact "int PK leaks out as the
+    model id" shape is the bug this module was just fixed for; a malformed
+    row or a future schema change must not be able to reintroduce it here.
     """
-    return model.get("canonical_id") or model.get("provider_model_id") or model.get("id")
+    display_id = model.get("canonical_id") or model.get("provider_model_id") or model.get("id")
+    return str(display_id) if display_id is not None else None
 
 
 def _blended_score(quality: float, cost: float, mode: OptimizationMode) -> float:

--- a/tests/db/test_models_catalog_db.py
+++ b/tests/db/test_models_catalog_db.py
@@ -111,6 +111,28 @@ def test_required_capabilities_filters_out_non_matching_models(sb):
     assert [m["id"] for m in result] == [1]
 
 
+def test_reasoning_is_a_recognized_capability(sb):
+    """Regression: `task_classifier.classify_task` adds "reasoning" to
+    `capability_names` for any prompt it judges needs multi-step reasoning.
+    Before "reasoning" was registered here, that made every such request an
+    "unknown capability" -> fail-closed to zero candidates -> the auto-router
+    outright rejected exactly the requests where routing quality matters most,
+    instead of routing to a reasoning-capable model.
+    """
+    fake_rows = [
+        {"id": 1, "model_name": "reasoning-model", "is_reasoning": True},
+        {"id": 2, "model_name": "regular-model", "is_reasoning": False},
+    ]
+    client, _, _ = _mock_client_for(fake_rows)
+
+    with patch("src.db.models_catalog_db.get_client_for_query", return_value=client):
+        from src.db.models_catalog_db import get_candidate_models
+
+        result = get_candidate_models(required_capabilities={"reasoning"})
+
+    assert [m["id"] for m in result] == [1]
+
+
 def test_required_capabilities_falls_back_to_family_heuristic(sb):
     """No explicit flag on the row -> model_capability_surface's family match decides."""
     fake_rows = [

--- a/tests/routes/test_chat_auto_routing.py
+++ b/tests/routes/test_chat_auto_routing.py
@@ -240,6 +240,40 @@ async def test_successful_resolution_mutates_req_model_in_place():
 
 
 @pytest.mark.asyncio
+async def test_successful_resolution_against_real_select_model_with_raw_catalog_row():
+    """End-to-end regression: `get_candidate_models` returns raw `models` table
+    rows (integer `id` PK, string `provider_model_id`, no `canonical_id`) --
+    exactly gatewayz-backend's live production shape. `select_model` itself is
+    NOT mocked here (only its own DB fetches are), so this exercises the real
+    `_quality_score`/`_display_model_id` path end-to-end. Before the fix, this
+    raised `AttributeError` on the first candidate (`.lower()` on an int) and
+    every real auto-routing request crashed instead of routing.
+    """
+    req = _req(model="auto")
+    classification = TaskClassification(
+        task_type="code_generation", capability_names=frozenset(), confidence=0.9
+    )
+    raw_row = {
+        "id": 2298,
+        "provider_model_id": "openai/gpt-4o-mini",
+        "canonical_id": None,
+        "supports_function_calling": True,
+    }
+
+    with (
+        _enabled(),
+        patch("asyncio.to_thread", new=_passthrough_to_thread()),
+        patch("src.db.models_catalog_db.get_candidate_models", return_value=[raw_row]),
+        patch("src.services.task_classifier.classify_task", return_value=classification),
+        patch("src.services.model_selector._fetch_pricing", return_value={}),
+        patch("src.services.model_selector._fetch_quality_priors", return_value={}),
+    ):
+        await resolve_auto_routed_model(req, is_anonymous=False)
+
+    assert req.model == "openai/gpt-4o-mini"
+
+
+@pytest.mark.asyncio
 async def test_classification_error_raises_400_and_leaves_model_unchanged():
     req = _req(model="auto")
     failed_classification = TaskClassification(error="timeout")

--- a/tests/services/test_model_capability_surface.py
+++ b/tests/services/test_model_capability_surface.py
@@ -222,6 +222,24 @@ class TestRawCatalogRow:
     def test_no_provider_model_id_and_non_string_id_is_safe(self):
         assert supports_tools({"id": 12345}) is False
 
+    def test_explicit_false_supports_function_calling_does_not_override_family_rescue(self):
+        """Regression (code review on gatewayz-backend#2227): `supports_function_calling`
+        is the catalog-sync heuristic KNOWN_TOOL_FAMILIES was added to rescue
+        models from (Kimi/Moonshot/etc under-reported by that narrower
+        heuristic). Treating its explicit False as authoritative here would
+        silently reintroduce that exact under-reporting bug for auto-routing.
+        """
+        row = {
+            "id": 4242,
+            "provider_model_id": "moonshot/kimi-k2.6",
+            "supports_function_calling": False,
+        }
+        assert supports_tools(row) is True
+
+    def test_explicit_true_supports_function_calling_is_trusted(self):
+        row = {"id": 1, "provider_model_id": "obscure/model", "supports_function_calling": True}
+        assert supports_tools(row) is True
+
 
 class TestSupportsReasoning:
     def test_flag_true(self):

--- a/tests/services/test_model_capability_surface.py
+++ b/tests/services/test_model_capability_surface.py
@@ -11,6 +11,7 @@ from src.services.model_capability_surface import (
     build_supported_parameters,
     enrich_model_with_capabilities,
     supports_caching,
+    supports_reasoning,
     supports_tools,
     supports_vision,
 )
@@ -175,3 +176,60 @@ class TestServeTimeEnrichment:
     def test_row_with_no_pricing_or_provider_still_enriches(self):
         model = enrich_model_with_capabilities({"id": "anthropic/claude-sonnet-4"})
         assert model["capabilities"]["tools"] is True
+
+
+class TestRawCatalogRow:
+    """`get_candidate_models` (auto-routing) passes raw `models` table rows,
+    not the public API-formatted dict every other test in this file uses.
+
+    That row shape has an INTEGER primary key in `id` (only meaningful for
+    the `model_pricing` join) and the actual model slug in `provider_model_id`
+    instead, with `provider_slug`/`source_gateway` nested under `metadata`.
+    Regression: every check here used to call `.lower()` on the raw int `id`
+    and raise `AttributeError` for every real auto-routing candidate.
+    """
+
+    DB_ROW = {
+        "id": 2298,
+        "provider_model_id": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+        "canonical_id": None,
+        "supports_function_calling": True,
+        "supports_vision": False,
+        "is_reasoning": False,
+        "metadata": {"provider_slug": "together", "source_gateway": "together"},
+    }
+
+    def test_supports_tools_does_not_raise_on_int_id(self):
+        assert supports_tools(dict(self.DB_ROW)) is True
+
+    def test_supports_vision_does_not_raise_on_int_id(self):
+        assert supports_vision(dict(self.DB_ROW)) is False
+
+    def test_supports_caching_does_not_raise_on_int_id(self):
+        # "together" isn't in CACHE_CAPABLE_PROVIDERS -- just must not crash.
+        assert supports_caching(dict(self.DB_ROW)) is False
+
+    def test_supports_caching_reads_provider_from_metadata(self):
+        row = dict(self.DB_ROW)
+        row["metadata"] = {"provider_slug": "anthropic", "source_gateway": "anthropic"}
+        assert supports_caching(row) is True  # cache-capable provider, nested under metadata
+
+    def test_family_fallback_uses_provider_model_id_not_int_id(self):
+        row = {"id": 999, "provider_model_id": "anthropic/claude-sonnet-4"}
+        assert supports_tools(row) is True
+        assert supports_caching(row) is True
+
+    def test_no_provider_model_id_and_non_string_id_is_safe(self):
+        assert supports_tools({"id": 12345}) is False
+
+
+class TestSupportsReasoning:
+    def test_flag_true(self):
+        assert supports_reasoning({"id": 1, "is_reasoning": True}) is True
+
+    def test_flag_false(self):
+        assert supports_reasoning({"id": 1, "is_reasoning": False}) is False
+
+    def test_missing_flag_fails_safe(self):
+        """No family-heuristic fallback -- unflagged models report unsupported."""
+        assert supports_reasoning({"id": "openai/o3"}) is False

--- a/tests/services/test_model_selector.py
+++ b/tests/services/test_model_selector.py
@@ -205,6 +205,22 @@ def test_select_model_on_raw_catalog_rows_returns_provider_model_id_not_db_pk():
     assert isinstance(result.model_id, str)
 
 
+def test_select_model_final_fallback_is_stringified_even_without_provider_model_id():
+    """Regression (code review on gatewayz-backend#2227): `provider_model_id`
+    is NOT NULL today, so this path isn't reachable for a real catalog row,
+    but a malformed row or future schema change must not be able to leak the
+    raw integer PK back out as `ModelSelection.model_id` -- that's the exact
+    bug class this module was just fixed for.
+    """
+    candidates = [{"id": 777}]
+    pricing = {777: {"in": 0.001, "out": 0.001}}
+
+    result = _patched_select(candidates, _classification(), pricing=pricing)
+
+    assert result.model_id == "777"
+    assert isinstance(result.model_id, str)
+
+
 def test_select_model_on_raw_catalog_rows_prefers_canonical_id_when_present():
     candidates = [{"id": 42, "provider_model_id": "raw/slug", "canonical_id": "openai/gpt-4o-mini"}]
     pricing = {42: {"in": 0.001, "out": 0.001}}

--- a/tests/services/test_model_selector.py
+++ b/tests/services/test_model_selector.py
@@ -39,6 +39,16 @@ def test_cost_score_tiers():
     assert _cost_score(None) == 50.0  # unknown -> neutral default
 
 
+def test_quality_score_does_not_raise_on_integer_model_id():
+    """Regression: `get_candidate_models` candidates carry the `models` table's
+    integer PK as `id` (canonical_id is unpopulated in production today), and
+    `.lower()` on that int used to raise `AttributeError` for every real
+    auto-routing candidate -- the classifier worked, but selection crashed
+    on the very first candidate scored.
+    """
+    assert _quality_score(2298, None, "code_generation", {}) == 50.0
+
+
 def test_quality_score_uses_canonical_id_not_display_id():
     priors = {"openai/gpt-4o-mini": {"code_generation": 80.0}}
 
@@ -166,6 +176,42 @@ def test_mode_changes_which_model_wins():
 
     assert price_mode.model_id == "cheap-low-quality"
     assert quality_mode.model_id == "pricey-high-quality"
+
+
+# --------------------------------------------------------------------------- #
+# select_model against real `get_candidate_models` row shape
+# --------------------------------------------------------------------------- #
+def test_select_model_on_raw_catalog_rows_returns_provider_model_id_not_db_pk():
+    """`get_candidate_models` returns raw `models` table rows: `id` is that
+    table's integer PK (meaningful only for the `model_pricing` join), and
+    the actual model string lives in `provider_model_id`. Before this fix,
+    `select_model` returned the raw int PK as `ModelSelection.model_id`,
+    which becomes `req.model` in chat_routing.py -- passing an integer
+    through as the model name would break every downstream provider-dispatch
+    and pricing-gate call expecting a string like "openai/gpt-4o-mini".
+    """
+    candidates = [
+        {"id": 2298, "provider_model_id": "together/Qwen3-Coder-480B", "canonical_id": None},
+        {"id": 5001, "provider_model_id": "openai/gpt-4o-mini", "canonical_id": None},
+    ]
+    pricing = {
+        2298: {"in": 0.00000005, "out": 0.00000005},  # cheapest -> wins in "price" mode
+        5001: {"in": 0.06, "out": 0.06},
+    }
+
+    result = _patched_select(candidates, _classification(), mode="price", pricing=pricing)
+
+    assert result.model_id == "together/Qwen3-Coder-480B"
+    assert isinstance(result.model_id, str)
+
+
+def test_select_model_on_raw_catalog_rows_prefers_canonical_id_when_present():
+    candidates = [{"id": 42, "provider_model_id": "raw/slug", "canonical_id": "openai/gpt-4o-mini"}]
+    pricing = {42: {"in": 0.001, "out": 0.001}}
+
+    result = _patched_select(candidates, _classification(), pricing=pricing)
+
+    assert result.model_id == "openai/gpt-4o-mini"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
- `get_candidate_models()` returns raw `models` table rows: `id` is that table's integer PK, and the real model identifier lives in `provider_model_id` (`canonical_id` is unpopulated for every active row in production). `model_selector._quality_score` and `model_capability_surface`'s `supports_tools`/`supports_caching` assumed a string `id` and called `.lower()` on it, so **every** live auto-routing request (`AUTO_ROUTING_ENABLED=true` in prod) raised an uncaught `AttributeError` before a model was ever selected.
- `select_model()` also returned the raw integer PK as the chosen `model_id`, which becomes `req.model` downstream — nonsense for the pricing gate and provider dispatch even once the crash above is fixed. It now returns `canonical_id` → `provider_model_id` → `id`, in that preference order.
- `get_candidate_models()` didn't recognize `"reasoning"` as a capability. `task_classifier` tags reasoning-needing prompts with it, so those requests were failing closed to zero candidates → 400, rejecting exactly the requests where routing quality matters most. `"reasoning"` is now backed by the catalog's `is_reasoning` flag.

## Known follow-up (not in this PR)
`model_quality_scores` only has 15 legacy models seeded back in April, with zero overlap against the current catalog, so quality-based "best model for the task" ranking still degrades to cost-tier-only for real candidates. Needs a data reseed + `canonical_id` backfill — a separate, larger effort.

## Test plan
- [x] New regression tests reproduce the crash/wrong-id/reasoning-400 against realistic raw-DB-row fixtures (`tests/services/test_model_capability_surface.py`, `tests/services/test_model_selector.py`, `tests/db/test_models_catalog_db.py`, `tests/routes/test_chat_auto_routing.py`)
- [x] Full suite: 2921 passed, 0 failed (no regressions)
- [x] Manually reproduced the original crash against the exact prod row shape and confirmed it's fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)