### PR TITLE
fix(pricing): is_free_model() must not trust a bare ":free" suffix

### DIFF
--- a/src/services/cache/model_capabilities_cache.py
+++ b/src/services/cache/model_capabilities_cache.py
@@ -336,12 +336,19 @@ def get_free_models() -> set[str]:
 
 
 def is_free_model(model_id: str) -> bool:
-    """Return True if model_id is a free model (case-insensitive)."""
+    """Return True if model_id is a known free model (case-insensitive).
+
+    Membership in the DB-backed set (or its hardcoded fallback) only — a bare
+    ``.endswith(":free")`` used to also match here, which meant any caller could
+    mark an arbitrary, non-cataloged model "free" just by naming it
+    ``<anything>:free``. That's a real gate: it's what exempts a request from the
+    credit check in chat.py and from the anonymous model allowlist in
+    anonymous_rate_limiter.py, so it must only trust models actually known to be free.
+    """
     _ensure_loaded()
     key = model_id.lower()
     free = _free_models if _free_models else _FREE_MODELS_FALLBACK
-    # Exact match or ends with :free
-    return key in free or key.endswith(":free")
+    return key in free
 
 
 def get_latency_tier(model_id: str, default: int = 3) -> int:

--- a/tests/services/test_is_free_model.py
+++ b/tests/services/test_is_free_model.py
@@ -1,0 +1,47 @@
+"""Regression test for the is_free_model() ":free" suffix bypass.
+
+is_free_model() used to return True for ANY model_id ending in ":free",
+regardless of whether it was an actual cataloged free model. That's a real
+security boundary: it's what exempts a request from the credit check in
+chat.py (src/routes/chat.py) and gates the anonymous model allowlist in
+anonymous_rate_limiter.py (is_model_allowed_for_anonymous). A caller could
+name any real paid model "<paid-model>:free" and skip both checks.
+
+The fix requires membership in the DB-backed free-model set (or its
+hardcoded fallback) — no bare suffix match.
+"""
+
+import time
+
+from src.services.cache import model_capabilities_cache as cache
+
+
+def _reset_cache(free_models: set[str]) -> None:
+    cache._free_models = set(free_models)
+    cache._cache_loaded = True
+    cache._cache_loaded_at = time.monotonic()  # fresh — _ensure_loaded() won't reload
+
+
+def test_known_free_model_is_free():
+    _reset_cache({"google/gemini-2.0-flash-exp:free"})
+    assert cache.is_free_model("google/gemini-2.0-flash-exp:free") is True
+    assert cache.is_free_model("Google/Gemini-2.0-Flash-Exp:free") is True  # case-insensitive
+
+
+def test_unknown_model_with_free_suffix_is_not_free():
+    _reset_cache({"google/gemini-2.0-flash-exp:free"})
+    # Fabricated ":free" suffix on a real, unrelated paid model — must NOT pass.
+    assert cache.is_free_model("openai/gpt-4o:free") is False
+    assert cache.is_free_model("anthropic/claude-opus-4.5:free") is False
+
+
+def test_paid_model_without_suffix_is_not_free():
+    _reset_cache({"google/gemini-2.0-flash-exp:free"})
+    assert cache.is_free_model("openai/gpt-4o") is False
+
+
+def test_falls_back_to_hardcoded_set_when_cache_empty():
+    _reset_cache(set())
+    fallback_model = next(iter(cache._FREE_MODELS_FALLBACK))
+    assert cache.is_free_model(fallback_model) is True
+    assert cache.is_free_model("openai/gpt-4o:free") is False


### PR DESCRIPTION
## Summary
- `is_free_model()` returned `True` for ANY `model_id` ending in `:free`, even one never seen in the catalog. This is a real security boundary: it's what exempts a request from the credit check in `chat.py` and gates the anonymous model allowlist in `anonymous_rate_limiter.py`. A caller could name any real paid model `<paid-model>:free` and skip both checks.
- Currently inert in production — nothing on the live request path strips the suffix before dispatching to a provider, so a spoofed ID just 404s upstream today — but it's exactly the kind of gap that becomes exploitable the moment routing logic changes elsewhere (e.g. the existing OpenRouter-circuit-breaker emergency failover path).
- Now requires real membership in the DB-backed free-model set (or its hardcoded fallback).
- Companion frontend fix (the actually-live vulnerability): https://github.com/Alpaca-Network/gatewayz-frontend/pull/1005

## Test plan
- [x] New `tests/services/test_is_free_model.py` — 4/4 pass
- [x] `tests/services/test_zero_price_gating.py` + `tests/conceptual_model/test_cm02_rate_limiting.py` — 25/25 pass, no regressions