### PR TITLE
fix(anonymous): stop hard-requiring a ":free" suffix for guest model access

### DIFF
--- a/src/routes/chat.py
+++ b/src/routes/chat.py
@@ -19,8 +19,8 @@ from src.db.chat_completion_requests import save_chat_completion_request_with_co
 from src.schemas import ProxyRequest
 from src.security.deps import get_optional_api_key
 from src.services.anonymous_rate_limiter import (
-    ANONYMOUS_ALLOWED_MODELS,
     ANONYMOUS_DAILY_LIMIT,
+    get_anonymous_allowed_models_sample,
     get_anonymous_rate_limit_headers,
     validate_anonymous_request,
 )
@@ -426,7 +426,7 @@ async def chat_completions(
                                     "message": anon_validation["reason"],
                                     "type": "model_not_allowed",
                                     "code": "anonymous_model_restricted",
-                                    "allowed_models": ANONYMOUS_ALLOWED_MODELS[:5],
+                                    "allowed_models": get_anonymous_allowed_models_sample(5),
                                 }
                             },
                         )

--- a/src/services/anonymous_rate_limiter.py
+++ b/src/services/anonymous_rate_limiter.py
@@ -12,7 +12,7 @@ Key Features:
 - Fallback to in-memory when Redis unavailable
 
 Security Design:
-- Anonymous users can ONLY use models ending with :free
+- Anonymous users can ONLY use models known to be free (DB is_free flag)
 - Maximum 3 requests per day per IP address
 - No credit deduction (free models have $0 cost)
 - IP fingerprinting to prevent simple bypasses
@@ -91,12 +91,38 @@ def _cleanup_memory_cache():
         logger.info(f"Cleaned up {len(expired_keys)} expired anonymous rate limit entries")
 
 
+def get_anonymous_allowed_models_sample(n: int = 5) -> list[str]:
+    """A sample of models currently usable by anonymous users, for error messages.
+
+    Prefers the real, DB-verified free catalog over ANONYMOUS_ALLOWED_MODELS,
+    which is a last-resort fallback that can drift out of sync with the DB
+    (see its own comment) and name models that don't exist in the catalog.
+    """
+    try:
+        from src.services.model_capabilities_cache import get_free_models
+
+        live_free = sorted(get_free_models())
+        if live_free:
+            return live_free[:n]
+    except Exception:
+        pass
+    return ANONYMOUS_ALLOWED_MODELS[:n]
+
+
 def is_model_allowed_for_anonymous(model_id: str) -> bool:
     """
     Check if a model is allowed for anonymous users.
 
-    Only models explicitly whitelisted AND ending with :free are allowed.
-    This prevents anonymous users from accessing expensive models.
+    Only models known to be free (DB is_free flag, or the hardcoded fallback
+    list when the DB cache is unavailable) are allowed. This prevents
+    anonymous users from accessing paid models.
+
+    A ``:free`` suffix used to be a hard prerequisite here, but the catalog's
+    actual free models aren't guaranteed to carry that suffix (production's
+    current free set — e.g. "unsloth/gemma-2-9b-it" — doesn't), which made
+    this reject every real free model and leave anonymous access fully
+    unusable. is_free_model() is the source of truth; it already only
+    matches models genuinely known to be free.
 
     Args:
         model_id: The model identifier
@@ -105,10 +131,6 @@ def is_model_allowed_for_anonymous(model_id: str) -> bool:
         True if model is allowed for anonymous access
     """
     if not model_id:
-        return False
-
-    # Must end with :free suffix
-    if not model_id.endswith(":free"):
         return False
 
     # Check DB-backed free model list first, then fall back to hardcoded whitelist
@@ -241,7 +263,7 @@ def validate_anonymous_request(ip_address: str, model_id: str) -> dict[str, Any]
     # Check model whitelist first (fast fail)
     model_allowed = is_model_allowed_for_anonymous(model_id)
     if not model_allowed:
-        allowed_models_str = ", ".join(ANONYMOUS_ALLOWED_MODELS[:3]) + "..."
+        allowed_models_str = ", ".join(get_anonymous_allowed_models_sample(3)) + "..."
         return {
             "allowed": False,
             "reason": f"Model '{model_id}' is not available for anonymous users. Anonymous access is limited to free models: {allowed_models_str}. Please sign up for an account to access this model.",

--- a/tests/services/test_anonymous_model_allowlist.py
+++ b/tests/services/test_anonymous_model_allowlist.py
@@ -1,0 +1,77 @@
+"""Regression test: anonymous model allowlist must not hard-require a ":free" suffix.
+
+is_model_allowed_for_anonymous() used to reject any model_id that didn't end in
+":free" before even checking is_free_model(). Production's actual free-model
+catalog (is_free=true rows) doesn't reliably carry that suffix — e.g.
+"unsloth/gemma-2-9b-it" — so the suffix check rejected every real free model
+and made anonymous chat fully unusable, not just paid-model-restricted.
+
+is_free_model() is the real gate (see test_is_free_model.py); this suffix
+requirement was a redundant, wrong precondition on top of it.
+"""
+
+from unittest.mock import patch
+
+from src.services.anonymous_rate_limiter import (
+    ANONYMOUS_ALLOWED_MODELS,
+    get_anonymous_allowed_models_sample,
+    is_model_allowed_for_anonymous,
+)
+
+
+def test_free_model_without_free_suffix_is_allowed():
+    with patch(
+        "src.services.model_capabilities_cache.is_free_model",
+        return_value=True,
+    ):
+        assert is_model_allowed_for_anonymous("unsloth/gemma-2-9b-it") is True
+
+
+def test_free_model_with_free_suffix_is_allowed():
+    with patch(
+        "src.services.model_capabilities_cache.is_free_model",
+        return_value=True,
+    ):
+        assert is_model_allowed_for_anonymous("google/gemini-2.0-flash-exp:free") is True
+
+
+def test_paid_model_is_rejected_regardless_of_suffix():
+    with patch(
+        "src.services.model_capabilities_cache.is_free_model",
+        return_value=False,
+    ):
+        assert is_model_allowed_for_anonymous("openai/gpt-4o") is False
+        assert is_model_allowed_for_anonymous("openai/gpt-4o:free") is False
+
+
+def test_empty_model_id_is_rejected():
+    assert is_model_allowed_for_anonymous("") is False
+    assert is_model_allowed_for_anonymous(None) is False  # type: ignore[arg-type]
+
+
+def test_falls_back_to_hardcoded_whitelist_when_cache_import_fails():
+    with patch(
+        "src.services.model_capabilities_cache.is_free_model",
+        side_effect=ImportError("cache unavailable"),
+    ):
+        known = ANONYMOUS_ALLOWED_MODELS[0]
+        assert is_model_allowed_for_anonymous(known) is True
+        assert is_model_allowed_for_anonymous("openai/gpt-4o") is False
+
+
+def test_allowed_models_sample_prefers_live_free_catalog():
+    with patch(
+        "src.services.model_capabilities_cache.get_free_models",
+        return_value={"unsloth/gemma-2-9b-it", "unsloth/llama-3.2-3b-instruct"},
+    ):
+        sample = get_anonymous_allowed_models_sample(5)
+        assert set(sample) == {"unsloth/gemma-2-9b-it", "unsloth/llama-3.2-3b-instruct"}
+
+
+def test_allowed_models_sample_falls_back_when_catalog_empty():
+    with patch(
+        "src.services.model_capabilities_cache.get_free_models",
+        return_value=set(),
+    ):
+        sample = get_anonymous_allowed_models_sample(3)
+        assert sample == ANONYMOUS_ALLOWED_MODELS[:3]


### PR DESCRIPTION
## Summary
Found while verifying the guest-chat security fix (#2228, frontend #1005) against production: guest chat is currently **100% broken**, not just paid-model-restricted.

- `is_model_allowed_for_anonymous()` required `model_id.endswith(":free")` before even checking `is_free_model()`.
- Production's real free catalog (`is_free=true` rows) doesn't reliably carry that suffix — right now it's just `unsloth/gemma-2-9b-it` and `unsloth/llama-3.2-3b-instruct`, neither `:free`-suffixed.
- So the suffix check rejected every real free model too. Combined with the recent switch to true anonymous auth for guests, every guest request — free or paid — got 403'd.
- `is_free_model()` (hardened in #2228) is already the real, correct gate. The suffix check was a redundant, now-wrong precondition.

Also fixed: the "model not allowed" error message named example models from `ANONYMOUS_ALLOWED_MODELS`, a hardcoded list explicitly documented as drifting out of sync with the DB — so the error told users to try models that don't actually work. Added `get_anonymous_allowed_models_sample()` to use the real, live free-model set instead.

## Verification
Ran directly against production's real DB via `railway run --service api --environment production`:
```
unsloth/gemma-2-9b-it -> True
unsloth/llama-3.2-3b-instruct -> True
openai/gpt-4o -> False
```

## Test plan
- [x] New `tests/services/test_anonymous_model_allowlist.py` — 7/7 pass
- [x] `test_is_free_model.py`, `test_zero_price_gating.py`, `test_cm02_rate_limiting.py` — 36/36 pass, no regressions
- [x] Verified live against production DB (see above)