### PR TITLE
style: fix Black formatting broken on main (Run Linters red for every PR)

### DIFF
--- a/src/services/task_classifier.py
+++ b/src/services/task_classifier.py
@@ -64,8 +64,7 @@ def _system_prompt_for(industry: str | None) -> str:
     if not industry or industry == "general":
         return _SYSTEM_PROMPT
     return (
-        _SYSTEM_PROMPT
-        + f" The user's line of work is {industry}; weigh that context when judging "
+        _SYSTEM_PROMPT + f" The user's line of work is {industry}; weigh that context when judging "
         "task_type, but don't let it override clear signals in the message itself."
     )
 

--- a/tests/routes/test_chat_auto_routing.py
+++ b/tests/routes/test_chat_auto_routing.py
@@ -385,9 +385,7 @@ async def test_routing_preferences_industry_threaded_into_classify_task():
         patch(
             "src.services.task_classifier.classify_task", return_value=classification
         ) as mock_classify,
-        patch(
-            "src.services.model_selector.select_model", return_value=selection
-        ) as mock_select,
+        patch("src.services.model_selector.select_model", return_value=selection) as mock_select,
     ):
         await resolve_auto_routed_model(req, is_anonymous=False, api_key="gw_live_abc123")
 
@@ -415,9 +413,7 @@ async def test_routing_preferences_auto_mode_resolves_via_adaptive_mapping():
         patch("asyncio.to_thread", new=_passthrough_to_thread()),
         patch("src.db.models_catalog_db.get_candidate_models", return_value=[{"id": "m"}]),
         patch("src.services.task_classifier.classify_task", return_value=classification),
-        patch(
-            "src.services.model_selector.select_model", return_value=selection
-        ) as mock_select,
+        patch("src.services.model_selector.select_model", return_value=selection) as mock_select,
     ):
         await resolve_auto_routed_model(req, is_anonymous=False)
 

--- a/tests/services/test_routing_preferences.py
+++ b/tests/services/test_routing_preferences.py
@@ -37,7 +37,7 @@ def test_invalid_industry_falls_back_to_default():
 
 
 def test_balanced_is_not_a_valid_user_selectable_mode():
-    """"balanced" is intentionally internal-only (model_selector's fallback);
+    """ "balanced" is intentionally internal-only (model_selector's fallback);
     a stray "balanced" value in settings must fall back to the default,
     never pass through as if it were user-selected."""
     user = {"settings": {"routing_mode": "balanced"}}


### PR DESCRIPTION
`Run Linters` fails on main itself — Black flags three files from the auto-router merge (`src/services/task_classifier.py`, `tests/routes/test_chat_auto_routing.py`, `tests/services/test_routing_preferences.py`). Every open PR inherits the red check (#2232 and #2234 fail lint with zero overlap between their diffs and these files).

Pure `black` run with the repo's pyproject config (line-length 100, target py312), no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)