### PR TITLE
fix: streaming error propagation, gpt-5 SDK bug, budget 503s, catalog servability (#2236)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 
     # External services
     "requests==2.31.0",
-    "openai==1.44.0",
+    "openai==1.109.1",
     "resend==0.8.0",
     "stripe==13.0.1",
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pydantic[email]==2.12.2
 supabase==2.12.0
 python-dotenv==1.0.0
 requests==2.32.3
-openai==1.44.0
+openai==1.109.1
 python-multipart==0.0.6
 email-validator==2.1.0
 cryptography>=44.0.1

--- a/src/routes/catalog.py
+++ b/src/routes/catalog.py
@@ -159,6 +159,50 @@ def _apply_health_gating(models: list) -> list:
         return models
 
 
+def _row_is_servable(m: dict) -> bool:
+    """Whether the inference pricing gate would admit this catalog row.
+
+    Mirrors ``enforce_model_pricing_gate``/``model_has_pricing`` from the row's
+    own data: explicitly free models are servable; paid models need a nonzero
+    prompt or completion price. Unparseable pricing fails closed — a row we
+    cannot price is a row the gate will refuse.
+    """
+    model_id = str(m.get("id") or "")
+    if m.get("is_free") or model_id.endswith(":free"):
+        return True
+
+    def _priced(pricing: dict) -> bool:
+        try:
+            prompt = float(pricing.get("prompt") or 0)
+            completion = float(pricing.get("completion") or 0)
+        except (TypeError, ValueError):
+            return False
+        return prompt > 0 or completion > 0
+
+    providers = m.get("providers")
+    if isinstance(providers, list) and providers:
+        # unique_models=True shape: one row, per-provider pricing.
+        return any(_priced(p.get("pricing") or {}) for p in providers if isinstance(p, dict))
+    return _priced(m.get("pricing") or {})
+
+
+def _annotate_servability(models: list) -> list:
+    """Stamp ``servable`` on each served model row.
+
+    ``is_active`` says a model exists in the catalog; it says nothing about
+    whether the pricing gate will admit it, and partners sync registries from
+    this response (issue #2236: xai/moonshot listed active, refused as
+    unpriced). Fails open — annotation trouble never blocks the catalog.
+    """
+    try:
+        for m in models:
+            if isinstance(m, dict):
+                m["servable"] = _row_is_servable(m)
+    except Exception as e:
+        logger.warning(f"servability annotation failed, returning unannotated models: {e}")
+    return models
+
+
 @router.get("/routers", tags=["routers"])
 async def get_intelligent_routers():
     """
@@ -676,7 +720,7 @@ async def get_models(
             logger.info(f"✅ Returning cached response for gateway={gateway_value}")
             # Defense-in-depth: re-apply health gating to cached data in case the
             # entry was cached before a model was marked 'down' (inert otherwise).
-            gated_data = _apply_health_gating(cached_response.get("data", []))
+            gated_data = _annotate_servability(_apply_health_gating(cached_response.get("data", [])))
             if len(gated_data) != len(cached_response.get("data", [])):
                 cached_response = {**cached_response, "data": gated_data}
             cached_json = _dumps_fast(cached_response)
@@ -880,7 +924,7 @@ async def get_models(
         # and paginating, so totals/pagination stay correct. Inert until a sweep
         # marks a model down; 429/timeout/auth never hide a model.
         _pre_gate_count = len(models)
-        models = _apply_health_gating(models)
+        models = _annotate_servability(_apply_health_gating(models))
         if len(models) != _pre_gate_count:
             logger.info(
                 f"Health gating removed {_pre_gate_count - len(models)} 'down' models "
@@ -1905,7 +1949,7 @@ async def get_models_by_category_api(
         )
 
     models = get_models_by_category(tag, limit=limit, include_inactive=include_inactive)
-    models = _apply_health_gating(models)
+    models = _annotate_servability(_apply_health_gating(models))
     return {
         "category": tag,
         "data": models,
@@ -2329,7 +2373,7 @@ async def search_models(
 
         # Match the primary catalog's health contract before applying search
         # filters, counts, sorting, or pagination.
-        all_models = _apply_health_gating(all_models)
+        all_models = _annotate_servability(_apply_health_gating(all_models))
 
         # Apply filters
         filtered_models = all_models

--- a/src/routes/catalog.py
+++ b/src/routes/catalog.py
@@ -720,7 +720,9 @@ async def get_models(
             logger.info(f"✅ Returning cached response for gateway={gateway_value}")
             # Defense-in-depth: re-apply health gating to cached data in case the
             # entry was cached before a model was marked 'down' (inert otherwise).
-            gated_data = _annotate_servability(_apply_health_gating(cached_response.get("data", [])))
+            gated_data = _annotate_servability(
+                _apply_health_gating(cached_response.get("data", []))
+            )
             if len(gated_data) != len(cached_response.get("data", [])):
                 cached_response = {**cached_response, "data": gated_data}
             cached_json = _dumps_fast(cached_response)

--- a/src/routes/messages.py
+++ b/src/routes/messages.py
@@ -98,6 +98,17 @@ def _sse(event: str, data: dict[str, Any]) -> str:
     return f"event: {event}\ndata: {json.dumps(data)}\n\n"
 
 
+# Gateway/stream error types -> Anthropic SSE error types
+# (https://docs.anthropic.com/en/api/errors). Anything unmapped is an api_error.
+_STREAM_ERROR_TYPE_MAP = {
+    "rate_limit_error": "rate_limit_error",
+    "plan_limit_exceeded": "rate_limit_error",
+    "auth_error": "authentication_error",
+    "not_found_error": "not_found_error",
+    "capacity_error": "overloaded_error",
+}
+
+
 async def _stream_anthropic_events(
     openai_stream,
     model: str,
@@ -155,6 +166,27 @@ async def _stream_anthropic_events(
             chunk = json.loads(payload)
         except json.JSONDecodeError:
             continue
+
+        # A provider failure travels through the inner stream as an error chunk
+        # (see stream_normalizer.create_error_sse_chunk). Before this check it
+        # fell into the no-choices `continue` below and the stream ended with a
+        # clean zero-usage message_stop — a fabricated success (issue #2236).
+        # Surface it as Anthropic's own SSE error event and stop.
+        if chunk.get("error"):
+            err = chunk["error"] if isinstance(chunk["error"], dict) else {}
+            yield _sse(
+                "error",
+                {
+                    "type": "error",
+                    "error": {
+                        "type": _STREAM_ERROR_TYPE_MAP.get(err.get("type"), "api_error"),
+                        "message": err.get("message")
+                        or str(chunk["error"])
+                        or "upstream provider error",
+                    },
+                },
+            )
+            return
 
         if chunk.get("usage"):
             usage = chunk["usage"]
@@ -321,6 +353,9 @@ async def create_message(
             403: "permission_error",
             404: "not_found_error",
             429: "rate_limit_error",
+            # Provider capacity/budget exhaustion (e.g. unfunded upstream
+            # account) surfaces as 503 — Anthropic SDKs retry overloaded_error.
+            503: "overloaded_error",
         }.get(exc.status_code, "api_error")
         raise _anthropic_error(exc.status_code, error_type, message) from exc
 

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -71,10 +71,7 @@ from src.schemas.payments import (
 from src.schemas.payments import (
     SubscriptionPlan as PaymentSubscriptionPlan,  # Stripe-specific models; Rename to avoid conflict
 )
-from src.schemas.payments import (
-    SubscriptionResponse,
-    WebhookProcessingResult,
-)
+from src.schemas.payments import SubscriptionResponse, WebhookProcessingResult
 
 # Plan models
 from src.schemas.plans import SubscriptionPlan  # This is the correct one for trial service

--- a/src/services/task_classifier.py
+++ b/src/services/task_classifier.py
@@ -64,8 +64,7 @@ def _system_prompt_for(industry: str | None) -> str:
     if not industry or industry == "general":
         return _SYSTEM_PROMPT
     return (
-        _SYSTEM_PROMPT
-        + f" The user's line of work is {industry}; weigh that context when judging "
+        _SYSTEM_PROMPT + f" The user's line of work is {industry}; weigh that context when judging "
         "task_type, but don't let it override clear signals in the message itself."
     )
 

--- a/src/utils/errors.py
+++ b/src/utils/errors.py
@@ -416,6 +416,9 @@ _PROVIDER_BUDGET_PATTERNS = (
     "weekly limit",
     "insufficient_quota",
     "payment required",
+    # Anthropic's unfunded-account error is an HTTP 400 (not 402) whose text is
+    # the only budget signal (issue #2236).
+    "credit balance is too low",
 )
 
 _URL_RE = re.compile(r"https?://\S+")

--- a/tests/routes/test_catalog_servability.py
+++ b/tests/routes/test_catalog_servability.py
@@ -1,0 +1,63 @@
+"""Catalog servability annotation (issue #2236).
+
+The catalog listed xai/moonshot models ``is_active: true`` while the pricing
+gate refused them at inference time — the catalog lied about servability and a
+partner nearly synced a registry from it. Every served model row now carries a
+``servable`` flag derived from the same signal the gate uses: pricing
+configured (nonzero prompt or completion price) or explicitly free.
+"""
+
+from src.routes.catalog import _annotate_servability, _row_is_servable
+
+
+class TestRowIsServable:
+    def test_priced_model_is_servable(self):
+        assert _row_is_servable({"id": "openai/gpt-4o", "pricing": {"prompt": "0.0000025", "completion": "0.00001"}}) is True
+
+    def test_missing_pricing_is_not_servable(self):
+        assert _row_is_servable({"id": "xai/grok-4"}) is False
+
+    def test_empty_pricing_is_not_servable(self):
+        assert _row_is_servable({"id": "moonshot/kimi-k2", "pricing": {}}) is False
+
+    def test_zero_priced_paid_model_is_not_servable(self):
+        assert _row_is_servable({"id": "xai/grok-4", "pricing": {"prompt": "0", "completion": "0"}}) is False
+
+    def test_free_flag_is_servable(self):
+        assert _row_is_servable({"id": "some/model", "is_free": True}) is True
+
+    def test_free_suffix_is_servable(self):
+        assert _row_is_servable({"id": "meta-llama/llama-3:free", "pricing": {}}) is True
+
+    def test_garbage_pricing_values_fail_closed(self):
+        assert _row_is_servable({"id": "m", "pricing": {"prompt": "n/a", "completion": None}}) is False
+
+    def test_unique_models_shape_any_priced_provider(self):
+        row = {
+            "id": "gpt-4o",
+            "providers": [
+                {"slug": "a", "pricing": {"prompt": "0", "completion": "0"}},
+                {"slug": "b", "pricing": {"prompt": "0.000001", "completion": "0.000002"}},
+            ],
+        }
+        assert _row_is_servable(row) is True
+
+    def test_unique_models_shape_no_priced_provider(self):
+        row = {"id": "x", "providers": [{"slug": "a", "pricing": {}}]}
+        assert _row_is_servable(row) is False
+
+
+class TestAnnotateServability:
+    def test_annotates_every_dict_row(self):
+        models = [
+            {"id": "a", "pricing": {"prompt": "0.001", "completion": "0.002"}},
+            {"id": "b", "pricing": {}},
+            "not-a-dict",
+        ]
+        out = _annotate_servability(models)
+        assert out[0]["servable"] is True
+        assert out[1]["servable"] is False
+        assert out[2] == "not-a-dict"
+
+    def test_returns_input_on_empty(self):
+        assert _annotate_servability([]) == []

--- a/tests/routes/test_catalog_servability.py
+++ b/tests/routes/test_catalog_servability.py
@@ -12,7 +12,12 @@ from src.routes.catalog import _annotate_servability, _row_is_servable
 
 class TestRowIsServable:
     def test_priced_model_is_servable(self):
-        assert _row_is_servable({"id": "openai/gpt-4o", "pricing": {"prompt": "0.0000025", "completion": "0.00001"}}) is True
+        assert (
+            _row_is_servable(
+                {"id": "openai/gpt-4o", "pricing": {"prompt": "0.0000025", "completion": "0.00001"}}
+            )
+            is True
+        )
 
     def test_missing_pricing_is_not_servable(self):
         assert _row_is_servable({"id": "xai/grok-4"}) is False
@@ -21,7 +26,10 @@ class TestRowIsServable:
         assert _row_is_servable({"id": "moonshot/kimi-k2", "pricing": {}}) is False
 
     def test_zero_priced_paid_model_is_not_servable(self):
-        assert _row_is_servable({"id": "xai/grok-4", "pricing": {"prompt": "0", "completion": "0"}}) is False
+        assert (
+            _row_is_servable({"id": "xai/grok-4", "pricing": {"prompt": "0", "completion": "0"}})
+            is False
+        )
 
     def test_free_flag_is_servable(self):
         assert _row_is_servable({"id": "some/model", "is_free": True}) is True
@@ -30,7 +38,9 @@ class TestRowIsServable:
         assert _row_is_servable({"id": "meta-llama/llama-3:free", "pricing": {}}) is True
 
     def test_garbage_pricing_values_fail_closed(self):
-        assert _row_is_servable({"id": "m", "pricing": {"prompt": "n/a", "completion": None}}) is False
+        assert (
+            _row_is_servable({"id": "m", "pricing": {"prompt": "n/a", "completion": None}}) is False
+        )
 
     def test_unique_models_shape_any_priced_provider(self):
         row = {

--- a/tests/routes/test_chat_auto_routing.py
+++ b/tests/routes/test_chat_auto_routing.py
@@ -385,9 +385,7 @@ async def test_routing_preferences_industry_threaded_into_classify_task():
         patch(
             "src.services.task_classifier.classify_task", return_value=classification
         ) as mock_classify,
-        patch(
-            "src.services.model_selector.select_model", return_value=selection
-        ) as mock_select,
+        patch("src.services.model_selector.select_model", return_value=selection) as mock_select,
     ):
         await resolve_auto_routed_model(req, is_anonymous=False, api_key="gw_live_abc123")
 
@@ -415,9 +413,7 @@ async def test_routing_preferences_auto_mode_resolves_via_adaptive_mapping():
         patch("asyncio.to_thread", new=_passthrough_to_thread()),
         patch("src.db.models_catalog_db.get_candidate_models", return_value=[{"id": "m"}]),
         patch("src.services.task_classifier.classify_task", return_value=classification),
-        patch(
-            "src.services.model_selector.select_model", return_value=selection
-        ) as mock_select,
+        patch("src.services.model_selector.select_model", return_value=selection) as mock_select,
     ):
         await resolve_auto_routed_model(req, is_anonymous=False)
 

--- a/tests/services/test_anthropic_messages_api.py
+++ b/tests/services/test_anthropic_messages_api.py
@@ -256,3 +256,83 @@ class TestErrorEnvelope:
                 req=req, background_tasks=None, request=_FakeRequest({}), api_key="k"
             )
         assert exc.value.status_code == 400
+
+
+class TestStreamErrorPropagation:
+    """A provider error inside the inner stream must surface as an Anthropic
+    ``error`` SSE event and terminate the stream — never be swallowed into a
+    well-formed empty ``message_stop`` (issue #2236: streaming fabricated
+    success for every failing provider)."""
+
+    async def _collect(self, chunks, model="claude-sonnet-4"):
+        async def _fake_stream():
+            for c in chunks:
+                yield c
+
+        events = []
+        async for e in _stream_anthropic_events(_fake_stream(), model, "msg_1"):
+            events.append(e)
+        return events
+
+    def _parse(self, events):
+        parsed = []
+        for e in events:
+            for line in e.strip().split("\n"):
+                if line.startswith("data: "):
+                    parsed.append(json.loads(line[len("data: ") :]))
+        return parsed
+
+    @pytest.mark.asyncio
+    async def test_error_chunk_becomes_error_event(self):
+        chunks = [
+            'data: {"error":{"message":"The model provider is temporarily unavailable.",'
+            '"type":"provider_error","status":502}}'
+        ]
+        events = await self._collect(chunks)
+        assert any(e.startswith("event: error") for e in events)
+        parsed = self._parse(events)
+        error_events = [p for p in parsed if p["type"] == "error"]
+        assert error_events, "expected an Anthropic error event"
+        assert error_events[0]["error"]["type"] == "api_error"
+        assert "temporarily unavailable" in error_events[0]["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_error_terminates_stream_without_fabricated_success(self):
+        chunks = [
+            'data: {"error":{"message":"boom","type":"provider_error","status":502}}',
+            # Anything after the error must not be processed.
+            'data: {"choices":[{"delta":{"content":"ghost"},"finish_reason":"stop"}]}',
+        ]
+        parsed = self._parse(await self._collect(chunks))
+        types = [p["type"] for p in parsed]
+        assert "message_stop" not in types, "error stream must not end with message_stop"
+        assert "message_delta" not in types, "error stream must not report end_turn/usage"
+        assert not any(p["type"] == "content_block_delta" for p in parsed)
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_maps_to_anthropic_rate_limit_error(self):
+        chunks = [
+            'data: {"error":{"message":"Rate limit exceeded. Please wait.",'
+            '"type":"rate_limit_error","status":429}}'
+        ]
+        parsed = self._parse(await self._collect(chunks))
+        error_events = [p for p in parsed if p["type"] == "error"]
+        assert error_events[0]["error"]["type"] == "rate_limit_error"
+
+    @pytest.mark.asyncio
+    async def test_capacity_error_maps_to_overloaded(self):
+        chunks = ['data: {"error":{"message":"capacity","type":"capacity_error","status":503}}']
+        parsed = self._parse(await self._collect(chunks))
+        error_events = [p for p in parsed if p["type"] == "error"]
+        assert error_events[0]["error"]["type"] == "overloaded_error"
+
+    @pytest.mark.asyncio
+    async def test_error_after_content_still_surfaces(self):
+        chunks = [
+            'data: {"choices":[{"delta":{"content":"partial"},"finish_reason":null}]}',
+            'data: {"error":{"message":"died mid-stream","type":"stream_timeout","status":504}}',
+        ]
+        parsed = self._parse(await self._collect(chunks))
+        types = [p["type"] for p in parsed]
+        assert "error" in types
+        assert "message_stop" not in types

--- a/tests/services/test_openai_sdk_params.py
+++ b/tests/services/test_openai_sdk_params.py
@@ -1,0 +1,32 @@
+"""Guard: the pinned openai SDK must accept the params the gateway forwards.
+
+Issue #2236: openai==1.44.0 predates ``max_completion_tokens`` (SDK 1.45.0) and
+``reasoning_effort``, so every gpt-5-family request died with
+``Completions.create() got an unexpected keyword argument 'max_completion_tokens'``.
+The gateway renames ``max_tokens`` to ``max_completion_tokens`` for OpenAI
+reasoning models (see src/services/providers/reasoning_effort.py) and forwards
+``reasoning_effort`` — the installed SDK must know both kwargs or the rename
+turns a valid request into a TypeError.
+"""
+
+import inspect
+
+from openai.resources.chat.completions import Completions
+
+
+def _create_params():
+    return inspect.signature(Completions.create).parameters
+
+
+def test_sdk_accepts_max_completion_tokens():
+    assert "max_completion_tokens" in _create_params(), (
+        "installed openai SDK predates max_completion_tokens; "
+        "gpt-5/o-series requests will TypeError (issue #2236)"
+    )
+
+
+def test_sdk_accepts_reasoning_effort():
+    assert "reasoning_effort" in _create_params(), (
+        "installed openai SDK predates reasoning_effort; "
+        "reasoning requests will TypeError"
+    )

--- a/tests/services/test_openai_sdk_params.py
+++ b/tests/services/test_openai_sdk_params.py
@@ -27,6 +27,5 @@ def test_sdk_accepts_max_completion_tokens():
 
 def test_sdk_accepts_reasoning_effort():
     assert "reasoning_effort" in _create_params(), (
-        "installed openai SDK predates reasoning_effort; "
-        "reasoning requests will TypeError"
+        "installed openai SDK predates reasoning_effort; " "reasoning requests will TypeError"
     )

--- a/tests/services/test_provider_budget_error.py
+++ b/tests/services/test_provider_budget_error.py
@@ -67,3 +67,22 @@ def test_map_provider_error_generic_message_is_sanitized():
     detail = str(result.detail)
     assert "http" not in detail
     assert "deadbeefdeadbeefdeadbeefdeadbeef00" not in detail
+
+
+# Anthropic's unfunded-account error is an HTTP 400 whose text names the credit
+# balance — no 402 anywhere. Issue #2236: this surfaced as an opaque 502
+# provider_error instead of the 503 capacity path (friendly message + Sentry
+# top-up alert).
+REAL_ANTHROPIC_LOW_CREDIT = (
+    "Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', "
+    "'message': 'Your credit balance is too low to access the Anthropic API. "
+    "Please go to Plans & Billing to upgrade or purchase credits.'}}"
+)
+
+
+def test_anthropic_low_credit_balance_is_budget_error():
+    assert is_provider_budget_error(REAL_ANTHROPIC_LOW_CREDIT) is True
+
+
+def test_generic_low_credit_phrasings_detected():
+    assert is_provider_budget_error("your credit balance is too low") is True

--- a/tests/services/test_routing_preferences.py
+++ b/tests/services/test_routing_preferences.py
@@ -37,7 +37,7 @@ def test_invalid_industry_falls_back_to_default():
 
 
 def test_balanced_is_not_a_valid_user_selectable_mode():
-    """"balanced" is intentionally internal-only (model_selector's fallback);
+    """ "balanced" is intentionally internal-only (model_selector's fallback);
     a stray "balanced" value in settings must fall back to the default,
     never pass through as if it were user-selected."""
     user = {"settings": {"routing_mode": "balanced"}}


### PR DESCRIPTION
Fixes the four code-fixable failure classes from #2236 (the fifth — upstream account funding — is operational, not code).

## Changes

**1. `/v1/messages` streaming no longer fabricates success** (`src/routes/messages.py`)
The inner stream signals provider failure as a `data: {"error": ...}` chunk (`create_error_sse_chunk`), but `_stream_anthropic_events` skipped any chunk without `choices` — so every failing streamed request ended as a well-formed, zero-usage `message_stop`. Error chunks now surface as Anthropic's own SSE `error` event (typed per https://docs.anthropic.com/en/api/errors) and terminate the stream. Non-streaming 503s map to `overloaded_error` so Anthropic SDKs retry them.

**2. gpt-5 family `max_completion_tokens` TypeError** (`requirements.txt`, `pyproject.toml`)
`openai==1.44.0` predates `max_completion_tokens` (SDK 1.45.0) and `reasoning_effort`, so the gateway's own `max_tokens` rename for reasoning models made every gpt-5 request die client-side with `Completions.create() got an unexpected keyword argument`. Bumped to `openai==1.109.1`; `tests/services/test_openai_sdk_params.py` guards the pin against regression.

**3. Unfunded upstream → 503 capacity path, not opaque 502** (`src/utils/errors.py`)
Anthropic reports an unfunded account as HTTP **400** with "credit balance is too low" — no 402 anywhere, so `is_provider_budget_error` missed it. Added the pattern: these now take the existing budget path (503, friendly message, Sentry top-up alert with `provider_budget_exhausted`).

**4. Catalog rows carry `servable`** (`src/routes/catalog.py`)
`is_active` said a model exists; it said nothing about whether the pricing gate would admit it (xai/moonshot: listed active, refused as unpriced). Every served row now includes `servable` — pricing-configured-or-free, mirroring `enforce_model_pricing_gate` — computed from the row's own pricing to avoid per-row DB lookups. Handles both flat and `unique_models=True` shapes; fails open.

## Testing
- New tests written red-first: 5 stream-error-propagation tests (verified failing on pre-fix code), SDK signature guards, budget-pattern tests, 11 servability tests.
- Full suite: **2979 passed, 0 failed** (451 skipped, 7 xfailed) with the bumped SDK.

## Not in this PR (needs funding, not code)
- Anthropic upstream account credits (blocks Flashy Stage 1)
- OpenAI account quota/funding (4o/4.1 throttling)

Closes #2236 (code items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)